### PR TITLE
Add state check for IM Invoke command

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -146,10 +146,10 @@ exit:
 CHIP_ERROR Command::PrepareCommand(const CommandPathParams * const apCommandPathParams, bool aIsStatus)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    CommandDataElement::Builder commandDataElement =
-        mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
-    err = commandDataElement.GetError();
+    CommandDataElement::Builder commandDataElement;
+    VerifyOrExit(mState == CommandState::Initialized || mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
+    commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+    err                = commandDataElement.GetError();
     SuccessOrExit(err);
 
     if (apCommandPathParams != nullptr)

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -132,10 +132,10 @@ protected:
     InteractionModelDelegate * mpDelegate      = nullptr;
     chip::System::PacketBufferHandle mCommandMessageBuf;
     uint8_t mCommandIndex = 0;
+    CommandState mState   = CommandState::Uninitialized;
 
 private:
     friend class TestCommandInteraction;
-    CommandState mState                    = CommandState::Uninitialized;
     TLV::TLVType mDataElementContainerType = TLV::kTLVType_NotSpecified;
     chip::System::PacketBufferTLVWriter mCommandMessageWriter;
 };

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -57,6 +57,8 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    VerifyOrExit(mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
+
     err = FinalizeCommandsMessage();
     SuccessOrExit(err);
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -38,6 +38,8 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    VerifyOrExit(mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
+
     err = FinalizeCommandsMessage();
     SuccessOrExit(err);
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -65,6 +65,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 class TestCommandInteraction
 {
 public:
+    static void TestCommandSenderWithWrongState(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandHandlerWithWrongState(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderWithSendCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendEmptyCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
@@ -170,6 +172,53 @@ void TestCommandInteraction::AddCommandDataElement(nlTestSuite * apSuite, void *
         err = apCommand->FinishCommand();
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     }
+}
+
+void TestCommandInteraction::TestCommandSenderWithWrongState(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    chip::app::CommandPathParams commandPathParams = { 1, // Endpoint
+                                                       2, // GroupId
+                                                       3, // ClusterId
+                                                       4, // CommandId
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandSender commandSender;
+
+    err = commandSender.PrepareCommand(&commandPathParams);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    commandSender.Shutdown();
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    err                            = commandSender.Init(&gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gAdminId);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+}
+
+void TestCommandInteraction::TestCommandHandlerWithWrongState(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    chip::app::CommandPathParams commandPathParams = { 1, // Endpoint
+                                                       2, // GroupId
+                                                       3, // ClusterId
+                                                       4, // CommandId
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::CommandHandler commandHandler;
+
+    err = commandHandler.PrepareCommand(&commandPathParams);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    commandHandler.Shutdown();
+
+    err = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    TestExchangeDelegate delegate;
+    commandHandler.mpExchangeCtx->SetDelegate(&delegate);
+    err = commandHandler.SendCommandResponse();
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    commandHandler.Shutdown();
 }
 
 void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSuite, void * apContext)
@@ -330,6 +379,8 @@ void InitializeChip(nlTestSuite * apSuite)
 // clang-format off
 const nlTest sTests[] =
 {
+    NL_TEST_DEF("TestCommandSenderWithWrongState", chip::app::TestCommandInteraction::TestCommandSenderWithWrongState),
+    NL_TEST_DEF("TestCommandHandlerWithWrongState", chip::app::TestCommandInteraction::TestCommandHandlerWithWrongState),
     NL_TEST_DEF("TestCommandSenderWithSendCommand", chip::app::TestCommandInteraction::TestCommandSenderWithSendCommand),
     NL_TEST_DEF("TestCommandHandlerWithSendEmptyCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand),
     NL_TEST_DEF("TestCommandSenderWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg),


### PR DESCRIPTION
#### Problem
Don't have state check for IM invoke Command

#### Change overview
--Add state check for Command Sender and CommandHandler

#### Testing
-- Add new unit test that check the incorrect state value when moving state from  uninitialized state to AddCommand state for IM sender and handler. Also check incorrect state when moving state from initialized state to sending state for IM Command Sender and Handler.

