### PR TITLE
Add support of chip_detail_logging and chip_mdns

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -38,11 +38,56 @@ CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/python_lib"
 ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 
+declare chip_detail_logging=false
+declare chip_mdns="minimal"
+
+help() {
+
+    echo "Usage: $file_name [ options ... ] [ -chip_detail_logging ChipDetailLoggingValue  ] [ -chip_mdns ChipMDNSValue  ]"
+
+    echo "General Options:
+  -h, --help                Display this information.
+Input Options:
+  -d, --chip_detail_logging ChipDetailLoggingValue          Specify ChipDetailLoggingValue as true or false.
+                                                            By default it is false.
+  -m, --chip_mdns           ChipMDNSValue                   Specify ChipMDNSValue as platform or minimal.
+                                                            By default it is minimal.
+"
+}
+
+file_name=${0##*/}
+
+while (($#)); do
+    case $1 in
+        --help | -h)
+            help
+            exit 1
+            ;;
+        --chip_detail_logging | -d)
+            chip_detail_logging=$2
+            shift
+            ;;
+        --chip_mdns | -m)
+            chip_mdns=$2
+            shift
+            ;;
+        -*)
+            help
+            echo "Unknown Option \"$1\""
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Print input values
+echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\""
+
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=false"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging chip_mdns=\"$chip_mdns\""
 
 # Compiles python files
 ninja -C "$OUTPUT_ROOT" python


### PR DESCRIPTION
#### Problem

* Currently chip_detail_logging and chip_mdns are not configurable for scripts/build_python.sh

#### Change overview

* Chip_detail_logging and chip_mdns can be configured by the user
* Otherwise default configurations will be passed 
* Added help for commands usage
* `./scripts/build_python.sh --help` command shows following usage:
```Usage: build_python.sh [ options ... ] [ -chip_detail_logging ChipDetailLoggingValue  ] [ -chip_mdns ChipMDNSValue  ]
General Options:
  -h, --help                Display this information.
Input Options:
  -d, --chip_detail_logging ChipDetailLoggingValue          Specify ChipDetailLoggingValue as true or false.
                                                            By default it is false.
  -m, --chip_mdns           ChipMDNSValue                   Specify ChipMDNSValue as platform or minimal.
                                                            By default it is minimal.
```



#### Testing

* Tested using commands like:
  - `./scripts/build_python.sh --chip_detail_logging true --chip_mdns platform`
  -  `./scripts/build_python.sh -d true -m platform`
  - `./scripts/build_python.sh --chip_detail_logging true`
  - `./scripts/build_python.sh --chip_mdns platform`
  - `./scripts/build_python.sh` etc.

* Argument values populated in out/python_lib/args.gn file are verified.