### PR TITLE
Revert "[controller] Move callbacks to CommandResponseStatus since ti…

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1459,15 +1459,17 @@ CHIP_ERROR DeviceControllerInteractionModelDelegate::CommandResponseStatus(
     const uint32_t aProtocolId, const uint16_t aProtocolCode, chip::EndpointId aEndpointId, const chip::ClusterId aClusterId,
     chip::CommandId aCommandId, uint8_t aCommandIndex)
 {
+    // #6308, #6559: Invoking success Callbacks in `CommandResponseProcessed` is not desired, but this is used to met current
+    // requirement of current callback framework that we should be able to send another command once ResponseCallback is called. By
+    // resolving #6308, the app can wait for the right event, and by #6559 the app can send command in a now command sender.
+    VerifyOrReturnError(aProtocolCode != 0, CHIP_NO_ERROR);
+
     // Generally IM has more detailed errors than ember library, here we always use the, the actual handling of the
     // commands should implement full IMDelegate.
     // #6308 By implement app side IM delegate, we should be able to accept detailed error codes.
     // Note: The IMDefaultResponseCallback is a bridge to the old CallbackMgr before IM is landed, so it still accepts EmberAfStatus
     // instead of IM status code.
-    IMDefaultResponseCallback(apCommandSender,
-                              (aProtocolCode == 0 && aGeneralCode == Protocols::SecureChannel::GeneralStatusCode::kSuccess)
-                                  ? EMBER_ZCL_STATUS_SUCCESS
-                                  : EMBER_ZCL_STATUS_FAILURE);
+    IMDefaultResponseCallback(apCommandSender, EMBER_ZCL_STATUS_FAILURE);
 
     return CHIP_NO_ERROR;
 }
@@ -1500,8 +1502,11 @@ CHIP_ERROR DeviceControllerInteractionModelDelegate::CommandResponseError(const 
 
 CHIP_ERROR DeviceControllerInteractionModelDelegate::CommandResponseProcessed(const app::CommandSender * apCommandSender)
 {
-    // No thing is needed in this case. The success callback is called in CommandResponseStatus, and failure callback is called in
-    // CommandResponseStatus, CommandResponseProtocolError and CommandResponseError.
+    // #6308, #6559: Invoking Callbacks in `CommandResponseProcessed` is not desired, but this is used to met current requirement of
+    // current callback framework that we should be able to send another command once ResponseCallback is called.
+    // By resolving #6308, the app can wait for the right event, and by #6559 the app can send command in a now command sender.
+    IMDefaultResponseCallback(apCommandSender, EMBER_ZCL_STATUS_SUCCESS);
+
     return CHIP_NO_ERROR;
 }
 void BasicSuccess(void * context, uint16_t val)


### PR DESCRIPTION
…ming related issue is resolved. (#7060)"

This reverts commit 46599f397df4743cf7f869bb7e039ab1491a98b3.

#### Problem
Darwin CI fails

#### Change overview
Revert the commit that bisect identifies as causing the failure

#### Testing
Locally ran the darwin CI test. 