### PR TITLE
Fix handling of node ID resolution failure when mDeviceBeingPaired is not set.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1513,10 +1513,9 @@ void BasicFailure(void * context, uint8_t status)
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 void DeviceCommissioner::OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData)
 {
-    Device * device = nullptr;
     if (mDeviceBeingPaired < kNumMaxActiveDevices)
     {
-        device = &mActiveDevices[mDeviceBeingPaired];
+        Device * device = &mActiveDevices[mDeviceBeingPaired];
         if (device->GetDeviceId() == nodeData.mPeerId.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
         {
             AdvanceCommissioningStage(CHIP_NO_ERROR);
@@ -1527,16 +1526,13 @@ void DeviceCommissioner::OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & n
 
 void DeviceCommissioner::OnNodeIdResolutionFailed(const chip::PeerId & peer, CHIP_ERROR error)
 {
-    Device * device = nullptr;
-    if (mDeviceBeingPaired >= kNumMaxActiveDevices)
+    if (mDeviceBeingPaired < kNumMaxActiveDevices)
     {
-        return;
-    }
-
-    device = &mActiveDevices[mDeviceBeingPaired];
-    if (device->GetDeviceId() == peer.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
-    {
-        OnSessionEstablishmentError(error);
+        Device * device = &mActiveDevices[mDeviceBeingPaired];
+        if (device->GetDeviceId() == peer.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
+        {
+            OnSessionEstablishmentError(error);
+        }
     }
     DeviceController::OnNodeIdResolutionFailed(peer, error);
 }


### PR DESCRIPTION
We should be calling DeviceController::OnNodeIdResolutionFailed but aren't.

#### Problem
`DeviceCommissioner::OnNodeIdResolutionFailed` is not calling `DeviceController::OnNodeIdResolutionFailed` in some cases.

#### Change overview
Instead of taking an early return and missing the call up to the superclass, ensure we do the superclass call.

#### Testing
Just CI.  I am not sure I know how to really exercise this code....

NOTE: This is a resurrection of https://github.com/project-chip/connectedhomeip/pull/7229; we really do need this part, I think.