### PR TITLE
[QPG6100] Enable compiler size optimization

### DIFF
--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -37,6 +37,9 @@ chip_inet_config_enable_raw_endpoint = false
 #chip_progress_logging = false
 chip_detail_logging = false
 
+# Use -Os
+is_debug = false
+
 chip_build_tests = false
 
 # GH #4224


### PR DESCRIPTION
#### Problem
More flash space should be freed up for current and future Matter features

#### Change overview
Enabled size optimization settings for compiler for QPG6100 platform

#### Testing
* Rebuild and manual test done with chip-device-ctrl
* Size comparison done - 42kB decrease in flash usage