### PR TITLE
Linux platform example app includes SHELL unconditionally.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
     [the build guide](./BUILDING.md)
 -   Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
-    [the cirque test guide](../src/test_driver/linux-cirque/README.md)
+    [the cirque test guide](src/test_driver/linux-cirque/README.md)
 -   Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -112,15 +112,11 @@ exit:
 
 void ChipLinuxAppMainLoop()
 {
-#if CHIP_ENABLE_SHELL
     std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
-#endif
 
     // Init ZCL Data Model and CHIP App Server
     InitServer();
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
-#if CHIP_ENABLE_SHELL
     shellThread.join();
-#endif
 }

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -31,7 +31,7 @@ source_set("app-main") {
     "Options.h",
   ]
 
-  defines = []
+  defines = [ "CHIP_ENABLE_SHELL" ]
 
   if (chip_enable_pw_rpc) {
     defines += [ "PW_RPC_ENABLED" ]
@@ -40,12 +40,12 @@ source_set("app-main") {
   public_deps = [
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/shell",
+    "${chip_root}/src/lib/shell:shell_core",
   ]
 
-  if (chip_enable_shell) {
-    defines += [ "CHIP_ENABLE_SHELL" ]
-    public_deps += [ "${chip_root}/src/lib/shell" ]
-  }
+    public_deps += [ 
+    ]
 
   public_configs = [ ":app-main-config" ]
 }

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -19,10 +19,6 @@ config("app-main-config") {
   include_dirs = [ "." ]
 }
 
-declare_args() {
-  chip_enable_shell = false
-}
-
 source_set("app-main") {
   sources = [
     "AppMain.cpp",
@@ -31,7 +27,7 @@ source_set("app-main") {
     "Options.h",
   ]
 
-  defines = [ "CHIP_ENABLE_SHELL" ]
+  defines = []
 
   if (chip_enable_pw_rpc) {
     defines += [ "PW_RPC_ENABLED" ]


### PR DESCRIPTION
Force defines and linkages as such, otherwise compilation with GN
without 'use shell' does not work.

TODO as followup: if shell is really optional, build it as such in linux
as well.

#### Problem
Vanilla build with GN fails with:

```
ERROR at //examples/platform/linux/AppMain.cpp:28:11: Include not allowed.
#include <lib/shell/Engine.h>
          ^-----------------
It is not in any dependency of
  //examples/platform/linux:app-main
The include file is in the target(s):
  //src/lib/shell:shell_core
```

#### Change overview
Make linux always compile with shell support. At least compilation passes

#### Testing

Success in compiling all with GN (failure is gone, code compiles)