### PR TITLE
Cleanup CASE state machine for error handling and logging

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -294,11 +294,11 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mState = State::NotInitialized;
 
-    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
-    // if (mExchangeMgr != nullptr)
-    // {
-    //     mExchangeMgr->Shutdown();
-    // }
+    if (mExchangeMgr != nullptr)
+    {
+        mExchangeMgr->Shutdown();
+    }
+
     if (mSessionMgr != nullptr)
     {
         mSessionMgr->Shutdown();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -294,11 +294,11 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mState = State::NotInitialized;
 
-    if (mExchangeMgr != nullptr)
-    {
-        mExchangeMgr->Shutdown();
-    }
-
+    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
+    // if (mExchangeMgr != nullptr)
+    // {
+    //     mExchangeMgr->Shutdown();
+    // }
     if (mSessionMgr != nullptr)
     {
         mSessionMgr->Shutdown();

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -224,6 +224,10 @@ private:
     CHIP_ERROR ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen);
 
     void SendErrorMsg(SigmaErrorType errorCode);
+
+    // This function always returns an error. The error value corresponds to the error in the received message.
+    // The returned error value helps top level message receiver/dispatcher to close the exchange context
+    // in a more seemless manner.
     CHIP_ERROR HandleErrorMsg(const System::PacketBufferHandle & msg);
 
     void CloseExchange();

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -227,7 +227,7 @@ private:
 
     // This function always returns an error. The error value corresponds to the error in the received message.
     // The returned error value helps top level message receiver/dispatcher to close the exchange context
-    // in a more seemless manner.
+    // in a more seamless manner.
     CHIP_ERROR HandleErrorMsg(const System::PacketBufferHandle & msg);
 
     void CloseExchange();

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -224,7 +224,9 @@ private:
     CHIP_ERROR ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen);
 
     void SendErrorMsg(SigmaErrorType errorCode);
-    void HandleErrorMsg(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleErrorMsg(const System::PacketBufferHandle & msg);
+
+    void CloseExchange();
 
     // TODO: Remove this and replace with system method to retrieve current time
     CHIP_ERROR SetEffectiveTime(void);


### PR DESCRIPTION
#### Problem
The CASE session holds on to exchange context even after Sigma handshake is complete. Also, the error handling and logging could be improved.

#### Change overview
Close exchange on Sigma handshake completion. Update logging to use `SecureChannel` tag. Cleanup error handling.

#### Testing
`TestCASESession` unit tests.
Tested with Python controller app, and iOS CHIPTool app for pairing.

Fixes #7070