### PR TITLE
Make test_suites.sh run multiple iterations of the tests.

### DIFF
--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -19,6 +19,24 @@
 set -e
 
 declare -a test_array="($(find src/app/tests/suites -type f -name "*.yaml" -exec basename {} .yaml \;))"
+declare -i iterations=20
+declare -i background_pid=0
+
+cleanup() {
+    if [[ $background_pid != 0 ]]; then
+        # In case we died on a failure before we cleaned up our background task.
+        kill -9 "$background_pid" || true
+    fi
+}
+trap cleanup EXIT
+
+if [[ -n $1 ]]; then
+    iterations=$1
+    if [[ $iterations == 0 ]]; then
+        echo "Invalid iteration count: '$1'"
+        exit 1
+    fi
+fi
 
 echo "Found tests:"
 for i in "${test_array[@]}"; do
@@ -27,20 +45,24 @@ done
 echo ""
 echo ""
 
-for i in "${test_array[@]}"; do
-    echo "  ===== Running test: $i"
-    echo "          * Starting cluster server"
-    rm -rf /tmp/chip_tool_config.ini
-    sleep 1
-    out/debug/chip-all-clusters-app &
-    background_pid=$!
-    sleep 1
-    echo "          * Pairing to device"
-    out/debug/standalone/chip-tool pairing onnetwork 1 20202021 3840 ::1 11097
-    sleep 1
-    echo "          * Starting test run: $i"
-    out/debug/standalone/chip-tool tests "$i"
-    kill -9 "$background_pid" || true
-    echo "  ===== Test complete: $i"
-    sleep 2
+declare -a iter_array="($(seq "$iterations"))"
+for j in "${iter_array[@]}"; do
+    echo " ===== Iteration $j starting"
+    for i in "${test_array[@]}"; do
+        echo "  ===== Running test: $i"
+        echo "          * Starting cluster server"
+        rm -rf /tmp/chip_tool_config.ini
+        out/debug/chip-all-clusters-app &
+        background_pid=$!
+        echo "          * Pairing to device"
+        out/debug/standalone/chip-tool pairing onnetwork 1 20202021 3840 ::1 11097
+        echo "          * Starting test run: $i"
+        out/debug/standalone/chip-tool tests "$i"
+        # Prevent cleanup trying to kill a process we already killed.
+        temp_background_pid=$background_pid
+        background_pid=0
+        kill -9 "$temp_background_pid" || true
+        echo "  ===== Test complete: $i"
+    done
+    echo " ===== Iteration $j completed"
 done


### PR DESCRIPTION
The default is to run 20 times (which takes ~3 seconds on a Mac
laptop), but it's configurable via the first command-line arg.

The changes to the actual loop body over test_array are:

1. Removing all the sleeps.
2. Making it less likely that we will kill some unrelated process (due to us
   killing $background_pid and then exiting with an error from the kill
   command and trying to kill it again).

#### Problem
Intermittent failures are only caught by some test runs.

#### Change overview
Have each test run run the tests 20 of times, making it more likely to catch intermittent problems.

#### Testing
Ran the script locally to make sure that the new setup does not fail.  Verified via the log that the tests did indeed get run 20 times.