### PR TITLE
Fix field id wild card representation

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -60,7 +60,7 @@ namespace app {
 
 constexpr size_t kMaxSecureSduLengthBytes = 1024;
 constexpr uint32_t kImMessageTimeoutMsec  = 6000;
-constexpr FieldId kRootFieldId            = 0;
+constexpr FieldId kRootFieldId            = 0xFF;
 /**
  * @class InteractionModelEngine
  *

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -121,7 +121,7 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     attributePathBuilder = attributePathListBuilder.CreateAttributePathBuilder();
     NL_TEST_ASSERT(apSuite, attributePathListBuilder.GetError() == CHIP_NO_ERROR);
     attributePathBuilder =
-        attributePathBuilder.NodeId(1).EndpointId(kTestEndpointId).ClusterId(kTestClusterId).FieldId(0).EndOfAttributePath();
+        attributePathBuilder.NodeId(1).EndpointId(kTestEndpointId).ClusterId(kTestClusterId).FieldId(kRootFieldId).EndOfAttributePath();
     NL_TEST_ASSERT(apSuite, attributePathBuilder.GetError() == CHIP_NO_ERROR);
     attributePathListBuilder.EndOfAttributePathList();
     readRequestBuilder.EventNumber(1);


### PR DESCRIPTION
#### Problem
Per spec, 0xFF is used to represent the wildcard/all for FieldID in attributePath

#### Change overview
Update FieldId kRootFieldId value with 0xFF

#### Testing
Update the existing unit test with updated kRootFieldId

