### PR TITLE
Fix mdns resolution on darwin

### DIFF
--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -478,7 +478,12 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
     nodeData.mAddress     = result->mAddress.ValueOr({});
     nodeData.mPort        = result->mPort;
 
-    ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64, ChipLogValueX64(nodeData.mPeerId.GetNodeId()));
+#if CHIP_PROGRESS_LOGGING
+    char addrBuffer[Inet::kMaxIPAddressStringLength + 1];
+    nodeData.mAddress.ToString(addrBuffer);
+#endif // CHIP_PROGRESS_LOGGING
+    ChipLogProgress(Discovery, "Node ID resolved for 0x" ChipLogFormatX64 " to %s", ChipLogValueX64(nodeData.mPeerId.GetNodeId()),
+                    addrBuffer);
     mgr->mResolverDelegate->OnNodeIdResolved(nodeData);
 }
 

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -415,6 +415,7 @@ static void OnGetAddrInfo(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t i
     service.mTextEntrySize = sdCtx->textEntries.empty() ? 0 : sdCtx->textEntries.size();
     service.mAddress.SetValue(chip::Inet::IPAddress::FromSockAddr(*address));
     strncpy(service.mName, sdCtx->name, sizeof(service.mName));
+    service.mInterface = sdCtx->interfaceId;
 
     sdCtx->callback(sdCtx->context, &service, CHIP_NO_ERROR);
     MdnsContexts::GetInstance().Remove(sdCtx);
@@ -428,7 +429,7 @@ static CHIP_ERROR GetAddrInfo(void * context, MdnsResolveCallback callback, uint
     DNSServiceRef sdRef;
     GetAddrInfoContext * sdCtx;
 
-    sdCtx = chip::Platform::New<GetAddrInfoContext>(context, callback, name, port);
+    sdCtx = chip::Platform::New<GetAddrInfoContext>(context, callback, name, interfaceId, port);
 
     char key[kMdnsKeyMaxSize];
     char value[kMdnsTextMaxSize];
@@ -474,6 +475,8 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
                       const char * fullname, const char * hostname, uint16_t port, uint16_t txtLen, const unsigned char * txtRecord,
                       void * context)
 {
+    ChipLogDetail(DeviceLayer, "Resolved interface id: %u", interfaceId);
+
     ResolveContext * sdCtx = reinterpret_cast<ResolveContext *>(context);
     VerifyOrReturn(CheckForSuccess(sdCtx, __func__, err, true));
 

--- a/src/platform/Darwin/MdnsImpl.h
+++ b/src/platform/Darwin/MdnsImpl.h
@@ -89,14 +89,17 @@ struct GetAddrInfoContext : public GenericContext
     MdnsResolveCallback callback;
     std::vector<TextEntry> textEntries;
     char name[kMdnsNameMaxSize + 1];
+    uint32_t interfaceId;
     uint16_t port;
 
-    GetAddrInfoContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName, uint16_t cbContextPort)
+    GetAddrInfoContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName, uint32_t cbInterfaceId,
+                       uint16_t cbContextPort)
     {
-        type     = ContextType::GetAddrInfo;
-        context  = cbContext;
-        callback = cb;
-        port     = cbContextPort;
+        type        = ContextType::GetAddrInfo;
+        context     = cbContext;
+        callback    = cb;
+        interfaceId = cbInterfaceId;
+        port        = cbContextPort;
         strncpy(name, cbContextName, sizeof(name));
     }
 };

--- a/src/platform/Darwin/MdnsImpl.h
+++ b/src/platform/Darwin/MdnsImpl.h
@@ -72,13 +72,15 @@ struct ResolveContext : public GenericContext
 {
     MdnsResolveCallback callback;
     char name[kMdnsNameMaxSize + 1];
+    chip::Inet::IPAddressType addressType;
 
-    ResolveContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName)
+    ResolveContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName, chip::Inet::IPAddressType cbAddressType)
     {
         type     = ContextType::Resolve;
         context  = cbContext;
         callback = cb;
         strncpy(name, cbContextName, sizeof(name));
+        addressType = cbAddressType;
     }
 };
 


### PR DESCRIPTION
#### Problem
There were two issues:
1. The address type argument to Resolve() was being ignored.
2. The interface id returned by resolution was not being propagated to the OnNodeIdResolved consumer.

#### Change overview
Propagate through the address type to the point where we can use it, and propagate the interface id out to our consumer.

#### Testing
1. Tested the address type bits by modifying `CHIPDeviceController.cpp` to only request IPv4 addresses, then testing pairing between all-clusters-app on an m5Stack and chip-tool on Mac using:
    ```
    ./out/debug/standalone/chip-tool pairing ble-wifi SSID PASSWD  0 12345678 3840 
    ```
    several times and ensuring that the IPv4 address was resolved up each time (verified via the logging this PR adds).

    Then repeated the same with `CHIPDeviceController.cpp` modified to request only IPv6 addresses and verified that an IPv6 address was resolved each time.

2. Verified that when a link-local IPv6 address is resolved, I can now send commands (e.g. `./out/debug/standalone/chip-tool onoff toggle 1`) to the device instead of getting "No route to host" errors.

This does not completely resolve #7120 (nor does it try to) but it's enough to make pairing a lot more reliable for me...