### PR TITLE
Switch from "dummy" to "default" toolchain

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -32,7 +32,7 @@ import("${chip_root}/build/chip/tools.gni")
 
 import("//src/crypto/crypto.gni")
 
-if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
+if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   declare_args() {
     chip_enable_python_modules =
         (current_os == "mac" || current_os == "linux") &&

--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -62,7 +62,7 @@ if (_chip_defaults.custom_toolchain != "") {
 } else if (target_os == host_os) {
   _default_toolchain = host_toolchain
 } else if (target_os == "all") {
-  _default_toolchain = "${_pigweed_overrides.dir_pw_toolchain}/dummy"
+  _default_toolchain = "${_pigweed_overrides.dir_pw_toolchain}/default"
 } else if (target_os == "freertos") {
   if (target_cpu == "arm") {
     _default_toolchain = "${_build_overrides.build_root}/toolchain/arm_gcc"


### PR DESCRIPTION
Switch from "dummy" to "default" toolchain

#### Problem
The "dummy" toolchain is being removed from Pigweed (https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/46924). See also https://crbug.com/pigweed/386 and https://source.android.com/setup/contribute/respectful-code. Not updating Pigweed now but the next update of Pigweed will require this change.

#### Change overview
Remove the "dummy" toolchain.

#### Testing
* Built but without additional testing. This change should have failed during build if it was going to fail.