### PR TITLE
Clearly document lifetime expectations for CommandSender.

### DIFF
--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -46,13 +46,22 @@ class CommandSender : public Command, public Messaging::ExchangeDelegate
 {
 public:
     // TODO: issue #6792 - the secure session parameter should be made non-optional and passed by reference.
+    // Once SendCommandRequest returns successfully, the CommandSender will
+    // handle calling Shutdown on itself once it decides it's done with waiting
+    // for a response (i.e. times out or gets a response).
+    //
+    // If SendCommandRequest is never called, or the call fails, the API
+    // consumer is responsible for calling Shutdown on the CommandSender.
     CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession = nullptr);
 
+private:
+    // ExchangeDelegate interface implementation.  Private so people won't
+    // accidentally call it on us when we're not being treated as an actual
+    // ExchangeDelegate.
     void OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                            const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
 
-private:
     CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
 };
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -100,7 +100,7 @@ public:
 
     /**
      *  Retrieve a CommandSender that the SDK consumer can use to send a set of commands.  If the call succeeds,
-     *  the consumer is responsible for calling Shutdown() on the CommandSender once it's done using it.
+     *  see CommandSender documentation for lifetime handling.
      *
      *  @param[out]    apCommandSender    A pointer to the CommandSender object.
      *


### PR DESCRIPTION
#### Problem
Documentation for CommandSender lifetime does not match reality.

#### Change overview
Fix the documentation

#### Testing
Comment-only change, no functional changes.