### PR TITLE
Include interface ID in the PeerAddress that gets handed up from UDP/TCP code

### DIFF
--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -193,6 +193,17 @@ public:
     INET_ERROR GetLocalInfo(IPAddress * retAddr, uint16_t * retPort);
 
     /**
+     * @brief   Extract the interface id of the TCP endpoint.
+     *
+     * @param[out]  retInterface  The interface id.
+     *
+     * @retval  INET_NO_ERROR           success: address and port extracted.
+     * @retval  INET_ERROR_INCORRECT_STATE  TCP connection not established.
+     * @retval  INET_ERROR_CONNECTION_ABORTED   TCP connection no longer open.
+     */
+    INET_ERROR GetInterfaceId(InterfaceId * retInterface);
+
+    /**
      * @brief   Send message text on TCP connection.
      *
      * @param[out]  data    Message text to send.

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -170,6 +170,10 @@ public:
     }
     static PeerAddress TCP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kTcp); }
     static PeerAddress TCP(const Inet::IPAddress & addr, uint16_t port) { return TCP(addr).SetPort(port); }
+    static PeerAddress TCP(const Inet::IPAddress & addr, uint16_t port, Inet::InterfaceId interface)
+    {
+        return TCP(addr).SetPort(port).SetInterface(interface);
+    }
 
 private:
     Inet::IPAddress mIPAddress;

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -356,9 +356,11 @@ INET_ERROR TCPBase::OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBuf
 {
     Inet::IPAddress ipAddress;
     uint16_t port;
+    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
 
     endPoint->GetPeerInfo(&ipAddress, &port);
-    PeerAddress peerAddress = PeerAddress::TCP(ipAddress, port);
+    endPoint->GetInterfaceId(&interfaceId);
+    PeerAddress peerAddress = PeerAddress::TCP(ipAddress, port, interfaceId);
 
     TCPBase * tcp  = reinterpret_cast<TCPBase *>(endPoint->AppState);
     CHIP_ERROR err = tcp->ProcessReceivedBuffer(endPoint, peerAddress, std::move(buffer));
@@ -379,9 +381,11 @@ void TCPBase::OnConnectionComplete(Inet::TCPEndPoint * endPoint, INET_ERROR inet
     TCPBase * tcp           = reinterpret_cast<TCPBase *>(endPoint->AppState);
     Inet::IPAddress ipAddress;
     uint16_t port;
+    Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
 
     endPoint->GetPeerInfo(&ipAddress, &port);
-    PeerAddress addr = PeerAddress::TCP(ipAddress, port);
+    endPoint->GetInterfaceId(&interfaceId);
+    PeerAddress addr = PeerAddress::TCP(ipAddress, port, interfaceId);
 
     // Send any pending packets
     for (size_t i = 0; i < tcp->mPendingPacketsSize; i++)
@@ -507,9 +511,11 @@ void TCPBase::Disconnect(const PeerAddress & address)
         {
             Inet::IPAddress ipAddress;
             uint16_t port;
+            Inet::InterfaceId interfaceId = INET_NULL_INTERFACEID;
 
             mActiveConnections[i].mEndPoint->GetPeerInfo(&ipAddress, &port);
-            if (address == PeerAddress::TCP(ipAddress, port))
+            mActiveConnections[i].mEndPoint->GetInterfaceId(&interfaceId);
+            if (address == PeerAddress::TCP(ipAddress, port, interfaceId))
             {
                 // NOTE: this leaves the socket in TIME_WAIT.
                 // Calling Abort() would clean it since SO_LINGER would be set to 0,

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -105,7 +105,7 @@ void UDP::OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBufferHan
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
-    PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort);
+    PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort, pktInfo->Interface);
 
     udp->HandleMessageReceived(peerAddress, std::move(buffer));
 


### PR DESCRIPTION
#### Problem
When our UDP and TCP code hands a PeerAddress up the stack for incoming messages, it does not include the interface id in that PeerAddress.  When upper layers then update their cached PeerAddress based on the incoming address, they can lose the ability to send messages properly (e.g if sending to an IPv6 link-local address).

#### Change overview
Hand up the right interface ID if we can.  For TCP this is half-baked at best and definitely does not work for LwIP.

#### Testing
Manually tried running `/out/debug/standalone/chip-tool onoff toggle 1` when paired to a device that has an IPv6 link-local address.  Without these changes the message gets sent but the standalone ack for the response gets "No route to host".  With these changes, the ack is also sent correctly.