### PR TITLE
[android] use Operational Dataset for Thread provisioning

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -170,9 +170,8 @@ public class ChipDeviceController {
     sendCommand(deviceControllerPtr, deviceId, command, value);
   }
 
-  public void enableThreadNetwork(
-      long deviceId, int channel, int panId, byte[] extPanId, byte[] masterKey) {
-    enableThreadNetwork(deviceControllerPtr, deviceId, channel, panId, extPanId, masterKey);
+  public void enableThreadNetwork(long deviceId, byte[] operationalDataset) {
+    enableThreadNetwork(deviceControllerPtr, deviceId, operationalDataset);
   }
 
   public boolean openPairingWindow(long deviceId, int duration) {
@@ -206,10 +205,7 @@ public class ChipDeviceController {
   private native void enableThreadNetwork(
       long deviceControllerPtr,
       long deviceId,
-      int channel,
-      int panId,
-      byte[] extPanId,
-      byte[] masterKey);
+      byte[] operationalDataset);
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -203,9 +203,7 @@ public class ChipDeviceController {
       long deviceControllerPtr, long deviceId, ChipCommandType command, int value);
 
   private native void enableThreadNetwork(
-      long deviceControllerPtr,
-      long deviceId,
-      byte[] operationalDataset);
+      long deviceControllerPtr, long deviceId, byte[] operationalDataset);
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 


### PR DESCRIPTION
#### Problem
When passing Thread network credentials to a CHIP device during Network provisioning,
the raw Thread Operational Dataset, which is encoded as a list of Thread TLVs, should be
used. Using the raw Thread TLVs has the benefits of forward compatibility.

#### Change overview
Change the Java binding to accept `Thread Operational Dataset` (byte array) rather than
`channel`, `panId`, `xPanId` and `masterKey` tuple.

#### Testing
Manually tested that the nrfconnect lighting app can be provisioned with the change.
