### PR TITLE
Do not load duplicate certs in ChipCertificateSet

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -232,9 +232,7 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
     // Verify we have room for the new certificate.
     VerifyOrReturnError(mCertCount < mMaxCerts, CHIP_ERROR_NO_MEMORY);
 
-    ChipCertificateData * new_cert = new (&mCerts[mCertCount]) ChipCertificateData();
-
-    *new_cert = cert;
+    new (&mCerts[mCertCount]) ChipCertificateData(cert);
     mCertCount++;
 
     return CHIP_NO_ERROR;
@@ -616,6 +614,7 @@ void ChipCertificateData::Clear()
 
 bool ChipCertificateData::IsEqual(const ChipCertificateData & other) const
 {
+    // TODO - Add an operator== on BitFlags class.
     return mSubjectDN.IsEqual(other.mSubjectDN) && mIssuerDN.IsEqual(other.mIssuerDN) &&
         mSubjectKeyId.IsEqual(other.mSubjectKeyId) && mAuthKeyId.IsEqual(other.mAuthKeyId) &&
         (mNotBeforeTime == other.mNotBeforeTime) && (mNotAfterTime == other.mNotAfterTime) &&

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -233,8 +233,8 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
     VerifyOrReturnError(mCertCount < mMaxCerts, CHIP_ERROR_NO_MEMORY);
 
     ChipCertificateData * new_cert = new (&mCerts[mCertCount]) ChipCertificateData();
-    memcpy(new_cert, &cert, sizeof(cert));
 
+    *new_cert = cert;
     mCertCount++;
 
     return CHIP_NO_ERROR;

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -299,6 +299,7 @@ struct ChipCertificateData
     ~ChipCertificateData();
 
     void Clear();
+    bool IsEqual(const ChipCertificateData & other) const;
 
     ChipDN mSubjectDN;                          /**< Certificate Subject DN. */
     ChipDN mIssuerDN;                           /**< Certificate Issuer DN. */

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -639,6 +639,38 @@ static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+static void TestChipCert_LoadDuplicateCerts(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    ChipCertificateSet certSet;
+    ValidationContext validContext;
+
+    certSet.Init(kStandardCertsCount, kTestCertBufSize);
+
+    // Let's load two distinct certificates, and make sure cert count is 2
+    err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = LoadTestCert(certSet, TestCert::kICA01, sNullLoadFlag, sGenTBSHashFlag);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+
+    // Let's load a previously loaded cert and make sure cert count is still 2
+    err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+
+    // Let's load the other previously loaded cert and make sure cert count is still 2
+    err = LoadTestCert(certSet, TestCert::kICA01, sNullLoadFlag, sGenTBSHashFlag);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+
+    // Let's load a new cert and make sure cert count updates to 3
+    err = LoadTestCert(certSet, TestCert::kNode01_01, sNullLoadFlag, sGenTBSHashFlag);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 3);
+}
+
 static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContext)
 {
     // Generate a new keypair for cert signing
@@ -931,6 +963,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test CHIP Certificate Validation time", TestChipCert_CertValidTime),
     NL_TEST_DEF("Test CHIP Certificate Usage", TestChipCert_CertUsage),
     NL_TEST_DEF("Test CHIP Certificate Type", TestChipCert_CertType),
+    NL_TEST_DEF("Test Loading Duplicate Certificates", TestChipCert_LoadDuplicateCerts),
     NL_TEST_DEF("Test CHIP Generate Root Certificate", TestChipCert_GenerateRootCert),
     NL_TEST_DEF("Test CHIP Generate Root Certificate with Fabric", TestChipCert_GenerateRootFabCert),
     NL_TEST_DEF("Test CHIP Generate ICA Certificate", TestChipCert_GenerateICACert),


### PR DESCRIPTION
#### Problem
The certificate loading fails after a few tries when the same cert is loaded repeatedly.

#### Change overview
The `ChipCertificateSet::LoadCert` doesn't check if the cert (being loaded) is already present in the certificate set. It parses it and adds it to the set. The current limit of certs in a set is set to 4 (3 in tests). This PR adds a new method to `ChipCertificateData` to compare two certificates. The `LoadCert()` loads the certificate in a temporary `ChipCertificateData` instance, and compares it to the existing certs. If the cert is not found, it gets copied to one of the available slot in the set. If the set has no available slot, the function will return error.

#### Testing
Added a new unit test `TestChipCert_LoadDuplicateCerts` to test this behavior.
The rest of `TestChipCert` test suite ensures no existing functionality is broken.