### PR TITLE
[server] Remove redundant call to "advertiseOperational"

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -444,34 +444,6 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindow
     return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, adminInfo);
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !CHIP_DEVICE_LAYER_TARGET_ESP32
-static void ChipEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t)
-{
-    const auto advertise = [] {
-        CHIP_ERROR err = app::Mdns::AdvertiseOperational();
-        if (err != CHIP_NO_ERROR)
-            ChipLogError(AppServer, "Failed to start operational advertising: %s", chip::ErrorStr(err));
-    };
-
-    switch (event->Type)
-    {
-    case DeviceLayer::DeviceEventType::kInternetConnectivityChange:
-        VerifyOrReturn(event->InternetConnectivityChange.IPv4 == DeviceLayer::kConnectivity_Established);
-        // TODO : Need to check if we're properly commissioned.
-        advertise();
-        break;
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    case DeviceLayer::DeviceEventType::kThreadStateChange:
-        VerifyOrReturn(event->ThreadStateChange.AddressChanged);
-        advertise();
-        break;
-#endif
-    default:
-        break;
-    }
-}
-#endif
-
 // The function will initialize datamodel handler and then start the server
 // The server assumes the platform's networking has been setup already
 void InitServer(AppDelegate * delegate)
@@ -558,7 +530,6 @@ void InitServer(AppDelegate * delegate)
 // ESP32 examples have a custom logic for enabling DNS-SD
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !CHIP_DEVICE_LAYER_TARGET_ESP32
     app::Mdns::StartServer();
-    PlatformMgr().AddEventHandler(ChipEventHandler, {});
 #endif
 
     gCallbacks.SetSessionMgr(&gSessions);


### PR DESCRIPTION
#### Problem
PR #6798 added another call to "advertiseOpertional()" which starts publishing the opertional node service on a receipt
of a valid EnableNetwork command. Consequently, the code which publishes the same service on a change in the network
configuration became redundant and actually harmful due to some issues with updating an SRP service (to be resolved after updating OpenThread version).

#### Change overview
Remove the redundant call to "advertiseOpertional()" function.

#### Testing
1. Started OTBR Posix in Docker and formed a new Thread network.
2. Flashed the nrfconnect lighting-app onto nRF52840DK
3. Performed commissioning over BLE using Python CHIP Controller
4. Tested operational discovery and ZCL over IP.
