### PR TITLE
Move the bootstrap output dir inside the environment

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -73,7 +73,8 @@ EOF
         [ ! -s "$_SETUP_SH" ]; then
         pw_bootstrap --shell-file "$_SETUP_SH" \
             --install-dir "$_PW_ACTUAL_ENVIRONMENT_ROOT" \
-            --config-file "$_CHIP_ROOT/$_CONFIG_FILE"
+            --config-file "$_CHIP_ROOT/$_CONFIG_FILE" \
+            --virtualenv-gn-out-dir "$_PW_ACTUAL_ENVIRONMENT_ROOT/gn_out"
         pw_finalize bootstrap "$_SETUP_SH"
     else
         pw_activate


### PR DESCRIPTION
Putting it at out/ causes problems:

1) Our scripts and docs use subdirectories of out/ as the build
   root to allow creating multiple output directories with different
   configurations. These directories are now nested inside the
   bootstrap dir which is likely to cause confusion.

2) Using a single location in and out of docker breaks. The vscode
   docker moves the environment to work around these conflicts.
   Using a common build directory will cause similar breakage.

3) Cleaning the environment without cleaning out/ results in errors.
   This indicates they should be co-located.

Move it to a sub-directory of the environment.

Tested by running `scripts/bootstrap.sh`