### PR TITLE
Don't automatically close exchanges if the underlying connection closes.

### DIFF
--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -209,6 +209,17 @@ private:
      */
     bool MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
 
+    /**
+     * Notify the exchange that its connection has expired.
+     */
+    void OnConnectionExpired();
+
+    /**
+     * Notify our delegate, if any, that we have timed out waiting for a
+     * response.
+     */
+    void NotifyResponseTimeout();
+
     CHIP_ERROR StartResponseTimer();
 
     void CancelResponseTimer();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -319,8 +319,9 @@ void ExchangeManager::OnConnectionExpired(SecureSessionHandle session, SecureSes
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->mSecureSession == session)
         {
-            ec->Close();
-            // Continue iterate because there can be multiple contexts associated with the connection.
+            ec->OnConnectionExpired();
+            // Continue to iterate because there can be multiple exchanges
+            // associated with the connection.
         }
         return true;
     });

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -249,9 +249,13 @@ private:
                            SecureSessionMgr * msgLayer) override;
 
     void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override;
+#if CHIP_CONFIG_TEST
+public: // Allow OnConnectionExpired to be called directly from tests.
+#endif  // CHIP_CONFIG_TEST
     void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
 
     // TransportMgrDelegate interface for rendezvous sessions
+private:
     void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override;
 };
 

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -89,6 +89,22 @@ public:
     bool IsOnMessageReceivedCalled = false;
 };
 
+class WaitForTimeoutDelegate : public ExchangeDelegate
+{
+public:
+    void OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                           System::PacketBufferHandle && buffer) override
+    {}
+
+    void OnResponseTimeout(ExchangeContext * ec) override
+    {
+        IsOnResponseTimeoutCalled = true;
+        ec->Close();
+    }
+
+    bool IsOnResponseTimeoutCalled = false;
+};
+
 void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
@@ -112,6 +128,48 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
 
     ec1->Close();
     ec2->Close();
+}
+
+void CheckSessionExpirationBasics(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    MockAppDelegate sendDelegate;
+    ExchangeContext * ec1 = ctx.NewExchangeToLocal(&sendDelegate);
+
+    // Expire the session this exchange is supposedly on.
+    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession(), &ctx.GetSecureSessionManager());
+
+    MockAppDelegate receiveDelegate;
+    CHIP_ERROR err =
+        ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, &receiveDelegate);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = ec1->SendMessage(Protocols::BDX::Id, kMsgType_TEST1, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                           SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !receiveDelegate.IsOnMessageReceivedCalled);
+
+    ec1->Close();
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+void CheckSessionExpirationTimeout(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    WaitForTimeoutDelegate sendDelegate;
+    ExchangeContext * ec1 = ctx.NewExchangeToLocal(&sendDelegate);
+
+    ec1->SendMessage(Protocols::BDX::Id, kMsgType_TEST1, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                     SendFlags(Messaging::SendMessageFlags::kExpectResponse).Set(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    NL_TEST_ASSERT(inSuite, !sendDelegate.IsOnResponseTimeoutCalled);
+
+    // Expire the session this exchange is supposedly on.  This should close the
+    // exchange.
+    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession(), &ctx.GetSecureSessionManager());
+    NL_TEST_ASSERT(inSuite, sendDelegate.IsOnResponseTimeoutCalled);
 }
 
 void CheckUmhRegistrationTest(nlTestSuite * inSuite, void * inContext)
@@ -167,6 +225,8 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     ec1->Close();
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
 // Test Suite
@@ -180,6 +240,8 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test ExchangeMgr::NewContext",               CheckNewContextTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckUmhRegistrationTest", CheckUmhRegistrationTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckExchangeMessages",    CheckExchangeMessages),
+    NL_TEST_DEF("Test OnConnectionExpired basics",            CheckSessionExpirationBasics),
+    NL_TEST_DEF("Test OnConnectionExpired timeout handling",  CheckSessionExpirationTimeout),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
Someone might still have a reference to those exchanges, and we will
end up with an unbalanced release.  Instead just notify our consumer
in the specific case when we are waiting for a response so it knows
the response will never come (and presumably closes the exchange as
needed).

#### Problem
Fixes https://github.com/project-chip/connectedhomeip/issues/7012

#### Change overview
Instead of hard-closing exchanges on connection close, just notify the ones that are waiting for a response that it won't be coming.

#### Testing
* There are automated tests for some basic behavior included in this PR.
* I manually tested that applying this on top of #7041 allows me to successfully complete ble-wifi pairing with the C++ chip-tool.