### PR TITLE
Fix for minimal mDNS 'No Memory' error.

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -300,6 +300,7 @@ void AdvertiserMinMdns::Clear()
 
 CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters & params)
 {
+    Clear();
     char nameBuffer[64] = "";
 
     /// need to set server name
@@ -363,6 +364,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
 CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & params)
 {
+    Clear();
     // TODO: need to detect colisions here
     char nameBuffer[64] = "";
     size_t len          = snprintf(nameBuffer, sizeof(nameBuffer), ChipLogFormatX64, GetRandU32(), GetRandU32());


### PR DESCRIPTION
#### Problem
When DNS-SD server starts it makes an entry for records. When the device disconnects and tries to connect to an AP again then DNS-SD server restarts and duplicates the record which leads to `NO MEMORY` error.
* Fix memory issue
* Log for error
```
I (176280) app-devicecallbacks: Server ready at: 192.168.43.120:11097
I (176290) chip[DIS]: Start dns-sd server
I (176290) chip[DIS]: CHIP minimal mDNS started advertising.
I (176300) chip[DIS]: Replying to DNS-SD service listing request
I (176300) chip[DIS]: Broadcasting mDns reply
E (176310) chip[DIS]: Failed to advertise records: LwIP Error 3000004 (0x002DC6C4): Routing problem.
I (176320) chip[DIS]: Found admin pairing for admin 0, node 0x000000000001B669
V (176330) chip[DIS]: Using wifi MAC for hostname
I (176330) chip[DIS]: Advertise operational node 0000000000000000-000000000001B669
**E (176350) chip[DIS]: Failed to add SRV record mDNS responder
E (176350) chip[DIS]: Failed to start mDNS server: CHIP Error 4000011 (0x003D090B): No memory**
I (176360) app-devicecallbacks: Current free heap: 99172
I (176750) chip[DL]: IP_EVENT_GOT_IP6
I (176750) chip[DL]: IPv6 addr available. Ready on WIFI_STA_DEF interface: fe80:0000:0000:0000:260a:c4ff:fec1:1b5c
I (176760) app-devicecallbacks: Current free heap: 100256
I (176760) chip[DIS]: Start dns-sd server
I (176770) chip[DIS]: CHIP minimal mDNS started advertising.
I (176780) chip[DIS]: Replying to DNS-SD service listing request
I (176780) chip[DIS]: Broadcasting mDns reply
I (176800) chip[DIS]: Broadcasting mDns reply
I (176800) chip[DIS]: Replying to DNS-SD service listing request
I (176800) chip[DIS]: Broadcasting mDns reply
I (176800) chip[DIS]: Broadcasting mDns reply
I (176820) chip[DIS]: Found admin pairing for admin 0, node 0x000000000001B669
V (176820) chip[DIS]: Using wifi MAC for hostname
I (176820) chip[DIS]: Advertise operational node 0000000000000000-000000000001B669
**E (176830) chip[DIS]: Failed to add service PTR record mDNS responder
E (176850) chip[DIS]: Failed to start mDNS server: CHIP Error 4000011 (0x003D090B): No memory**
```
#### Change overview
When the router is up, then old entries on the device side are cleared and new records can be added successfully.

#### Testing
* Flashed all-clusters-app on a device and connected a device to the router using python controller.
* Turned off the router and device disconnects
* When router is turned on again, then device tries to reconnect and create the entry for DNS records successfully.
