### PR TITLE
Build FlatAllocatedQName from array, use for TXT.

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -175,8 +175,7 @@ private:
         return AddAllocatedResponder(chip::Platform::New<ResponderType>(std::forward<Args>(args)...));
     }
 
-    template <typename... Args>
-    FullQName AllocateQName(Args &&... names)
+    void * AllocateQNameSpace(size_t size)
     {
         for (size_t i = 0; i < kMaxAllocatedQNameData; i++)
         {
@@ -185,19 +184,36 @@ private:
                 continue;
             }
 
-            mAllocatedQNameParts[i] =
-                chip::Platform::MemoryAlloc(FlatAllocatedQName::RequiredStorageSize(std::forward<Args>(names)...));
-
+            mAllocatedQNameParts[i] = chip::Platform::MemoryAlloc(size);
             if (mAllocatedQNameParts[i] == nullptr)
             {
                 ChipLogError(Discovery, "QName memory allocation failed");
-                return FullQName();
             }
-            return FlatAllocatedQName::Build(mAllocatedQNameParts[i], std::forward<Args>(names)...);
+            return mAllocatedQNameParts[i];
         }
-
         ChipLogError(Discovery, "Failed to find free slot for adding a qname");
-        return FullQName();
+        return nullptr;
+    }
+
+    template <typename... Args>
+    FullQName AllocateQName(Args &&... names)
+    {
+        void * storage = AllocateQNameSpace(FlatAllocatedQName::RequiredStorageSize(std::forward<Args>(names)...));
+        if (storage == nullptr)
+        {
+            return FullQName();
+        }
+        return FlatAllocatedQName::Build(storage, std::forward<Args>(names)...);
+    }
+
+    FullQName AllocateQNameFromArray(char const * const * names, size_t num)
+    {
+        void * storage = AllocateQNameSpace(FlatAllocatedQName::RequiredStorageSizeFromArray(names, num));
+        if (storage == nullptr)
+        {
+            return FullQName();
+        }
+        return FlatAllocatedQName::BuildFromArray(storage, names, num);
     }
 
     FullQName GetCommisioningTextEntries(const CommissionAdvertisingParameters & params);
@@ -544,34 +560,28 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
 
 FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertisingParameters & params)
 {
+    char * txtFields[9];
+    size_t numTxtFields = 0;
+
     char txtVidPid[chip::Mdns::kKeyVendorProductMaxLength + 4];
     if (params.GetProductId().HasValue())
     {
         sprintf(txtVidPid, "VP=%d+%d", params.GetVendorId().Value(), params.GetProductId().Value());
-    }
-    else
-    {
-        sprintf(txtVidPid, "VP=%d", params.GetVendorId().Value());
+        txtFields[numTxtFields++] = txtVidPid;
     }
 
     char txtDeviceType[chip::Mdns::kKeyDeviceTypeMaxLength + 4];
     if (params.GetDeviceType().HasValue())
     {
         sprintf(txtDeviceType, "DT=%d", params.GetDeviceType().Value());
-    }
-    else
-    {
-        txtDeviceType[0] = '\0';
+        txtFields[numTxtFields++] = txtDeviceType;
     }
 
     char txtDeviceName[chip::Mdns::kKeyDeviceNameMaxLength + 4];
     if (params.GetDeviceName().HasValue())
     {
         sprintf(txtDeviceName, "DN=%s", params.GetDeviceName().Value());
-    }
-    else
-    {
-        txtDeviceName[0] = '\0';
+        txtFields[numTxtFields++] = txtDeviceName;
     }
 
     // the following sub types only apply to commissionable node advertisements
@@ -580,6 +590,7 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
         // a discriminator always exists
         char txtDiscriminator[chip::Mdns::kKeyDiscriminatorMaxLength + 3];
         sprintf(txtDiscriminator, "D=%d", params.GetLongDiscriminator());
+        txtFields[numTxtFields++] = txtDiscriminator;
 
         if (!params.GetVendorId().HasValue())
         {
@@ -588,55 +599,39 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
 
         char txtCommissioningMode[chip::Mdns::kKeyCommissioningModeMaxLength + 4];
         sprintf(txtCommissioningMode, "CM=%d", params.GetCommissioningMode() ? 1 : 0);
+        txtFields[numTxtFields++] = txtCommissioningMode;
 
         char txtOpenWindowCommissioningMode[chip::Mdns::kKeyAdditionalPairingMaxLength + 4];
         if (params.GetCommissioningMode() && params.GetOpenWindowCommissioningMode())
         {
             sprintf(txtOpenWindowCommissioningMode, "AP=1");
-        }
-        else
-        {
-            txtOpenWindowCommissioningMode[0] = '\0';
+            txtFields[numTxtFields++] = txtOpenWindowCommissioningMode;
         }
 
         char txtRotatingDeviceId[chip::Mdns::kKeyRotatingIdMaxLength + 4];
         if (params.GetRotatingId().HasValue())
         {
             sprintf(txtRotatingDeviceId, "RI=%s", params.GetRotatingId().Value());
-        }
-        else
-        {
-            txtRotatingDeviceId[0] = '\0';
+            txtFields[numTxtFields++] = txtRotatingDeviceId;
         }
 
         char txtPairingHint[chip::Mdns::kKeyPairingInstructionMaxLength + 4];
         if (params.GetPairingHint().HasValue())
         {
             sprintf(txtPairingHint, "PH=%d", params.GetPairingHint().Value());
-        }
-        else
-        {
-            txtPairingHint[0] = '\0';
+            txtFields[numTxtFields++] = txtPairingHint;
         }
 
         char txtPairingInstr[chip::Mdns::kKeyPairingInstructionMaxLength + 4];
         if (params.GetPairingInstr().HasValue())
         {
             sprintf(txtPairingInstr, "PI=%s", params.GetPairingInstr().Value());
+            txtFields[numTxtFields++] = txtPairingInstr;
         }
-        else
-        {
-            txtPairingInstr[0] = '\0';
-        }
+    }
 
-        return AllocateQName(txtDiscriminator, txtVidPid, txtCommissioningMode, txtOpenWindowCommissioningMode, txtDeviceType,
-                             txtDeviceName, txtRotatingDeviceId, txtPairingHint, txtPairingInstr);
-    }
-    else
-    {
-        return AllocateQName(txtVidPid, txtDeviceType, txtDeviceName);
-    }
-}
+    return AllocateQNameFromArray(txtFields, numTxtFields);
+} // namespace
 
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)
 {

--- a/src/lib/mdns/minimal/core/tests/TestFlatAllocatedQName.cpp
+++ b/src/lib/mdns/minimal/core/tests/TestFlatAllocatedQName.cpp
@@ -59,9 +59,76 @@ void TestFlatAllocatedQName(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+void SizeCompare(nlTestSuite * inSuite, void * inContext)
+{
+    const char kThis[]    = "this";
+    const char kIs[]      = "is";
+    const char kA[]       = "a";
+    const char kTest[]    = "test";
+    const char kVest[]    = "vest";
+    const char kBee[]     = "bee";
+    const char kRobbery[] = "robbery";
+    const char kExtra[]   = "extra";
+
+    const char * kSameArraySameSize[4]        = { kThis, kIs, kA, kTest };
+    const char * kDifferentArraySameSize[4]   = { kThis, kIs, kA, kVest };
+    const char * kDifferenArrayLongerWord[4]  = { kThis, kIs, kA, kRobbery };
+    const char * kDifferenArrayShorterWord[4] = { kThis, kIs, kA, kBee };
+    const char * kSameArrayExtraWord[5]       = { kThis, kIs, kA, kTest, kExtra };
+    const char * kShorterArray[3]             = { kThis, kIs, kA };
+
+    const size_t kTestStorageSize = FlatAllocatedQName::RequiredStorageSize(kThis, kIs, kA, kTest);
+
+    NL_TEST_ASSERT(inSuite, kTestStorageSize == FlatAllocatedQName::RequiredStorageSizeFromArray(kSameArraySameSize, 4));
+    NL_TEST_ASSERT(inSuite, kTestStorageSize == FlatAllocatedQName::RequiredStorageSizeFromArray(kDifferentArraySameSize, 4));
+    NL_TEST_ASSERT(inSuite, kTestStorageSize < FlatAllocatedQName::RequiredStorageSizeFromArray(kDifferenArrayLongerWord, 4));
+    NL_TEST_ASSERT(inSuite, kTestStorageSize > FlatAllocatedQName::RequiredStorageSizeFromArray(kDifferenArrayShorterWord, 4));
+
+    // Although the size of the array is larger, if we tell the function there are only 4 words, it should still work.
+    NL_TEST_ASSERT(inSuite, kTestStorageSize == FlatAllocatedQName::RequiredStorageSizeFromArray(kSameArrayExtraWord, 4));
+    // If we add the extra word, the sizes should not match
+    NL_TEST_ASSERT(inSuite, kTestStorageSize < FlatAllocatedQName::RequiredStorageSizeFromArray(kSameArrayExtraWord, 5));
+
+    NL_TEST_ASSERT(inSuite, kTestStorageSize > FlatAllocatedQName::RequiredStorageSizeFromArray(kShorterArray, 3));
+    NL_TEST_ASSERT(inSuite,
+                   FlatAllocatedQName::RequiredStorageSizeFromArray(kSameArraySameSize, 3) ==
+                       FlatAllocatedQName::RequiredStorageSizeFromArray(kShorterArray, 3));
+}
+
+void BuildCompare(nlTestSuite * inSuite, void * inContext)
+{
+    const char kThis[]  = "this";
+    const char kIs[]    = "is";
+    const char kA[]     = "a";
+    const char kTest[]  = "test";
+    const char kExtra[] = "extra";
+
+    const char * kSameArraySameSize[4]  = { kThis, kIs, kA, kTest };
+    const char * kSameArrayExtraWord[5] = { kThis, kIs, kA, kTest, kExtra };
+    const char * kShorterArray[3]       = { kThis, kIs, kA };
+
+    uint8_t storage[256];
+
+    const FullQName kTestQName = FlatAllocatedQName::Build(storage, kThis, kIs, kA, kTest);
+
+    NL_TEST_ASSERT(inSuite, kTestQName == FlatAllocatedQName::BuildFromArray(storage, kSameArraySameSize, 4));
+
+    // Although the size of the array is larger, if we tell the function there are only 4 words, it should still work.
+    NL_TEST_ASSERT(inSuite, kTestQName == FlatAllocatedQName::BuildFromArray(storage, kSameArrayExtraWord, 4));
+    // If we add the extra word, the names
+    NL_TEST_ASSERT(inSuite, kTestQName != FlatAllocatedQName::BuildFromArray(storage, kSameArrayExtraWord, 5));
+
+    NL_TEST_ASSERT(inSuite, kTestQName != FlatAllocatedQName::BuildFromArray(storage, kShorterArray, 3));
+    NL_TEST_ASSERT(inSuite,
+                   FlatAllocatedQName::BuildFromArray(storage, kSameArraySameSize, 3) ==
+                       FlatAllocatedQName::BuildFromArray(storage, kShorterArray, 3));
+}
+
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestFlatAllocatedQName", TestFlatAllocatedQName), //
-    NL_TEST_SENTINEL()                                             //
+    NL_TEST_DEF("TestFlatAllocatedQName", TestFlatAllocatedQName),   //
+    NL_TEST_DEF("TestFlatAllocatedQNameRequiredSizes", SizeCompare), //
+    NL_TEST_DEF("TestFlatAllocatedQNameBuild", BuildCompare),        //
+    NL_TEST_SENTINEL()                                               //
 };
 
 } // namespace


### PR DESCRIPTION


#### Problem
The argument version of the Build command allows the name parts to
be easily specified within the build function, but does not allow
a run-time change of the number of args. This is fine for the
service names, but causes problems for the variable-length txt
fields. Previously we were sending 0-length txt fields, but this
causes problems on some impementations. It's better to just not send
the fields we don't need.
* Fixes #7209

#### Change overview
Adds the ability to create a FlatAllocatedQName from an array of char* s. Adds tests for new functions. Uses new functions in Advertiser_ImplMinimalMdns.cpp and switches TXT record addition function to use the new FlatAllocatedQName function so it can send in a variable number of text fields.

#### Testing
Unit tests for the new FlatAllocatedQName functions - tests that the char* array version match the sizes and FullQNames of the arg versions.
Advertiser_ImplMinimalMdns tested using M5 and chip-device-ctrl. Packets verified using Wireshark.
