### PR TITLE
Make it hard to accidentally commit the Darwin framework build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Build System
 out/
 /src/test_driver/nrfconnect/build/
+/src/darwin/Framework/build/
 
 # Environment directory
 .environment/


### PR DESCRIPTION
#### Problem
Running darwin CI locally creates a build/ dir under Framework that is too easy to accidentally git add.

#### Change overview
Add the build dir to .gitignore.

#### Testing
Manually ran darwin tests and checked that `git status` comes back clean.  We could try to add something to Darwin CI that does that if we really want to...