### PR TITLE
Run cirque bootstrap only when executing from GITHUB_ACTION

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -129,12 +129,17 @@ function cirquetest_bootstrap() {
     __cirquetest_build_ot_lazy
     pip3 install -r requirements_nogrpc.txt
 
-    set +x
+    if [[ "x$GITHUB_ACTION_RUN" = "x1" ]]; then
+        # We may run Cirque tests locally, in that case, we will run
+        # CHIP bootstrap script elsewhere. Don't run bootstrap so we
+        # won't break local environment.
+        set +x
 
-    # Call activate here so the later tests can be faster
-    # set -e will cause error if activate.sh is sourced twice
-    # this is an expected behavior caused by pigweed/activate.sh
-    source "$REPO_DIR/scripts/bootstrap.sh"
+        # Call activate here so the later tests can be faster
+        # set -e will cause error if activate.sh is sourced twice
+        # this is an expected behavior caused by pigweed/activate.sh
+        source "$REPO_DIR/scripts/bootstrap.sh"
+    fi
 }
 
 function cirquetest_run_test() {

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -71,7 +71,7 @@ class TestEcho(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "gdb -batch -return-child-result -q -ex run -ex bt --args chip-echo-requester {}"
+        command = "gdb -return-child-result -q -ex run -ex bt --args chip-echo-requester {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -71,7 +71,7 @@ class TestInteractionModel(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "gdb -batch -return-child-result -q -ex run -ex bt --args chip-im-initiator {}"
+        command = "gdb -return-child-result -q -ex run -ex bt --args chip-im-initiator {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(


### PR DESCRIPTION
#### Problem
- We need to run Cirque locally, in which case cirque bootstrap will break local environment.
- Command line for run commands in cirque is not correct.

#### Change overview
- Run CHIP bootstrap only when $GITHUB_ACTION_RUN is set
- Remove `batch` flag so it can return child status correctly

#### Testing
- This test updates Cirque test framework, see comment for Cirque run result locally.
