### PR TITLE
Remove workarounds for threading problems from chip-tool commands.

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -38,11 +38,10 @@ void Commands::Register(const char * clusterName, commands_list commandsList)
     }
 }
 
-// TODO: Remove this work around due to crashes when storage is accessed from multiple threads and passed around
-static PersistentStorage gStorage;
 int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    PersistentStorage storage;
 
     err = chip::Platform::MemoryInit();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Memory failure: %s", chip::ErrorStr(err)));
@@ -52,12 +51,12 @@ int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
     SuccessOrExit(err = chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(/* BLE adapter ID */ 0, /* BLE central */ true));
 #endif
 
-    err = gStorage.Init();
+    err = storage.Init();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Storage failure: %s", chip::ErrorStr(err)));
 
-    chip::Logging::SetLogFilter(gStorage.GetLoggingLevel());
+    chip::Logging::SetLogFilter(storage.GetLoggingLevel());
 
-    err = RunCommand(gStorage, localId, remoteId, argc, argv);
+    err = RunCommand(storage, localId, remoteId, argc, argv);
     SuccessOrExit(err);
 
 exit:

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -20,18 +20,6 @@
 
 constexpr uint16_t kWaitDurationInSeconds = 30;
 
-static void test_os_sleep_ms(uint64_t millisecs)
-{
-    struct timespec sleep_time;
-    uint64_t s = millisecs / 1000;
-
-    millisecs -= s * 1000;
-    sleep_time.tv_sec  = static_cast<time_t>(s);
-    sleep_time.tv_nsec = static_cast<long>(millisecs * 1000000);
-
-    nanosleep(&sleep_time, nullptr);
-}
-
 CHIP_ERROR TestCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
 {
     ReturnErrorOnFailure(mOpCredsIssuer.Initialize(storage));
@@ -53,10 +41,6 @@ CHIP_ERROR TestCommand::Run(PersistentStorage & storage, NodeId localId, NodeId 
 
     mCommissioner.ServiceEventSignal();
 
-    // Give some time for all the pending messages to flush before shutting down
-    // Note: This is working around racy code in message queues during shutdown
-    // TODO: Remove this workaround once we understand the message queue and shutdown race
-    test_os_sleep_ms(1000);
     mCommissioner.Shutdown();
 
     VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
This change depends on
https://github.com/project-chip/connectedhomeip/pull/7428 and
https://github.com/project-chip/connectedhomeip/pull/7430 which fix
the problems properly.

Fixes https://github.com/project-chip/connectedhomeip/issues/7408
Fixes https://github.com/project-chip/connectedhomeip/issues/7409
Fixes https://github.com/project-chip/connectedhomeip/issues/7410

#### Problem
We have some workarounds added in #7381 that we don't really need once we do #7428 and #7430

#### Change overview
Remove the workarounds.

#### Testing
Ran the tests that #7381 added by hand many hundreds of times, without any problems.