### PR TITLE
[esp32] reduce default event queue size

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -350,7 +350,7 @@ menu "CHIP Device Layer"
         config MAX_EVENT_QUEUE_SIZE
             int "Max Event Queue Size"
             range 0 65535
-            default 100
+            default 25
             help
                 The maximum number of events that can be held in the CHIP Platform event queue.
 


### PR DESCRIPTION
#### Problem

The event queue is way too large by default, occupying 6.4 KB.

#### Change overview

Reduce the default event queue size to 25. This value has teen long used in qpg and efr platforms.

#### Testing

Build all-cluster-app on ESP32 and pair with chip-device-ctrl. The pairing flow can still work.

