### PR TITLE
[linux] Fix gettid breaking compatibility with glibc <2.30

### DIFF
--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -4,8 +4,8 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <sys/syscall.h>
 #include <sys/time.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 namespace chip {
@@ -36,7 +36,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     gettimeofday(&tv, nullptr);
 
     printf("[%" PRIu64 ".%06" PRIu64 "][%ld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
-           static_cast<long>(gettid()), module);
+           static_cast<long>(syscall(SYS_gettid)), module);
     vprintf(msg, v);
     printf("\n");
     fflush(stdout);


### PR DESCRIPTION
#### Problem
The change in PR #7299 is not compatible with glibc versions older than 2.30, because `gettid` syscall wrapper was not provided until then. This breaks backward compatibility with older distros.

Symptom: `../../src/platform/Linux/Logging.cpp:39:30: error: ‘gettid’ was not declared in this scope` is shown when compiling the code on Debian 10.

#### Change overview
Replace the wrapper call with a syscall, which maintains backward and forward compatibilities.

#### Testing
`ninja -C out/host check` passing on macOS 11.4 and Debian 10.
