### PR TITLE
Message counter storage issue temporary fix

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -235,6 +235,14 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
     mLocalMessageCounter = Encoding::LittleEndian::HostSwap32(serializable.mLocalMessageCounter);
     mPeerMessageCounter  = Encoding::LittleEndian::HostSwap32(serializable.mPeerMessageCounter);
 
+    // TODO - Remove the hack that's incrementing message counter while deserializing device
+    // This hack was added as a quick workaround for TE3 testing. The commissioning code
+    // is closing the exchange after the device has already been serialized and persisted to the storage.
+    // While closing the exchange, the outstanding ack gets sent to the device, thus incrementing
+    // the local message counter. As the device information was stored prior to sending the ack, it now has
+    // the old counter value (which is 1 less than the updated counter).
+    mLocalMessageCounter++;
+
     mCASESessionKeyId           = Encoding::LittleEndian::HostSwap16(serializable.mCASESessionKeyId);
     mDeviceProvisioningComplete = (serializable.mDeviceProvisioningComplete != 0);
 


### PR DESCRIPTION
#### Problem
The message counter in stored device structure on commissioner is out of sync from the actual counter value.

#### Change overview
The commissioning code is closing the exchange after the device has already been serialized and persisted to the storage.
While closing the exchange, the outstanding ack gets sent to the device, thus incrementing the local message counter. As the device information was stored prior to sending the ack, it now has the old counter value (which is 1 less than the updated counter).

This PR is a temporary hack to support TE3 testing. The commissioner will increment the local message counter value by 1 after reading it from the storage.

A TODO is added to remove this hack, once the final solution has been identified and implemented.

#### Testing
Pair the device using chip-tool app, and make sure the pairing, and on/off cluster commands are working fine.