### PR TITLE
ESP32: Fix temperature-measurement app

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/gen/af-gen-event.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/af-gen-event.h
@@ -22,15 +22,4 @@
 #ifndef __AF_GEN_EVENT__
 #define __AF_GEN_EVENT__
 
-// Code used to configure the cluster event mechanism
-#define EMBER_AF_GENERATED_EVENT_CODE                                                                                              \
-    extern EmberEventControl emberAfPluginTemperatureMeasurementServerReadEventControl;                                            \
-    extern void emberAfPluginTemperatureMeasurementServerReadEventHandler(void);
-
-// EmberEventData structs used to populate the EmberEventData table
-#define EMBER_AF_GENERATED_EVENTS                                                                                                  \
-    { &emberAfPluginTemperatureMeasurementServerReadEventControl, emberAfPluginTemperatureMeasurementServerReadEventHandler },
-
-#define EMBER_AF_GENERATED_EVENT_STRINGS "Temperature Measurement Server Cluster Plugin Read",
-
 #endif // __AF_GEN_EVENT__


### PR DESCRIPTION

#### Problem
temperature-measurement-app for ESP32 cannot compile at ToT

This is due to the latest changes related to temeprature-measurement cluster #7026 

#### Change overview
The APIs emberAfPluginTemperatureMeasurementServerReadEventControl and emberAfPluginTemperatureMeasurementServerReadEventHandler are removed from the above PR and hence removing them from here

#### Testing
Locally compiled the temperature-measurement app with CMake 

Fixes #7302 