### PR TITLE
Remove dead symlinks in nrfconnect lighting app

### DIFF
--- a/examples/lighting-app/nrfconnect/main/pigweed_lighting.options
+++ b/examples/lighting-app/nrfconnect/main/pigweed_lighting.options
@@ -1,1 +1,0 @@
-../../lighting-common/lighting_service/pigweed_lighting.options

--- a/examples/lighting-app/nrfconnect/main/pigweed_lighting.proto
+++ b/examples/lighting-app/nrfconnect/main/pigweed_lighting.proto
@@ -1,1 +1,0 @@
-../../lighting-common/lighting_service/pigweed_lighting.proto


### PR DESCRIPTION
The files these point to don't exist.

#### Problem
We have symlinks pointing to non-existent files.

#### Change overview
Remove the symlinks.

#### Testing
Manually checked that the nrfconnect compile works correctly after this.