### PR TITLE
Implement basic rand()

### DIFF
--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -30,8 +30,6 @@
 
 #include <app/server/OnboardingCodesUtil.h>
 
-#include <app/server/DataModelHandler.h>
-
 #include <ti/drivers/apps/Button.h>
 #include <ti/drivers/apps/LED.h>
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -301,6 +301,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "cc13x2_26x2/Logging.cpp",
         "cc13x2_26x2/PlatformManagerImpl.cpp",
         "cc13x2_26x2/PlatformManagerImpl.h",
+        "cc13x2_26x2/Random.c",
         "cc13x2_26x2/SystemPlatformConfig.h",
       ]
 

--- a/src/platform/cc13x2_26x2/Random.c
+++ b/src/platform/cc13x2_26x2/Random.c
@@ -36,4 +36,3 @@ void srand(unsigned int seed)
 {
     next = seed;
 }
-

--- a/src/platform/cc13x2_26x2/Random.c
+++ b/src/platform/cc13x2_26x2/Random.c
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020 Texas Instruments Incorporated
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdlib.h>
+
+/* Basic implementation of psudo-random number generation to override the
+ * default newlib-nano implementation.
+ */
+
+static unsigned long int next = 1;
+
+/* Return next random integer */
+int rand()
+{
+    next = next * 1103515245L + 12345;
+    return (unsigned int) (next / 65536L) % 32768L;
+}
+
+/* Set seed for random generator */
+void srand(unsigned int seed)
+{
+    next = seed;
+}
+

--- a/src/platform/cc13x2_26x2/Random.c
+++ b/src/platform/cc13x2_26x2/Random.c
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 
-/* Basic implementation of psudo-random number generation to override the
+/* Basic implementation of pseudo-random number generation to override the
  * default newlib-nano implementation.
  */
 

--- a/third_party/ti_simplelink_sdk/ti_simplelink_sdk.gni
+++ b/third_party/ti_simplelink_sdk/ti_simplelink_sdk.gni
@@ -309,6 +309,9 @@ template("ti_simplelink_sdk") {
       # DMM/BLE:
       "${ti_simplelink_sdk_root}/source",
 
+      # Eclipse the SDK config header from DMM
+      "${chip_root}/src/platform/cc13x2_26x2",
+
       # CHIPoBLE Added include dirs
       "${ti_simplelink_sdk_root}/source/ti/dmm/apps/common/freertos/",
       "${ti_simplelink_sdk_root}/source/ti/dmm/apps/common/freertos/itm",


### PR DESCRIPTION
Disabled shadowing of the FreeRTOS config by the DMM header.
Implemented a basic PRNG for ctor startup.

The global initialization of the global message counter struct in
`src/transport/MessageCounter.h` results in a call to the C standard library
function `rand()` from a C++ ctor. This results in a call to pvPortMalloc,
causing a hard fault with the current buffer implementation.

 #### Problem

`rand()` is called before `main()` so the calls to allocate a reent struct fail.

 #### Summary of Changes

Added a basic non-reent PRNG for the TI platform.

Fixes #6997

#### Testing

Manually tested with an LP_CC2652R7. Execution was traced from the `ResetISR` to `main` with CCS and the device was left to free run. log output was viewed on the debug UART connection and the processor was halted in the power idle loop.
