### PR TITLE
Move serialization of chip::Device earlier.

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -391,6 +391,36 @@ CHIP_ERROR Device::UpdateAddress(const Transport::PeerAddress & addr)
     return CHIP_NO_ERROR;
 }
 
+void Device::Reset()
+{
+    if (IsActive() && mStorageDelegate != nullptr && mSessionManager != nullptr)
+    {
+        // If a session can be found, persist the device so that we track the newest message counter values
+        Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
+        if (connectionState != nullptr)
+        {
+            Persist();
+        }
+    }
+
+    SetActive(false);
+    mState          = ConnectionState::NotConnected;
+    mSessionManager = nullptr;
+    mStatusDelegate = nullptr;
+    mInetLayer      = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
+    mBleLayer = nullptr;
+#endif
+    if (mExchangeMgr)
+    {
+        // Ensure that any exchange contexts we have open get closed now,
+        // because we don't want them to call back in to us after this
+        // point.
+        mExchangeMgr->CloseAllContextsForDelegate(this);
+    }
+    mExchangeMgr = nullptr;
+}
+
 CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -526,16 +556,6 @@ Device::~Device()
         // because we don't want them to call back in to us after this
         // point.
         mExchangeMgr->CloseAllContextsForDelegate(this);
-    }
-
-    if (mStorageDelegate != nullptr && mSessionManager != nullptr)
-    {
-        // If a session can be found, persist the device so that we track the newest message counter values
-        Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
-        if (connectionState != nullptr)
-        {
-            Persist();
-        }
     }
 }
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -308,25 +308,7 @@ public:
 
     bool IsSecureConnected() const { return IsActive() && mState == ConnectionState::SecureConnected; }
 
-    void Reset()
-    {
-        SetActive(false);
-        mState          = ConnectionState::NotConnected;
-        mSessionManager = nullptr;
-        mStatusDelegate = nullptr;
-        mInetLayer      = nullptr;
-#if CONFIG_NETWORK_LAYER_BLE
-        mBleLayer = nullptr;
-#endif
-        if (mExchangeMgr)
-        {
-            // Ensure that any exchange contexts we have open get closed now,
-            // because we don't want them to call back in to us after this
-            // point.
-            mExchangeMgr->CloseAllContextsForDelegate(this);
-        }
-        mExchangeMgr = nullptr;
-    }
+    void Reset();
 
     NodeId GetDeviceId() const { return mDeviceId; }
 


### PR DESCRIPTION
Serializing in the destructor doesn't really do the right thing,
because by then Reset() has usually been called and hence
mSessionManager is null.

Instead, serialize in Reset() if were resetting an active device.

This fixes the remaining problems I was seeing with chip-tool messages
being rejected for having the wrong message counter values (due to us
never serializing the incremented message counter).

#### Testing
Manually tested as follows on Mac:
```
% cd examples/all-clusters-app/esp32
% source idf.sh
% idf make erase_flash flash monitor -j16 ESPPORT=/dev/tty.SLAB_USBtoUART
```
and in another terminal:
```
% ./gn_build.sh
% ./out/debug/standalone/chip-tool pairing ble-wifi SSID PASSWD 0 12345678 3840
% ./out/debug/standalone/chip-tool onoff toggle 1
% ./out/debug/standalone/chip-tool onoff toggle 1
% ./out/debug/standalone/chip-tool onoff toggle 1
% ./out/debug/standalone/chip-tool onoff toggle 1
```
Without this change, the toggle commands get rejected by message counter verification.