### PR TITLE
Introduction 64-bit formatting macro for nano printf lib

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -550,10 +550,11 @@ exit:
         currentBuffer->UpdateFirstLastEventTime(opts.mTimestamp);
 
 #if CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
-        ChipLogDetail(EventLogging,
-                      "LogEvent event number: %u schema priority: %u cluster id: 0x%x event id: 0x%x sys timestamp: 0x%" PRIx64,
-                      aEventNumber, opts.mpEventSchema->mPriority, opts.mpEventSchema->mClusterId, opts.mpEventSchema->mEventId,
-                      opts.mTimestamp.mValue);
+        ChipLogDetail(
+            EventLogging,
+            "LogEvent event number: %u schema priority: %u cluster id: 0x%x event id: 0x%x sys timestamp: 0x" ChipLogFormatX64,
+            aEventNumber, opts.mpEventSchema->mPriority, opts.mpEventSchema->mClusterId, opts.mpEventSchema->mEventId,
+            ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
         ScheduleFlushIfNeeded(opts.mUrgent);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -245,10 +245,11 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 // TODO: Remove this after codegen is ready.
 CHIP_ERROR __attribute__((weak)) ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter)
 {
-    ChipLogDetail(
-        DataManagement,
-        "Received Cluster Command: Cluster=%" PRIx16 " NodeId=%" PRIx64 " Endpoint=%" PRIx8 " FieldId=%" PRIx8 " ListIndex=%" PRIx8,
-        aClusterInfo.mClusterId, aClusterInfo.mNodeId, aClusterInfo.mEndpointId, aClusterInfo.mFieldId, aClusterInfo.mListIndex);
+    ChipLogDetail(DataManagement,
+                  "Received Cluster Command: Cluster=%" PRIx16 " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx8 " FieldId=%" PRIx8
+                  " ListIndex=%" PRIx8,
+                  aClusterInfo.mClusterId, ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId, aClusterInfo.mFieldId,
+                  aClusterInfo.mListIndex);
     ChipLogError(DataManagement,
                  "Default ReadSingleClusterData is called, this should be replaced by actual dispatched for cluster");
     return CHIP_NO_ERROR;
@@ -257,8 +258,9 @@ CHIP_ERROR __attribute__((weak)) ReadSingleClusterData(ClusterInfo & aClusterInf
 CHIP_ERROR __attribute__((weak)) WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader)
 {
     ChipLogDetail(DataManagement,
-                  "Received Cluster Attribute: Cluster=%" PRIx16 " NodeId=%" PRIx64 " Endpoint=%" PRIx8 " FieldId=%" PRIx8,
-                  " ListIndex=%" PRIx8, aClusterInfo.mClusterId, aClusterInfo.mNodeId, aClusterInfo.mEndpointId,
+                  "Received Cluster Attribute: Cluster=%" PRIx16 " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx8
+                  " FieldId=%" PRIx8,
+                  " ListIndex=%" PRIx8, aClusterInfo.mClusterId, ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId,
                   aClusterInfo.mFieldId, aClusterInfo.mListIndex);
     ChipLogError(DataManagement,
                  "Default WriteSingleClusterData is called, this should be replaced by actual dispatched for cluster");

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -88,9 +88,9 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, i
     fabricDescriptor.VendorId = vendorId;
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                   "OpCreds: Writing admin into attribute store at index %d: fabricId %" PRIX64 ", nodeId %" PRIX64
-                   " vendorId %" PRIX16,
-                   index, fabricId, nodeId, vendorId);
+                   "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64
+                   ", nodeId 0x" ChipLogFormatX64 " vendorId %" PRIX16,
+                   index, ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
     status = writeFabricAttribute((uint8_t *) &fabricDescriptor, index);
     return status;
 }
@@ -112,15 +112,16 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
         if (nodeId == kUndefinedNodeId || fabricId == kUndefinedFabricId || vendorId == kUndefinedVendorId)
         {
             emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                           "OpCreds: Skipping over unitialized admin with fabricId %" PRIX64 ", nodeId %" PRIX64
-                           " vendorId %" PRIX16,
-                           fabricId, nodeId, vendorId);
+                           "OpCreds: Skipping over unitialized admin with fabricId 0x" ChipLogFormatX64
+                           ", nodeId 0x" ChipLogFormatX64 " vendorId %" PRIX16,
+                           ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
             continue;
         }
         else if (writeFabric(fabricId, nodeId, vendorId, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
         {
-            emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write admin with fabricId %" PRIX64 " in fabrics list",
-                           fabricId);
+            emberAfPrintln(EMBER_AF_PRINT_DEBUG,
+                           "OpCreds: Failed to write admin with fabricId 0x" ChipLogFormatX64 " in fabrics list",
+                           ChipLogValueX64(fabricId));
             err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
             break;
         }
@@ -128,10 +129,10 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
     }
 
     // Store the count of fabrics we just stored
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Stored %" PRIX32 " admins in fabrics list attribute.", fabricIndex);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Stored %" PRIu32 " admins in fabrics list attribute.", fabricIndex);
     if (writeFabricAttribute((uint8_t *) &fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write admin count %" PRIX32 " in fabrics list", fabricIndex);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write admin count %" PRIu32 " in fabrics list", fabricIndex);
         err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 
@@ -150,7 +151,7 @@ static AdminPairingInfo * retrieveCurrentAdmin()
 {
     uint64_t fabricId = emberAfCurrentCommand()->SourceNodeId();
     // TODO: Figure out how to get device node id so we can do FindAdminForNode(fabricId, nodeId)...
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Finding admin with fabricId  %" PRIX64 ".", fabricId);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Finding admin with fabricId 0x" ChipLogFormatX64 ".", ChipLogValueX64(fabricId));
     return GetGlobalAdminPairingTable().FindAdminForNode(fabricId);
 }
 
@@ -174,9 +175,10 @@ class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
     void OnAdminRetrievedFromStorage(AdminPairingInfo * admin) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Admin %" PRIX16 " was retrieved from storage. FabricId %" PRIX64 ", NodeId %" PRIX64
-                       ", VendorId %" PRIX64,
-                       admin->GetAdminId(), admin->GetFabricId(), admin->GetNodeId());
+                       "OpCreds: Admin %" PRIX16 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
+                       ", NodeId 0x" ChipLogFormatX64 ", VendorId %" PRIX16,
+                       admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
+                       admin->GetVendorId());
         writeAdminsIntoFabricsListAttribute();
     }
 
@@ -184,9 +186,10 @@ class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
     void OnAdminPersistedToStorage(AdminPairingInfo * admin) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Admin %" PRIX16 " was persisted to storage. FabricId %" PRIX64 ", NodeId %" PRIX64
-                       ", VendorId %" PRIX64,
-                       admin->GetAdminId(), admin->GetFabricId(), admin->GetNodeId());
+                       "OpCreds: Admin %" PRIX16 " was persisted to storage. FabricId %0x" ChipLogFormatX64
+                       ", NodeId %0x" ChipLogFormatX64 ", VendorId %" PRIX16,
+                       admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
+                       admin->GetVendorId());
         writeAdminsIntoFabricsListAttribute();
     }
 };
@@ -229,7 +232,7 @@ exit:
 // TODO: remove SetFabric once AddOptCert + FabricIndex are implemented
 bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * commandObj, uint16_t VendorId)
 {
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: SetFabric with vendorId %d", VendorId);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: SetFabric with vendorId %" PRIX16, VendorId);
 
     EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
     EmberStatus sendStatus = EMBER_SUCCESS;
@@ -241,7 +244,7 @@ bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * 
 
     // Store vendorId
     admin->SetVendorId(VendorId);
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: vendorId is now set %d", admin->GetVendorId());
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: vendorId is now set %" PRIX16, admin->GetVendorId());
     err = GetGlobalAdminPairingTable().Store(admin->GetAdminId());
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
@@ -276,7 +279,7 @@ exit:
     }
     if (sendStatus != EMBER_SUCCESS)
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to send %s response: 0x%x", "set_fabric", sendStatus);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to send SetFabric response: 0x%x", sendStatus);
     }
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -89,7 +89,7 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, i
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                    "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64
-                   ", nodeId 0x" ChipLogFormatX64 " vendorId %" PRIX16,
+                   ", nodeId 0x" ChipLogFormatX64 " vendorId 0x%04" PRIX16,
                    index, ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
     status = writeFabricAttribute((uint8_t *) &fabricDescriptor, index);
     return status;
@@ -101,7 +101,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Loop through admins
-    int32_t fabricIndex = 0;
+    uint32_t fabricIndex = 0;
     for (auto & pairing : GetGlobalAdminPairingTable())
     {
         NodeId nodeId     = pairing.GetNodeId();
@@ -113,7 +113,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
         {
             emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                            "OpCreds: Skipping over unitialized admin with fabricId 0x" ChipLogFormatX64
-                           ", nodeId 0x" ChipLogFormatX64 " vendorId %" PRIX16,
+                           ", nodeId 0x" ChipLogFormatX64 " vendorId 0x%04" PRIX16,
                            ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
             continue;
         }
@@ -167,7 +167,7 @@ class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
     // Gets called when a fabric is deleted from KVS store
     void OnAdminDeletedFromStorage(AdminId adminId) override
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Admin %" PRIX16 " was deleted from admin storage.", adminId);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Admin 0x%" PRIX16 " was deleted from admin storage.", adminId);
         writeAdminsIntoFabricsListAttribute();
     }
 
@@ -175,8 +175,8 @@ class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
     void OnAdminRetrievedFromStorage(AdminPairingInfo * admin) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Admin %" PRIX16 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
-                       ", NodeId 0x" ChipLogFormatX64 ", VendorId %" PRIX16,
+                       "OpCreds: Admin 0x%" PRIX16 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
+                       ", NodeId 0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
                        admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
                        admin->GetVendorId());
         writeAdminsIntoFabricsListAttribute();
@@ -187,7 +187,7 @@ class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                        "OpCreds: Admin %" PRIX16 " was persisted to storage. FabricId %0x" ChipLogFormatX64
-                       ", NodeId %0x" ChipLogFormatX64 ", VendorId %" PRIX16,
+                       ", NodeId %0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
                        admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
                        admin->GetVendorId());
         writeAdminsIntoFabricsListAttribute();

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -50,9 +50,8 @@ NodeId GetCurrentNodeId()
     auto pairing = GetGlobalAdminPairingTable().cbegin();
     if (pairing != GetGlobalAdminPairingTable().cend())
     {
-        ChipLogProgress(Discovery, "Found admin paring for admin %" PRIX16 ", node 0x%08" PRIx32 "%08" PRIx32,
-                        pairing->GetAdminId(), static_cast<uint32_t>(pairing->GetNodeId() >> 32),
-                        static_cast<uint32_t>(pairing->GetNodeId()));
+        ChipLogProgress(Discovery, "Found admin pairing for admin %" PRIX16 ", node 0x" ChipLogFormatX64, pairing->GetAdminId(),
+                        ChipLogValueX64(pairing->GetNodeId()));
         return pairing->GetNodeId();
     }
 
@@ -107,11 +106,9 @@ CHIP_ERROR AdvertiseOperational()
 
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
 
-    ChipLogProgress(Discovery, "Advertise operational node %08" PRIx32 "%08" PRIx32 "-%08" PRIx32 "%08" PRIx32,
-                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetFabricId() >> 32),
-                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetFabricId()),
-                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetNodeId() >> 32),
-                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetNodeId()));
+    ChipLogProgress(Discovery, "Advertise operational node " ChipLogFormatX64 "-" ChipLogFormatX64,
+                    ChipLogValueX64(advertiseParameters.GetPeerId().GetFabricId()),
+                    ChipLogValueX64(advertiseParameters.GetPeerId().GetNodeId()));
     return mdnsAdvertiser.Advertise(advertiseParameters);
 }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -129,8 +129,8 @@ CHIP_ERROR RestoreAllAdminPairingsFromKVS(AdminPairingTable & adminPairings, Adm
             AdminPairingInfo * admin = adminPairings.FindAdminWithId(id);
             if (admin != nullptr)
             {
-                ChipLogProgress(AppServer, "Found admin pairing for %d, node ID 0x%08" PRIx32 "%08" PRIx32, admin->GetAdminId(),
-                                static_cast<uint32_t>(admin->GetNodeId() >> 32), static_cast<uint32_t>(admin->GetNodeId()));
+                ChipLogProgress(AppServer, "Found admin pairing for %d, node ID 0x" ChipLogFormatX64, admin->GetAdminId(),
+                                ChipLogValueX64(admin->GetNodeId()));
             }
         }
     }
@@ -168,9 +168,8 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr, Rende
         {
             connection.GetPASESession(session);
 
-            ChipLogProgress(AppServer, "Fetched the session information: from 0x%08" PRIx32 "%08" PRIx32,
-                            static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId() >> 32),
-                            static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId()));
+            ChipLogProgress(AppServer, "Fetched the session information: from 0x" ChipLogFormatX64,
+                            ChipLogValueX64(session->PeerConnection().GetPeerNodeId()));
             sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->PeerConnection().GetPeerAddress()),
                                   session->PeerConnection().GetPeerNodeId(), session, SecureSession::SessionRole::kResponder,
                                   connection.GetAdminId(), nullptr);

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -110,7 +110,8 @@ static CHIP_ERROR DecodeConvertDN(TLVReader & reader, ASN1Writer & writer, ChipD
                     if (IsChip64bitDNAttr(attrOID))
                     {
                         // For CHIP 64-bit attribute the string representation is 16 uppercase hex characters.
-                        snprintf(reinterpret_cast<char *>(chipAttrStr), sizeof(chipAttrStr), "%016" PRIX64, chipAttr);
+                        snprintf(reinterpret_cast<char *>(chipAttrStr), sizeof(chipAttrStr), ChipLogFormatX64,
+                                 ChipLogValueX64(chipAttr));
                         asn1AttrVal    = chipAttrStr;
                         asn1AttrValLen = 16;
                     }

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -277,7 +277,8 @@ CHIP_ERROR EncodeChipDNs(ChipDNParams * params, uint8_t numParams, ASN1Writer & 
             ASN1_START_SET
             {
                 uint8_t chipAttrStr[kChip64bitAttrUTF8Length + 1];
-                snprintf(reinterpret_cast<char *>(chipAttrStr), sizeof(chipAttrStr), "%016" PRIX64, params[i].Value);
+                snprintf(reinterpret_cast<char *>(chipAttrStr), sizeof(chipAttrStr), ChipLogFormatX64,
+                         ChipLogValueX64(params[i].Value));
 
                 ASN1_START_SEQUENCE
                 {

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -67,9 +67,14 @@ static void _log_mbedTLS_error(int error_code)
 {
     if (error_code != 0)
     {
+#if defined(MBEDTLS_ERROR_C)
         char error_str[MAX_ERROR_STR_LEN];
         mbedtls_strerror(error_code, error_str, sizeof(error_str));
-        ChipLogError(Crypto, "mbedTLS error: %s\n", error_str);
+        ChipLogError(Crypto, "mbedTLS error: %s", error_str);
+#else
+        // Error codes defined in 16-bit negative hex numbers. Ease lookup by printing likewise
+        ChipLogError(Crypto, "mbedTLS error: -0x%04X", -static_cast<uint16_t>(error_code));
+#endif
     }
 }
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -1007,7 +1007,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ComputeProvisioningHash(
         err = Impl()->_GetManufacturerDeviceId(deviceId);
         SuccessOrExit(err);
 
-        snprintf(inputBuf, sizeof(inputBuf), "0010%016" PRIX64, deviceId);
+        snprintf(inputBuf, sizeof(inputBuf), "0010" ChipLogFormatX64, ChipLogValueX64(deviceId));
 
         hash.AddData((uint8_t *) inputBuf, kLenFieldLen + kDeviceIdLen);
     }
@@ -1118,7 +1118,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
     ChipLogProgress(DeviceLayer, "Device Configuration:");
 
 #if CHIP_CONFIG_ENABLE_FABRIC_STATE
-    ChipLogProgress(DeviceLayer, "  Device Id: %016" PRIX64, FabricState.LocalNodeId);
+    ChipLogProgress(DeviceLayer, "  Device Id: 0x" ChipLogFormatX64, ChipLogValueX64(FabricState.LocalNodeId));
 #endif
 
     {
@@ -1190,7 +1190,7 @@ void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 #if CHIP_CONFIG_ENABLE_FABRIC_STATE
     if (FabricState.FabricId != kFabricIdNotSpecified)
     {
-        ChipLogProgress(DeviceLayer, "  Fabric Id: %016" PRIX64, FabricState.FabricId);
+        ChipLogProgress(DeviceLayer, "  Fabric Id: 0x" ChipLogFormatX64, ChipLogValueX64(FabricState.FabricId));
     }
     else
     {

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -245,7 +245,7 @@ void InitNetwork()
             uint64_t iid    = gNetworkOptions.LocalIPv6Addr[j].InterfaceId();
             char * tap_name = (char *) chip::Platform::MemoryAlloc(sizeof(gDefaultTapDeviceName));
             assert(tap_name);
-            snprintf(tap_name, sizeof(gDefaultTapDeviceName), "chip-dev-%" PRIx64, iid & 0xFFFF);
+            snprintf(tap_name, sizeof(gDefaultTapDeviceName), "chip-dev-%" PRIx16, static_cast<uint16_t>(iid));
             gNetworkOptions.TapDeviceName.push_back(tap_name);
         }
     }

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -365,7 +365,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
 {
     // TODO: need to detect colisions here
     char nameBuffer[64] = "";
-    size_t len          = snprintf(nameBuffer, sizeof(nameBuffer), "%016" PRIX64, GetRandU64());
+    size_t len          = snprintf(nameBuffer, sizeof(nameBuffer), ChipLogFormatX64, GetRandU32(), GetRandU32());
     if (len >= sizeof(nameBuffer))
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -479,8 +479,7 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
     nodeData.mAddress     = result->mAddress.ValueOr({});
     nodeData.mPort        = result->mPort;
 
-    ChipLogProgress(Discovery, "Node ID resolved for 0x08%" PRIX32 "08%" PRIX32,
-                    static_cast<uint32_t>(nodeData.mPeerId.GetNodeId() >> 32), static_cast<uint32_t>(nodeData.mPeerId.GetNodeId()));
+    ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(nodeData.mPeerId.GetNodeId()));
     mgr->mResolverDelegate->OnNodeIdResolved(nodeData);
 }
 

--- a/src/lib/shell/commands/Config.cpp
+++ b/src/lib/shell/commands/Config.cpp
@@ -82,7 +82,7 @@ static CHIP_ERROR ConfigGetDeviceId(bool printHeader)
         streamer_printf(sout, "DeviceId:        ");
     }
     ReturnErrorOnFailure(ConfigurationMgr().GetDeviceId(value64));
-    streamer_printf(sout, "%" PRIu64 " (0x%" PRIX64 ")\r\n", value64, value64);
+    streamer_printf(sout, "%" PRIu64 " (0x" ChipLogFormatX64 ")\r\n", value64, ChipLogValueX64(value64));
     return CHIP_NO_ERROR;
 }
 
@@ -124,7 +124,7 @@ static CHIP_ERROR ConfigGetFabricId(bool printHeader)
         streamer_printf(sout, "FabricId:        ");
     }
     ReturnErrorOnFailure(ConfigurationMgr().GetFabricId(value64));
-    streamer_printf(sout, "%" PRIu64 " (0x%" PRIX64 ")\r\n", value64, value64);
+    streamer_printf(sout, "%" PRIu64 " (0x" ChipLogFormatX64 ")\r\n", value64, ChipLogValueX64(value64));
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -40,6 +40,7 @@
 
 #include <support/logging/Constants.h>
 
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
 
@@ -296,10 +297,9 @@ bool IsCategoryEnabled(uint8_t category);
 
 #endif // CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING
 
-/*  @def ChipLogFormatX64
- *
+/*
  *  @brief
- * 	Macro for use in a string formatter for a 64-bit hex print.
+ *      Macro for use in a string formatter for a 64-bit hex print.
  *      Will split into 2x 32-bit prints to support small printf libraries
  *
  *  Example Usage:
@@ -307,17 +307,16 @@ bool IsCategoryEnabled(uint8_t category);
  *  @code
  *  void foo() {
  *      uint64_t value = 0x1122334455667788;
- *  	ChipLogProgress(Foo, "A 64-bit value: 0x" ChipLogFormatX64, ChipLogValueX64(value));
+ *      ChipLogProgress(Foo, "A 64-bit value: 0x" ChipLogFormatX64, ChipLogValueX64(value));
  *  }
  *  @endcode
  *
  */
 #define ChipLogFormatX64 "%08" PRIX32 "%08" PRIX32
 
-/*  @def ChipLogValueX64
- *
+/*
  *  @brief
- * 	Macro for use in a printf parameter list for a 64-bit value.
+ *      Macro for use in a printf parameter list for a 64-bit value.
  *      Will split into MSB/LSB 32-bit values to use only 32-bit formatting.
  *
  *  Example Usage:
@@ -329,7 +328,7 @@ bool IsCategoryEnabled(uint8_t category);
  *  }
  *  @endcode
  *
- *  @param[in]  aValue	64-bit value that will be split in 32-bit MSB/LSB part
+ *  @param[in]  aValue    64-bit value that will be split in 32-bit MSB/LSB part
  */
 #define ChipLogValueX64(aValue) static_cast<uint32_t>(aValue >> 32), static_cast<uint32_t>(aValue)
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -296,5 +296,42 @@ bool IsCategoryEnabled(uint8_t category);
 
 #endif // CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING
 
+/*  @def ChipLogFormatX64
+ *
+ *  @brief
+ * 	Macro for use in a string formatter for a 64-bit hex print.
+ *      Will split into 2x 32-bit prints to support small printf libraries
+ *
+ *  Example Usage:
+ *
+ *  @code
+ *  void foo() {
+ *      uint64_t value = 0x1122334455667788;
+ *  	ChipLogProgress(Foo, "A 64-bit value: 0x" ChipLogFormatX64, ChipLogValueX64(value));
+ *  }
+ *  @endcode
+ *
+ */
+#define ChipLogFormatX64 "%08" PRIX32 "%08" PRIX32
+
+/*  @def ChipLogValueX64
+ *
+ *  @brief
+ * 	Macro for use in a printf parameter list for a 64-bit value.
+ *      Will split into MSB/LSB 32-bit values to use only 32-bit formatting.
+ *
+ *  Example Usage:
+ *
+ *  @code
+ *  void foo() {
+ *      uint64_t value = 0x1122334455667788;
+ *      ChipLogProgress(Foo, "A 64-bit value: 0x" ChipLogFormatX64, ChipLogValueX64(value));
+ *  }
+ *  @endcode
+ *
+ *  @param[in]  aValue	64-bit value that will be split in 32-bit MSB/LSB part
+ */
+#define ChipLogValueX64(aValue) static_cast<uint32_t>(aValue >> 32), static_cast<uint32_t>(aValue)
+
 } // namespace Logging
 } // namespace chip

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -333,9 +333,10 @@ AdminPairingInfo * AdminPairingTable::FindAdminForNode(FabricId fabricId, NodeId
         if (state.IsInitialized())
         {
             ChipLogProgress(Discovery,
-                            "Looking at index %d with fabricID %llu nodeID %llu vendorId %d to see if it matches fabricId %llu "
-                            "nodeId %llu vendorId %d.",
-                            index, state.GetFabricId(), state.GetNodeId(), state.GetVendorId(), fabricId, nodeId, vendorId);
+                            "Checking ind:%d [fabricId 0x" ChipLogFormatX64 " nodeId 0x" ChipLogFormatX64 " vendorId %d] vs"
+                            " [fabricId 0x" ChipLogFormatX64 " nodeId 0x" ChipLogFormatX64 " vendorId %d]",
+                            index, ChipLogValueX64(state.GetFabricId()), ChipLogValueX64(state.GetNodeId()), state.GetVendorId(),
+                            ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
         }
         if (state.IsInitialized() && state.GetFabricId() == fabricId &&
             (nodeId == kUndefinedNodeId || state.GetNodeId() == nodeId) &&
@@ -372,7 +373,7 @@ CHIP_ERROR AdminPairingTable::Store(AdminId id)
 exit:
     if (err == CHIP_NO_ERROR && mDelegate != nullptr)
     {
-        ChipLogProgress(Discovery, "Admin (%d) persisted to storage. Calling OnAdminPersistedToStorage.", id);
+        ChipLogProgress(Discovery, "Admin (%d) persisted to storage. Calling OnAdminPersistedToStorage", id);
         mDelegate->OnAdminPersistedToStorage(admin);
     }
     return err;
@@ -401,7 +402,7 @@ exit:
     }
     else if (err == CHIP_NO_ERROR && mDelegate != nullptr)
     {
-        ChipLogProgress(Discovery, "Admin (%d) loaded from storage. Calling OnAdminRetrievedFromStorage.", id);
+        ChipLogProgress(Discovery, "Admin (%d) loaded from storage. Calling OnAdminRetrievedFromStorage", id);
         mDelegate->OnAdminRetrievedFromStorage(admin);
     }
     return err;
@@ -424,7 +425,7 @@ exit:
         ReleaseAdminId(id);
         if (mDelegate != nullptr && adminIsInitialized)
         {
-            ChipLogProgress(Discovery, "Admin (%d) deleted. Calling OnAdminDeletedFromStorage.", id);
+            ChipLogProgress(Discovery, "Admin (%d) deleted. Calling OnAdminDeletedFromStorage", id);
             mDelegate->OnAdminDeletedFromStorage(id);
         }
     }
@@ -435,7 +436,7 @@ CHIP_ERROR AdminPairingTable::Init(PersistentStorageDelegate * storage)
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mStorage = storage;
-    ChipLogProgress(Discovery, "Init admin pairing table with server storage.");
+    ChipLogDetail(Discovery, "Init admin pairing table with server storage");
     return CHIP_NO_ERROR;
 }
 
@@ -443,7 +444,7 @@ CHIP_ERROR AdminPairingTable::SetAdminPairingDelegate(AdminPairingTableDelegate 
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mDelegate = delegate;
-    ChipLogProgress(Discovery, "Set the admin pairing table delegate");
+    ChipLogDetail(Discovery, "Set the admin pairing table delegate");
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -87,8 +87,7 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, System::Layer * systemLaye
 
     mGlobalEncryptedMessageCounter.Init();
 
-    ChipLogProgress(Inet, "local node id is 0x%08" PRIx32 "%08" PRIx32, static_cast<uint32_t>(mLocalNodeId >> 32),
-                    static_cast<uint32_t>(mLocalNodeId));
+    ChipLogProgress(Inet, "local node id is 0x" ChipLogFormatX64, ChipLogValueX64(mLocalNodeId));
 
     ScheduleExpiryTimer();
 
@@ -191,11 +190,8 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
         (*bufferRetainSlot) = msgBuf.Retain();
     }
 
-    ChipLogProgress(Inet,
-                    "Sending msg from 0x%08" PRIx32 "%08" PRIx32 " to 0x%08" PRIx32 "%08" PRIx32 " at utc time: %" PRId64 " msec",
-                    static_cast<uint32_t>(localNodeId >> 32), static_cast<uint32_t>(localNodeId),
-                    static_cast<uint32_t>(state->GetPeerNodeId() >> 32), static_cast<uint32_t>(state->GetPeerNodeId()),
-                    System::Layer::GetClock_MonotonicMS());
+    ChipLogProgress(Inet, "Sending msg from 0x" ChipLogFormatX64 " to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec",
+                    ChipLogValueX64(localNodeId), ChipLogValueX64(state->GetPeerNodeId()), System::Layer::GetClock_MonotonicMS());
 
     if (state->GetTransport() != nullptr)
     {
@@ -387,18 +383,18 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
                               state->GetAdminId()));
     if (packetHeader.GetDestinationNodeId().HasValue() && admin->GetNodeId() != kUndefinedNodeId)
     {
-        VerifyOrExit(
-            admin->GetNodeId() == packetHeader.GetDestinationNodeId().Value(),
-            ChipLogError(
-                Inet,
-                "Secure transport received message, but destination node ID (%llu) doesn't match our node ID (%llu), discarding",
-                packetHeader.GetDestinationNodeId().Value(), admin->GetNodeId()));
+        VerifyOrExit(admin->GetNodeId() == packetHeader.GetDestinationNodeId().Value(),
+                     ChipLogError(Inet,
+                                  "Secure transport received message, but destination node ID (0x" ChipLogFormatX64
+                                  ") doesn't match our node ID (0x" ChipLogFormatX64 "), discarding",
+                                  ChipLogValueX64(packetHeader.GetDestinationNodeId().Value()),
+                                  ChipLogValueX64(admin->GetNodeId())));
     }
 
     if (packetHeader.GetDestinationNodeId().HasValue())
     {
-        ChipLogError(Inet, "Secure transport received message destined to node ID (%llu)",
-                     packetHeader.GetDestinationNodeId().Value());
+        ChipLogError(Inet, "Secure transport received message destined to node ID (0x" ChipLogFormatX64 ")",
+                     ChipLogValueX64(packetHeader.GetDestinationNodeId().Value()));
     }
     else
     {


### PR DESCRIPTION
#### Problem
 64-bit print formatters are not available in nano printf libraries.
This gives corrupted logging whenever PRIx64, %llx or alike is used.

For example:
`[P][ZCL] OpCreds: Admin 0 was persisted to storage. FabricId lX, NodeId lX, VendorId lX`

#### Summary of Changes
* Adding ChipLogFormatX64/ChipLogValueX64  macro's
  to construct 64-bit formatting with nano printf lib
  Old PR with macro proposal: #6936 
* Replaced most current occurences of 64-bit format specifiers
* Enable minimal mbed error logging if MBEDTLS_ERROR_C is not used

#### Tested with
* Check of CI build and unitTests log output
    * Verified libs supporting 64-bit still print reliable 32-bit+32-bit combinations
* QPG6100 (using nano print lib) log 
    * output verified to have correct printed values

#### Notes
* Some places still use PRIu64 or PRId64 - if a real integer is required it's not solveable currently.
  Resides in code normally not used by devices utilizing nano printf.
* No enforcement is in place to use the macro's iso PRIx64/%llx combinations.
