### PR TITLE
Add support of chip_mdns without default value

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -39,7 +39,7 @@ OUTPUT_ROOT="$CHIP_ROOT/out/python_lib"
 ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 
 declare chip_detail_logging=false
-declare chip_mdns="minimal"
+declare chip_mdns
 declare clusters=true
 
 help() {
@@ -94,7 +94,8 @@ echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$
 source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging chip_mdns=\"$chip_mdns\" chip_use_clusters_for_ip_commissioning=$clusters"
+[[ -n "$chip_mdns" ]] && chip_mdns_arg="chip_mdns=\"$chip_mdns\"" || chip_mdns_arg=""
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging chip_use_clusters_for_ip_commissioning=$clusters $chip_mdns_arg"
 
 # Compiles python files
 ninja -C "$OUTPUT_ROOT" python


### PR DESCRIPTION
#### Problem
* Currently python build is defaulted to use minimal mdns 
* It doesn't hold for other examples which use platform mdns as default
* Fixes #7402 

#### Change overview
* No any default value for chip_mdns variable is given
* Populates and sends chip_mdns only when it is passed through command line
* Else, the default values for each platform would be appropriately chosen

#### Testing
* Argument values populated in out/python_lib/args.gn file are verified.
