### PR TITLE
Add broken links GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2020-2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lint Code Base
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  check-broken-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check broken links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
#### Problem
Sometimes broken links on documentation are hard to detect, specially those which point to external URLs.

#### Change overview
This change provides a GitHub action which scans markdown documents and it reports internal and external broken links.

#### Testing
Once this action is added into the CI workflow, new PRs will trigger it execution and report any broken existing link.
