### PR TITLE
Fix resolve on BLE from ip network commissioning.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1527,15 +1527,13 @@ void BasicFailure(void * context, uint8_t status)
 void DeviceCommissioner::OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData)
 {
     Device * device = nullptr;
-    if (mDeviceBeingPaired >= kNumMaxActiveDevices)
+    if (mDeviceBeingPaired < kNumMaxActiveDevices)
     {
-        return;
-    }
-
-    device = &mActiveDevices[mDeviceBeingPaired];
-    if (device->GetDeviceId() == nodeData.mPeerId.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
-    {
-        AdvanceCommissioningStage(CHIP_NO_ERROR);
+        device = &mActiveDevices[mDeviceBeingPaired];
+        if (device->GetDeviceId() == nodeData.mPeerId.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
+        {
+            AdvanceCommissioningStage(CHIP_NO_ERROR);
+        }
     }
     DeviceController::OnNodeIdResolved(nodeData);
 }


### PR DESCRIPTION
IP network provisioning was incorrectly early-returning from the
resolve callback and not sending data through to the python stack
for BLE.

#### Problem
IP network commissioning broke the resolve portion of the BLE connection

#### Change overview
Fixes the OnNodeIdResolved function to remove early return that bypassed the python delegate.

#### Testing
Set up M5 with no network credentials. Connected via chip-device-ctrl using BLE
connect -qr "[qrcode]"
zcl NetworkCommissioning AddWiFiNetwork [nodeid] 0 0 ssid=str:[ssid] credentials=str:[pass] breadcrumb=0 timeoutMs=1000
zcl NetworkCommissioning EnableNetwork [nodeid] 0 0 networkID=str:[ssid] breadcrumb=0 timeoutMs=1000
resolve 0 [nodeid]  

Last resolve used to fail, now it passes.
