### PR TITLE
Add chip-tool support for octet string arguments with non-ASCII bytes in them.

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -11516,9 +11516,8 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                        chip::ByteSpan(chip::Uint8::from_char(mOperationalDataset), strlen(mOperationalDataset)),
-                                        mBreadcrumb, mTimeoutMs);
+        return cluster.AddThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mOperationalDataset, mBreadcrumb,
+                                        mTimeoutMs);
     }
 
 private:
@@ -11527,7 +11526,7 @@ private:
             OnNetworkCommissioningClusterAddThreadNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mOperationalDataset;
+    chip::ByteSpan mOperationalDataset;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11558,9 +11557,8 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddWiFiNetwork(
-            onSuccessCallback->Cancel(), onFailureCallback->Cancel(), chip::ByteSpan(chip::Uint8::from_char(mSsid), strlen(mSsid)),
-            chip::ByteSpan(chip::Uint8::from_char(mCredentials), strlen(mCredentials)), mBreadcrumb, mTimeoutMs);
+        return cluster.AddWiFiNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mSsid, mCredentials, mBreadcrumb,
+                                      mTimeoutMs);
     }
 
 private:
@@ -11569,8 +11567,8 @@ private:
             OnNetworkCommissioningClusterAddWiFiNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mSsid;
-    char * mCredentials;
+    chip::ByteSpan mSsid;
+    chip::ByteSpan mCredentials;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11600,8 +11598,7 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.DisableNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                      chip::ByteSpan(chip::Uint8::from_char(mNetworkID), strlen(mNetworkID)), mBreadcrumb,
+        return cluster.DisableNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mNetworkID, mBreadcrumb,
                                       mTimeoutMs);
     }
 
@@ -11611,7 +11608,7 @@ private:
             OnNetworkCommissioningClusterDisableNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mNetworkID;
+    chip::ByteSpan mNetworkID;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11641,9 +11638,7 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.EnableNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                     chip::ByteSpan(chip::Uint8::from_char(mNetworkID), strlen(mNetworkID)), mBreadcrumb,
-                                     mTimeoutMs);
+        return cluster.EnableNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mNetworkID, mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -11652,7 +11647,7 @@ private:
             OnNetworkCommissioningClusterEnableNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mNetworkID;
+    chip::ByteSpan mNetworkID;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11716,9 +11711,7 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.RemoveNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                     chip::ByteSpan(chip::Uint8::from_char(mNetworkID), strlen(mNetworkID)), mBreadcrumb,
-                                     mTimeoutMs);
+        return cluster.RemoveNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mNetworkID, mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -11727,7 +11720,7 @@ private:
             OnNetworkCommissioningClusterRemoveNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mNetworkID;
+    chip::ByteSpan mNetworkID;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11757,8 +11750,7 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ScanNetworks(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                    chip::ByteSpan(chip::Uint8::from_char(mSsid), strlen(mSsid)), mBreadcrumb, mTimeoutMs);
+        return cluster.ScanNetworks(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mSsid, mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -11767,7 +11759,7 @@ private:
             OnNetworkCommissioningClusterScanNetworksResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mSsid;
+    chip::ByteSpan mSsid;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11797,8 +11789,7 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.UpdateThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                           chip::ByteSpan(chip::Uint8::from_char(mOperationalDataset), strlen(mOperationalDataset)),
+        return cluster.UpdateThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mOperationalDataset,
                                            mBreadcrumb, mTimeoutMs);
     }
 
@@ -11808,7 +11799,7 @@ private:
             OnNetworkCommissioningClusterUpdateThreadNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mOperationalDataset;
+    chip::ByteSpan mOperationalDataset;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -11839,9 +11830,8 @@ public:
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.UpdateWiFiNetwork(
-            onSuccessCallback->Cancel(), onFailureCallback->Cancel(), chip::ByteSpan(chip::Uint8::from_char(mSsid), strlen(mSsid)),
-            chip::ByteSpan(chip::Uint8::from_char(mCredentials), strlen(mCredentials)), mBreadcrumb, mTimeoutMs);
+        return cluster.UpdateWiFiNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mSsid, mCredentials, mBreadcrumb,
+                                         mTimeoutMs);
     }
 
 private:
@@ -11850,8 +11840,8 @@ private:
             OnNetworkCommissioningClusterUpdateWiFiNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mSsid;
-    char * mCredentials;
+    chip::ByteSpan mSsid;
+    chip::ByteSpan mCredentials;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -12207,10 +12197,8 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddOpCert(
-            onSuccessCallback->Cancel(), onFailureCallback->Cancel(), chip::ByteSpan(chip::Uint8::from_char(mNoc), strlen(mNoc)),
-            chip::ByteSpan(chip::Uint8::from_char(mICACertificate), strlen(mICACertificate)),
-            chip::ByteSpan(chip::Uint8::from_char(mIPKValue), strlen(mIPKValue)), mCaseAdminNode, mAdminVendorId);
+        return cluster.AddOpCert(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mNoc, mICACertificate, mIPKValue,
+                                 mCaseAdminNode, mAdminVendorId);
     }
 
 private:
@@ -12219,9 +12207,9 @@ private:
             OnOperationalCredentialsClusterOpCertResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mNoc;
-    char * mICACertificate;
-    char * mIPKValue;
+    chip::ByteSpan mNoc;
+    chip::ByteSpan mICACertificate;
+    chip::ByteSpan mIPKValue;
     chip::NodeId mCaseAdminNode;
     uint16_t mAdminVendorId;
 };
@@ -12249,8 +12237,7 @@ public:
 
         chip::Controller::OperationalCredentialsCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.OpCSRRequest(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                    chip::ByteSpan(chip::Uint8::from_char(mCSRNonce), strlen(mCSRNonce)));
+        return cluster.OpCSRRequest(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mCSRNonce);
     }
 
 private:
@@ -12259,7 +12246,7 @@ private:
             OnOperationalCredentialsClusterOpCSRResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mCSRNonce;
+    chip::ByteSpan mCSRNonce;
 };
 
 /*
@@ -15873,8 +15860,7 @@ public:
 
         chip::Controller::TestClusterCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttributeOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                 chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)));
+        return cluster.WriteAttributeOctetString(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mValue);
     }
 
 private:
@@ -15882,7 +15868,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mValue;
+    chip::ByteSpan mValue;
 };
 
 /*
@@ -16661,9 +16647,7 @@ public:
 
         chip::Controller::TrustedRootCertificatesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.AddTrustedRootCertificate(
-            onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-            chip::ByteSpan(chip::Uint8::from_char(mRootCertificate), strlen(mRootCertificate)));
+        return cluster.AddTrustedRootCertificate(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mRootCertificate);
     }
 
 private:
@@ -16671,7 +16655,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mRootCertificate;
+    chip::ByteSpan mRootCertificate;
 };
 
 /*
@@ -16697,9 +16681,8 @@ public:
 
         chip::Controller::TrustedRootCertificatesCluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.RemoveTrustedRootCertificate(
-            onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-            chip::ByteSpan(chip::Uint8::from_char(mTrustedRootIdentifier), strlen(mTrustedRootIdentifier)));
+        return cluster.RemoveTrustedRootCertificate(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                    mTrustedRootIdentifier);
     }
 
 private:
@@ -16707,7 +16690,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mTrustedRootIdentifier;
+    chip::ByteSpan mTrustedRootIdentifier;
 };
 
 /*

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -20,6 +20,7 @@
 
 #include <controller/CHIPDeviceController.h>
 #include <inet/InetInterface.h>
+#include <support/Span.h>
 #include <support/logging/CHIPLogging.h>
 
 #include <atomic>
@@ -56,7 +57,8 @@ enum ArgumentType
     Number_int16,
     Number_int32,
     Number_int64,
-    String,
+    CharString,
+    OctetString,
     Attribute,
     Address
 };
@@ -100,13 +102,17 @@ public:
     size_t AddArgument(const char * name, const char * value);
     /**
      * @brief
-     *   Add a string command argument
+     *   Add a char string command argument
      *
      * @param name  The name that will be displayed in the command help
      * @param value A pointer to a `char *` where the argv value will be stored
      * @returns The number of arguments currently added to the command
      */
     size_t AddArgument(const char * name, char ** value);
+    /**
+     * Add an octet string command argument
+     */
+    size_t AddArgument(const char * name, chip::ByteSpan * value);
     size_t AddArgument(const char * name, AddressWithInterface * out);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out)
     {
@@ -154,7 +160,7 @@ public:
     void WaitForResponse(uint16_t duration);
 
 private:
-    bool InitArgument(size_t argIndex, const char * argValue);
+    bool InitArgument(size_t argIndex, char * argValue);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out);
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -209,19 +209,16 @@ CHIP_ERROR PairingCommand::AddThreadNetwork()
 {
     Callback::Cancelable * successCallback = mOnAddThreadNetworkCallback->Cancel();
     Callback::Cancelable * failureCallback = mOnFailureCallback->Cancel();
-    ByteSpan operationalDataset            = ByteSpan(Uint8::from_char(mOperationalDataset), strlen(mOperationalDataset));
 
-    return mCluster.AddThreadNetwork(successCallback, failureCallback, operationalDataset, kBreadcrumb, kTimeoutMs);
+    return mCluster.AddThreadNetwork(successCallback, failureCallback, mOperationalDataset, kBreadcrumb, kTimeoutMs);
 }
 
 CHIP_ERROR PairingCommand::AddWiFiNetwork()
 {
     Callback::Cancelable * successCallback = mOnAddWiFiNetworkCallback->Cancel();
     Callback::Cancelable * failureCallback = mOnFailureCallback->Cancel();
-    ByteSpan ssid                          = ByteSpan(Uint8::from_char(mSSID), strlen(mSSID));
-    ByteSpan credentials                   = ByteSpan(Uint8::from_char(mPassword), strlen(mPassword));
 
-    return mCluster.AddWiFiNetwork(successCallback, failureCallback, ssid, credentials, kBreadcrumb, kTimeoutMs);
+    return mCluster.AddWiFiNetwork(successCallback, failureCallback, mSSID, mPassword, kBreadcrumb, kTimeoutMs);
 }
 
 CHIP_ERROR PairingCommand::EnableNetwork()
@@ -232,7 +229,7 @@ CHIP_ERROR PairingCommand::EnableNetwork()
     ByteSpan networkId;
     if (mNetworkType == PairingNetworkType::WiFi)
     {
-        networkId = ByteSpan(Uint8::from_char(mSSID), strlen(mSSID));
+        networkId = mSSID;
     }
     else
     {

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -24,6 +24,7 @@
 #include "gen/CHIPClusters.h"
 
 #include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <support/Span.h>
 
 enum class PairingMode
 {
@@ -134,9 +135,9 @@ private:
     uint64_t mFabricId;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
-    char * mOperationalDataset;
-    char * mSSID;
-    char * mPassword;
+    chip::ByteSpan mOperationalDataset;
+    chip::ByteSpan mSSID;
+    chip::ByteSpan mPassword;
 
     chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> * mOnAddThreadNetworkCallback;
     chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback;

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -205,7 +205,7 @@ public:
 
         chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asCamelCased label false}}), strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asCamelCased label false}}), strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_server_cluster_command_arguments}});
     }
 
 private:
@@ -216,7 +216,7 @@ private:
     {{/if}}
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     {{#chip_server_cluster_command_arguments}}
-    {{#if (isString type)}}
+    {{#if (isCharString type)}}
     char * m{{asCamelCased label false}};
     {{else}}
     {{chipType}} m{{asCamelCased label false}};
@@ -321,13 +321,13 @@ public:
 
         chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), {{#if (isString type)}} chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)){{else}}mValue{{/if}});
+        return cluster.WriteAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)){{else}}mValue{{/if}});
     }
 
 private:
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    {{#if (isString type)}}
+    {{#if (isCharString type)}}
     char * mValue;
     {{else}}
     {{chipType}} mValue;

--- a/src/app/zap-templates/README.md
+++ b/src/app/zap-templates/README.md
@@ -61,7 +61,7 @@ To generate the application additional files, the command is:
 For example, to generate `chip-tool` additional files the command is:
 
 ```
-./scripts/tools/zap/generate.py examples/chip-tool/chip-tool.zap -t examples/chip-tool/templates/templates.json
+./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap -t examples/chip-tool/templates/templates.json
 ```
 
 For more information please see the documentation under `docs/` in

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -96,6 +96,23 @@ inline CHIP_ERROR BytesToLowercaseHexString(const uint8_t * src_bytes, size_t sr
     return BytesToHex(src_bytes, src_size, dest_hex_str, dest_size_max, HexFlags::kNullTerminate);
 }
 
+/**
+ * Convert a buffer of hexadecimal characters to bytes.  Supports both lowercase
+ * and uppercase (or a mix of cases) hexadecimal characters. Supported input is
+ * [0-9a-fA-F].
+ *
+ * @param srcHex a pointer to the character buffer to convert.  It is not
+ *               assumed to be null-terminated.
+ * @param srcLen the length of the character buffer to convert.
+ * @param destBytes the buffer to fill with the decoded bytes.
+ * @param destMaxLen the total size of the buffer to be filled.
+ *
+ * @return 0 on errors:
+ *           - destMaxLen not big enough.
+ *           - srcLen not even.
+ *           - Some character not in [0-9a-fA-F] is present in srcHex.
+ *         number of bytes actually decoded from the string on success.
+ */
 size_t HexToBytes(const char * srcHex, const size_t srcLen, uint8_t * destBytes, size_t destMaxLen);
 
 } // namespace Encoding


### PR DESCRIPTION
For an octet-string argument we support three formats:

1. hex: followed by hex representation of the bytes.
2. str: followed by just the chars, if they are all nicely printable
3. Just the bytes/chars, if they are all nicely printable.

Format 1 is needed when the value contains non-printable chars, and
especially nulls.  Formats 2 and 3 are easier to use for the typical use case
of Wi-Fi SSIDs and passwords.

Formats 1 and 2 match chip-device-ctrl.

#### Problem
Not possible to pass a useful Thread operational dataset to `chip-tool pairing ble-thread` because that might contain non-printable chars.

#### Change overview
Store octet strings as `ByteSpan` in chip-tool and allow passing them in hex-encoded on the command line to support non-printable-char use cases.

#### Testing
Manually tested on a Mac doing `pairing ble-wifi` with m5stack as follows (with `idf.py -p /dev/tty.SLAB_USBtoUART erase_flash` and `idf.py -p /dev/tty.SLAB_USBtoUART flash monitor` between every chip-tool invocation)
```
./out/debug/standalone/chip-tool pairing ble-wifi aaa bbb 0 12345678 3840
./out/debug/standalone/chip-tool pairing ble-wifi hex:616161 str:bbb 0 12345678 3840
./out/debug/standalone/chip-tool pairing ble-wifi hex:616161 hex:626262 0 12345678 3840
./out/debug/standalone/chip-tool pairing ble-wifi hex:616161 hex:626263 0 12345678 3840
```
(with my actual SSID and password instead of `aaa` and `bbb`) and made sure that in the first three cases the m5stack joined the wifi network while in the fourth case (where the wrong password is passed in as hex) it did not.