### PR TITLE
[linux] Print log with timestamp and thread id

### DIFF
--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -2,7 +2,11 @@
 
 #include <platform/logging/LogV.h>
 
-#include <stdio.h>
+#include <cinttypes>
+#include <cstdio>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -25,7 +29,14 @@ namespace Platform {
  */
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-    printf("CHIP:%s: ", module);
+    struct timeval tv;
+
+    // Should not fail per man page of gettimeofday(), but failed to get time is not a fatal error in log. The bad time value will
+    // indicate the error occurred during getting time.
+    gettimeofday(&tv, nullptr);
+
+    printf("[%" PRIu64 ".%06" PRIu64 "][%ld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
+           static_cast<long>(gettid()), module);
     vprintf(msg, v);
     printf("\n");
     fflush(stdout);


### PR DESCRIPTION
#### Problem
We don't have timestamp in log, makes it hard to debug with multiple devices, we need to figure out the order of event happened.

#### Change overview
Add timestamp and thread id in log.

#### Testing
- Log update, checked with local build on linux.