### PR TITLE
Do not trigger CASE session setup

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -424,11 +424,12 @@ CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
                                       SecureSession::SessionRole::kInitiator, mAdminId);
     SuccessOrExit(err);
 
-    if (IsProvisioningComplete())
-    {
-        err = EstablishCASESession();
-        SuccessOrExit(err);
-    }
+    // TODO - Enable CASE Session setup before message is sent to a fully provisioned device
+    // if (IsProvisioningComplete())
+    // {
+    //     err = EstablishCASESession();
+    //     SuccessOrExit(err);
+    // }
 
 exit:
 


### PR DESCRIPTION
#### Problem
The repeated CASE Session setup causes device to run out of heap.

#### Change overview
The `CASEServer` code needs to detect duplicate sessions and free the older one, before setting up the new session. Currently, the repeated sessions are causing the device to hold on to the older session, while a new one gets setup.

This PR removes the trigger to setup CASE session, as it's not needed for TE3.

Reference: https://github.com/project-chip/connectedhomeip/issues/7235

#### Testing
Tested using Python controller and iOS CHIPTool app.