### PR TITLE
Increase EFR32 Lock_app heap by 1k 

### DIFF
--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -59,7 +59,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(12 * 1024)",
+    "SL_HEAP_SIZE=(13 * 1024)",
   ]
 }
 


### PR DESCRIPTION
#### Problem
EFR32 lock_app MG21 is failing CSR during secure session

```
CHIP:ZCL: DefaultResponse:
CHIP:ZCL:   Transaction: 0xffff9518a3b8
CHIP:ZCL:   status: EMBER_ZCL_STATUS_FAILURE (0x01)
CHIP:CTL: Device failed to receive the operational certificate Response: 0x01
CHIP:CTL: SyncSetKeyValue on StartKeyID
Failed to establish secure session to device: 4172  
```

#### Change overview
Crypto is slower in MG21 and takes more heap to complete than MG12. 
Bump the example heap form 12k to 13k


#### Testing
* Complete the secure session with the python controller
*  connect -ble 3840 73141520 1
```
CHIP:ZCL:   Transaction: 0xffff82f512a0
CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
CHIP:CTL: Device confirmed that it has received the root certificate
CHIP:CTL: Operational credentials provisioned on device 0xfecaf8
CHIP:CTL: SyncSetKeyValue on PairedDevice1
CHIP:CTL: SyncSetKeyValue on ListPairedDevices0
CHIP:CTL: SyncSetKeyValue on StartKeyID
Secure Session to Device Established
```