### PR TITLE
Fix relative link path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
     [the build guide](./BUILDING.md)
 -   Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
-    [the cirque test guide](src/test_driver/linux-cirque/README.md)
+    [the cirque test guide](../src/test_driver/linux-cirque/README.md)
 -   Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)


### PR DESCRIPTION
#### Problem
CI on commits is full-red because we now check link paths.

#### Change overview
Add an extra '../' to a reference from docs/Readme.md into src

#### Testing
Text  file modification only, checked that path looks ok. Final test will be CI.