### PR TITLE
Fix no-op 'git checkout' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ interactive rebase:
 
 ```bash
 # Rebase all commits on your development branch
-git checkout
+git checkout <branch-name>
 git rebase -i master
 ```
 


### PR DESCRIPTION
`git checkout` command in interactive rebase instructions was missing the branch name.