### PR TITLE
Unlock BLE stack mutex for all callbacks from JNI to Java

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -38,6 +38,18 @@ class AndroidDeviceControllerWrapper : public chip::Controller::DevicePairingDel
 public:
     ~AndroidDeviceControllerWrapper();
 
+    // Use StackUnlockGuard to temporarily unlock the CHIP BLE stack, e.g. when calling application
+    // or Android BLE code as a result of a BLE event.
+    struct StackUnlockGuard
+    {
+    public:
+        StackUnlockGuard(pthread_mutex_t * mutex) : mMutex(mutex) { pthread_mutex_unlock(mMutex); }
+        ~StackUnlockGuard() { pthread_mutex_lock(mMutex); }
+
+    private:
+        pthread_mutex_t * mMutex;
+    };
+
     chip::Controller::DeviceCommissioner * Controller() { return mController.get(); }
     chip::Controller::ExampleOperationalCredentialsIssuer & OpCredsIssuer() { return mOpCredsIssuer; }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
@@ -65,15 +77,17 @@ public:
         return reinterpret_cast<AndroidDeviceControllerWrapper *>(handle);
     }
 
-    static AndroidDeviceControllerWrapper * AllocateNew(JavaVM * vm, jobject deviceControllerObj, chip::NodeId nodeId,
-                                                        chip::System::Layer * systemLayer, chip::Inet::InetLayer * inetLayer,
-                                                        CHIP_ERROR * errInfoOnFailure);
+    static AndroidDeviceControllerWrapper * AllocateNew(JavaVM * vm, jobject deviceControllerObj, pthread_mutex_t * stackLock,
+                                                        chip::NodeId nodeId, chip::System::Layer * systemLayer,
+                                                        chip::Inet::InetLayer * inetLayer, CHIP_ERROR * errInfoOnFailure);
 
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
 
     ChipDeviceControllerPtr mController;
     chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+
+    pthread_mutex_t * mStackLock;
 
     JavaVM * mJavaVM       = nullptr;
     jobject mJavaObjectRef = nullptr;
@@ -82,7 +96,9 @@ private:
 
     jclass GetPersistentStorageClass() { return GetJavaEnv()->FindClass("chip/devicecontroller/PersistentStorage"); }
 
-    AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller) : mController(std::move(controller)) {}
+    AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller, pthread_mutex_t * stackLock) :
+        mController(std::move(controller)), mStackLock(stackLock)
+    {}
 };
 
 inline jlong AndroidDeviceControllerWrapper::ToJNIHandle()


### PR DESCRIPTION
#### Problem
`StackUnlockGuard` should be used for all callbacks from JNI to Java, or else calling a native function from Java within the callback can deadlock.

#### Change overview
Move `StackUnlockGuard` to `AndroidDeviceControllerWrapper` so it can be reused across classes.
Add `StackUnlockGuard` to `OnStatusUpdate()`, `OnPairingComplete()`, and `OnPairingDeleted()` callbacks.

#### Testing
Tested manually by calling JNI methods guarded by `ScopedPthreadLock` within `onPairingComplete` callback.
Need #7286 before unit tests can be added.