### PR TITLE
Fix crash caused by uninitialized variable

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -272,11 +272,11 @@ protected:
     bool mPairedDevicesInitialized;
 
     NodeId mLocalDeviceId;
-    DeviceTransportMgr * mTransportMgr;
-    SecureSessionMgr * mSessionMgr;
-    Messaging::ExchangeManager * mExchangeMgr;
-    secure_channel::MessageCounterManager * mMessageCounterManager;
-    PersistentStorageDelegate * mStorageDelegate;
+    DeviceTransportMgr * mTransportMgr = nullptr;
+    SecureSessionMgr * mSessionMgr = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
+    secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
+    PersistentStorageDelegate * mStorageDelegate = nullptr;
     DeviceControllerInteractionModelDelegate * mDefaultIMDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
@@ -284,11 +284,11 @@ protected:
     static constexpr int kMaxCommissionableNodes = 10;
     Mdns::CommissionableNodeData mCommissionableNodes[kMaxCommissionableNodes];
 #endif
-    Inet::InetLayer * mInetLayer;
+    Inet::InetLayer * mInetLayer = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif
-    System::Layer * mSystemLayer;
+    System::Layer * mSystemLayer = nullptr;
 
     uint16_t mListenPort;
     uint16_t GetInactiveDeviceIndex();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -277,7 +277,7 @@ protected:
     Messaging::ExchangeManager * mExchangeMgr;
     secure_channel::MessageCounterManager * mMessageCounterManager;
     PersistentStorageDelegate * mStorageDelegate;
-    DeviceControllerInteractionModelDelegate * mDefaultIMDelegate;
+    DeviceControllerInteractionModelDelegate * mDefaultIMDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -272,12 +272,12 @@ protected:
     bool mPairedDevicesInitialized;
 
     NodeId mLocalDeviceId;
-    DeviceTransportMgr * mTransportMgr = nullptr;
-    SecureSessionMgr * mSessionMgr = nullptr;
-    Messaging::ExchangeManager * mExchangeMgr = nullptr;
+    DeviceTransportMgr * mTransportMgr                             = nullptr;
+    SecureSessionMgr * mSessionMgr                                 = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr                      = nullptr;
     secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
-    PersistentStorageDelegate * mStorageDelegate = nullptr;
-    DeviceControllerInteractionModelDelegate * mDefaultIMDelegate = nullptr;
+    PersistentStorageDelegate * mStorageDelegate                   = nullptr;
+    DeviceControllerInteractionModelDelegate * mDefaultIMDelegate  = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.


### PR DESCRIPTION
#### Problem
What is being fixed?
* Fix crash in DeviceController::Shutdown()
* Fixes #7188 chip-device-ctrl always crashes in DeviceController::Shutdown()

#### Change overview
This PR fixes crash caused by uninitialized member variable. The crash happened in DeviceController::Shutdown().

#### Testing
How was this tested? (at least one bullet point required)
* launch chip-device-ctrl
* commission accessory e.g. connect -ble 3840 12345678 12344321
* optionally enter any other commands
* issue exit command

Result without the fix: crash with segmentation fault on the following place in src/controller/CHIPDeviceController .cpp DeviceController::Shutdown()

chip::Platform::Delete(mDefaultIMDelegate);

Result with the fix: application tears down correctly and exits.

