### PR TITLE
Commissioner Discovery based on DNS-SD using ChipTool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -25,6 +25,7 @@ executable("chip-tool") {
     "commands/common/Command.cpp",
     "commands/common/Commands.cpp",
     "commands/discover/DiscoverCommand.cpp",
+    "commands/discover/DiscoverCommissionersCommand.cpp",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "DiscoverCommand.h"
+#include "DiscoverCommissionersCommand.h"
 #include <controller/DeviceAddressUpdateDelegate.h>
 #include <mdns/Resolver.h>
 
@@ -54,7 +55,7 @@ public:
         ChipLogProgress(chipTool, "NodeId Resolution: failed!");
         SetCommandExitStatus(false);
     }
-    void OnCommissionableNodeFound(const chip::Mdns::CommissionableNodeData & nodeData) override {}
+    void OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData) override {}
 };
 
 class Update : public DiscoverCommand
@@ -94,6 +95,7 @@ void registerCommandsDiscover(Commands & commands)
     commands_list clusterCommands = {
         make_unique<Resolve>(),
         make_unique<Update>(),
+        make_unique<DiscoverCommissionersCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -1,0 +1,91 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "DiscoverCommissionersCommand.h"
+#include <arpa/inet.h>
+
+using namespace ::chip;
+
+constexpr uint16_t kWaitDurationInSeconds = 3;
+
+CHIP_ERROR DiscoverCommissionersCommand::Run(NodeId localId, NodeId remoteId)
+{
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
+    UpdateWaitForResponse(true);
+
+    {
+        chip::DeviceLayer::StackLock lock;
+
+        ReturnErrorOnFailure(mCommissionableNodeController.DiscoverCommissioners());
+    }
+
+    WaitForResponse(kWaitDurationInSeconds);
+
+    int commissionerCount = 0;
+    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
+    {
+        const Mdns::DiscoveredNodeData * commissioner = mCommissionableNodeController.GetDiscoveredCommissioner(i);
+        if (commissioner != nullptr)
+        {
+            printf("Discovered Commisioner #%d\n", ++commissionerCount);
+            if (strcmp(commissioner->deviceName, "") != 0)
+            {
+                printf("Device Name: %s\n", commissioner->deviceName);
+            }
+            if (commissioner->vendorId > 0)
+            {
+                printf("Vendor ID: %d\n", commissioner->vendorId);
+            }
+            if (commissioner->productId > 0)
+            {
+                printf("Product ID: %d\n", commissioner->productId);
+            }
+            if (commissioner->deviceType > 0)
+            {
+                printf("Device Type: %d\n", commissioner->deviceType);
+            }
+            if (commissioner->longDiscriminator > 0)
+            {
+                printf("Long Discriminator: %d\n", commissioner->longDiscriminator);
+            }
+            if (!commissioner->IsHost(""))
+            {
+                printf("Hostname: %s\n", commissioner->hostName);
+            }
+            if (commissioner->numIPs > 0)
+            {
+                printf("Number of IP addresses: %d. IP Adddress(es): ", commissioner->numIPs);
+                for (int j = 0; j < commissioner->numIPs; j++)
+                {
+                    char ipAddress[Inet::kMaxIPAddressStringLength];
+                    printf("%s, ", commissioner->ipAddress[j].ToString(ipAddress, sizeof(ipAddress)));
+                }
+                printf("\n");
+            }
+
+            printf("\n");
+        }
+    }
+
+    printf("Total of %d commissioner(s) discovered in %d sec\n", commissionerCount, kWaitDurationInSeconds);
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
@@ -1,0 +1,32 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/Command.h"
+#include <controller/CHIPCommissionableNodeController.h>
+
+class DiscoverCommissionersCommand : public Command
+{
+public:
+    DiscoverCommissionersCommand() : Command("discover-commissioners") {}
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+
+private:
+    chip::Controller::CommissionableNodeController mCommissionableNodeController;
+};

--- a/src/controller/AbstractMdnsDiscoveryController.cpp
+++ b/src/controller/AbstractMdnsDiscoveryController.cpp
@@ -1,0 +1,92 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module header, comes first
+#include <controller/AbstractMdnsDiscoveryController.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
+#include <core/CHIPEncoding.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace Controller {
+
+void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData)
+{
+    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
+    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    {
+        if (!mDiscoveredNodes[i].IsValid())
+        {
+            continue;
+        }
+        if (strcmp(mDiscoveredNodes[i].hostName, nodeData.hostName) == 0)
+        {
+            mDiscoveredNodes[i] = nodeData;
+            return;
+        }
+    }
+    // Node not yet in the list
+    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    {
+        if (!mDiscoveredNodes[i].IsValid())
+        {
+            mDiscoveredNodes[i] = nodeData;
+            return;
+        }
+    }
+    ChipLogError(Discovery, "Failed to add discovered node with hostname %s- Insufficient space", nodeData.hostName);
+}
+
+CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscovery()
+{
+    chip::Mdns::Resolver::Instance().SetResolverDelegate(this);
+#if CONFIG_DEVICE_LAYER
+    ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().StartResolver(&DeviceLayer::InetLayer, kMdnsPort));
+#endif
+
+    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
+    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    {
+        mDiscoveredNodes[i].Reset();
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscoveryLongDiscriminator(uint16_t long_discriminator)
+{
+    filter = Mdns::DiscoveryFilter(Mdns::DiscoveryFilterType::kLong, long_discriminator);
+    return SetUpNodeDiscovery();
+}
+
+const Mdns::DiscoveredNodeData * AbstractMdnsDiscoveryController::GetDiscoveredNode(int idx)
+{
+    // TODO(cecille): Add assertion about main loop.
+    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
+    if (mDiscoveredNodes[idx].IsValid())
+    {
+        return &mDiscoveredNodes[idx];
+    }
+    return nullptr;
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/AbstractMdnsDiscoveryController.h
+++ b/src/controller/AbstractMdnsDiscoveryController.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <mdns/Resolver.h>
+#include <platform/CHIPDeviceConfig.h>
+
+namespace chip {
+
+namespace Controller {
+
+constexpr uint16_t kMdnsPort = 5353;
+
+/**
+ * @brief
+ *   Convenient superclass for controller implementations that need to discover
+ *   Commissioners or CommissionableNodes using mDNS. This Abstract class
+ *   provides base implementations for logic to setup mDNS discovery requests,
+ *   handling of received DiscoveredNodeData, etc. while expecting child classes
+ *   to maintain a list of DiscoveredNodes and providing the implementation
+ *   of the template GetDiscoveredNodes() function.
+ */
+class DLL_EXPORT AbstractMdnsDiscoveryController : public Mdns::ResolverDelegate
+{
+public:
+    AbstractMdnsDiscoveryController(){};
+    virtual ~AbstractMdnsDiscoveryController() {}
+
+    void OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData) override;
+
+protected:
+    CHIP_ERROR SetUpNodeDiscovery();
+    CHIP_ERROR SetUpNodeDiscoveryLongDiscriminator(uint16_t long_discriminator);
+    const Mdns::DiscoveredNodeData * GetDiscoveredNode(int idx);
+    virtual Mdns::DiscoveredNodeData * GetDiscoveredNodes() = 0;
+
+    Mdns::DiscoveryFilter filter;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -19,8 +19,10 @@ static_library("controller") {
 
   sources = [
     "${chip_root}/src/app/util/CHIPDeviceCallbacksMgr.cpp",
+    "AbstractMdnsDiscoveryController.cpp",
     "CHIPCluster.cpp",
     "CHIPCluster.h",
+    "CHIPCommissionableNodeController.cpp",
     "CHIPDevice.cpp",
     "CHIPDevice.h",
     "CHIPDeviceController.cpp",

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module header, comes first
+#include <controller/CHIPCommissionableNodeController.h>
+
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace Controller {
+
+CHIP_ERROR CommissionableNodeController::DiscoverCommissioners()
+{
+    ReturnErrorOnFailure(SetUpNodeDiscovery());
+    return chip::Mdns::Resolver::Instance().FindCommissioners();
+}
+
+CHIP_ERROR CommissionableNodeController::DiscoverCommissionersLongDiscriminator(uint16_t long_discriminator)
+{
+    ReturnErrorOnFailure(SetUpNodeDiscoveryLongDiscriminator(long_discriminator));
+    return chip::Mdns::Resolver::Instance().FindCommissioners(filter);
+}
+
+const Mdns::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)
+{
+    return GetDiscoveredNode(idx);
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <controller/AbstractMdnsDiscoveryController.h>
+#include <mdns/Resolver.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+
+namespace Controller {
+
+/**
+ *    @brief
+ *      CHIPCommissionableNodeController is a Controller class that
+ *      centralizes (acts as facade) discovery of commissioners, sending User
+ *      Directed Commissioning requests, Commissionable Node advertisement and
+ *      Commissioning of the node
+ */
+class DLL_EXPORT CommissionableNodeController : public AbstractMdnsDiscoveryController
+{
+public:
+    CommissionableNodeController(){};
+    virtual ~CommissionableNodeController() {}
+
+    CHIP_ERROR DiscoverCommissionersLongDiscriminator(uint16_t long_discriminator);
+
+    CHIP_ERROR DiscoverCommissioners();
+
+    const Mdns::DiscoveredNodeData * GetDiscoveredCommissioner(int idx);
+
+    void OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData) override
+    {
+        ChipLogError(Controller, "Unsupported operation CommissionableNodeController::OnNodeIdResolved");
+    }
+
+    void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
+    {
+        ChipLogError(Controller, "Unsupported operation CommissionableNodeController::OnNodeIdResolutionFailed");
+    }
+
+protected:
+    Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mDiscoveredCommissioners; }
+
+private:
+    Mdns::DiscoveredNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -94,10 +94,6 @@ namespace Controller {
 
 using namespace chip::Encoding;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-constexpr uint16_t kMdnsPort = 5353;
-#endif
-
 constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondPerSecond;
 
 constexpr uint32_t kMaxCHIPOpCertLength = 1024;
@@ -746,32 +742,6 @@ void DeviceController::OnNodeIdResolutionFailed(const chip::PeerId & peer, CHIP_
         mDeviceAddressUpdateDelegate->OnAddressUpdateComplete(peer.GetNodeId(), error);
     }
 };
-
-void DeviceController::OnCommissionableNodeFound(const chip::Mdns::CommissionableNodeData & nodeData)
-{
-    for (int i = 0; i < kMaxCommissionableNodes; ++i)
-    {
-        if (!mCommissionableNodes[i].IsValid())
-        {
-            continue;
-        }
-        if (strcmp(mCommissionableNodes[i].hostName, nodeData.hostName) == 0)
-        {
-            mCommissionableNodes[i] = nodeData;
-            return;
-        }
-    }
-    // Didn't find the host name already in our list, return an invalid
-    for (int i = 0; i < kMaxCommissionableNodes; ++i)
-    {
-        if (!mCommissionableNodes[i].IsValid())
-        {
-            mCommissionableNodes[i] = nodeData;
-            return;
-        }
-    }
-    ChipLogError(Discovery, "Failed to add discovered commissionable node with hostname %s- Insufficient space", nodeData.hostName);
-}
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
@@ -1435,32 +1405,27 @@ void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * a
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 CHIP_ERROR DeviceCommissioner::DiscoverAllCommissioning()
 {
-    for (int i = 0; i < kMaxCommissionableNodes; ++i)
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if ((err = SetUpNodeDiscovery()) == CHIP_NO_ERROR)
     {
-        mCommissionableNodes[i].Reset();
+        return chip::Mdns::Resolver::Instance().FindCommissionableNodes();
     }
-    return Mdns::Resolver::Instance().FindCommissionableNodes();
+    return err;
 }
 
 CHIP_ERROR DeviceCommissioner::DiscoverCommissioningLongDiscriminator(uint16_t long_discriminator)
 {
-    // TODO(cecille): Add assertion about main loop.
-    for (int i = 0; i < kMaxCommissionableNodes; ++i)
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if ((err = SetUpNodeDiscoveryLongDiscriminator(long_discriminator)) == CHIP_NO_ERROR)
     {
-        mCommissionableNodes[i].Reset();
+        return chip::Mdns::Resolver::Instance().FindCommissionableNodes(filter);
     }
-    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kLong, long_discriminator);
-    return Mdns::Resolver::Instance().FindCommissionableNodes(filter);
+    return err;
 }
 
-const Mdns::CommissionableNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)
+const Mdns::DiscoveredNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)
 {
-    // TODO(cecille): Add assertion about main loop.
-    if (mCommissionableNodes[idx].IsValid())
-    {
-        return &mCommissionableNodes[idx];
-    }
-    return nullptr;
+    return GetDiscoveredNode(idx);
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <app/InteractionModelDelegate.h>
+#include <controller/AbstractMdnsDiscoveryController.h>
 #include <controller/CHIPDevice.h>
 #include <controller/OperationalCredentialsDelegate.h>
 #include <controller/data_model/gen/CHIPClientCallbacks.h>
@@ -180,7 +181,7 @@ public:
 class DLL_EXPORT DeviceController : public Messaging::ExchangeDelegate,
                                     public Messaging::ExchangeMgrDelegate,
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-                                    public Mdns::ResolverDelegate,
+                                    public AbstractMdnsDiscoveryController,
 #endif
                                     public app::InteractionModelDelegate
 {
@@ -304,7 +305,7 @@ protected:
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.
     static constexpr int kMaxCommissionableNodes = 10;
-    Mdns::CommissionableNodeData mCommissionableNodes[kMaxCommissionableNodes];
+    Mdns::DiscoveredNodeData mCommissionableNodes[kMaxCommissionableNodes];
 #endif
     Inet::InetLayer * mInetLayer = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
@@ -339,7 +340,7 @@ protected:
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData) override;
     void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
-    void OnCommissionableNodeFound(const chip::Mdns::CommissionableNodeData & nodeData) override;
+    Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mCommissionableNodes; }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
 private:
@@ -484,9 +485,9 @@ public:
      * @brief
      *   Returns information about discovered devices.
      *   Should be called on main loop thread.
-     * @return const CommissionableNodeData* info about the selected device. May be nullptr if no information has been returned yet.
+     * @return const DiscoveredNodeData* info about the selected device. May be nullptr if no information has been returned yet.
      */
-    const Mdns::CommissionableNodeData * GetDiscoveredDevice(int idx);
+    const Mdns::DiscoveredNodeData * GetDiscoveredDevice(int idx);
 
     /**
      * @brief

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -256,7 +256,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceComm
 {
     for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
     {
-        const chip::Mdns::CommissionableNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        const chip::Mdns::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
         if (dnsSdInfo == nullptr)
         {
             continue;
@@ -288,7 +288,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceComm
 bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len)
 {
-    const chip::Mdns::CommissionableNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
+    const chip::Mdns::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
     if (dnsSdInfo == nullptr)
     {
         return false;

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -66,7 +66,7 @@ public:
         }
     }
 
-    void OnCommissionableNodeFound(const CommissionableNodeData & nodeData) override {}
+    void OnNodeDiscoveryComplete(const DiscoveredNodeData & nodeData) override {}
 
     void SetSuccessCallback(DiscoverSuccessCallback cb) { mSuccessCallback = cb; }
     void SetFailureCallback(DiscoverFailureCallback cb) { mFailureCallback = cb; }

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -633,6 +633,15 @@
 #endif
 
 /**
+ * CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES
+ *
+ * Maximum number of CHIP Commissioners or Commissionable Nodes that can be discovered
+ */
+#ifndef CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES
+#define CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES 10
+#endif
+
+/**
  * CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
  *
  * Enable support to DNS-SD SRP client usage for service advertising and discovery in CHIP.

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -449,7 +449,7 @@ void DiscoveryImplPlatform::HandleCommissionableNodeResolve(void * context, Mdns
         return;
     }
     DiscoveryImplPlatform * mgr = static_cast<DiscoveryImplPlatform *>(context);
-    CommissionableNodeData data;
+    DiscoveredNodeData data;
     Platform::CopyString(data.hostName, result->mHostName);
 
     if (result->mAddress.HasValue())
@@ -463,7 +463,7 @@ void DiscoveryImplPlatform::HandleCommissionableNodeResolve(void * context, Mdns
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, &data);
     }
-    mgr->mResolverDelegate->OnCommissionableNodeFound(data);
+    mgr->mResolverDelegate->OnNodeDiscoveryComplete(data);
 }
 
 CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter)

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -56,6 +56,8 @@ public:
 
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
 
+    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     static DiscoveryImplPlatform & GetInstance();
 
 private:

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -39,7 +39,7 @@ struct ResolvedNodeData
 constexpr size_t kMaxDeviceNameLen         = 32;
 constexpr size_t kMaxRotatingIdLen         = 50;
 constexpr size_t kMaxPairingInstructionLen = 128;
-struct CommissionableNodeData
+struct DiscoveredNodeData
 {
     // TODO(cecille): is 4 OK? IPv6 LL, GUA, ULA, IPv4?
     static constexpr int kMaxIPAddresses = 5;
@@ -80,7 +80,7 @@ struct CommissionableNodeData
             ipAddress[i] = chip::Inet::IPAddress::Any;
         }
     }
-    CommissionableNodeData() { Reset(); }
+    DiscoveredNodeData() { Reset(); }
     bool IsHost(const char * host) const { return strcmp(host, hostName) == 0; }
     bool IsValid() const { return !IsHost("") && ipAddress[0] != chip::Inet::IPAddress::Any; }
 };
@@ -94,6 +94,7 @@ enum class DiscoveryFilterType : uint8_t
     kDeviceType,
     kCommissioningMode,
     kCommissioningModeFromCommand,
+    kCommissioner
 };
 struct DiscoveryFilter
 {
@@ -114,8 +115,8 @@ public:
     /// Called when a CHIP node ID resolution has failed
     virtual void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) = 0;
 
-    // Called when a CHIP Node in commissioning mode is found
-    virtual void OnCommissionableNodeFound(const CommissionableNodeData & nodeData) = 0;
+    // Called when a CHIP Node acting as Commissioner or in commissioning mode is found
+    virtual void OnNodeDiscoveryComplete(const DiscoveredNodeData & nodeData) = 0;
 };
 
 /// Interface for resolving CHIP services
@@ -138,6 +139,9 @@ public:
 
     // Finds all nodes with the given filter that are currently in commissioning mode.
     virtual CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) = 0;
+
+    // Finds all nodes with the given filter that are currently acting as Commissioners.
+    virtual CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
     /// Provides the system-wide implementation of the service resolver
     static Resolver & Instance();

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -44,16 +44,17 @@ enum class DiscoveryType
     kUnknown,
     kOperational,
     kCommissionableNode,
+    kCommissionerNode
 };
 
 class TxtRecordDelegateImpl : public mdns::Minimal::TxtRecordDelegate
 {
 public:
-    TxtRecordDelegateImpl(CommissionableNodeData * nodeData) : mNodeData(nodeData) {}
+    TxtRecordDelegateImpl(DiscoveredNodeData * nodeData) : mNodeData(nodeData) {}
     void OnRecord(const mdns::Minimal::BytesRange & name, const mdns::Minimal::BytesRange & value);
 
 private:
-    CommissionableNodeData * mNodeData;
+    DiscoveredNodeData * mNodeData;
 };
 
 const ByteSpan GetSpan(const mdns::Minimal::BytesRange & range)
@@ -101,7 +102,7 @@ private:
     ResolverDelegate * mDelegate = nullptr;
     DiscoveryType mDiscoveryType;
     ResolvedNodeData mNodeData;
-    CommissionableNodeData mCommissionableNodeData;
+    DiscoveredNodeData mDiscoveredNodeData;
     BytesRange mPacketRange;
 
     bool mValid       = false;
@@ -111,7 +112,7 @@ private:
     void OnCommissionableNodeSrvRecord(SerializedQNameIterator name, const SrvRecord & srv);
     void OnOperationalSrvRecord(SerializedQNameIterator name, const SrvRecord & srv);
 
-    void OnCommissionableNodeIPAddress(const chip::Inet::IPAddress & addr);
+    void OnDiscoveredNodeIPAddress(const chip::Inet::IPAddress & addr);
     void OnOperationalIPAddress(const chip::Inet::IPAddress & addr);
 };
 
@@ -164,7 +165,7 @@ void PacketDataReporter::OnCommissionableNodeSrvRecord(SerializedQNameIterator n
     {
         return;
     }
-    strncpy(mCommissionableNodeData.hostName, it.Value(), sizeof(CommissionableNodeData::hostName));
+    strncpy(mDiscoveredNodeData.hostName, it.Value(), sizeof(DiscoveredNodeData::hostName));
 }
 
 void PacketDataReporter::OnOperationalIPAddress(const chip::Inet::IPAddress & addr)
@@ -179,13 +180,13 @@ void PacketDataReporter::OnOperationalIPAddress(const chip::Inet::IPAddress & ad
     mHasIP             = true;
 }
 
-void PacketDataReporter::OnCommissionableNodeIPAddress(const chip::Inet::IPAddress & addr)
+void PacketDataReporter::OnDiscoveredNodeIPAddress(const chip::Inet::IPAddress & addr)
 {
-    if (mCommissionableNodeData.numIPs >= CommissionableNodeData::kMaxIPAddresses)
+    if (mDiscoveredNodeData.numIPs >= DiscoveredNodeData::kMaxIPAddresses)
     {
         return;
     }
-    mCommissionableNodeData.ipAddress[mCommissionableNodeData.numIPs++] = addr;
+    mDiscoveredNodeData.ipAddress[mDiscoveredNodeData.numIPs++] = addr;
 }
 
 bool HasQNamePart(SerializedQNameIterator qname, QNamePart part)
@@ -233,9 +234,9 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
                 mValid = false;
             }
         }
-        else if (mDiscoveryType == DiscoveryType::kCommissionableNode)
+        else if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
         {
-            if (HasQNamePart(data.GetName(), kCommissionableServiceName))
+            if (HasQNamePart(data.GetName(), kCommissionableServiceName) || HasQNamePart(data.GetName(), kCommissionerServiceName))
             {
                 OnCommissionableNodeSrvRecord(data.GetName(), srv);
             }
@@ -247,9 +248,9 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
         break;
     }
     case QType::TXT:
-        if (mDiscoveryType == DiscoveryType::kCommissionableNode)
+        if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
         {
-            TxtRecordDelegateImpl textRecordDelegate(&mCommissionableNodeData);
+            TxtRecordDelegateImpl textRecordDelegate(&mDiscoveredNodeData);
             ParseTxtRecord(data.GetData(), &textRecordDelegate);
         }
         break;
@@ -266,9 +267,9 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
             {
                 OnOperationalIPAddress(addr);
             }
-            else if (mDiscoveryType == DiscoveryType::kCommissionableNode)
+            else if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
             {
-                OnCommissionableNodeIPAddress(addr);
+                OnDiscoveredNodeIPAddress(addr);
             }
         }
         break;
@@ -286,9 +287,9 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
             {
                 OnOperationalIPAddress(addr);
             }
-            else if (mDiscoveryType == DiscoveryType::kCommissionableNode)
+            else if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
             {
-                OnCommissionableNodeIPAddress(addr);
+                OnDiscoveredNodeIPAddress(addr);
             }
         }
         break;
@@ -300,9 +301,10 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
 
 void PacketDataReporter::OnComplete()
 {
-    if (mDiscoveryType == DiscoveryType::kCommissionableNode && mCommissionableNodeData.IsValid())
+    if ((mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode) &&
+        mDiscoveredNodeData.IsValid())
     {
-        mDelegate->OnCommissionableNodeFound(mCommissionableNodeData);
+        mDelegate->OnNodeDiscoveryComplete(mDiscoveredNodeData);
     }
     else if (mDiscoveryType == DiscoveryType::kOperational && mHasIP && mHasNodePort)
     {
@@ -323,6 +325,7 @@ public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
 private:
     ResolverDelegate * mDelegate = nullptr;
@@ -407,6 +410,11 @@ CHIP_ERROR MinMdnsResolver::FindCommissionableNodes(DiscoveryFilter filter)
     return BrowseNodes(DiscoveryType::kCommissionableNode, filter);
 }
 
+CHIP_ERROR MinMdnsResolver::FindCommissioners(DiscoveryFilter filter)
+{
+    return BrowseNodes(DiscoveryType::kCommissionerNode, filter);
+}
+
 // TODO(cecille): Extend filter and use this for Resolve
 CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filter)
 {
@@ -429,6 +437,19 @@ CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filt
             char subtypeStr[kMaxSubtypeDescSize];
             ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), filter));
             qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionableServiceName, kCommissionProtocol,
+                                          kLocalDomain);
+        }
+        break;
+    case DiscoveryType::kCommissionerNode:
+        if (filter.type == DiscoveryFilterType::kNone)
+        {
+            qname = CheckAndAllocateQName(kCommissionerServiceName, kCommissionProtocol, kLocalDomain);
+        }
+        else
+        {
+            char subtypeStr[kMaxSubtypeDescSize];
+            ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), filter));
+            qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionerServiceName, kCommissionProtocol,
                                           kLocalDomain);
         }
         break;

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -36,6 +36,7 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 };
 
 NoneResolver gResolver;

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -157,6 +157,13 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         }
         requiredSize = snprintf(buffer, bufferLen, "_C%u", subtype.code);
         break;
+    case DiscoveryFilterType::kCommissioner:
+        if (subtype.code > 1)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        requiredSize = snprintf(buffer, bufferLen, "_D%u", subtype.code);
+        break;
     case DiscoveryFilterType::kCommissioningModeFromCommand:
         // 1 is the only valid value
         if (subtype.code != 1)

--- a/src/lib/mdns/TxtFields.cpp
+++ b/src/lib/mdns/TxtFields.cpp
@@ -206,7 +206,7 @@ TxtFieldKey GetTxtFieldKey(const ByteSpan & key)
 
 } // namespace Internal
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionableNodeData * nodeData)
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DiscoveredNodeData * nodeData)
 {
     Internal::TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
     switch (keyType)

--- a/src/lib/mdns/TxtFields.h
+++ b/src/lib/mdns/TxtFields.h
@@ -61,7 +61,7 @@ void GetPairingInstruction(const ByteSpan & value, char * pairingInstruction);
 } // namespace Internal
 #endif
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommissionableNodeData * nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DiscoveredNodeData * nodeData);
 
 } // namespace Mdns
 } // namespace chip

--- a/src/lib/mdns/tests/TestTxtFields.cpp
+++ b/src/lib/mdns/tests/TestTxtFields.cpp
@@ -279,7 +279,7 @@ void TestGetPairingInstruction(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, strcmp(ret, data) == 0);
 }
 
-bool NodeDataIsEmpty(const CommissionableNodeData & node)
+bool NodeDataIsEmpty(const DiscoveredNodeData & node)
 {
 
     if (node.longDiscriminator != 0 || node.vendorId != 0 || node.productId != 0 || node.additionalPairing != 0 ||
@@ -291,7 +291,7 @@ bool NodeDataIsEmpty(const CommissionableNodeData & node)
     {
         return false;
     }
-    for (size_t i = 0; i < sizeof(CommissionableNodeData::rotatingId); ++i)
+    for (size_t i = 0; i < sizeof(DiscoveredNodeData::rotatingId); ++i)
     {
         if (node.rotatingId[i] != 0)
         {
@@ -306,7 +306,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
 {
     char key[3];
     char val[16];
-    CommissionableNodeData filled;
+    DiscoveredNodeData filled;
 
     // Long discriminator
     sprintf(key, "D");


### PR DESCRIPTION
#### Problem
1. [Commissioner Discovery](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/secure_channel/Discovery.adoc#3-commissioner-discovery) was unimplemented. _[Final goal is to implement the following flow end-to-end, which can be used in TV casting applications (amongst other uses): [commissioner discovery from an on network device](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/rendezvous/InitiatingSetup.adoc#24-commissioner-discovery-from-an-on-network-device), so more PRs will follow to complete the flow using new CHIPTool commands]_
2. This PR also has a refactor of **pre-existing** code. Significant parts of the CommissionableNode discovery logic was reusable for Commissioner Discovery, but the  abstraction inhibited easy leverage of the code for Commissioner Discovery without copying it. This change re-organizes the implementation to make reuse with little-to-no copying easier. The refactor was posted as a [supporting refactor PR](https://github.com/sharadb-amazon/connectedhomeip/pull/1) as well, to distinguish it from the main Commissioner discovery change described above.

#### Change overview
* A new command called "discover-commissioners" is introduced under "casting" which is a new command group in the ChipTool (cpp). The command calls into a new CHIPCommissionableNodeController to actually initiate discovery of commissioners, or listen to replies. In the future, this class will be also used as a facade to centralize other actions a CommissionableNode wants to perform like AdvertiseCommissionableNode() or SendUserDirectedCommissioningRequest(), etc.
* The refactor increases code reusability by pulling common code into a super class AbstractMdnsDiscoveryController and renaming struct CommissionableNodeData (to DiscoveredNodeData) and function OnCommissionableNodeFound() (to OnNodeDiscoveryComplete()). More details on the refactor are posted in the [supporting refactor PR](https://github.com/sharadb-amazon/connectedhomeip/pull/1)

#### Testing
Testing done by manually running the newly introduced discover-commissioners command in the chip-tool against the chip-tv-app (which advertises itself as a Commissioner). See below for output from the chip-tool as it successfully discovers commissioners:

> $ ./chip-tool discover discover-commissioners
[1623803498.280299][35198] CHIP:IN: TransportMgr initialized
[1623803498.280346][35198] CHIP:DIS: Init admin pairing table with server storage
[1623803498.280459][35198] CHIP:IN: Loading certs from KVS
[1623803498.280497][35198] CHIP:IN: local node id is 0x000000000001B669
[1623803498.280868][35198] CHIP:ZCL: Using ZAP configuration...
[1623803498.280929][35198] CHIP:ZCL: deactivate report event
[1623803498.280944][35198] CHIP:CTL: Getting operational keys
[1623803498.280955][35198] CHIP:CTL: Generating credentials
[1623803498.281312][35198] CHIP:CTL: Loaded credentials successfully
[1623803498.281575][35203] CHIP:DL: CHIP task running
[1623803498.282161][35198] CHIP:DIS: mDNS broadcast success
[1623803498.293129][35198] CHIP:DIS: mDNS broadcast success
[1623803498.293316][35198] CHIP:DIS: mDNS broadcast success
[1623803498.293513][35198] CHIP:DIS: mDNS broadcast success
[1623803498.294102][35198] CHIP:DIS: mDNS broadcast success
[1623803498.294254][35198] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2101 (0x00000835): Network is unreachable
[1623803501.297280][35198] CHIP:TOO: No response from device
Discovered Commisioner #1
Device Name: Test TV
Vendor ID: 9050
Product ID: 65279
Device Type: 35
Hostname: 025000000001
Number of IP addresses: 4. IP Adddress(es): fe80::50:ff:fe00:1, 192.168.65.3, fe80::50:ff:fe00:1, 192.168.65.3, 

>Total of 1 commissioner(s) discovered in 3 sec
[1623803501.298388][35198] CHIP:CTL: Shutting down the commissioner
[1623803501.298441][35198] CHIP:CTL: Shutting down the controller
[1623803501.298488][35198] CHIP:DL: Inet Layer shutdown
[1623803501.298589][35198] CHIP:DL: BLE layer shutdown
[1623803501.298635][35198] CHIP:DL: System Layer shutdown