### PR TITLE
[im] Print message for cluster not found[TE3]

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -116,6 +116,11 @@ exit:
         // Currently, it could be failed to decode Path or failed to find cluster / command on desired endpoint.
         // TODO: The behavior when receiving a malformed message is not clear in the Spec. (Spec#3259)
         // TODO: The error code should be updated after #7072 added error codes required by IM.
+        if (err == CHIP_ERROR_INVALID_PROFILE_ID)
+        {
+            ChipLogDetail(DataManagement, "Cannot found cluster 0x%" PRIx16 " on endpoint 0x%" PRIx8, clusterId, endpointId);
+        }
+
         AddStatusCode(&returnStatusParam,
                       err == CHIP_ERROR_INVALID_PROFILE_ID ? GeneralStatusCode::kNotFound : GeneralStatusCode::kInvalidArgument,
                       Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -118,7 +118,7 @@ exit:
         // TODO: The error code should be updated after #7072 added error codes required by IM.
         if (err == CHIP_ERROR_INVALID_PROFILE_ID)
         {
-            ChipLogDetail(DataManagement, "Cannot found cluster 0x%" PRIx16 " on endpoint 0x%" PRIx8, clusterId, endpointId);
+            ChipLogDetail(DataManagement, "No Cluster 0x%" PRIx16 " on Endpoint 0x%" PRIx8, clusterId, endpointId);
         }
 
         AddStatusCode(&returnStatusParam,

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -21,6 +21,7 @@ TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
 TEST_THREAD_NETWORK_ID = "fedcba9876543210"
 
 ENDPOINT_ID = 0
+LIGHTING_ENDPOINT_ID = 1
 GROUP_ID = 0
 
 
@@ -67,9 +68,12 @@ def main():
               "Failed to finish network commissioning")
 
     FailIfNot(test.TestOnOffCluster(nodeid=1,
-                                    endpoint=ENDPOINT_ID,
-                                    group=GROUP_ID)
-              , "Failed to test on off cluster")
+                                    endpoint=LIGHTING_ENDPOINT_ID,
+                                    group=GROUP_ID), "Failed to test on off cluster")
+
+    FailIfNot(test.TestOnOffCluster(nodeid=1,
+                                    endpoint=233,
+                                    group=GROUP_ID), "Failed to test on off cluster on non-exist endpoint")
 
     FailIfNot(test.TestReadBasicAttribiutes(nodeid=1,
                                             endpoint=ENDPOINT_ID,

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -95,7 +95,7 @@ class TestPythonController(CHIPVirtualHome):
         for device_id in server_ids:
             self.logger.info("checking device log for {}".format(
                 self.get_device_pretty_id(device_id)))
-            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)", "Cannot found cluster 0x6 on endpoint 0xe9"]),
+            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)", "No Cluster 0x6 on Endpoint 0xe9"]),
                             "Datamodel test failed: cannot find matching string from device {}".format(device_id))
 
         # Check if the device response proper Basic Cluster values to controller.

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -95,7 +95,7 @@ class TestPythonController(CHIPVirtualHome):
         for device_id in server_ids:
             self.logger.info("checking device log for {}".format(
                 self.get_device_pretty_id(device_id)))
-            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)"]),
+            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)", "Cannot found cluster 0x6 on endpoint 0xe9"]),
                             "Datamodel test failed: cannot find matching string from device {}".format(device_id))
 
         # Check if the device response proper Basic Cluster values to controller.


### PR DESCRIPTION
#### Problem
* When a cluster not found on an endpoint, we don't have a message for debug.
* Fixes #7208

#### Change overview
* Add a log at "Detail" level for debug

#### Testing
* Since we need to parse device output, cirque test is added for checking device log.