### PR TITLE
Correction SRP service removal from local cache

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1167,6 +1167,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveSrpServic
     ChipLogProgress(DeviceLayer, "removing srp service: %s.%s", aInstanceName, aName);
     error = MapOpenThreadError(otSrpClientRemoveService(mOTInst, &(srpService->mService)));
 
+    // Clear service entry from local cache
+    memset(srpService, 0, sizeof(typename SrpClient::Service));
+
 exit:
     Impl()->UnlockThreadStack();
 
@@ -1185,6 +1188,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveAllSrpSer
     VerifyOrExit(services != nullptr, error = CHIP_NO_ERROR);
 
     error = MapOpenThreadError(otSrpClientRemoveHostAndServices(mOTInst, false));
+
+    // Clear all service entries in local cache
+    memset(mSrpClient.mServices, 0, sizeof(mSrpClient.mServices));
 
 exit:
     Impl()->UnlockThreadStack();


### PR DESCRIPTION
#### Problem
Removal of a SRP service was not applied to the local cache held at CHIP level.
Check is done on the name content, but that is not cleared in `_RemoveSrpService` 

This appears when re-using a single service entry.

https://github.com/project-chip/connectedhomeip/blob/fd547be39cc61bd542d84f7c027d6f41a7a39f8f/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp#L1143

#### Change overview
Clearing service entries when removal is called/expected.
This allows the memcmp for allocation or lookup to work

#### Testing
* Running OT commissioning with chip-device-ctrl.py
* 'Duplicate Entry' error returned in fail case - no SRP registration continuing
* No failures reported in logging after applying removal fix - SRP registration proceeds