### PR TITLE
Fix data corruption/mangling in DeviceCommissioner::SendOperationalCertificate

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1218,21 +1218,8 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(Device * device, const
     Callback::Cancelable * successCallback = mOpCertResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCertFailureCallback.Cancel();
 
-    // TODO - Update ZAP to use 16 bit length for OCTET_STRING. This is a temporary hack, as OCTET_STRING only supports 8 bit
-    // strings.
-    if (opCertBuf.size() >= UINT8_MAX)
-    {
-        ByteSpan tempCertFragment(&opCertBuf.data()[UINT8_MAX], opCertBuf.size() - UINT8_MAX);
-        ByteSpan opCertFragment(opCertBuf.data(), UINT8_MAX);
-
-        ReturnErrorOnFailure(cluster.AddOpCert(successCallback, failureCallback, opCertFragment, tempCertFragment,
-                                               ByteSpan(nullptr, 0), mLocalDeviceId, 0));
-    }
-    else
-    {
-        ReturnErrorOnFailure(cluster.AddOpCert(successCallback, failureCallback, opCertBuf, ByteSpan(nullptr, 0),
-                                               ByteSpan(nullptr, 0), mLocalDeviceId, 0));
-    }
+    ReturnErrorOnFailure(
+        cluster.AddOpCert(successCallback, failureCallback, opCertBuf, icaCertBuf, ByteSpan(nullptr, 0), mLocalDeviceId, 0));
 
     ChipLogProgress(Controller, "Sent operational certificate to the device");
 


### PR DESCRIPTION
#### Problem
What is being fixed?
* fixes TODO in DeviceCommissioner::SendOperationalCertificate, which was corrupting the op cert and failing to send the ICA cert
* Fixes #6877

#### Change overview
What's in this PR

DeviceCommissioner::SendOperationalCertificate now correctly sends both the op cert and the ICA cert. Previously it was corrupting them both, thinking that TempZCL protocol needs to be supported which has a 255 byte limitation. TempZCL protocol is not involved here, the code uses Interaction Model exclusively which ends up in OperationalCredentialsCluster::AddOpCert which already does the right thing when the byte span is larger than 255 bytes.

#### Testing
How was this tested? (at least one bullet point required)
* tested manually by sending more than 255 bytes per certificate and verifying the following:
* certs are not split (previously op cert was split)
* both certs are sent (previously ica cert was ignored)

