### PR TITLE
[im] Fix error code cases in IM[TE3]

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -114,8 +114,9 @@ exit:
                                                            0, // GroupId
                                                            clusterId, commandId, (chip::app::CommandPathFlags::kEndpointIdValid) };
 
-        // The Path is not present when there is an error to be conveyed back. ResponseCommandElement would only have status code,
-        // set the error with CHIP_NO_ERROR, then continue to process rest of commands
+        // The Path is the path in the request if there are any error occurred before we dispatch the command to clusters.
+        // Currently, it could be failed to decode Path or failed to find cluster / command on desired endpoint.
+        // Set the error with CHIP_NO_ERROR, then continue to process rest of commands
         AddStatusCode(&returnStatusParam,
                       err == CHIP_ERROR_INVALID_PROFILE_ID ? GeneralStatusCode::kNotFound : GeneralStatusCode::kInvalidArgument,
                       Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -115,12 +115,13 @@ exit:
         // The Path is the path in the request if there are any error occurred before we dispatch the command to clusters.
         // Currently, it could be failed to decode Path or failed to find cluster / command on desired endpoint.
         // TODO: The behavior when receiving a malformed message is not clear in the Spec. (Spec#3259)
+        // TODO: The error code should be updated after #7072 added error codes required by IM.
         AddStatusCode(&returnStatusParam,
                       err == CHIP_ERROR_INVALID_PROFILE_ID ? GeneralStatusCode::kNotFound : GeneralStatusCode::kInvalidArgument,
                       Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
     }
-    // We have handled the error status above and puts the error status in response, now return success status so we can process
-    // other commands in the invoke request (by caller).
+    // We have handled the error status above and put the error status in response, now return success status so we can process
+    // other commands in the invoke request.
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -161,6 +161,7 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
     }
     else if (CHIP_END_OF_TLV == err)
     {
+        // TODO(Spec#3258): The endpoint id in response command is not clear, so we cannot do "ClientClusterCommandExists" check.
         err = aCommandElement.GetData(&commandDataReader);
         SuccessOrExit(err);
         // TODO(#4503): Should call callbacks of cluster that sends the command.

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -166,15 +166,15 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj);
 
 /**
- *  Check if a cluster command exists, the caller would expect this function to look up a catalog to find if the cluster / command
- * exists on the endpoint.
+ *  Check whether the given cluster exists on the given endpoint and supports the given command.
  *  TODO: The implementation lives in ember-compatibility-functions.cpp, this should be replaced by IM command catalog look up
  * function after we have a cluster catalog in interaction model engine.
+ *  TODO: The endpoint id on response command (client side command) is unclear, so we don't have a ClientClusterCommandExists
+ * function. (Spec#3258)
  *
- *  @retval  #CHIP_NO_ERROR There is a command on cluster on the endpoint.
- *  @retval  #CHIP_ERROR_INVALID_PROFILE_ID The command or cluster not exists on the endpoint.
+ *  @retval  If the endpoint contains the cluster and command.
  */
-CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId);
+bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId);
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter);
 CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader);
 } // namespace app

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -172,7 +172,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
  *  TODO: The endpoint id on response command (client side command) is unclear, so we don't have a ClientClusterCommandExists
  * function. (Spec#3258)
  *
- *  @retval  If the endpoint contains the cluster and command.
+ *  @retval  True if the endpoint contains the server side of the given cluster and that cluster implements the given command, false
+ * otherwise.
  */
 bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId);
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter);

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -164,6 +164,7 @@ private:
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj);
+CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId);
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter);
 CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader);
 } // namespace app

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -164,6 +164,16 @@ private:
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj);
+
+/**
+ *  Check if a cluster command exists, the caller would expect this function to look up a catalog to find if the cluster / command
+ * exists on the endpoint.
+ *  TODO: The implementation lives in ember-compatibility-functions.cpp, this should be replaced by IM command catalog look up
+ * function after we have a cluster catalog in interaction model engine.
+ *
+ *  @retval  #CHIP_NO_ERROR There is a command on cluster on the endpoint.
+ *  @retval  #CHIP_ERROR_INVALID_PROFILE_ID The command or cluster not exists on the endpoint.
+ */
 CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId);
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter);
 CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -85,7 +85,7 @@ public:
     static void TestCommandSenderWithSendCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendEmptyCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
-    static void TestCommandSenderWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendSimpleCommandData(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendSimpleStatusCode(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendEmptyResponse(nlTestSuite * apSuite, void * apContext);
@@ -315,7 +315,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg(nlTestSuit
     commandHandler.Shutdown();
 }
 
-void TestCommandInteraction::TestCommandSenderWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext)
+void TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
@@ -376,7 +376,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestCommandHandlerWithSendSimpleStatusCode", chip::app::TestCommandInteraction::TestCommandHandlerWithSendSimpleStatusCode),
     NL_TEST_DEF("TestCommandHandlerWithSendEmptyResponse", chip::app::TestCommandInteraction::TestCommandHandlerWithSendEmptyResponse),
     NL_TEST_DEF("TestCommandHandlerWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg),
-    NL_TEST_DEF("TestCommandHandlerWithProcessReceivedInvalidCommand", chip::app::TestCommandInteraction::TestCommandSenderWithProcessReceivedNotExistCommand),
+    NL_TEST_DEF("TestCommandHandlerWithProcessReceivedNotExistCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistCommand),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -62,6 +62,12 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                   aCommandId, aEndPointId);
 }
 
+CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+{
+    // Always return no error in test.
+    return CHIP_NO_ERROR;
+}
+
 class TestCommandInteraction
 {
 public:

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -326,7 +326,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistComman
     GenerateReceivedCommand(apSuite, apContext, commandDatabuf, 0xDE /* endpoint */, 0xADBE /* cluster */, 0xEF /* command */);
 
     // TODO: Need to find a way to get the response instead of only check if a function on key path is called.
-    // We should not reach CommandDispatch if requisted command does not exist.
+    // We should not reach CommandDispatch if requested command does not exist.
     gCommandReachedDispatch = false;
     err                     = commandHandler.ProcessCommandMessage(std::move(commandDatabuf), Command::CommandRoleId::HandlerId);
     NL_TEST_ASSERT(apSuite, !gCommandReachedDispatch);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -71,12 +71,10 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                   aCommandId, aEndPointId);
 }
 
-CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
     // Mock cluster catalog, only support one command on one cluster on one endpoint.
-    return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestEndpointId)
-        ? CHIP_NO_ERROR
-        : CHIP_ERROR_INVALID_PROFILE_ID;
+    return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestEndpointId);
 }
 
 class TestCommandInteraction

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -83,7 +83,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
     // Mock cluster catalog, only support one command on one cluster on one endpoint.
-    return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestEndpointId);
+    return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestCommandId);
 }
 
 class TestCommandInteraction

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -306,10 +306,10 @@ public:
 namespace chip {
 namespace app {
 
-CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
-    // Always return no error in test.
-    return CHIP_NO_ERROR;
+    // Always return true in test.
+    return true;
 }
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -75,7 +75,7 @@ uint64_t gReadCount = 0;
 // Count of the number of CommandResponses received.
 uint64_t gReadRespCount = 0;
 
-// If the last command successed.
+// Whether the last command successed.
 enum class TestCommandResult : uint8_t
 {
     kUndefined,

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -45,10 +45,11 @@
 namespace {
 // Max value for the number of message request sent.
 
-constexpr size_t kMaxCommandMessageCount    = 3;
-constexpr size_t kMaxReadMessageCount       = 3;
-constexpr int32_t gMessageIntervalSeconds   = 1;
-constexpr chip::Transport::AdminId gAdminId = 0;
+constexpr size_t kMaxCommandMessageCount          = 3;
+constexpr size_t kTotalFailureCommandMessageCount = 1;
+constexpr size_t kMaxReadMessageCount             = 3;
+constexpr int32_t gMessageIntervalSeconds         = 1;
+constexpr chip::Transport::AdminId gAdminId       = 0;
 
 // The ReadClient object.
 chip::app::ReadClient * gpReadClient = nullptr;
@@ -73,6 +74,16 @@ uint64_t gReadCount = 0;
 
 // Count of the number of CommandResponses received.
 uint64_t gReadRespCount = 0;
+
+// If the last command successed.
+enum class TestCommandResult : uint8_t
+{
+    kUndefined,
+    kSuccess,
+    kFailure
+};
+
+TestCommandResult gLastCommandResult = TestCommandResult::kUndefined;
 
 std::condition_variable gCond;
 
@@ -106,6 +117,43 @@ CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
     SuccessOrExit(err);
 
     err = writer->Put(chip::TLV::ContextTag(2), effectVariant);
+    SuccessOrExit(err);
+
+    err = commandSender->FinishCommand();
+    SuccessOrExit(err);
+
+    err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);
+    SuccessOrExit(err);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        gCommandCount++;
+    }
+    else
+    {
+        printf("Send invoke command request failed, err: %s\n", chip::ErrorStr(err));
+    }
+exit:
+    return err;
+}
+
+CHIP_ERROR SendBadCommandRequest(chip::app::CommandSender * commandSender)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+
+    printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+
+    chip::app::CommandPathParams commandPathParams = { 0xDE,   // Bad Endpoint
+                                                       0xADBE, // Bad GroupId
+                                                       0xEFCA, // Bad ClusterId
+                                                       0xFE,   // Bad CommandId
+                                                       chip::app::CommandPathFlags::kEndpointIdValid };
+
+    err = commandSender->PrepareCommand(&commandPathParams);
     SuccessOrExit(err);
 
     err = commandSender->FinishCommand();
@@ -220,6 +268,9 @@ public:
         printf("CommandResponseStatus with GeneralCode %d, ProtocolId %d, ProtocolCode %d, EndpointId %d, ClusterId %d, CommandId "
                "%d, CommandIndex %d",
                static_cast<uint16_t>(aGeneralCode), aProtocolId, aProtocolCode, aEndpointId, aClusterId, aCommandId, aCommandIndex);
+        gLastCommandResult = (aGeneralCode == chip::Protocols::SecureChannel::GeneralStatusCode::kSuccess && aProtocolCode == 0)
+            ? TestCommandResult::kSuccess
+            : TestCommandResult::kFailure;
         return CHIP_NO_ERROR;
     }
 
@@ -273,6 +324,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     {
         chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
     }
+
+    gLastCommandResult = TestCommandResult::kSuccess;
 }
 
 CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader)
@@ -353,13 +406,35 @@ int main(int argc, char * argv[])
         if (err != CHIP_NO_ERROR)
         {
             printf("Send command request failed: %s\n", chip::ErrorStr(err));
-            goto exit;
+            ExitNow();
         }
 
         if (gCond.wait_for(lock, std::chrono::seconds(gMessageIntervalSeconds)) == std::cv_status::timeout)
         {
             printf("Invoke Command: No response received\n");
         }
+
+        VerifyOrExit(gLastCommandResult == TestCommandResult::kSuccess, err = CHIP_ERROR_INCORRECT_STATE);
+    }
+
+    // Test with invalid endpoint / cluster / command combination.
+    {
+        chip::app::CommandSender * commandSender;
+        err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&commandSender);
+        SuccessOrExit(err);
+        err = SendBadCommandRequest(commandSender);
+        if (err != CHIP_NO_ERROR)
+        {
+            printf("Send command request failed: %s\n", chip::ErrorStr(err));
+            ExitNow();
+        }
+
+        if (gCond.wait_for(lock, std::chrono::seconds(gMessageIntervalSeconds)) == std::cv_status::timeout)
+        {
+            printf("Invoke Command: No response received\n");
+        }
+
+        VerifyOrExit(gLastCommandResult == TestCommandResult::kFailure, err = CHIP_ERROR_INCORRECT_STATE);
     }
 
     // Connection has been established. Now send the ReadRequests.
@@ -383,7 +458,7 @@ int main(int argc, char * argv[])
     ShutdownChip();
 
 exit:
-    if (err != CHIP_NO_ERROR || (gCommandRespCount != kMaxCommandMessageCount))
+    if (err != CHIP_NO_ERROR || (gCommandRespCount != kMaxCommandMessageCount + kTotalFailureCommandMessageCount))
     {
         printf("ChipCommandSender failed: %s\n", chip::ErrorStr(err));
         exit(EXIT_FAILURE);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -255,6 +255,12 @@ public:
 namespace chip {
 namespace app {
 
+CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+{
+    // Always return no error in test.
+    return CHIP_NO_ERROR;
+}
+
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -47,7 +47,9 @@ namespace app {
 
 CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
-    // Always return no error in test.
+    // The Mock cluster catalog -- only have one command on one cluster on one endpoint.
+    VerifyOrReturnError(aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestCommandId,
+                        CHIP_ERROR_INVALID_PROFILE_ID);
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -44,6 +44,13 @@
 
 namespace chip {
 namespace app {
+
+CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+{
+    // Always return no error in test.
+    return CHIP_NO_ERROR;
+}
+
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -45,12 +45,10 @@
 namespace chip {
 namespace app {
 
-CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
     // The Mock cluster catalog -- only have one command on one cluster on one endpoint.
-    VerifyOrReturnError(aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestCommandId,
-                        CHIP_ERROR_INVALID_PROFILE_ID);
-    return CHIP_NO_ERROR;
+    return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestCommandId);
 }
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -87,11 +87,11 @@ void ResetEmberAfObjects()
 
 } // namespace Compatibility
 
-CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
     // TODO: Currently, we are using cluster catalog from the ember library, this should be modified or replaced after several
     // updates to Commands.
-    return emberAfContainsServer(aEndPointId, aClusterId) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_PROFILE_ID;
+    return emberAfContainsServer(aEndPointId, aClusterId);
 }
 
 } // namespace app

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -21,9 +21,9 @@
  *          when calling ember callbacks.
  */
 
-#include <app/util/ember-compatibility-functions.h>
-
 #include <app/Command.h>
+#include <app/InteractionModelEngine.h>
+#include <app/util/ember-compatibility-functions.h>
 #include <app/util/util.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLV.h>
@@ -65,15 +65,17 @@ bool IMEmberAfSendDefaultResponseWithCallback(EmberAfStatus status)
         return false;
     }
 
-    chip::app::CommandPathParams returnStatusParam = { imCompatibilityEmberApsFrame.sourceEndpoint,
+    chip::app::CommandPathParams returnStatusParam = { imCompatibilityEmberApsFrame.destinationEndpoint,
                                                        0, // GroupId
                                                        imCompatibilityEmberApsFrame.clusterId,
                                                        imCompatibilityEmberAfCluster.commandId,
                                                        (chip::app::CommandPathFlags::kEndpointIdValid) };
 
-    CHIP_ERROR err =
-        currentCommandObject->AddStatusCode(&returnStatusParam, chip::Protocols::SecureChannel::GeneralStatusCode::kSuccess,
-                                            chip::Protocols::InteractionModel::Id, status);
+    CHIP_ERROR err = currentCommandObject->AddStatusCode(&returnStatusParam,
+                                                         status == EMBER_ZCL_STATUS_SUCCESS
+                                                             ? chip::Protocols::SecureChannel::GeneralStatusCode::kSuccess
+                                                             : chip::Protocols::SecureChannel::GeneralStatusCode::kFailure,
+                                                         chip::Protocols::InteractionModel::Id, status);
     return CHIP_NO_ERROR == err;
 }
 
@@ -84,5 +86,13 @@ void ResetEmberAfObjects()
 }
 
 } // namespace Compatibility
+
+CHIP_ERROR CheckIfClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
+{
+    // TODO: Currently, we are using cluster catalog from the ember library, this should be modified or replaced after several
+    // updates to Commands.
+    return emberAfContainsServer(aEndPointId, aClusterId) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_PROFILE_ID;
+}
+
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
The current code may return wrong success or unexpected error code when
one cluster is not enabled on endpoint, this commit added a function
thay will query cluster from ember cluster catalog, the function will be
updated by future im command code (see comment in code).

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
- We don't check if one cluster is enabled on one endpoint, this causes some issues.
- The error code endpoint should be the endpoint on server.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Changes

- Return error when some cluster is not enabled on some endpoint
- Update status code endpoint id and general error code.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

#### Tests

- UT included (since "Add UT" commit)
- Also Tested with chip-device-ctrl

OnOff cluster is not enabled on endpoint 0

```
chip-device-ctrl > zcl OnOff On 1 0 0
CHIP:DMG: ICR moving to [Initialize]
CHIP:DMG: ICR moving to [AddCommand]
CHIP:IN: Secure message was encrypted: Msg ID 3
CHIP:IN: Sending msg from 0x000000000001b669 to 0x0000000000000001 at utc time: 354422368 msec
CHIP:IN: Sending secure msg on generic transport
CHIP:IN: Secure msg send status No Error
CHIP:DMG: ICR moving to [   Sending]
CHIP:IN: Secure transport received message destined to node ID (112233)
CHIP:EM: Received message of type 9 and protocolId 327680
CHIP:DMG: InvokeCommand =
CHIP:DMG: {
CHIP:DMG:       CommandList =
CHIP:DMG:       [
CHIP:DMG:               CommandDataElement =
CHIP:DMG:               {
CHIP:DMG:                       CommandPath =
CHIP:DMG:                       {
CHIP:DMG:                               EndpointId = 0x0,
CHIP:DMG:                               ClusterId = 0x6,
CHIP:DMG:                               CommandId = 0x1,
CHIP:DMG:                       },
CHIP:DMG: 
CHIP:DMG:                       StatusElement =
CHIP:DMG:                       {
CHIP:DMG:                               GeneralCode = 0xd,
CHIP:DMG:                               ProtocolId = 0x0,
CHIP:DMG:                               protocolCode = 0xffff,
CHIP:DMG:                       },
CHIP:DMG: 
CHIP:DMG:               },
CHIP:DMG: 
CHIP:DMG:       ],
CHIP:DMG: 
CHIP:DMG: }
SetCommandIndexStatus commandHandle=140534550478280 commandIndex=1
CHIP:ZCL: DefaultResponse:
CHIP:ZCL:   Transaction: 0x7fd0bff5bdc8
CHIP:ZCL:   status: EMBER_ZCL_STATUS_FAILURE (0x01)
CHIP:ZCL: emberAfDefaultResponseCallback: Missing success callback
CHIP:ZCL: emberAfDefaultResponseCallback: Missing failure callback
CHIP:EM: Sending Standalone Ack for MsgId:00000005
CHIP:IN: Secure message was encrypted: Msg ID 4
CHIP:IN: Sending msg from 0x000000000001b669 to 0x0000000000000001 at utc time: 354422371 msec
CHIP:IN: Sending secure msg on generic transport
CHIP:IN: Secure msg send status No Error
CHIP:EM: Flushed pending ack for MsgId:00000005
CHIP:ZCL: DefaultResponse:
CHIP:ZCL:   Transaction: 0x7fd0bff5bdc8
CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
CHIP:ZCL: emberAfDefaultResponseCallback: Missing success callback
CHIP:ZCL: emberAfDefaultResponseCallback: Missing failure callback
CHIP:DMG: ICR moving to [Uninitiali]
Received command status response:
Container: 
    ProtocolId = 0
    ProtocolCode = 65535
    EndpointId = 0
    ClusterId = 6
    CommandId = 1
    CommandIndex = 1
```

It will report error when cluster is not found on device.
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Tests: Cirque test and local device controller run against all cluster app in two raspberry pi