### PR TITLE
Allow post event from any thread to CHIP main event loop.

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartChipTimer(int64_t 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_PostEvent(const ChipDeviceEvent * event)
 {
-    mChipEventQueue.Push(event);
+    mChipEventQueue.Push(*event);
     SysOnEventSignal(this); // Trigger wake select on CHIP thread
 }
 
@@ -156,8 +156,8 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::ProcessDeviceEvents()
 {
     while (!mChipEventQueue.Empty())
     {
-        Impl()->DispatchEvent(mChipEventQueue.Front());
-        mChipEventQueue.Pop();
+        const ChipDeviceEvent event = mChipEventQueue.PopFront();
+        Impl()->DispatchEvent(&event);
     }
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -147,22 +147,17 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartChipTimer(int64_t 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_PostEvent(const ChipDeviceEvent * event)
 {
-    // Critical section
-    {
-        std::unique_lock<std::mutex> lock(mEventQueueLock);
-        mChipEventQueue.push(*event);
-    }
+    mChipEventQueue.Push(event);
     SysOnEventSignal(this); // Trigger wake select on CHIP thread
 }
 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::ProcessDeviceEvents()
 {
-    std::unique_lock<std::mutex> lock(mEventQueueLock);
-    while (!mChipEventQueue.empty())
+    while (!mChipEventQueue.Empty())
     {
-        Impl()->DispatchEvent(&mChipEventQueue.front());
-        mChipEventQueue.pop();
+        Impl()->DispatchEvent(mChipEventQueue.Front());
+        mChipEventQueue.Pop();
     }
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -67,8 +67,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     CHIP_ERROR err = CHIP_NO_ERROR;
     int ret        = 0;
 
-    mChipStackLock  = PTHREAD_MUTEX_INITIALIZER;
-    mEventQueueLock = PTHREAD_MUTEX_INITIALIZER;
+    mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
 
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
@@ -148,36 +147,23 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartChipTimer(int64_t 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_PostEvent(const ChipDeviceEvent * event)
 {
-    LockEventQueue();
-    mChipEventQueue.push(*event); // Thread safe due to ChipStackLock taken by App thread
-    SysOnEventSignal(this);       // Trigger wake select on CHIP thread
-    UnlockEventQueue();
+    // Critical section
+    {
+        std::unique_lock<std::mutex> lock(mEventQueueLock);
+        mChipEventQueue.push(*event);
+    }
+    SysOnEventSignal(this); // Trigger wake select on CHIP thread
 }
 
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::ProcessDeviceEvents()
 {
-    LockEventQueue();
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
     while (!mChipEventQueue.empty())
     {
         Impl()->DispatchEvent(&mChipEventQueue.front());
         mChipEventQueue.pop();
     }
-    UnlockEventQueue();
-}
-
-template <class ImplClass>
-void GenericPlatformManagerImpl_POSIX<ImplClass>::LockEventQueue()
-{
-    int err = pthread_mutex_lock(&mEventQueueLock);
-    assert(err == 0);
-}
-
-template <class ImplClass>
-void GenericPlatformManagerImpl_POSIX<ImplClass>::UnlockEventQueue()
-{
-    int err = pthread_mutex_unlock(&mEventQueueLock);
-    assert(err == 0);
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <mutex>
 #include <pthread.h>
 #include <queue>
 
@@ -61,7 +62,6 @@ protected:
 
     // OS-specific members (pthread)
     pthread_mutex_t mChipStackLock;
-    pthread_mutex_t mEventQueueLock;
     std::queue<ChipDeviceEvent> mChipEventQueue;
 
     enum TaskType
@@ -118,12 +118,11 @@ private:
 
     void SysUpdate();
     void SysProcess();
-    void LockEventQueue();
-    void UnlockEventQueue();
     static void SysOnEventSignal(void * arg);
 
     void ProcessDeviceEvents();
 
+    std::mutex mEventQueueLock;
     std::atomic<bool> mShouldRunEventLoop;
     static void * EventLoopTaskMain(void * arg);
 };

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -62,7 +62,6 @@ protected:
 
     // OS-specific members (pthread)
     pthread_mutex_t mChipStackLock;
-    std::queue<ChipDeviceEvent> mChipEventQueue;
 
     enum TaskType
     {

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -61,6 +61,7 @@ protected:
 
     // OS-specific members (pthread)
     pthread_mutex_t mChipStackLock;
+    pthread_mutex_t mEventQueueLock;
     std::queue<ChipDeviceEvent> mChipEventQueue;
 
     enum TaskType
@@ -117,6 +118,8 @@ private:
 
     void SysUpdate();
     void SysProcess();
+    void LockEventQueue();
+    void UnlockEventQueue();
     static void SysOnEventSignal(void * arg);
 
     void ProcessDeviceEvents();

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <platform/DeviceSafeQueue.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
 #include <fcntl.h>
@@ -33,7 +34,6 @@
 #include <unistd.h>
 
 #include <atomic>
-#include <mutex>
 #include <pthread.h>
 #include <queue>
 
@@ -122,7 +122,7 @@ private:
 
     void ProcessDeviceEvents();
 
-    std::mutex mEventQueueLock;
+    DeviceSafeQueue mChipEventQueue;
     std::atomic<bool> mShouldRunEventLoop;
     static void * EventLoopTaskMain(void * arg);
 };

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -350,6 +350,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "Darwin/PosixConfig.cpp",
         "Darwin/PosixConfig.h",
         "Darwin/SystemPlatformConfig.h",
+        "DeviceSafeQueue.cpp",
+        "DeviceSafeQueue.h",
       ]
 
       if (chip_enable_ble) {
@@ -487,6 +489,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       public_deps += [ "${chip_root}/src/crypto" ]
     } else if (chip_device_platform == "linux") {
       sources += [
+        "DeviceSafeQueue.cpp",
+        "DeviceSafeQueue.h",
         "Linux/BLEManagerImpl.cpp",
         "Linux/BLEManagerImpl.h",
         "Linux/BlePlatformConfig.h",

--- a/src/platform/DeviceSafeQueue.cpp
+++ b/src/platform/DeviceSafeQueue.cpp
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the CHIP device event queue which operates in a FIFO context (first-in first-out),
+ *      and provides a specific set of member functions to access its elements wth thread safety.
+ */
+
+#include <platform/DeviceSafeQueue.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+void DeviceSafeQueue::Push(const ChipDeviceEvent * event)
+{
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
+    mEventQueue.push(*event);
+}
+
+void DeviceSafeQueue::Pop()
+{
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
+    mEventQueue.pop();
+}
+
+bool DeviceSafeQueue::Empty()
+{
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
+    return mEventQueue.empty();
+}
+
+const ChipDeviceEvent * DeviceSafeQueue::Front()
+{
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
+    return mEventQueue.empty() ? nullptr : &mEventQueue.front();
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/DeviceSafeQueue.cpp
+++ b/src/platform/DeviceSafeQueue.cpp
@@ -28,16 +28,10 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-void DeviceSafeQueue::Push(const ChipDeviceEvent * event)
+void DeviceSafeQueue::Push(const ChipDeviceEvent & event)
 {
     std::unique_lock<std::mutex> lock(mEventQueueLock);
-    mEventQueue.push(*event);
-}
-
-void DeviceSafeQueue::Pop()
-{
-    std::unique_lock<std::mutex> lock(mEventQueueLock);
-    mEventQueue.pop();
+    mEventQueue.push(event);
 }
 
 bool DeviceSafeQueue::Empty()
@@ -46,10 +40,14 @@ bool DeviceSafeQueue::Empty()
     return mEventQueue.empty();
 }
 
-const ChipDeviceEvent * DeviceSafeQueue::Front()
+const ChipDeviceEvent DeviceSafeQueue::PopFront()
 {
     std::unique_lock<std::mutex> lock(mEventQueueLock);
-    return mEventQueue.empty() ? nullptr : &mEventQueue.front();
+
+    const ChipDeviceEvent event = mEventQueue.front();
+    mEventQueue.pop();
+
+    return event;
 }
 
 } // namespace Internal

--- a/src/platform/DeviceSafeQueue.h
+++ b/src/platform/DeviceSafeQueue.h
@@ -50,10 +50,9 @@ public:
     DeviceSafeQueue()  = default;
     ~DeviceSafeQueue() = default;
 
-    void Push(const ChipDeviceEvent * event);
-    void Pop();
+    void Push(const ChipDeviceEvent & event);
     bool Empty();
-    const ChipDeviceEvent * Front();
+    const ChipDeviceEvent PopFront();
 
 private:
     std::queue<ChipDeviceEvent> mEventQueue;

--- a/src/platform/DeviceSafeQueue.h
+++ b/src/platform/DeviceSafeQueue.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares the CHIP device event queue which operates in a FIFO context (first-in first-out),
+ *      and provides a specific set of member functions to access its elements wth thread safety.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <queue>
+
+#include <core/CHIPCore.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <platform/CHIPDeviceEvent.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *  @class DeviceSafeQueue
+ *
+ *  @brief
+ *      This class represents a thread-safe message queue implemented with C++ Standard Library, the message queue
+ *      is used by the CHIP event loop to hold incoming messages. Each message is sequentially dequeued, decoded,
+ *      and then an action is performed.
+ *
+ */
+class DeviceSafeQueue
+{
+public:
+    DeviceSafeQueue()  = default;
+    ~DeviceSafeQueue() = default;
+
+    void Push(const ChipDeviceEvent * event);
+    void Pop();
+    bool Empty();
+    const ChipDeviceEvent * Front();
+
+private:
+    std::queue<ChipDeviceEvent> mEventQueue;
+    std::mutex mEventQueueLock;
+
+    DeviceSafeQueue(const DeviceSafeQueue &) = delete;
+    DeviceSafeQueue & operator=(const DeviceSafeQueue &) = delete;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -107,9 +107,7 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                         ChipLogDetail(DeviceLayer, "Got IP address on interface: %s IP: %s", name,
                                       event.InternetConnectivityChange.address);
 
-                        PlatformMgr().LockChipStack();
                         PlatformMgr().PostEvent(&event);
-                        PlatformMgr().UnlockChipStack();
                     }
                     routeInfo = RTA_NEXT(routeInfo, rtl);
                 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
Currently, we use C++ Standard Library to implement the Message Queue on POSIX platform,  this queue is not thread-safe. 

Right now, we need to take big CHIP lock to prevent chip from event processing before we post an event to CHIP Message Queue 

```
PlatformMgr().LockChipStack();                        
PlatformMgr().PostEvent(&amp;event);                        
PlatformMgr().UnlockChipStack();
```

This design prevent us from posting events from threads which already taken CHIP lock to CHIP main event loop. we should make the queue thread-safe and should not need locks when posting to this queue.

#### Change overview
Protect CHIP Message Queue with a dedicated lock to make it thread-safe on POSIX platforms.

#### Testing
How was this tested? (at least one bullet point required)
Run ./chip-im-responder on the server device
Run ./chip-im-initiator [server ip] from the client device
Confirm Read and Invoke interactions works as before via this new mechanism.

Run ./chip-shell on RPi4.
Run command wifi connect ssid psk and confirm the device is connected to the specified ssid.
