### PR TITLE
Revert "Add Label to FabricDescriptorStruct and hook up logic with UpdateFabricLabel (#6670)

### DIFF
--- a/config/nrfconnect/app/enable-gnu-std.cmake
+++ b/config/nrfconnect/app/enable-gnu-std.cmake
@@ -1,3 +1,0 @@
-add_library(gnu17 INTERFACE)
-target_compile_options(gnu17 INTERFACE -std=gnu++17 -D_SYS__PTHREADTYPES_H_)
-target_link_libraries(app PRIVATE gnu17)

--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -420,7 +420,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -434,15 +434,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -866,7 +858,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -879,7 +879,6 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(void * cont
         ChipLogProgress(chipTool, "  FabricId: %" PRIu64 "", entries[i].FabricId);
         ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entries[i].VendorId);
         ChipLogProgress(chipTool, "  NodeId: %" PRIu64 "", entries[i].NodeId);
-        ChipLogProgress(Zcl, "  Label: %zu", entries[i].Label.size());
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);

--- a/examples/lighting-app/lighting-common/gen/attribute-size.cpp
+++ b/examples/lighting-app/lighting-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,15 +140,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -342,7 +334,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -34,8 +34,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrfconnect-lighting-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_compile_options(app PRIVATE -Werror)
 
 target_include_directories(app PRIVATE

--- a/examples/lock-app/lock-common/gen/attribute-size.cpp
+++ b/examples/lock-app/lock-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,15 +140,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -342,7 +334,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -36,8 +36,6 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-lock-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_include_directories(app PRIVATE 
                            main/include 
                            ${LOCK_COMMON} 

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -31,8 +31,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-pigweed-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_compile_options(app PRIVATE -Werror)
 
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -30,8 +30,6 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-pump-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_include_directories(app PRIVATE 
                            main/include 
                            ${PUMP_COMMON} 

--- a/examples/pump-app/pump-common/gen/attribute-size.cpp
+++ b/examples/pump-app/pump-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,15 +140,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -342,7 +334,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -30,8 +30,6 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-pump-controller-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_include_directories(app PRIVATE 
                            main/include 
                            ${PUMPC_COMMON} 

--- a/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,15 +140,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -342,7 +334,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -27,8 +27,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrfconnect-shell-example)
 
-include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
-
 target_compile_options(app PRIVATE -Werror)
 
 target_include_directories(app PRIVATE

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,15 +140,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -187,7 +179,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -324,7 +324,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 52;
+            entryLength = 18;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -338,15 +338,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId));      // NODE_ID
-            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
-            if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
-            {
-                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
-                return 0;
-            }
-            entryOffset = static_cast<uint16_t>(entryOffset + 34);
+                           sizeof(entry->NodeId)); // NODE_ID
             break;
         }
         }
@@ -682,7 +674,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 52;
+            entryLength = 18;
             break;
         }
         break;

--- a/src/app/common/gen/af-structs.h
+++ b/src/app/common/gen/af-structs.h
@@ -219,7 +219,6 @@ typedef struct _FabricDescriptor
     chip::FabricId FabricId;
     uint16_t VendorId;
     chip::NodeId NodeId;
-    chip::ByteSpan Label;
 } EmberAfFabricDescriptor;
 
 // Struct for GpPairingConfigurationGroupList

--- a/src/app/zap-templates/zcl/custom-types.xml
+++ b/src/app/zap-templates/zcl/custom-types.xml
@@ -58,7 +58,7 @@ limitations under the License.
      <item name="FabricId" type="FABRIC_ID"/>
      <item name="VendorId" type="INT16U"/> // Change INT16U to new type VendorID #2395
      <item name="NodeId" type="NODE_ID"/>
-     <item name="Label" type="OCTET_STRING" length="32"/>// TODO: Add Label once CHAR_STRING or OCTET_STRING works
+     // TODO: Add Label once CHAR_STRING or OCTET_STRING works
    </struct>
    <struct name="TestListStructOctet">
      <item name="fabricIndex" type="INT64U"/>

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -730,9 +730,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             CHECK_MESSAGE_LENGTH(8);
                             data[i].NodeId = emberAfGetInt64u(message, 0, 8);
                             message += 8;
-                            CHECK_STATUS(ReadByteSpan(message, 34, &data[i].Label));
-                            messageLen -= 34;
-                            message += 34;
                         }
 
                         Callback::Callback<OperationalCredentialsFabricsListListAttributeCallback> * cb =

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -244,7 +244,6 @@
 - (IBAction)removeAllFabricsButtonPressed:(id)sender
 {
     NSLog(@"Request to Remove All Fabrics.");
-    [self.removeFabricTextField resignFirstResponder];
     UIAlertController * alert =
         [UIAlertController alertControllerWithTitle:@"Remove All Fabrics?"
                                             message:@"Are you sure you want to remove all fabrics, this will remove all fabrics on "
@@ -281,7 +280,6 @@
 {
     NSString * label = _updateFabricLabelTextField.text;
     NSLog(@"Request to updateFabricLabel %@", label);
-    [self.updateFabricLabelTextField resignFirstResponder];
     [self updateResult:[NSString stringWithFormat:@"updateFabricLabel command sent."] isError:NO];
     [self.cluster
         updateFabricLabel:label
@@ -289,20 +287,18 @@
               dispatch_async(dispatch_get_main_queue(), ^{
                   if (error) {
                       NSLog(@"Got back error trying to updateFabricLabel %@", error);
+                      self->_updateFabricLabelTextField.text = @"";
                       dispatch_async(dispatch_get_main_queue(), ^{
-                          self->_updateFabricLabelTextField.text = @"";
                           [self updateResult:[NSString stringWithFormat:@"Command updateFabricLabel failed with error %@", error]
                                      isError:YES];
                       });
                   } else {
                       NSLog(@"Successfully updated the label: %@", values);
                       dispatch_async(dispatch_get_main_queue(), ^{
-                          self->_updateFabricLabelTextField.text = @"";
                           [self
                               updateResult:[NSString
                                                stringWithFormat:@"Command updateFabricLabel succeeded to update label to %@", label]
                                    isError:NO];
-                          [self fetchFabricsList];
                       });
                   }
               });

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -3096,9 +3096,7 @@ public:
             for (uint16_t i = 0; i < count; i++) {
                 values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                                   @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
-                                                  [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId",
-                                                  [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()],
-                                                  @"Label", nil];
+                                                  [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -30,16 +30,6 @@ using namespace Crypto;
 
 namespace Transport {
 
-CHIP_ERROR AdminPairingInfo::SetFabricLabel(const uint8_t * fabricLabel)
-{
-    const char * charFabricLabel = Uint8::to_const_char(fabricLabel);
-    size_t stringLength          = strnlen(charFabricLabel, kFabricLabelMaxLengthInBytes);
-    memcpy(mFabricLabel, charFabricLabel, stringLength);
-    mFabricLabel[stringLength] = '\0'; // Set null terminator
-
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -54,10 +44,6 @@ CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
     info->mAdmin    = Encoding::LittleEndian::HostSwap16(mAdmin);
     info->mFabricId = Encoding::LittleEndian::HostSwap64(mFabricId);
     info->mVendorId = Encoding::LittleEndian::HostSwap16(mVendorId);
-
-    size_t stringLength = strnlen(mFabricLabel, kFabricLabelMaxLengthInBytes);
-    memcpy(info->mFabricLabel, mFabricLabel, stringLength);
-    info->mFabricLabel[stringLength] = '\0'; // Set null terminator
 
     if (mOperationalKey != nullptr)
     {
@@ -117,7 +103,6 @@ CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
 
     AdminId id;
     uint16_t rootCertLen, opCertLen;
-    size_t stringLength;
 
     SuccessOrExit(err = kvs->SyncGetKeyValue(key, info, infoSize));
 
@@ -127,10 +112,6 @@ CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
     mVendorId   = Encoding::LittleEndian::HostSwap16(info->mVendorId);
     rootCertLen = Encoding::LittleEndian::HostSwap16(info->mRootCertLen);
     opCertLen   = Encoding::LittleEndian::HostSwap16(info->mOpCertLen);
-
-    stringLength = strnlen(info->mFabricLabel, kFabricLabelMaxLengthInBytes);
-    memcpy(mFabricLabel, info->mFabricLabel, stringLength);
-    mFabricLabel[stringLength] = '\0'; // Set null terminator
 
     VerifyOrExit(mAdmin == id, err = CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -25,7 +25,6 @@
 #include <core/CHIPPersistentStorageDelegate.h>
 #include <credentials/CHIPOperationalCredentials.h>
 #include <crypto/CHIPCryptoPAL.h>
-#include <lib/core/CHIPSafeCasts.h>
 #include <support/CHIPMem.h>
 #include <support/DLLUtil.h>
 #include <support/Span.h>
@@ -35,8 +34,7 @@ namespace chip {
 namespace Transport {
 
 typedef uint16_t AdminId;
-static constexpr AdminId kUndefinedAdminId            = UINT16_MAX;
-static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
+static constexpr AdminId kUndefinedAdminId = UINT16_MAX;
 
 // KVS store is sensitive to length of key strings, based on the underlying
 // platform. Keeping them short.
@@ -67,12 +65,6 @@ class DLL_EXPORT AdminPairingInfo
 {
 public:
     AdminPairingInfo() { Reset(); }
-
-    // Returns a pointer to a null terminated char array
-    const uint8_t * GetFabricLabel() const { return Uint8::from_const_char(mFabricLabel); };
-
-    // Expects a pointer to a null terminated char array
-    CHIP_ERROR SetFabricLabel(const uint8_t * fabricLabel);
 
     ~AdminPairingInfo()
     {
@@ -137,11 +129,10 @@ public:
      */
     void Reset()
     {
-        mNodeId         = kUndefinedNodeId;
-        mAdmin          = kUndefinedAdminId;
-        mFabricId       = kUndefinedFabricId;
-        mVendorId       = kUndefinedVendorId;
-        mFabricLabel[0] = '\0';
+        mNodeId   = kUndefinedNodeId;
+        mAdmin    = kUndefinedAdminId;
+        mFabricId = kUndefinedFabricId;
+        mVendorId = kUndefinedVendorId;
 
         if (mOperationalKey != nullptr)
         {
@@ -154,11 +145,10 @@ public:
     friend class AdminPairingTable;
 
 private:
-    NodeId mNodeId                                      = kUndefinedNodeId;
-    FabricId mFabricId                                  = kUndefinedFabricId;
-    AdminId mAdmin                                      = kUndefinedAdminId;
-    uint16_t mVendorId                                  = kUndefinedVendorId;
-    char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
+    NodeId mNodeId     = kUndefinedNodeId;
+    FabricId mFabricId = kUndefinedFabricId;
+    AdminId mAdmin     = kUndefinedAdminId;
+    uint16_t mVendorId = kUndefinedVendorId;
 
     AccessControlList mACL;
 
@@ -188,8 +178,6 @@ private:
         uint64_t mNodeId;   /* This field is serialized in LittleEndian byte order */
         uint64_t mFabricId; /* This field is serialized in LittleEndian byte order */
         uint16_t mVendorId; /* This field is serialized in LittleEndian byte order */
-
-        char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
 
         uint16_t mRootCertLen; /* This field is serialized in LittleEndian byte order */
         uint16_t mOpCertLen;   /* This field is serialized in LittleEndian byte order */


### PR DESCRIPTION
This reverts commit e1cb60847fdb66d2330dfb1a8bde8769d6e36c95 because
that breaks Darwin tests: it changes StorableAdminPairingInfo but
something is setting up admins in kvs without going through
`AdminPairingInfo::StoreIntoKVS` so our code and our stored data end
up out of sync.

#### Problem
What is being fixed?  Examples:
darwin tests fail, at least when running locally.

#### Change overview
Revert #6670

#### Testing
Ran darwin tests locally after revert and they pass.