### PR TITLE
Move hotlink linter to manual run as it was checked in as red to start with

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,16 @@
 
 name: Lint Code Base
 # yamllint disable-line rule:truthy
-on:
-  push:
-    branches:
-      - 'master'
+on: workflow_dispatch 
+
+# On-push disabled until the workflow can run fully green
+# At that point the workflow should be enabled both on push and on PRs to not
+# allow failing links to be checked in. 
+#
+# on:
+#  push:
+#    branches:
+#      - 'master'
 
 jobs:
   check-broken-links:


### PR DESCRIPTION
#### Problem
ToT linter marks everything as red due to bad links.

#### Change overview
Move the linter to 'on demand' instead of automatic on merge

#### Testing
Github workflow, cannot test
