### PR TITLE
Unit test for CRMP to discard entries with missing retained buffer

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -135,10 +135,11 @@ void ReliableMessageMgr::ExecuteActions()
 
         if (entry.retainedBuf.IsNull())
         {
-            // The exchange allocates an entry for the retransmit buffer and provides it to
-            // underlying message dispatch to fill in with the message buffer. If the dispatch
-            // does fill in the message buffer, the entry is still in the retransmit table.
-            // This check clears such entries from the retransmit table.
+            // We generally try to prevent entries with a null buffer being in a table, but it could happen
+            // if the message dispatch (which is supposed to fill in the buffer) fails to do so _and_ returns
+            // success (so its caller doesn't clear out the bogus table entry).
+            // 
+            // If that were to happen, we would crash in the code below.  Guard against it, just in case.
             ClearRetransTable(entry);
             continue;
         }

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -133,6 +133,13 @@ void ReliableMessageMgr::ExecuteActions()
         if (!rc || entry.nextRetransTimeTick != 0)
             continue;
 
+        if (entry.retainedBuf.IsNull())
+        {
+            // Discard the current entry if the retained buffer is null
+            ClearRetransTable(entry);
+            continue;
+        }
+
         uint8_t sendCount = entry.sendCount;
         uint32_t msgId    = entry.retainedBuf.GetMsgId();
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -138,7 +138,7 @@ void ReliableMessageMgr::ExecuteActions()
             // We generally try to prevent entries with a null buffer being in a table, but it could happen
             // if the message dispatch (which is supposed to fill in the buffer) fails to do so _and_ returns
             // success (so its caller doesn't clear out the bogus table entry).
-            // 
+            //
             // If that were to happen, we would crash in the code below.  Guard against it, just in case.
             ClearRetransTable(entry);
             continue;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -135,7 +135,10 @@ void ReliableMessageMgr::ExecuteActions()
 
         if (entry.retainedBuf.IsNull())
         {
-            // Discard the current entry if the retained buffer is null
+            // The exchange allocates an entry for the retransmit buffer and provides it to
+            // underlying message dispatch to fill in with the message buffer. If the dispatch
+            // does fill in the message buffer, the entry is still in the retransmit table.
+            // This check clears such entries from the retransmit table.
             ClearRetransTable(entry);
             continue;
         }

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -346,7 +346,6 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     MockSessionEstablishmentDelegate mockSender;
-    // TODO: temporarily create a SecureSessionHandle from node id, will be fix in PR 3602
     ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockSender);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -115,7 +115,7 @@ public:
 
         if (retainedMessage != nullptr && mRetainMessageOnSend)
         {
-            retainedMessage->MarkEncrypted(message.Retain());
+            *retainedMessage = EncryptedPacketBufferHandle::MarkEncrypted(message.Retain());
         }
         return gTransportMgr.SendMessage(Transport::PeerAddress(), std::move(message));
     }

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -115,7 +115,7 @@ public:
 
         if (retainedMessage != nullptr && mRetainMessageOnSend)
         {
-            (*retainedMessage) = message.Retain();
+            retainedMessage->MarkEncrypted(message.Retain());
         }
         return gTransportMgr.SendMessage(Transport::PeerAddress(), std::move(message));
     }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -134,7 +134,6 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, E
                                                   EncryptedPacketBufferHandle * bufferRetainSlot)
 {
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(msgBuf.IsEncrypted(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Advancing the start to encrypted header, since SendMessage will attach the packet header on top of it.
@@ -188,7 +187,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
-        bufferRetainSlot->MarkEncrypted(msgBuf.Retain());
+        *bufferRetainSlot = EncryptedPacketBufferHandle::MarkEncrypted(msgBuf.Retain());
     }
 
     ChipLogProgress(Inet, "Sending msg from 0x" ChipLogFormatX64 " to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec",

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -134,6 +134,7 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, E
                                                   EncryptedPacketBufferHandle * bufferRetainSlot)
 {
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(msgBuf.IsEncrypted(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Advancing the start to encrypted header, since SendMessage will attach the packet header on top of it.
@@ -187,7 +188,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
-        (*bufferRetainSlot) = msgBuf.Retain();
+        bufferRetainSlot->MarkEncrypted(msgBuf.Retain());
     }
 
     ChipLogProgress(Inet, "Sending msg from 0x" ChipLogFormatX64 " to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec",

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -94,19 +94,20 @@ public:
     CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
+
+    // Making operator= available to tests by making it public.
 #ifdef CHIP_CONFIG_TEST
-    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
+public:
+#else
+private:
 #endif
+    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
 
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle
     friend class SecureSessionMgr;
 
     EncryptedPacketBufferHandle(PacketBufferHandle && aBuffer) : PacketBufferHandle(std::move(aBuffer)) {}
-
-#ifndef CHIP_CONFIG_TEST
-    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
-#endif
 };
 
 /**

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -94,13 +94,19 @@ public:
     CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
+#ifdef CHIP_CONFIG_TEST
     void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
+#endif
 
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle
     friend class SecureSessionMgr;
 
     EncryptedPacketBufferHandle(PacketBufferHandle && aBuffer) : PacketBufferHandle(std::move(aBuffer)) {}
+
+#ifndef CHIP_CONFIG_TEST
+    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
+#endif
 };
 
 /**

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -94,7 +94,6 @@ public:
     CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
-
     // Making operator= available to tests by making it public.
 #ifdef CHIP_CONFIG_TEST
 public:

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -70,12 +70,7 @@ public:
      *
      * @returns empty handle on allocation failure.
      */
-    EncryptedPacketBufferHandle CloneData()
-    {
-        EncryptedPacketBufferHandle handle = EncryptedPacketBufferHandle(PacketBufferHandle::CloneData());
-        handle.mEncryptedPacketBuffer      = mEncryptedPacketBuffer;
-        return handle;
-    }
+    EncryptedPacketBufferHandle CloneData() { return EncryptedPacketBufferHandle(PacketBufferHandle::CloneData()); }
 
 #ifdef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
     /**
@@ -97,18 +92,13 @@ public:
     CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
-    void MarkEncrypted(PacketBufferHandle && aBuffer)
+    static EncryptedPacketBufferHandle MarkEncrypted(PacketBufferHandle && aBuffer)
     {
-        PacketBufferHandle::operator=(std::move(aBuffer));
-        mEncryptedPacketBuffer      = true;
+        return EncryptedPacketBufferHandle(std::move(aBuffer));
     }
-
-    bool IsEncrypted() const { return mEncryptedPacketBuffer; }
 
 private:
     EncryptedPacketBufferHandle(PacketBufferHandle && aBuffer) : PacketBufferHandle(std::move(aBuffer)) {}
-
-    bool mEncryptedPacketBuffer = false;
 };
 
 /**

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -63,6 +63,8 @@ public:
 
     uint32_t GetMsgId() const;
 
+    bool IsNull() const { return System::PacketBufferHandle::IsNull(); }
+
     /**
      * Creates a copy of the data in this packet.
      *
@@ -92,13 +94,13 @@ public:
     CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
+    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
+
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle
     friend class SecureSessionMgr;
 
     EncryptedPacketBufferHandle(PacketBufferHandle && aBuffer) : PacketBufferHandle(std::move(aBuffer)) {}
-
-    void operator=(PacketBufferHandle && aBuffer) { PacketBufferHandle::operator=(std::move(aBuffer)); }
 };
 
 /**


### PR DESCRIPTION
#### Problem
Reliable message retransmission accesses retained message buffer without checking if it is valid. This leads to crash.

#### Change overview
Add a unit test for the problem scenario. The test is able to recreate the problem. Fix the problem by ignoring the retransmission entries with no message buffer.

#### Testing
`CheckFailedMessageRetainOnSend` is the new unit test that tests the code change.
Rest of CRMP unit tests (in `TestReliableMessageProtocol`) ensure that existing functionality is still intact.
