### PR TITLE
[QPG6100] Correction floating point abi

### DIFF
--- a/third_party/qpg_sdk/qpg6100_arm.gni
+++ b/third_party/qpg_sdk/qpg6100_arm.gni
@@ -15,6 +15,4 @@
 arm_arch = "armv7e-m"
 arm_abi = "aapcs"
 arm_cpu = "cortex-m4"
-
-arm_float_abi = "softfp"
-#arm_fpu = "fpv4-sp-d16"
+arm_float_abi = "soft"


### PR DESCRIPTION
#### Problem
After review of build settings it was seen that float-abi was incorrectly set to `softfp`
This could lead to insertion of HW FPU instructions

#### Change overview
Selecting the correct `soft` abi for float operations

#### Testing
* Review of disassembly for any ARM HW FPU instructions after rebuild
* Manual commissioning run against python chip-device-ctrl