### PR TITLE
Inject 1 second delay before start next test to improve the stability…

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -413,6 +413,11 @@ int main(int argc, char * argv[])
         {
             printf("Invoke Command: No response received\n");
         }
+        else
+        {
+            // Inject 1 second delay before start next test to improve the stability in cirque.
+            sleep(1);
+        }
 
         VerifyOrExit(gLastCommandResult == TestCommandResult::kSuccess, err = CHIP_ERROR_INCORRECT_STATE);
     }
@@ -432,6 +437,11 @@ int main(int argc, char * argv[])
         if (gCond.wait_for(lock, std::chrono::seconds(gMessageIntervalSeconds)) == std::cv_status::timeout)
         {
             printf("Invoke Command: No response received\n");
+        }
+        else
+        {
+            // Inject 1 second delay before start next test to improve the stability in cirque.
+            sleep(1);
         }
 
         VerifyOrExit(gLastCommandResult == TestCommandResult::kFailure, err = CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
… in cirque.

#### Problem
What is being fixed?  
* We observed some flaky issue during IM integration test with Cirque, the root cause of this issue is messaging sending and receiving are running within different threads respectively, and Cirque is looping back the echo response message from same system, if we start the test in sequence and race may occurs before all test run into complete.

I proposed one candidate solution by putting both messaging sending and receiving into the same event loop, this approach is demonstrated in #7117. This proposal is still under discussion, at the same time, we can just inject 1 second delay before start next test to prevent event inter-loop. 

#### Change overview
Inject 1 second delay before start next test to improve the stability in Cirque IM test.

#### Testing
How was this tested? 
1. Setting up cirque environment
git submodule update --init
./scripts/tests/cirque_tests.sh bootstrap

2. Run IM test
./scripts/tests/cirque_tests.sh run_test InteractionModelTest
