### PR TITLE
Extend build flags for ip commissioning on linux[TE3]

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -68,7 +68,11 @@ int ChipLinuxAppInit(int argc, char ** argv)
     SuccessOrExit(err);
 
     ConfigurationMgr().LogDeviceConfig();
+#ifdef CONFIG_RENDEZVOUS_MODE
+    PrintOnboardingCodes(static_cast<chip::RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE));
+#else
     PrintOnboardingCodes(chip::RendezvousInformationFlag::kBLE);
+#endif
 
 #if defined(PW_RPC_ENABLED)
     chip::rpc::Init();

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
+import("${chip_root}/src/app/common_flags.gni")
 
 config("app-main-config") {
   include_dirs = [ "." ]
@@ -24,6 +25,7 @@ declare_args() {
 }
 
 source_set("app-main") {
+  defines = []
   sources = [
     "AppMain.cpp",
     "AppMain.h",
@@ -35,6 +37,10 @@ source_set("app-main") {
 
   if (chip_enable_pw_rpc) {
     defines += [ "PW_RPC_ENABLED" ]
+  }
+  if (chip_ip_commissioning) {
+    # BLE and on-network. Code defaults to BLE if this is not set.
+    defines += [ "CONFIG_RENDEZVOUS_MODE=6" ]
   }
 
   public_deps = [

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -120,6 +120,15 @@ static_library("app") {
     assert(false, "Unknown IM critical section implementation.")
   }
 
+  if (chip_ip_commissioning) {
+    defines = [
+      "CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING=1",
+      "CONFIG_RENDEZVOUS_WAIT_FOR_COMMISSIONING_COMPLETE=1",
+      "CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY=1",
+      "CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING=1",
+    ]
+  }
+
   public_deps = [
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -15,4 +15,5 @@
 declare_args() {
   # Temporary flag for interaction model and echo protocols, set it to true to enable
   chip_app_use_echo = false
+  chip_ip_commissioning = false
 }


### PR DESCRIPTION
Lets the linux builds be built with IP commissioning support. Adds
the on-network flag to the QR code on the app main.

Test: lighting-app on linux - comes up in commissioning mode,
      chip-device-ctrl connect -qr "[qr code]" can find and
      commission the device.

#### Problem
Not all the device paths support on-network commissioning

#### Change overview
Adds gn build flag to set defines for IP commissioning

#### Testing
Tested using lighting-app built for linux with chip_ip_commissioning flag set. Connected to lighting app using chip-device-ctrl, was able to discover and commission automatically using connect -qr "[qr code]"