### PR TITLE
[shell] make shell really optional in Linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -29,6 +29,7 @@ assert(chip_root == "//")
 
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/src/lib/shell/shell.gni")
 
 import("//src/crypto/crypto.gni")
 
@@ -101,7 +102,6 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     if (chip_build_tools) {
       deps += [
         ":certification",
-        "${chip_root}/examples/shell/standalone:chip-shell",
         "${chip_root}/src/app/tests/integration:chip-im-initiator",
         "${chip_root}/src/app/tests/integration:chip-im-responder",
         "${chip_root}/src/messaging/tests/echo:chip-echo-requester",
@@ -109,6 +109,9 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
         "${chip_root}/src/qrcodetool",
         "${chip_root}/src/setup_payload",
       ]
+      if (chip_shell) {
+        deps += [ "${chip_root}/examples/shell/standalone:chip-shell" ]
+      }
       if (chip_crypto == "openssl") {
         deps += [ "${chip_root}/src/tools/chip-cert" ]
       }

--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -72,7 +72,7 @@ if (NOT CONFIG_USE_MINIMAL_MDNS)
 endif()
 
 if (CONFIG_ENABLE_CHIP_SHELL)
-    chip_gn_arg_append("chip_build_libshell"                "true")
+    chip_gn_arg_append("chip_shell"                         "true")
 endif()
 
 

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -140,7 +140,7 @@ endif
 	  echo "dir_pw_third_party_nanopb = \"//third_party/connectedhomeip/third_party/nanopb/repo\"" >>$(OUTPUT_DIR)/args.gn         ;\
 	fi
 	if [[ "$(CONFIG_ENABLE_CHIP_SHELL)" = "y" ]]; then \
-	  echo "chip_build_libshell = true" >> $(OUTPUT_DIR)/args.gn ;\
+	  echo "chip_shell = true" >> $(OUTPUT_DIR)/args.gn ;\
 	fi
 	if [[ "$(CONFIG_USE_MINIMAL_MDNS)" = "n" ]]; then \
 	  echo "chip_mdns = platform" >> $(OUTPUT_DIR)/args.gn ;\

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -205,7 +205,7 @@ chip_gn_arg_bool  ("chip_monolithic_tests"                  CONFIG_CHIP_BUILD_TE
 chip_gn_arg_bool  ("chip_inet_config_enable_raw_endpoint"   CONFIG_CHIP_BUILD_TESTS)
 chip_gn_arg_bool  ("chip_inet_config_enable_tcp_endpoint"   CONFIG_CHIP_BUILD_TESTS)
 chip_gn_arg_bool  ("chip_inet_config_enable_dns_resolver"   CONFIG_CHIP_BUILD_TESTS)
-chip_gn_arg_bool  ("chip_build_libshell"                    CONFIG_CHIP_STANDALONE_SHELL)
+chip_gn_arg_bool  ("chip_shell"                             CONFIG_CHIP_STANDALONE_SHELL)
 chip_gn_arg_bool  ("chip_build_zephyr_shell"                CONFIG_CHIP_ZEPHYR_SHELL)
 chip_gn_arg_bool  ("chip_build_pw_rpc_lib"                  CONFIG_CHIP_PW_RPC)
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -25,7 +25,6 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <core/CHIPError.h>
-#include <lib/shell/Engine.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/CHIPMem.h>
@@ -35,13 +34,19 @@
 #include <CommonRpc.h>
 #endif
 
+#if CHIP_SHELL_ENABLED
+#include <lib/shell/Engine.h>
+#endif
+
 #include "Options.h"
 
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
+#if CHIP_SHELL_ENABLED
 using chip::Shell::Engine;
+#endif
 
 namespace {
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
@@ -112,11 +117,15 @@ exit:
 
 void ChipLinuxAppMainLoop()
 {
+#if CHIP_SHELL_ENABLED
     std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
+#endif
 
     // Init ZCL Data Model and CHIP App Server
     InitServer();
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+#if CHIP_SHELL_ENABLED
     shellThread.join();
+#endif
 }

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
+import("${chip_root}/src/lib/shell/shell.gni")
 
 config("app-main-config") {
   include_dirs = [ "." ]
@@ -36,12 +37,13 @@ source_set("app-main") {
   public_deps = [
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
-    "${chip_root}/src/lib/shell",
-    "${chip_root}/src/lib/shell:shell_core",
   ]
 
-    public_deps += [ 
-    ]
+  if (chip_shell) {
+    public_deps += [ "${chip_root}/src/lib/shell" ]
+
+    defines += [ "CHIP_SHELL_ENABLED=1" ]
+  }
 
   public_configs = [ ":app-main-config" ]
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/ble/ble.gni")
+import("${chip_root}/src/lib/shell/shell.gni")
 import("${chip_root}/src/lwip/lwip.gni")
 import("${chip_root}/src/platform/device.gni")
 
@@ -83,7 +84,7 @@ if (chip_build_tests) {
       deps += [ "${chip_root}/src/lwip/tests" ]
     }
 
-    if (current_os != "zephyr" && chip_device_platform != "esp32") {
+    if (chip_shell) {
       deps += [ "${chip_root}/src/lib/shell/tests" ]
     }
 

--- a/src/lib/BUILD.gn
+++ b/src/lib/BUILD.gn
@@ -14,9 +14,7 @@
 
 import("//build_overrides/chip.gni")
 
-declare_args() {
-  chip_build_libshell = false
-}
+import("${chip_root}/src/lib/shell/shell.gni")
 
 config("includes") {
   include_dirs = [ "." ]
@@ -40,7 +38,7 @@ static_library("lib") {
     "${chip_root}/src/transport",
   ]
 
-  if (chip_build_libshell) {
+  if (chip_shell) {
     public_deps += [ "${chip_root}/src/lib/shell" ]
   }
 

--- a/src/lib/shell/BUILD.gn
+++ b/src/lib/shell/BUILD.gn
@@ -15,51 +15,57 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/lib/core/core.gni")
+import("${chip_root}/src/lib/shell/shell.gni")
 import("${chip_root}/src/platform/device.gni")
 
-source_set("shell_core") {
-  sources = [
-    "Commands.h",
-    "Engine.cpp",
-    "Engine.h",
-    "streamer.cpp",
-    "streamer.h",
-  ]
-
-  public_deps = [
-    "${chip_root}/src/lib/core",
-    "${chip_root}/src/lib/support",
-    "${chip_root}/src/platform",
-  ]
-}
-
-static_library("shell") {
-  output_name = "libCHIPShell"
-  output_dir = "${root_out_dir}/lib"
-
-  sources = []
-
-  if (chip_target_style == "unix") {
-    sources += [ "streamer_stdio.cpp" ]
-  }
-
-  if (chip_device_platform == "esp32") {
-    sources += [
-      "MainLoopESP32.cpp",
-      "streamer_esp32.cpp",
+if (chip_shell) {
+  source_set("shell_core") {
+    sources = [
+      "Commands.h",
+      "Engine.cpp",
+      "Engine.h",
+      "streamer.cpp",
+      "streamer.h",
     ]
-  } else {
-    sources += [ "MainLoopDefault.cpp" ]
+
+    public_deps = [
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support",
+      "${chip_root}/src/platform",
+    ]
   }
 
-  if (current_os == "zephyr") {
-    sources += [ "streamer_zephyr.cpp" ]
+  static_library("shell") {
+    output_name = "libCHIPShell"
+    output_dir = "${root_out_dir}/lib"
+
+    sources = []
+
+    if (chip_target_style == "unix") {
+      sources += [ "streamer_stdio.cpp" ]
+    }
+
+    if (chip_device_platform == "esp32") {
+      sources += [
+        "MainLoopESP32.cpp",
+        "streamer_esp32.cpp",
+      ]
+    } else {
+      sources += [ "MainLoopDefault.cpp" ]
+    }
+
+    if (current_os == "zephyr") {
+      sources += [ "streamer_zephyr.cpp" ]
+    }
+
+    cflags = [ "-Wconversion" ]
+
+    public_deps = [
+      ":shell_core",
+      "${chip_root}/src/lib/shell/commands",
+    ]
   }
-
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
-    ":shell_core",
-    "${chip_root}/src/lib/shell/commands",
-  ]
+} else {
+  group("shell") {
+  }
 }

--- a/src/lib/shell/shell.gni
+++ b/src/lib/shell/shell.gni
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
-
-import("${chip_root}/config/standalone/args.gni")
-
-chip_shell = true
+declare_args() {
+  # Enable shell.
+  chip_shell = false
+}

--- a/src/lib/shell/tests/BUILD.gn
+++ b/src/lib/shell/tests/BUILD.gn
@@ -17,22 +17,25 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/src/lib/shell/shell.gni")
 
-chip_test_suite("tests") {
-  output_name = "libTestShell"
+if (chip_shell) {
+  chip_test_suite("tests") {
+    output_name = "libTestShell"
 
-  sources = [
-    "TestStreamerStdio.cpp",
-    "TestStreamerStdio.h",
-  ]
+    sources = [
+      "TestStreamerStdio.cpp",
+      "TestStreamerStdio.h",
+    ]
 
-  cflags = [ "-Wconversion" ]
+    cflags = [ "-Wconversion" ]
 
-  public_deps = [
-    "${chip_root}/src/lib/core",
-    "${chip_root}/src/lib/shell",
-    "${nlunit_test_root}:nlunit-test",
-  ]
+    public_deps = [
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/shell",
+      "${nlunit_test_root}:nlunit-test",
+    ]
 
-  tests = [ "TestStreamerStdio" ]
+    tests = [ "TestStreamerStdio" ]
+  }
 }


### PR DESCRIPTION

#### Problem

Fix the TODO in https://github.com/project-chip/connectedhomeip/pull/7205


#### Change overview

Add global `chip_shell` gn args and use it as the only flag to enable/disable shell.

#### Testing

Build with `gn gen out/debug --args='chip_shell=false'` and  `gn gen out/debug --args='chip_shell=true'` 