### PR TITLE
[nrfconnect] Enabled BLE advertising for DFU despite being provisioned.

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -462,7 +462,20 @@ CHIP-enabled Thread network.
 
 ### Testing Device Firmware Upgrade
 
-Read the section about downloading the new image to a device on the
-[FOTA upgrades](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf52.html#fota-upgrades)
-page in the nRF Connect documentation to see how to upgrade your device firmware
-over Bluetooth LE using a smartphone.
+> **_NOTE:_** Currently performing DFU over BLE is supported only using
+> smartphone with dedicated Nordic application installed.
+
+To upgrade your device firmware over Bluetooth LE using smartphone, complete the
+following tasks:
+
+1. Install on your smartphone
+   [nRF Connect for Mobile](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-mobile)
+   or
+   [nRF Toolbox](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox)
+   application.
+2. Push **Button 4** on the device to start Bluetooth LE advertising.
+3. Push **Button 1** on the device to enable software update functionality.
+4. Follow the instructions in the section about downloading the new image to a
+   device on the
+   [FOTA upgrades](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf52.html#fota-upgrades)
+   page in the nRF Connect documentation.

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -415,7 +415,8 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != BLE_ADVERTISEMENT_START_BUTTON)
         return;
 
-    if (chip::DeviceLayer::ConnectivityMgr().IsThreadProvisioned())
+    // In case of having software update enabled, allow on starting BLE advertising after Thread provisioning.
+    if (chip::DeviceLayer::ConnectivityMgr().IsThreadProvisioned() && !sAppTask.mSoftwareUpdateEnabled)
     {
         LOG_INF("NFC Tag emulation and BLE advertisement not started - device is commissioned to a Thread network.");
         return;

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -454,7 +454,20 @@ CHIP-enabled Thread network.
 
 ### Testing Device Firmware Upgrade
 
-Read the section about downloading the new image to a device on the
-[FOTA upgrades](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf52.html#fota-upgrades)
-page in the nRF Connect documentation to see how to upgrade your device firmware
-over Bluetooth LE using a smartphone.
+> **_NOTE:_** Currently performing DFU over BLE is supported only using
+> smartphone with dedicated Nordic application installed.
+
+To upgrade your device firmware over Bluetooth LE using smartphone, complete the
+following tasks:
+
+1. Install on your smartphone
+   [nRF Connect for Mobile](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-mobile)
+   or
+   [nRF Toolbox](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox)
+   application.
+2. Push **Button 4** on the device to start Bluetooth LE advertising.
+3. Push **Button 1** on the device to enable software update functionality.
+4. Follow the instructions in the section about downloading the new image to a
+   device on the
+   [FOTA upgrades](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf52.html#fota-upgrades)
+   page in the nRF Connect documentation.

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -416,7 +416,8 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != BLE_ADVERTISEMENT_START_BUTTON)
         return;
 
-    if (ConnectivityMgr().IsThreadProvisioned())
+    // In case of having software update enabled, allow on starting BLE advertising after Thread provisioning.
+    if (ConnectivityMgr().IsThreadProvisioned() && !sAppTask.mSoftwareUpdateEnabled)
     {
         LOG_INF("NFC Tag emulation and BLE advertisement not started - device is commissioned to a Thread network.");
         return;


### PR DESCRIPTION
#### Problem
Currently BLE advertising is stopped after provisioning Thread, and it cannot be restarted again. In order to perform Device
Firmware Upgrade (DFU) over BLE we need having BLE advertising working, so for now it is impossible to update firmware after provisioning.

#### Change overview
* Modified condition to allow starting BLE advertising despite having Thread provisioned in case of having also DFU enabled.
* Improved documentation presenting how to perform DFU.

#### Testing
Change is related only to the nrfconnect platform, so it was tested manually only with that platform. DFU is currently supported only using Nordic mobile application, so it was tested using nRF Connect for Mobile app.

What was tested:
* Verified that performing DFU over BLE on not commissioned device works properly.
* Verified that change doesn't have impact on Thread provisioning and it works using Python CHIP controller. 
* Checked that it is possible to enable BLE advertising despite having Thread provisioned.
* Verified that performing DFU over BLE on provisioned device works properly.
* Verified that after upgrading device firmware and rebooting application, Thread and CHIP settings are not removed, so device is still able to communicate with Python CHIP controller with zcl commands.
