### PR TITLE
Put protections against accidental mutation of EncryptedPacketBufferHandle back in.

### DIFF
--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -48,6 +48,11 @@ public:
                            ReliableMessageContext * reliableMessageContext, bool isReliableTransmission, Protocols::Id protocol,
                            uint8_t type, System::PacketBufferHandle && message);
 
+    /**
+     * The 'message' and 'retainedMessage' arguments may point to the same
+     * handle.  Therefore, callees _must_ ensure that any moving out of
+     * 'message' happens before writing to *retainedMessage.
+     */
     virtual CHIP_ERROR ResendMessage(SecureSessionHandle session, EncryptedPacketBufferHandle && message,
                                      EncryptedPacketBufferHandle * retainedMessage) const
     {


### PR DESCRIPTION
This adds an explicit "I will now be resending this, give me access"
method, adds some pass-throughs for non-mutating methods, and makes
the inheritance from SystemPacketBuffer private again.

#### Testing
There should be no observable behavior changes in existing code, so no way to test that specifically.  The idea is to prevent possible future mistakes from compiling.  Unfortunately, we don't have a way to test "this file should not compile" kind of things.