### PR TITLE
[python] Add flag to disable BLE for controller

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -39,6 +39,7 @@ import textwrap
 import time
 import string
 import re
+import traceback
 from cmd import Cmd
 from chip.ChipBleUtility import FAKE_CONN_OBJ_VALUE
 from chip.setup_payload import SetupPayload
@@ -151,8 +152,13 @@ class DeviceMgrCmd(Cmd):
 
         # If we are on Linux and user selects non-default bluetooth adapter.
         if sys.platform.startswith("linux") and (bluetoothAdapter is not None):
-            self.bleMgr = BleManager(self.devCtrl)
-            self.bleMgr.ble_adapter_select("hci{}".format(bluetoothAdapter))
+            try:
+                self.bleMgr = BleManager(self.devCtrl)
+                self.bleMgr.ble_adapter_select("hci{}".format(bluetoothAdapter))
+            except Exception as ex:
+                traceback.print_exc()
+                print("Failed to initialize BLE, if you don't have BLE, run chip-device-ctrl with --no-ble")
+                raise ex
 
         self.historyFileName = os.path.expanduser(
             "~/.chip-device-ctrl-history")
@@ -743,8 +749,14 @@ def main():
             dest="bluetoothAdapter",
             default="hci0",
             type="str",
-            help="Controller bluetooth adapter ID",
+            help="Controller bluetooth adapter ID, use --no-ble to disable bluetooth functions.",
             metavar="<bluetooth-adapter>",
+        )
+        optParser.add_option(
+            "--no-ble",
+            action="store_true",
+            dest="disableBluetooth",
+            help="Disable bluetooth, calling BLE related feature with this flag results in undefined behavior.",
         )
     (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
 
@@ -754,7 +766,9 @@ def main():
 
     adapterId = None
     if sys.platform.startswith("linux"):
-        if not options.bluetoothAdapter.startswith("hci"):
+        if options.disableBluetooth:
+            adapterId = None
+        elif not options.bluetoothAdapter.startswith("hci"):
             print(
                 "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
             sys.exit(-1)
@@ -766,8 +780,14 @@ def main():
                     "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
                 sys.exit(-1)
 
-    devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr,
-                             controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
+    try:
+        devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr,
+                                 controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
+    except Exception as ex:
+        print(ex)
+        print("Failed to bringup CHIPDeviceController CLI")
+        sys.exit(1)
+
     print("Chip Device Controller Shell")
     if options.rendezvousAddr:
         print("Rendezvous address set to %s" % options.rendezvousAddr)


### PR DESCRIPTION
#### Problem

Sometimes, we may run chip-device-ctrl on devices that does not support BLE, in this case, it will crash.

#### Change overview

Add a `--no-ble` flag so the user can choose not to bringup bluetooth.

#### Testing

- Tested using Docker, which does not have bluez and bluetooth interface.
