### PR TITLE
Make test-only functions in ReliableMessageManager only be compiled for tests.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -503,6 +503,7 @@ void ReliableMessageMgr::StopTimer()
     mSystemLayer->CancelTimer(Timeout, this);
 }
 
+#if CHIP_CONFIG_TEST
 int ReliableMessageMgr::TestGetCountRetransTable()
 {
     int count = 0;
@@ -516,6 +517,7 @@ int ReliableMessageMgr::TestGetCountRetransTable()
 
     return count;
 }
+#endif // CHIP_CONFIG_TEST
 
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -219,9 +219,11 @@ public:
      */
     void ExpireTicks();
 
+#if CHIP_CONFIG_TEST
     // Functions for testing
     int TestGetCountRetransTable();
     void TestSetIntervalShift(uint16_t value) { mTimerIntervalShift = value; }
+#endif // CHIP_CONFIG_TEST
 
 private:
     BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & mContextPool;


### PR DESCRIPTION
#### Problem
We have test-only functions exposed as public API.

#### Change overview
Ifdef the functions so they are only compiled when compiling tests.

#### Testing
No functional changes in unit tests, and we don't really have a way to test that something _doesn't_ compile.