### PR TITLE
[doxygen] Enable deployment to the external repo

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -41,8 +41,7 @@ jobs:
               run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
               id: extract_branch
             - name: Deploy if master
-              #if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
-              if: github.event_name == 'workflow_dispatch'
+              if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
               uses: peaceiris/actions-gh-pages@v3
               with:
                   deploy_key: ${{ secrets.DOXYGEN_DEPLOY_KEY }}


### PR DESCRIPTION
#### Problem
PR #7259 added deployment of the doxygen output to the external repo: https://github.com/project-chip/connectedhomeip-doc/ but temporarily enabled the deployment only for manually triggered actions. As it seems to be working fine (see the output in https://project-chip.github.io/connectedhomeip-doc/) re-enable the automatic deployment.

#### Change overview
Re-enable the automatic deployment of the doxygen output.

#### Testing
CI only - no testing needed.
