### PR TITLE
Fix dependency checker in the unified build

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -25,11 +25,14 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <core/CHIPError.h>
-#include <lib/shell/Engine.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/CHIPMem.h>
 #include <support/RandUtils.h>
+
+#if defined(CHIP_ENABLE_SHELL)
+#include <lib/shell/Engine.h> // nogncheck
+#endif
 
 #if defined(PW_RPC_ENABLED)
 #include <CommonRpc.h>
@@ -41,7 +44,10 @@ using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
+
+#if defined(CHIP_ENABLE_SHELL)
 using chip::Shell::Engine;
+#endif
 
 namespace {
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)


### PR DESCRIPTION
Add a preprocessor condition to avoid including <lib/shell/Engine.h>
when shell integration is disabled.

Unfortunately, since the checker doesn't preprocess the code, this
results in a false positive. Suppress that with // nogncheck.

Tested by:
```
source scripts/activate.sh
./gn_build.sh
(cd examples/lighting-app/linux && gn gen out/with_shell --args=chip_enable_shell=true && ninja -C out/with_shell)
(cd examples/lighting-app/linux && gn gen out/without_shell --args=chip_enable_shell=false && ninja -C out/without_shell)
```

fixes #7200
