### PR TITLE
Fix System vs Inet and BLE shutdown order

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -307,10 +307,10 @@ CHIP_ERROR DeviceController::Shutdown()
 #if CONFIG_DEVICE_LAYER
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
 #else
-    mSystemLayer->Shutdown();
     mInetLayer->Shutdown();
-    chip::Platform::Delete(mSystemLayer);
+    mSystemLayer->Shutdown();
     chip::Platform::Delete(mInetLayer);
+    chip::Platform::Delete(mSystemLayer);
 #endif // CONFIG_DEVICE_LAYER
 
     mSystemLayer     = nullptr;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -229,8 +229,8 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     sBleLayer.Shutdown();
 #endif
 
-    sSystemLayer.Shutdown();
     sInetLayer.Shutdown();
+    sSystemLayer.Shutdown();
     sJVM = NULL;
 
     chip::Platform::MemoryShutdown();

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -124,8 +124,6 @@ template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 {
     CHIP_ERROR err;
-    ChipLogError(DeviceLayer, "System Layer shutdown");
-    err = SystemLayer.Shutdown();
     ChipLogError(DeviceLayer, "Inet Layer shutdown");
     err = InetLayer.Shutdown();
 
@@ -133,6 +131,10 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
     ChipLogError(DeviceLayer, "BLE layer shutdown");
     err = BLEMgr().GetBleLayer()->Shutdown();
 #endif
+
+    ChipLogError(DeviceLayer, "System Layer shutdown");
+    err = SystemLayer.Shutdown();
+
     return err;
 }
 


### PR DESCRIPTION
#### Problem

Inet and BLE contain pointers to the System::Layer, but in some
implementations System::Layer is shut down first, leaving those
pointers invalid. (There appear to be no current uses of those
invalid pointers in the tree.)

#### Change overview

Shut down system layer after the others in:
- `DeviceController::Shutdown()`
- `GenericPlatformManagerImpl::_Shutdown()`
- `JNI_OnUnload()`

#### Testing

- Some existing unit tests use the correct order (System last),
  so it's known to work.
- Manually tested with platforms using `GenericPlatformManagerImpl::_Shutdown()`
  (Linux paired with ESP32).
