### PR TITLE
Rename CRMP to MRP (Message  Reliability Protocol)

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -58,8 +58,8 @@ public:
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
         mUsingTCP = false;
 #endif
-        mUsingCRMP = true;
-        mEchoPort  = CHIP_PORT;
+        mUsingMRP = true;
+        mEchoPort = CHIP_PORT;
     }
 
     uint64_t GetLastEchoTime() const { return mLastEchoTime; }
@@ -93,8 +93,8 @@ public:
     void SetUsingTCP(bool value) { mUsingTCP = value; }
 #endif
 
-    bool IsUsingCRMP() const { return mUsingCRMP; }
-    void SetUsingCRMP(bool value) { mUsingCRMP = value; }
+    bool IsUsingMRP() const { return mUsingMRP; }
+    void SetUsingMRP(bool value) { mUsingMRP = value; }
 
 private:
     // The last time a echo request was attempted to be sent.
@@ -125,7 +125,7 @@ private:
     bool mUsingTCP;
 #endif
 
-    bool mUsingCRMP;
+    bool mUsingMRP;
 } gPingArguments;
 
 Protocols::Echo::EchoClient gEchoClient;
@@ -156,7 +156,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
     payloadBuf = MessagePacketBuffer::NewWithData(requestData, size);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
-    if (gPingArguments.IsUsingCRMP())
+    if (gPingArguments.IsUsingMRP())
     {
         sendFlags.Set(Messaging::SendMessageFlags::kNone);
     }
@@ -363,7 +363,7 @@ void PrintUsage(streamer_t * stream)
     streamer_printf(stream, "  -p  <port>      echo server port\n");
     streamer_printf(stream, "  -i  <interval>  ping interval time in seconds\n");
     streamer_printf(stream, "  -c  <count>     stop after <count> replies\n");
-    streamer_printf(stream, "  -r  <1|0>       enable or disable CRMP\n");
+    streamer_printf(stream, "  -r  <1|0>       enable or disable MRP\n");
     streamer_printf(stream, "  -s  <size>      payload size in bytes\n");
 }
 
@@ -446,11 +446,11 @@ int cmd_ping(int argc, char ** argv)
 
                 if (arg == 0)
                 {
-                    gPingArguments.SetUsingCRMP(false);
+                    gPingArguments.SetUsingMRP(false);
                 }
                 else if (arg == 1)
                 {
-                    gPingArguments.SetUsingCRMP(true);
+                    gPingArguments.SetUsingMRP(true);
                 }
                 else
                 {

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -54,8 +54,8 @@ public:
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
         mUsingTCP = false;
 #endif
-        mUsingCRMP = true;
-        mPort      = CHIP_PORT;
+        mUsingMRP = true;
+        mPort     = CHIP_PORT;
     }
 
     uint64_t GetLastSendTime() const { return mLastSendTime; }
@@ -78,8 +78,8 @@ public:
     void SetUsingTCP(bool value) { mUsingTCP = value; }
 #endif
 
-    bool IsUsingCRMP() const { return mUsingCRMP; }
-    void SetUsingCRMP(bool value) { mUsingCRMP = value; }
+    bool IsUsingMRP() const { return mUsingMRP; }
+    void SetUsingMRP(bool value) { mUsingMRP = value; }
 
 private:
     // The last time a CHIP message was attempted to be sent.
@@ -94,7 +94,7 @@ private:
     bool mUsingTCP;
 #endif
 
-    bool mUsingCRMP;
+    bool mUsingMRP;
 } gSendArguments;
 
 class MockAppDelegate : public Messaging::ExchangeDelegate
@@ -155,7 +155,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     payloadBuf = MessagePacketBuffer::NewWithData(requestData, size);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
-    if (gSendArguments.IsUsingCRMP())
+    if (gSendArguments.IsUsingMRP())
     {
         sendFlags.Set(Messaging::SendMessageFlags::kNone);
     }
@@ -316,7 +316,7 @@ void PrintUsage(streamer_t * stream)
     streamer_printf(stream, "  -P  <protocol>  protocol ID\n");
     streamer_printf(stream, "  -T  <type>      message type\n");
     streamer_printf(stream, "  -p  <port>      server port number\n");
-    streamer_printf(stream, "  -r  <1|0>       enable or disable CRMP\n");
+    streamer_printf(stream, "  -r  <1|0>       enable or disable MRP\n");
     streamer_printf(stream, "  -s  <size>      payload size in bytes\n");
 }
 
@@ -399,11 +399,11 @@ int cmd_send(int argc, char ** argv)
 
                 if (arg == 0)
                 {
-                    gSendArguments.SetUsingCRMP(false);
+                    gSendArguments.SetUsingMRP(false);
                 }
                 else if (arg == 1)
                 {
-                    gSendArguments.SetUsingCRMP(true);
+                    gSendArguments.SetUsingMRP(true);
                 }
                 else
                 {

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -101,7 +101,7 @@ CHIP_ERROR AdvertiseOperational()
             .SetPeerId(PeerId().SetFabricId(fabricId).SetNodeId(GetCurrentNodeId()))
             .SetMac(FillMAC(mac))
             .SetPort(CHIP_PORT)
-            .SetCRMPRetryIntervals(CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL, CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL)
+            .SetMRPRetryIntervals(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL, CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL)
             .EnableIpV4(true);
 
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();

--- a/src/app/tests/integration/README.md
+++ b/src/app/tests/integration/README.md
@@ -14,7 +14,7 @@ must create an ExchangeContext object before initiating a CHIP conversation.
 
 After constructing a CHIP ExchangeContext, CHIP messages are sent and received
 using the ChipMessageLayer class which sends the CHIP message over a chosen
-transport (TCP, UDP, or CRMP).
+transport (TCP, UDP, or MRP).
 
 ## Example Applications Walk Through
 

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -96,7 +96,7 @@ public:
     // Amount of mDNS text entries required for this advertising type
     static constexpr uint8_t kNumAdvertisingTxtEntries = 2;
     static constexpr uint8_t kTxtMaxKeySize            = 3 + 1; // "CRI"/"CRA" as possible keys
-    static constexpr uint8_t kTxtMaxValueSize          = 7 + 1; // Max for text representation of the 32-bit CRMP intervals
+    static constexpr uint8_t kTxtMaxValueSize          = 7 + 1; // Max for text representation of the 32-bit MRP intervals
 
     OperationalAdvertisingParameters & SetPeerId(const PeerId & peerId)
     {
@@ -105,22 +105,22 @@ public:
     }
     PeerId GetPeerId() const { return mPeerId; }
 
-    OperationalAdvertisingParameters & SetCRMPRetryIntervals(uint32_t intervalIdle, uint32_t intervalActive)
+    OperationalAdvertisingParameters & SetMRPRetryIntervals(uint32_t intervalIdle, uint32_t intervalActive)
     {
-        mCrmpRetryIntervalIdle   = intervalIdle;
-        mCrmpRetryIntervalActive = intervalActive;
+        mMrpRetryIntervalIdle   = intervalIdle;
+        mMrpRetryIntervalActive = intervalActive;
         return *this;
     }
-    void GetCRMPRetryIntervals(uint32_t & intervalIdle, uint32_t & intervalActive) const
+    void GetMRPRetryIntervals(uint32_t & intervalIdle, uint32_t & intervalActive) const
     {
-        intervalIdle   = mCrmpRetryIntervalIdle;
-        intervalActive = mCrmpRetryIntervalActive;
+        intervalIdle   = mMrpRetryIntervalIdle;
+        intervalActive = mMrpRetryIntervalActive;
     }
 
 private:
     PeerId mPeerId;
-    uint32_t mCrmpRetryIntervalIdle   = 0;
-    uint32_t mCrmpRetryIntervalActive = 0;
+    uint32_t mMrpRetryIntervalIdle   = 0;
+    uint32_t mMrpRetryIntervalActive = 0;
 };
 
 class CommissionAdvertisingParameters : public BaseAdvertisingParams<CommissionAdvertisingParameters>

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -336,19 +336,19 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     // TODO: That value should be defined in the ReliableMessageProtocolConfig.h,
     // but for now it is not possible to access it from src/lib/mdns. It should be
     // refactored after creating common DNS-SD layer.
-    constexpr uint32_t kMaxCRMPRetryInterval = 3600000;
-    // kMaxCRMPRetryInterval max value is 3600000, what gives 7 characters and newline
+    constexpr uint32_t kMaxMRPRetryInterval = 3600000;
+    // kMaxMRPRetryInterval max value is 3600000, what gives 7 characters and newline
     // necessary to represent it in the text form.
-    constexpr uint8_t kMaxCRMPRetryBufferSize = 7 + 1;
-    char crmpRetryIntervalIdleBuf[kMaxCRMPRetryBufferSize];
-    char crmpRetryIntervalActiveBuf[kMaxCRMPRetryBufferSize];
-    TextEntry crmpRetryIntervalEntries[OperationalAdvertisingParameters::kNumAdvertisingTxtEntries];
+    constexpr uint8_t kMaxMRPRetryBufferSize = 7 + 1;
+    char mrpRetryIntervalIdleBuf[kMaxMRPRetryBufferSize];
+    char mrpRetryIntervalActiveBuf[kMaxMRPRetryBufferSize];
+    TextEntry mrpRetryIntervalEntries[OperationalAdvertisingParameters::kNumAdvertisingTxtEntries];
     size_t textEntrySize = 0;
-    uint32_t crmpRetryIntervalIdle, crmpRetryIntervalActive;
+    uint32_t mrpRetryIntervalIdle, mrpRetryIntervalActive;
     int writtenCharactersNumber;
-    params.GetCRMPRetryIntervals(crmpRetryIntervalIdle, crmpRetryIntervalActive);
+    params.GetMRPRetryIntervals(mrpRetryIntervalIdle, mrpRetryIntervalActive);
 
-    // TODO: Issue #5833 - CRMP retry intervals should be updated on the poll period value
+    // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value
     // change or device type change.
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (chip::DeviceLayer::ConnectivityMgr().GetThreadDeviceType() ==
@@ -356,45 +356,44 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     {
         uint32_t sedPollPeriod;
         ReturnErrorOnFailure(chip::DeviceLayer::ThreadStackMgr().GetPollPeriod(sedPollPeriod));
-        // Increment default CRMP retry intervals by SED poll period to be on the safe side
+        // Increment default MRP retry intervals by SED poll period to be on the safe side
         // and avoid unnecessary retransmissions.
-        crmpRetryIntervalIdle += sedPollPeriod;
-        crmpRetryIntervalActive += sedPollPeriod;
+        mrpRetryIntervalIdle += sedPollPeriod;
+        mrpRetryIntervalActive += sedPollPeriod;
     }
 #endif
 
-    if (crmpRetryIntervalIdle > kMaxCRMPRetryInterval)
+    if (mrpRetryIntervalIdle > kMaxMRPRetryInterval)
     {
-        ChipLogProgress(Discovery, "CRMP retry interval idle value exceeds allowed range of 1 hour, using maximum available",
+        ChipLogProgress(Discovery, "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available",
                         chip::ErrorStr(error));
-        crmpRetryIntervalIdle = kMaxCRMPRetryInterval;
+        mrpRetryIntervalIdle = kMaxMRPRetryInterval;
     }
-    writtenCharactersNumber =
-        snprintf(crmpRetryIntervalIdleBuf, sizeof(crmpRetryIntervalIdleBuf), "%" PRIu32, crmpRetryIntervalIdle);
-    VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kMaxCRMPRetryBufferSize),
+    writtenCharactersNumber = snprintf(mrpRetryIntervalIdleBuf, sizeof(mrpRetryIntervalIdleBuf), "%" PRIu32, mrpRetryIntervalIdle);
+    VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kMaxMRPRetryBufferSize),
                         CHIP_ERROR_INVALID_STRING_LENGTH);
-    crmpRetryIntervalEntries[textEntrySize++] = { "CRI", reinterpret_cast<const uint8_t *>(crmpRetryIntervalIdleBuf),
-                                                  strlen(crmpRetryIntervalIdleBuf) };
+    mrpRetryIntervalEntries[textEntrySize++] = { "CRI", reinterpret_cast<const uint8_t *>(mrpRetryIntervalIdleBuf),
+                                                 strlen(mrpRetryIntervalIdleBuf) };
 
-    if (crmpRetryIntervalActive > kMaxCRMPRetryInterval)
+    if (mrpRetryIntervalActive > kMaxMRPRetryInterval)
     {
-        ChipLogProgress(Discovery, "CRMP retry interval active value exceeds allowed range of 1 hour, using maximum available",
+        ChipLogProgress(Discovery, "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available",
                         chip::ErrorStr(error));
-        crmpRetryIntervalActive = kMaxCRMPRetryInterval;
+        mrpRetryIntervalActive = kMaxMRPRetryInterval;
     }
     writtenCharactersNumber =
-        snprintf(crmpRetryIntervalActiveBuf, sizeof(crmpRetryIntervalActiveBuf), "%" PRIu32, crmpRetryIntervalActive);
-    VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kMaxCRMPRetryBufferSize),
+        snprintf(mrpRetryIntervalActiveBuf, sizeof(mrpRetryIntervalActiveBuf), "%" PRIu32, mrpRetryIntervalActive);
+    VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kMaxMRPRetryBufferSize),
                         CHIP_ERROR_INVALID_STRING_LENGTH);
-    crmpRetryIntervalEntries[textEntrySize++] = { "CRA", reinterpret_cast<const uint8_t *>(crmpRetryIntervalActiveBuf),
-                                                  strlen(crmpRetryIntervalActiveBuf) };
+    mrpRetryIntervalEntries[textEntrySize++] = { "CRA", reinterpret_cast<const uint8_t *>(mrpRetryIntervalActiveBuf),
+                                                 strlen(mrpRetryIntervalActiveBuf) };
 
     ReturnErrorOnFailure(SetupHostname(params.GetMac()));
     ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), params.GetPeerId()));
     strncpy(service.mType, kOperationalServiceName, sizeof(service.mType));
     service.mProtocol      = MdnsServiceProtocol::kMdnsProtocolTcp;
     service.mPort          = CHIP_PORT;
-    service.mTextEntries   = crmpRetryIntervalEntries;
+    service.mTextEntries   = mrpRetryIntervalEntries;
     service.mTextEntrySize = textEntrySize;
     service.mInterface     = INET_NULL_INTERFACEID;
     service.mAddressType   = Inet::kIPAddressType_Any;

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -157,7 +157,7 @@ void ExchangeContext::DoClose(bool clearRetransTable)
     FlushAcks();
 
     // In case the protocol wants a harder release of the EC right away, such as calling Abort(), exchange
-    // needs to clear the CRMP retransmission table immediately.
+    // needs to clear the MRP retransmission table immediately.
     if (clearRetransTable)
     {
         mExchangeMgr->GetReliableMessageMgr()->ClearRetransTable(static_cast<ReliableMessageContext *>(this));
@@ -382,7 +382,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, con
         mDispatch->OnMessageReceived(payloadHeader, packetHeader.GetMessageId(), peerAddress, GetReliableMessageContext());
     SuccessOrExit(err);
 
-    // The SecureChannel::StandaloneAck message type is only used for CRMP; do not pass such messages to the application layer.
+    // The SecureChannel::StandaloneAck message type is only used for MRP; do not pass such messages to the application layer.
     if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck))
     {
         ExitNow(err = CHIP_NO_ERROR);

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR ExchangeMessageDispatch::SendMessage(SecureSessionHandle session, uin
     }
     else
     {
-        // If the channel itself is providing reliability, let's not request CRMP acks
+        // If the channel itself is providing reliability, let's not request MRP acks
         payloadHeader.SetNeedsAck(false);
         ReturnErrorOnFailure(SendMessageImpl(session, payloadHeader, std::move(message), nullptr));
     }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -211,7 +211,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->MatchExchange(session, packetHeader, payloadHeader))
         {
-            // Found a matching exchange. Set flag for correct subsequent CRMP
+            // Found a matching exchange. Set flag for correct subsequent MRP
             // retransmission timeout selection.
             if (!ec->HasRcvdMsgFromPeer())
             {

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -43,7 +43,7 @@ namespace Messaging {
 #endif // CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
 
 /**
- *  @def CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+ *  @def CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
  *
  *  @brief
  *    Active retransmit interval, or time to wait before retransmission after
@@ -53,12 +53,12 @@ namespace Messaging {
  *  needs (e.g. sleeping period) using Service Discovery TXT record CRA key.
  *
  */
-#ifndef CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
-#define CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL (300)
-#endif // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+#ifndef CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
+#define CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL (300)
+#endif // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
 
 /**
- *  @def CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
+ *  @def CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
  *
  *  @brief
  *    Initial retransmission interval, or time to wait before retransmission after first
@@ -67,9 +67,9 @@ namespace Messaging {
  * This is the default value, that might be adjusted by end device depending on its
  * needs (e.g. sleeping period) using Service Discovery TXT record CRI key.
  */
-#ifndef CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-#define CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL (5000)
-#endif // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
+#ifndef CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+#define CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL (5000)
+#endif // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
 
 /**
  *  @def CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK
@@ -121,8 +121,8 @@ struct ReliableMessageProtocolConfig
 };
 
 const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = {
-    CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
-    CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
+    CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+    CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
 };
 
 // clang-format on

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -257,8 +257,8 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
     // Let's drop the initial message
@@ -322,8 +322,8 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
     // Let's drop the initial message
@@ -386,8 +386,8 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
     err = mockSender.mMessageDispatch.Init(rm);
@@ -447,8 +447,8 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
     // Let's drop the initial message
@@ -522,8 +522,8 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     rc->SetConfig({
-        1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+        1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
     });
 
     err = mockSender.mMessageDispatch.Init(rm);

--- a/src/messaging/tests/echo/README.md
+++ b/src/messaging/tests/echo/README.md
@@ -17,7 +17,7 @@ must create an ExchangeContext object before initiating a CHIP conversation.
 
 After constructing a CHIP ExchangeContext, CHIP messages are sent and received
 using the ChipMessageLayer class which sends the CHIP message over a chosen
-transport (TCP, UDP, or CRMP).
+transport (TCP, UDP, or MRP).
 
 ## Building
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -212,8 +212,8 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
         NL_TEST_ASSERT(inSuite, rc != nullptr);
 
         rc->SetConfig({
-            1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
-            1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
+            1, // CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL
+            1, // CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL
         });
         gLoopback.mContext = &ctx;
     }


### PR DESCRIPTION
#### Problem
What is being fixed? 
CRMP has been rename to to MRP (Message  Reliability Protocol) in spec.

#### Change overview
Rename CRMP to MRP (Message  Reliability Protocol) to align with spec.

#### Testing
How was this tested? (at least one bullet point required)
Run ./gn_build and confirm nothing break.
