### PR TITLE
Fix nodeid for connect -qr[TE3]

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -479,6 +479,8 @@ class DeviceMgrCmd(Cmd):
             elif args[0] == "-ble" and len(args) >= 3:
                 self.devCtrl.ConnectBLE(int(args[1]), int(args[2]), nodeid)
             elif args[0] == '-qr' and len(args) >=2:
+                if len(args) == 3:
+                    nodeid = int(args[2])
                 print("Parsing QR code {}".format(args[1]))
                 setupPayload = SetupPayload().ParseQrCode(args[1])
                 self.ConnectFromSetupPayload(setupPayload, nodeid)


### PR DESCRIPTION
#### Problem
Node id is not properly passed through on connect -qr call in python controller

#### Change overview
Parses the node id from the connect arg
Fixes #7367

#### Testing
Tested chip-device-ctrl and lighting-app on linux.
connect -qr "[code]" 3333  : saw proper node ID being registered, 
zcl OnOff Toggle 3333 1 0  : response received.
