### PR TITLE
[example] Set log level LightingManager::InitiateAction to Progress

### DIFF
--- a/examples/lighting-app/linux/LightingManager.cpp
+++ b/examples/lighting-app/linux/LightingManager.cpp
@@ -50,13 +50,13 @@ bool LightingManager::InitiateAction(Action_t aAction)
     switch (aAction)
     {
     case ON_ACTION:
-        ChipLogDetail(AppServer, "LightingManager::InitiateAction(ON_ACTION)");
+        ChipLogProgress(AppServer, "LightingManager::InitiateAction(ON_ACTION)");
         break;
     case OFF_ACTION:
-        ChipLogDetail(AppServer, "LightingManager::InitiateAction(OFF_ACTION)");
+        ChipLogProgress(AppServer, "LightingManager::InitiateAction(OFF_ACTION)");
         break;
     default:
-        ChipLogDetail(AppServer, "LightingManager::InitiateAction(unknown)");
+        ChipLogProgress(AppServer, "LightingManager::InitiateAction(unknown)");
         break;
     }
 


### PR DESCRIPTION
#### Problem
The `ChipLogDetail` is not printed in some build config. Thus `LightingManager::InitiateAction(OFF_ACTION)` won't be print, however, user may rely on this line of log so they can get if the virtual light on linux is turned on  / off.

#### Change overview
Set log level to `Progress`

#### Testing
- Verified locally that it can print this log with `chip_detail_logging=config`
