### PR TITLE
ESP32: Fix header file for lock-app example

### DIFF
--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -21,9 +21,9 @@
 #include "Button.h"
 #include "LEDWidget.h"
 #include "esp_log.h"
-#include "gen/attribute-id.h"
-#include "gen/attribute-type.h"
-#include "gen/cluster-id.h"
+#include <app/common/gen/attribute-id.h>
+#include <app/common/gen/attribute-type.h>
+#include <app/common/gen/cluster-id.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/af-enums.h>


### PR DESCRIPTION
  #### Problem
  * Compilation for lock-app esp32 example fails.
  
  #### Change overview
  Fixed the header file in source files of lock-app esp32.
  
  #### Testing
  * Checked the successful compilation for lock-app.