### PR TITLE
Add IM event path filter

### DIFF
--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <app/ClusterInfo.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>
@@ -168,10 +169,12 @@ struct EventLoadOutContext
     TLV::TLVWriter & mWriter;
     PriorityLevel mPriority          = PriorityLevel::Invalid;
     EventNumber mStartingEventNumber = 0;
+    Timestamp mPreviousSystemTime;
     Timestamp mCurrentSystemTime;
     EventNumber mCurrentEventNumber = 0;
     Timestamp mCurrentUTCTime;
-    bool mFirst = true;
+    ClusterInfo * mpInterestedEventPaths = nullptr;
+    bool mFirst                          = true;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -92,6 +92,10 @@ struct EventEnvelopeContext
     Timestamp mDeltaSystemTime = Timestamp::System(0);
     Timestamp mDeltaUtc        = Timestamp::UTC(0);
     PriorityLevel mPriority    = PriorityLevel::First;
+    NodeId mNodeId             = 0;
+    ClusterId mClusterId       = 0;
+    EndpointId mEndpointId     = 0;
+    EventId mEventId           = 0;
 };
 
 EventManagement::EventManagement(Messaging::ExchangeManager * apExchangeMgr, int aNumBuffers,
@@ -433,7 +437,8 @@ CHIP_ERROR EventManagement::CopyAndAdjustDeltaTime(const TLVReader & aReader, si
         }
         else
         {
-            err = ctx->mpWriter->CopyElement(reader);
+            err = ctx->mpWriter->Put(TLV::ContextTag(EventDataElement::kCsTag_DeltaSystemTimestamp),
+                                     ctx->mpContext->mCurrentSystemTime.mValue - ctx->mpContext->mPreviousSystemTime.mValue);
         }
     }
     else
@@ -595,6 +600,25 @@ exit:
     return err;
 }
 
+static bool IsInterestedEventPaths(EventLoadOutContext * eventLoadOutContext, const EventEnvelopeContext & event)
+{
+    ClusterInfo * interestedEventPaths = eventLoadOutContext->mpInterestedEventPaths;
+    if (eventLoadOutContext->mCurrentEventNumber < eventLoadOutContext->mStartingEventNumber)
+    {
+        return false;
+    }
+    while (interestedEventPaths != nullptr)
+    {
+        if (interestedEventPaths->mNodeId == event.mNodeId && interestedEventPaths->mEndpointId == event.mEndpointId &&
+            interestedEventPaths->mClusterId == event.mClusterId && interestedEventPaths->mEventId == event.mEventId)
+        {
+            return true;
+        }
+        interestedEventPaths = interestedEventPaths->mpNext;
+    }
+    return false;
+}
+
 CHIP_ERROR EventManagement::EventIterator(const TLVReader & aReader, size_t aDepth, EventLoadOutContext * apEventLoadOutContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -603,28 +627,30 @@ CHIP_ERROR EventManagement::EventIterator(const TLVReader & aReader, size_t aDep
     EventEnvelopeContext event;
 
     innerReader.Init(aReader);
-    err = innerReader.EnterContainer(tlvType);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(innerReader.EnterContainer(tlvType));
 
     err = TLV::Utilities::Iterate(innerReader, FetchEventParameters, &event, false /*recurse*/);
-    VerifyOrExit(event.mFieldsToRead == kRequiredEventField, err = CHIP_NO_ERROR);
+    if (event.mFieldsToRead != kRequiredEventField)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     if (err == CHIP_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;
     }
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(err);
 
     if (event.mPriority == apEventLoadOutContext->mPriority)
     {
         apEventLoadOutContext->mCurrentSystemTime.mValue += event.mDeltaSystemTime.mValue;
-        VerifyOrExit(apEventLoadOutContext->mCurrentEventNumber < apEventLoadOutContext->mStartingEventNumber,
-                     err = CHIP_EVENT_ID_FOUND);
-        apEventLoadOutContext->mCurrentEventNumber++;
+        if (IsInterestedEventPaths(apEventLoadOutContext, event))
+        {
+            return CHIP_EVENT_ID_FOUND;
+        }
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aDepth, void * apContext)
@@ -633,6 +659,7 @@ CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aD
     TLV::TLVWriter checkpoint;
     EventLoadOutContext * loadOutContext = static_cast<EventLoadOutContext *>(apContext);
     err                                  = EventIterator(aReader, aDepth, loadOutContext);
+    loadOutContext->mCurrentEventNumber++;
     if (err == CHIP_EVENT_ID_FOUND)
     {
         // checkpoint the writer
@@ -646,9 +673,8 @@ CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aD
         // before we began the copy operation.
         VerifyOrExit((err == CHIP_NO_ERROR) || (err == CHIP_END_OF_TLV), loadOutContext->mWriter = checkpoint);
 
-        loadOutContext->mCurrentSystemTime.mValue = 0;
-        loadOutContext->mFirst                    = false;
-        loadOutContext->mCurrentEventNumber++;
+        loadOutContext->mPreviousSystemTime.mValue = loadOutContext->mCurrentSystemTime.mValue;
+        loadOutContext->mFirst                     = false;
     }
 
 exit:
@@ -673,6 +699,7 @@ CHIP_ERROR EventManagement::FetchEventsSince(TLVWriter & aWriter, ClusterInfo * 
         buf = buf->GetNextCircularEventBuffer();
     }
 
+    context.mpInterestedEventPaths    = apClusterInfolist;
     context.mCurrentSystemTime.mValue = buf->GetFirstEventSystemTimestamp();
     context.mCurrentEventNumber       = buf->GetFirstEventNumber();
     err                               = GetEventReader(reader, aPriority, &bufWrapper);
@@ -711,6 +738,17 @@ CHIP_ERROR EventManagement::FetchEventParameters(const TLVReader & aReader, size
     TLVReader reader;
     uint16_t extPriority; // Note: the type here matches the type case in EventManagement::LogEvent, priority section
     reader.Init(aReader);
+
+    if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_EventPath))
+    {
+        EventPath::Parser path;
+        SuccessOrExit(err = path.Init(aReader));
+        SuccessOrExit(err = path.GetNodeId(&(envelope->mNodeId)));
+        SuccessOrExit(err = path.GetEndpointId(&(envelope->mEndpointId)));
+        SuccessOrExit(err = path.GetClusterId(&(envelope->mClusterId)));
+        SuccessOrExit(err = path.GetEventId(&(envelope->mEventId)));
+        envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_EventPath;
+    }
 
     if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_PriorityLevel))
     {

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -39,9 +39,9 @@
 
 namespace chip {
 namespace app {
-constexpr size_t kMaxEventSizeReserve = 512;
-constexpr uint16_t kRequiredEventField =
-    (1 << EventDataElement::kCsTag_PriorityLevel) | (1 << EventDataElement::kCsTag_DeltaSystemTimestamp);
+constexpr size_t kMaxEventSizeReserve  = 512;
+constexpr uint16_t kRequiredEventField = (1 << EventDataElement::kCsTag_PriorityLevel) |
+    (1 << EventDataElement::kCsTag_DeltaSystemTimestamp) | (1 << EventDataElement::kCsTag_EventPath);
 
 /**
  * @brief

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -61,6 +61,7 @@ namespace app {
 constexpr size_t kMaxSecureSduLengthBytes = 1024;
 constexpr uint32_t kImMessageTimeoutMsec  = 6000;
 constexpr FieldId kRootFieldId            = 0;
+
 /**
  * @class InteractionModelEngine
  *

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -48,7 +48,8 @@
 
 namespace {
 
-static const chip::NodeId kTestDeviceNodeId     = 0x18B4300000000001ULL;
+static const chip::NodeId kTestDeviceNodeId1    = 0x18B4300000000001ULL;
+static const chip::NodeId kTestDeviceNodeId2    = 0x18B4300000000002ULL;
 static const chip::ClusterId kLivenessClusterId = 0x00000022;
 static const uint32_t kLivenessChangeEvent      = 1;
 static const chip::EndpointId kTestEndpointId   = 2;
@@ -71,7 +72,7 @@ void InitializeChip(nlTestSuite * apSuite)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, kTestDeviceNodeId);
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, kTestDeviceNodeId1);
 
     NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
 
@@ -80,7 +81,7 @@ void InitializeChip(nlTestSuite * apSuite)
 
     gSystemLayer.Init(nullptr);
 
-    err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
+    err = gSessionManager.Init(kTestDeviceNodeId1, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = gExchangeManager.Init(&gSessionManager);
@@ -143,7 +144,7 @@ static void CheckLogState(nlTestSuite * apSuite, chip::app::EventManagement & aL
 }
 
 static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & alogMgmt, chip::app::PriorityLevel priority,
-                            chip::EventNumber startingEventNumber, size_t expectedNumEvents)
+                            chip::EventNumber startingEventNumber, size_t expectedNumEvents, chip::app::ClusterInfo * clusterInfo)
 {
     CHIP_ERROR err;
     chip::TLV::TLVReader reader;
@@ -151,9 +152,7 @@ static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & 
     uint8_t backingStore[1024];
     size_t elementCount;
     writer.Init(backingStore, 1024);
-    chip::app::ClusterInfo testClusterInfo;
-    testClusterInfo.mEventId = 1;
-    err                      = alogMgmt.FetchEventsSince(writer, &testClusterInfo, priority, startingEventNumber);
+    err = alogMgmt.FetchEventsSince(writer, clusterInfo, priority, startingEventNumber);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR || err == CHIP_END_OF_TLV);
 
     reader.Init(backingStore, writer.GetLengthWritten());
@@ -161,7 +160,6 @@ static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & 
     err = chip::TLV::Utilities::Count(reader, elementCount, false);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(apSuite, elementCount == expectedNumEvents);
-
     reader.Init(backingStore, writer.GetLengthWritten());
     chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
 }
@@ -186,39 +184,42 @@ static void CheckLogEventWithEvictToNextBuffer(nlTestSuite * apSuite, void * apC
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::EventNumber eid1, eid2, eid3, eid4, eid5, eid6;
-    chip::app::EventSchema schema = { kTestDeviceNodeId, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
-                                      chip::app::PriorityLevel::Info };
-    chip::app::EventOptions options;
+    chip::app::EventSchema schema1 = { kTestDeviceNodeId1, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
+                                       chip::app::PriorityLevel::Info };
+    chip::app::EventSchema schema2 = { kTestDeviceNodeId2, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
+                                       chip::app::PriorityLevel::Info };
+    chip::app::EventOptions options1;
+    chip::app::EventOptions options2;
     TestEventGenerator testEventGenerator;
 
-    options.mpEventSchema = &schema;
-
+    options1.mpEventSchema               = &schema1;
+    options2.mpEventSchema               = &schema2;
     chip::app::EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
     testEventGenerator.SetStatus(0);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid1);
+    err = logMgmt.LogEvent(&testEventGenerator, options1, eid1);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 1, chip::app::PriorityLevel::Debug);
     testEventGenerator.SetStatus(1);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid2);
+    err = logMgmt.LogEvent(&testEventGenerator, options1, eid2);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 2, chip::app::PriorityLevel::Debug);
     testEventGenerator.SetStatus(0);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid3);
+    err = logMgmt.LogEvent(&testEventGenerator, options1, eid3);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
     // Start to copy info event to next buffer since current debug buffer is full and info event is higher priority
     testEventGenerator.SetStatus(1);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid4);
+    err = logMgmt.LogEvent(&testEventGenerator, options2, eid4);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 4, chip::app::PriorityLevel::Info);
 
     testEventGenerator.SetStatus(0);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid5);
+    err = logMgmt.LogEvent(&testEventGenerator, options2, eid5);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 5, chip::app::PriorityLevel::Info);
 
     testEventGenerator.SetStatus(1);
-    err = logMgmt.LogEvent(&testEventGenerator, options, eid6);
+    err = logMgmt.LogEvent(&testEventGenerator, options2, eid6);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     CheckLogState(apSuite, logMgmt, 6, chip::app::PriorityLevel::Info);
 
@@ -229,19 +230,31 @@ static void CheckLogEventWithEvictToNextBuffer(nlTestSuite * apSuite, void * apC
     NL_TEST_ASSERT(apSuite, (eid3 + 1) == eid4);
     NL_TEST_ASSERT(apSuite, (eid4 + 1) == eid5);
     NL_TEST_ASSERT(apSuite, (eid5 + 1) == eid6);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid1, 6);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid2, 5);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid3, 4);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid4, 3);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid5, 2);
-    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid6, 1);
+
+    chip::app::ClusterInfo testClusterInfo1;
+    testClusterInfo1.mNodeId     = kTestDeviceNodeId1;
+    testClusterInfo1.mEndpointId = kTestEndpointId;
+    testClusterInfo1.mClusterId  = kLivenessClusterId;
+    testClusterInfo1.mEventId    = kLivenessChangeEvent;
+    chip::app::ClusterInfo testClusterInfo2;
+    testClusterInfo2.mNodeId     = kTestDeviceNodeId2;
+    testClusterInfo2.mEndpointId = kTestEndpointId;
+    testClusterInfo2.mClusterId  = kLivenessClusterId;
+    testClusterInfo2.mEventId    = kLivenessChangeEvent;
+
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid1, 3, &testClusterInfo1);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid2, 2, &testClusterInfo1);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid3, 1, &testClusterInfo1);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid4, 3, &testClusterInfo2);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid5, 2, &testClusterInfo2);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid6, 1, &testClusterInfo2);
 }
 
 static void CheckLogEventWithDiscardLowEvent(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::EventNumber eid1, eid2, eid3, eid4, eid5, eid6;
-    chip::app::EventSchema schema = { kTestDeviceNodeId, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
+    chip::app::EventSchema schema = { kTestDeviceNodeId1, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
                                       chip::app::PriorityLevel::Debug };
     chip::app::EventOptions options;
     TestEventGenerator testEventGenerator;

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -64,12 +64,12 @@ CHIP_ERROR ReadSingleClusterData(AttributePathParams & aAttributePathParams, TLV
     VerifyOrExit(aAttributePathParams.mClusterId == kTestClusterId && aAttributePathParams.mEndpointId == kTestEndpointId,
                  err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (aAttributePathParams.mFieldId == kRootFieldId || aAttributePathParams.mFieldId == kTestFieldId1)
+    if (aAttributePathParams.mFieldId == kTestFieldId1)
     {
         err = aWriter.Put(TLV::ContextTag(kTestFieldId1), kTestFieldValue1);
         SuccessOrExit(err);
     }
-    if (aAttributePathParams.mFieldId == kRootFieldId || aAttributePathParams.mFieldId == kTestFieldId2)
+    if (aAttributePathParams.mFieldId == kTestFieldId2)
     {
         err = aWriter.Put(TLV::ContextTag(kTestFieldId2), kTestFieldValue2);
         SuccessOrExit(err);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR SendReadRequest(void)
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
     chip::EventNumber number = 0;
-    chip::app::EventPathParams eventPathParams(chip::kTestDeviceNodeId, kTestEndpointId, kTestClusterId, kLivenessChangeEvent,
+    chip::app::EventPathParams eventPathParams(kTestNodeId, kTestEndpointId, kTestClusterId, kLivenessChangeEvent,
                                                false /*not urgent*/);
 
     chip::app::AttributePathParams attributePathParams(chip::kTestDeviceNodeId, kTestEndpointId, kTestClusterId, 1, 0,

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -32,6 +32,8 @@
 
 extern chip::Messaging::ExchangeManager gExchangeManager;
 
+constexpr chip::NodeId kTestNodeId           = 0x1ULL;
+constexpr chip::NodeId kTestNodeId1          = 0x2ULL;
 constexpr chip::ClusterId kTestClusterId     = 6;
 constexpr chip::CommandId kTestCommandId     = 40;
 constexpr chip::EndpointId kTestEndpointId   = 1;


### PR DESCRIPTION
#### Problem
Per IM encoding spec, we need to filter event path from event buffers

#### Change overview
-- Pass the particular interested event Path to EventManagement, and
fetch events based upon those path.

#### Testing
-- Update unit test to filter the interested path with multiple clusters, and calculate the number
of filtered event, and compare with the expected event number.
