### PR TITLE
[cirque] Pull cirque version and add simulated latency to cirque

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 
 RUN apt-get update \
   && apt-get install --no-install-recommends -y sudo git ca-certificates psmisc dhcpcd5 wpasupplicant wireless-tools \
-  && apt-get install -y libglib2.0 avahi-daemon libavahi-client3 \
+  && apt-get install -y libglib2.0 avahi-daemon libavahi-client3 iproute2 \
   && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
   && git clone https://github.com/openthread/ot-br-posix . \
   && git checkout $OT_BR_POSIX_CHECKOUT \

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -139,7 +139,7 @@ class CHIPVirtualHome:
         for device_id in devices:
             # Wait for otbr-agent and CHIP server start
             self.assertTrue(self.wait_for_device_output(device_id, "Border router agent started.", 10))
-            self.assertTrue(self.wait_for_device_output(device_id, "CHIP:SVR: Server Listening...", 10))
+            self.assertTrue(self.wait_for_device_output(device_id, "CHIP:SVR: Server Listening...", 15))
             # Clear default Thread network commissioning data
             self.logger.info("Resetting thread network on {}".format(
                 self.get_device_pretty_id(device_id)))

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -35,14 +35,16 @@ DEVICE_CONFIG = {
     'device0': {
         'type': 'CHIP-Echo-Requester',
         'base_image': 'chip_echo_requester',
-        'capability': ['Thread', 'Interactive'],
+        'capability': ['Thread', 'Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     },
     'device1': {
         'type': 'CHIP-Echo-Responder',
         'base_image': 'chip_echo_responder',
-        'capability': ['Thread', 'Interactive'],
+        'capability': ['Thread', 'Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     }
 }
 

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -35,14 +35,16 @@ DEVICE_CONFIG = {
     'device0': {
         'type': 'CHIP-IM-Initiator',
         'base_image': 'chip_im_initiator',
-        'capability': ['Thread', 'Interactive'],
+        'capability': ['Thread', 'Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     },
     'device1': {
         'type': 'CHIP-IM-Responder',
         'base_image': 'chip_im_responder',
-        'capability': ['Thread', 'Interactive'],
+        'capability': ['Thread', 'Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     }
 }
 

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -36,14 +36,16 @@ DEVICE_CONFIG = {
     'device0': {
         'type': 'MobileDevice',
         'base_image': 'chip_mobile_device',
-        'capability': ['Interactive'],
+        'capability': ['Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     },
     'device1': {
         'type': 'CHIPEndDevice',
         'base_image': 'chip_server',
-        'capability': ['Thread', 'Interactive'],
+        'capability': ['Thread', 'Interactive', 'TrafficControl'],
         'rcp_mode': True,
+        'traffic_control': {'latencyMs': 100}
     }
 }
 


### PR DESCRIPTION
#### Problem
Cirque introduces "traffic control" feature which can add latency & random packet loss to network interface.

#### Change overview
* Modify test to enable traffic control feature in cirque tests.

#### Testing
* Test update