### PR TITLE
[android] Add code for service discovery

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -63,7 +63,9 @@ class OnOffClientFragment : Fragment() {
 
   override fun onStart() {
     super.onStart()
-    fabricIdEd.setText(5544332211.toString())
+    // TODO: use the fabric ID that was used to commission the device
+    val testFabricId = "5544332211"
+    fabricIdEd.setText(testFabricId)
     deviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
   }
 
@@ -95,6 +97,7 @@ class OnOffClientFragment : Fragment() {
       serviceType = "_chip._tcp"
     }
 
+    // TODO: implement the common CHIP mDNS interface for Android and make CHIP stack call the resolver
     val resolverListener = object : NsdManager.ResolveListener {
       override fun onResolveFailed(serviceInfo: NsdServiceInfo?, errorCode: Int) {
         showMessage("Address resolution failed: $errorCode")

--- a/src/android/CHIPTool/app/src/main/res/layout/on_off_client_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/on_off_client_fragment.xml
@@ -4,24 +4,50 @@
     android:layout_height="match_parent">
 
     <EditText
-        android:id="@+id/deviceIdEd"
-        android:layout_width="match_parent"
+        android:id="@+id/fabricIdEd"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:inputType="text"
+        android:textSize="20sp"
+        android:hint="@string/enter_fabric_id_hint_text"/>
+
+    <EditText
+        android:id="@+id/deviceIdEd"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_toEndOf="@id/fabricIdEd"
         android:inputType="text"
         android:textSize="20sp"
         android:hint="@string/enter_device_id_hint_text"/>
+
+    <TextView
+        android:id="@+id/updateAddressBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:layout_margin="16dp"
+        android:layout_gravity="center"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/deviceIdEd"
+        android:background="@android:color/darker_gray"
+        android:text="@string/update_device_address_btn_text"
+        android:textSize="16sp"/>
 
     <TextView
         android:id="@+id/onBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="16dp"
-        android:layout_margin="32dp"
+        android:layout_margin="16dp"
         android:layout_gravity="center"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/deviceIdEd"
+        android:layout_below="@id/updateAddressBtn"
         android:background="@android:color/darker_gray"
         android:text="@string/send_command_on_btn_text"
         android:textSize="16sp"/>
@@ -32,10 +58,10 @@
         android:layout_height="wrap_content"
         android:padding="16dp"
         android:layout_marginStart="48dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="48dp"
         android:layout_gravity="center"
-        android:layout_below="@id/deviceIdEd"
+        android:layout_below="@id/updateAddressBtn"
         android:layout_toEndOf="@id/onBtn"
         android:layout_toStartOf="@+id/offBtn"
         android:background="@android:color/darker_gray"
@@ -47,11 +73,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="16dp"
-        android:layout_margin="32dp"
+        android:layout_margin="16dp"
         android:layout_gravity="center"
         android:gravity="center"
         android:layout_alignParentEnd="true"
-        android:layout_below="@id/deviceIdEd"
+        android:layout_below="@id/updateAddressBtn"
         android:background="@android:color/darker_gray"
         android:text="@string/send_command_off_btn_text"
         android:textSize="16sp"/>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -29,8 +29,10 @@
     <string name="echo_client_btn_text">Echo Client</string>
     <string name="on_off_level_btn_text">Light On/Off &amp; Level Cluster</string>
     <string name="enter_ip_address_hint_text">Enter IP Address (eg. 192.168.10.2)</string>
+    <string name="enter_fabric_id_hint_text">Enter Fabric ID</string>
     <string name="enter_device_id_hint_text">Enter Device ID</string>
     <string name="echo_input_hint_text">Enter message for device</string>
+    <string name="update_device_address_btn_text">Update address</string>
 
     <string name="send_command_on_btn_text">On</string>
     <string name="send_command_off_btn_text">Off</string>

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -162,6 +162,10 @@ public class ChipDeviceController {
     return getIpAddress(deviceControllerPtr, deviceId);
   }
 
+  public void updateAddress(long deviceId, String address, int port) {
+    updateAddress(deviceControllerPtr, deviceId, address, port);
+  }
+
   public void sendMessage(long deviceId, String message) {
     sendMessage(deviceControllerPtr, deviceId, message);
   }
@@ -196,6 +200,8 @@ public class ChipDeviceController {
   private native void deleteDeviceController(long deviceControllerPtr);
 
   private native String getIpAddress(long deviceControllerPtr, long deviceId);
+
+  private native void updateAddress(long deviceControllerPtr, long deviceId, String address, int port);
 
   private native void sendMessage(long deviceControllerPtr, long deviceId, String message);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -201,7 +201,8 @@ public class ChipDeviceController {
 
   private native String getIpAddress(long deviceControllerPtr, long deviceId);
 
-  private native void updateAddress(long deviceControllerPtr, long deviceId, String address, int port);
+  private native void updateAddress(
+      long deviceControllerPtr, long deviceId, String address, int port);
 
   private native void sendMessage(long deviceControllerPtr, long deviceId, String message);
 


### PR DESCRIPTION
#### Problem
Android CHIPTool doesn't provide any feature for testing operational discovery and updating a device address after
commissioning it into a network. 

#### Change overview
* Add "Update address" button in the "On/Off" screen and implement temporary service discovery using NsdManager from
the Android library to unblock the testing. 
* Ideally, we would have CHIP DNS-SD layer involved, but this requires more work as Android doesn't have a platform layer
in CHIP and the minimal mDNS implementation doesn't seem to work on Android (does Android block listening on port 5353?). I guess we really need some minimal Android platform component to simplify adding new features for Android - see https://github.com/project-chip/connectedhomeip/issues/6220.

#### Testing
1. Installed OTBR Posix on RPi4 and formed a new Thread network.
2. Commissioned the nrfconnect lighting device into the network.
3. Verified that tapping the "Update address" button resolves the device's node ID to its IPv6 address and updates the `CHIPDevice` instance.

Sending ZCL commands can't be tested as Android CHIPTool hasn't been updated after recent changes in the ZCL message construction code (the work is in progress by @austinh0)
