### PR TITLE
Fix incorrect test termination condition in TestCommand subclasses.

### DIFF
--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -31,6 +31,12 @@ public:
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, "TestCluster: Test complete");
+            SetCommandExitStatus(true);
+        }
+
         switch (mTestIndex)
         {
         case 0:
@@ -51,10 +57,10 @@ public:
         }
         mTestIndex++;
 
-        if (mTestCount == mTestIndex || CHIP_NO_ERROR != err)
+        if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "TestCluster: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(CHIP_NO_ERROR == err);
+            SetCommandExitStatus(false);
         }
 
         return err;
@@ -438,6 +444,12 @@ public:
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, "OnOffCluster: Test complete");
+            SetCommandExitStatus(true);
+        }
+
         switch (mTestIndex)
         {
         case 0:
@@ -458,10 +470,10 @@ public:
         }
         mTestIndex++;
 
-        if (mTestCount == mTestIndex || CHIP_NO_ERROR != err)
+        if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "OnOffCluster: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(CHIP_NO_ERROR == err);
+            SetCommandExitStatus(false);
         }
 
         return err;

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -9,6 +9,12 @@ class {{asCamelCased filename false}}: public TestCommand
     {
       CHIP_ERROR err = CHIP_NO_ERROR;
 
+      if (mTestCount == mTestIndex)
+      {
+          ChipLogProgress(chipTool, "{{filename}}: Test complete");
+          SetCommandExitStatus(true);
+      }
+
       switch (mTestIndex)
       {
         {{#chip_tests_items}}
@@ -19,10 +25,10 @@ class {{asCamelCased filename false}}: public TestCommand
       }
       mTestIndex++;
 
-      if (mTestCount == mTestIndex || CHIP_NO_ERROR != err)
+      if (CHIP_NO_ERROR != err)
       {
           ChipLogProgress(chipTool, "{{filename}}: %s", chip::ErrorStr(err));
-          SetCommandExitStatus(CHIP_NO_ERROR == err);
+          SetCommandExitStatus(false);
       }
 
       return err;


### PR DESCRIPTION
The logic in NextTest was doing the following:

1. Start the test at mTestIndex.
2. Increment mTestIndex.
3. If mTestCount == mTestIndex (i.e. no more tests to run), start shutdown (by
   calling SetCommandExitStatus, which unblocks the shutdown sequence)..

This failed when running the last test: we would start the test,
increment mTestIndex, then hit that mTestCount condition and
immediately start shutdown, before waiting for the last test to
complete.

The fix is to test for the "no more tests to run" condition on entry
to NextTest.  This way the last test runs compeletely, and when it's
done and calls NextTest we go ahead and shut down.

#### Problem
Last test in a TestCommand was not being allowed to actually complete.

#### Change overview
Wait for it to complete.

#### Testing
Unfortunately, nothing in our CI right now catches the "test did not actually complete" situation.  I was considering adding some more machinery around this, but wasn't quite sure how best to do that.

I did test that removing some of our raciness workarounds causes `scripts/tests/test_suites.sh` to crash ~10% of the time without this fix even if I ensure that shutdown is somewhat synchronized with message processing, because of the following sequence of events:
1. Controller starts last test.
2. Controller sends message.
3. Controller waits for the message thread lock, then releases it (long story)
4. Controller starts shutdown on controller's thread.
5. While inside shutdown, the reply to the last test message arrives and processing of that reply crashes.

With this fix those crashes disappeared.

Any suggestions on better tests here would be much appreciated, of course, but it's a bit hard to test bugs in the test harness... ;)
