### PR TITLE
[doxygen] Deploy doxygen output to connectedhomeip-doc repo

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -17,6 +17,7 @@ name: Doxygen
 on:
     push:
     pull_request:
+    workflow_dispatch:
 
 jobs:
     doxygen:
@@ -38,8 +39,12 @@ jobs:
               run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
               id: extract_branch
             - name: Deploy if master
-              if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
+              #if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
+              if: github.event_name == 'workflow_dispatch'
               uses: peaceiris/actions-gh-pages@v3
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  deploy_key: ${{ secrets.DOXYGEN_DEPLOY_KEY }}
+                  external_repository: project-chip/connectedhomeip-doc
                   publish_dir: ./docs/html
+                  # Keep only the latest version of the documentation
+                  force_orphan: true


### PR DESCRIPTION
#### Problem
Currently, doxygen HTML files are deployed to "gh-pages" branch of the main connectedhomeip repo. As a result, it takes more and more time to checkout the entire repo.

#### Change overview
* Move the doxygen output to an external repository.
* Temporarily, kick off the deployment only when the workflow is manually triggered (to test the solution, first).

#### Testing
Tested an equivalent change on a fork (with different pair of ssh keys).
This exact change will be tested with a manual workflow trigger.
