### PR TITLE
Fix documentation's broken links

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check broken links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: mlc_config.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
     [the build guide](./BUILDING.md)
 -   Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
-    [the cirque test guide](src/test_driver/linux-cirque/README.md)
+    [the cirque test guide](../src/test_driver/linux-cirque/README.md)
 -   Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)

--- a/docs/guides/nxp_k32w_android_commissioning.md
+++ b/docs/guides/nxp_k32w_android_commissioning.md
@@ -3,7 +3,7 @@
 This article describes how to use
 [CHIPTool](../../src/android/CHIPTool/README.md) for Android smartphones to
 commission an NXP K32W061 DK6 running
-[NXP K32W Lock/Light Example Application](../../examples/lock-light-app/k32w/README.md)
+[NXP K32W Lock/Light Example Application](../../examples/lighting-app/k32w/README.md)
 onto a CHIP-enabled Thread network.
 
 <hr>

--- a/docs/guides/nxp_k32w_android_commissioning.md
+++ b/docs/guides/nxp_k32w_android_commissioning.md
@@ -2,8 +2,8 @@
 
 This article describes how to use
 [CHIPTool](../../src/android/CHIPTool/README.md) for Android smartphones to
-commission an NXP K32W061 DK6 running
-[NXP K32W Lock/Light Example Application](../../examples/lighting-app/k32w/README.md)
+commission an NXP K32W061 DK6 running NXP K32W [Light](../../examples/lighting-app/k32w/README.md)
+and [Lock](../../examples/lock-app/k32w/README.md) Example Applications
 onto a CHIP-enabled Thread network.
 
 <hr>

--- a/docs/guides/openthread_rcp_nrf_dongle.md
+++ b/docs/guides/openthread_rcp_nrf_dongle.md
@@ -8,7 +8,7 @@ You can build and program
 (RCP) firmware onto Nordic Semiconductor's
 [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle).
 Once programmed, the dongle can be used for
-[configuring Thread network on a Linux machine](linux_thread_connectivity.md).
+[setup OpenThread Border Router](https://openthread.io/guides/border-router)
 
 ## Building and programming the RCP firmware onto an nRF52840 Dongle
 

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -41,8 +41,8 @@ Silicon Labs platform.
 ## Building
 
 -   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)
+    development environment, and ensure that `commander` is your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -40,8 +40,8 @@ Silicon Labs platform.
 ## Building
 
 -   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)
+    development environment, and ensure that `commander` is your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 

--- a/examples/persistent-storage/efr32/README.md
+++ b/examples/persistent-storage/efr32/README.md
@@ -43,8 +43,8 @@ defines = [
 ### Building
 
 -   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)
+    development environment, and ensure that `commander` is your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 

--- a/examples/pigweed-app/efr32/README.md
+++ b/examples/pigweed-app/efr32/README.md
@@ -38,8 +38,8 @@ following features are available:
     export EFR32_SDK_ROOT=<Path to cloned git repo>
 
 -   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)
+    development environment, and ensure that `commander` is your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 

--- a/examples/window-app/efr32/README.md
+++ b/examples/window-app/efr32/README.md
@@ -43,8 +43,8 @@ Silicon Labs platform.
 ## Building
 
 -   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)
+    development environment, and ensure that `commander` is your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,8 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://ti.com/chip_sdk"
+    }
+  ],
+  "aliveStatusCodes": [200, 206, 0]
+}

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/project-chip/connectedhomeip.git
 
 2. Build the CHIP python package
 
-Follow [BUILDING.md](/docs/BUILDING.md) to setup CHIP on your platform.
+Follow [BUILDING.md](../../../docs/BUILDING.md) to setup CHIP on your platform.
 
 Genrally, once build dependencies are satisfied you can build the `python`
 target.


### PR DESCRIPTION
#### Problem
#7105 enables a GitHub action which validates links on documentation. This tool detected some existing broken links which are affecting the CI results.

#### Change overview
This change configures `markdown-link-check` tool to ignore some false positives and fixes the existing broken links on the documentation.

#### Testing
In order to emulate what the CI does, it's necessary to install [`markdown-link-check` tool](https://www.npmjs.com/package/markdown-link-check) and run the following command:

```bash
find . -name '*.md' -not -path './node_modules/*' -exec markdown-link-check -c mlc_config.json '{}' ';'
```
