### PR TITLE
[nrfconnect] Bring back BLE write requests

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -68,7 +68,7 @@ _bt_gatt_ccc CHIPoBLEChar_TX_CCC = BT_GATT_CCC_INITIALIZER(nullptr, BLEManagerIm
 BT_GATT_SERVICE_DEFINE(CHIPoBLE_Service,
     BT_GATT_PRIMARY_SERVICE(&UUID16_CHIPoBLEService.uuid),
         BT_GATT_CHARACTERISTIC(&UUID128_CHIPoBLEChar_RX.uuid,
-                               BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+                               BT_GATT_CHRC_WRITE | BT_GATT_CHRC_WRITE_WITHOUT_RESP,
                                BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
                                nullptr, BLEManagerImpl::HandleRXWrite, nullptr),
         BT_GATT_CHARACTERISTIC(&UUID128_CHIPoBLEChar_TX.uuid,


### PR DESCRIPTION
#### Problem
PR #6955, apart from changing from BLE indications to notifications on nRF Connect platform, started require
controllers to use only GATT WriteCommand procedure (aka Write without response) as that is required by the spec.

However, Darwin platform layer still uses WriteRequest (aka Write with response) method, so the change broke compatibility between mac and nRF Connect platforms.

#### Change overview
Support both methods on the firmware side until all platforms switch to the new spec-recommended method.

#### Testing
No unit or integration tests are added/modified as the change can only be tested on hardware.
The change has been tested manually by using Python CHIP Controller on mac OS and nRF Connect lock-app.
