### PR TITLE
Added Compare Operators and empty() Method to Span/FixedSpan Classes

### DIFF
--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <string.h>
 
 namespace chip {
 
@@ -38,6 +39,11 @@ public:
 
     const T * data() const { return mDataBuf; }
     size_t size() const { return mDataLen; }
+    bool empty() const { return size() == 0; }
+    bool data_equal(const Span & other) const
+    {
+        return (size() == other.size()) && (empty() || (memcmp(data(), other.data(), size() * sizeof(T)) == 0));
+    }
 
 private:
     const T * mDataBuf;
@@ -53,6 +59,12 @@ public:
 
     const T * data() const { return mDataBuf; }
     size_t size() const { return N; }
+    bool empty() const { return data() == nullptr; }
+    bool data_equal(const FixedSpan & other) const
+    {
+        return (empty() && other.empty()) ||
+            (!empty() && !other.empty() && (memcmp(data(), other.data(), size() * sizeof(T)) == 0));
+    }
 
 private:
     const T * mDataBuf;

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -29,24 +29,89 @@
 
 using namespace chip;
 
-static void SpanConstructors(nlTestSuite * inSuite, void * inContext)
+static void TestByteSpan(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t arr[] = { 1, 2, 3 };
-    Span<uint8_t> s1(arr, 2);
 
+    ByteSpan s0 = ByteSpan();
+    NL_TEST_ASSERT(inSuite, s0.data() == nullptr);
+    NL_TEST_ASSERT(inSuite, s0.size() == 0);
+    NL_TEST_ASSERT(inSuite, s0.empty());
+    NL_TEST_ASSERT(inSuite, s0.data_equal(s0));
+
+    ByteSpan s1(arr, 2);
     NL_TEST_ASSERT(inSuite, s1.data() == arr);
     NL_TEST_ASSERT(inSuite, s1.size() == 2);
+    NL_TEST_ASSERT(inSuite, !s1.empty());
+    NL_TEST_ASSERT(inSuite, s1.data_equal(s1));
+    NL_TEST_ASSERT(inSuite, !s1.data_equal(s0));
 
-    Span<uint8_t> s2(arr);
+    ByteSpan s2(arr);
     NL_TEST_ASSERT(inSuite, s2.data() == arr);
     NL_TEST_ASSERT(inSuite, s2.size() == 3);
+    NL_TEST_ASSERT(inSuite, s2.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s2.empty());
+    NL_TEST_ASSERT(inSuite, s2.data_equal(s2));
+    NL_TEST_ASSERT(inSuite, !s2.data_equal(s1));
+
+    ByteSpan s3 = s2;
+    NL_TEST_ASSERT(inSuite, s3.data() == arr);
+    NL_TEST_ASSERT(inSuite, s3.size() == 3);
+    NL_TEST_ASSERT(inSuite, s3.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s3.empty());
+    NL_TEST_ASSERT(inSuite, s3.data_equal(s2));
+
+    uint8_t arr2[] = { 3, 2, 1 };
+    ByteSpan s4(arr2);
+    NL_TEST_ASSERT(inSuite, !s4.data_equal(s2));
+
+    ByteSpan s5(arr2, 0);
+    NL_TEST_ASSERT(inSuite, s5.data() != nullptr);
+    NL_TEST_ASSERT(inSuite, !s5.data_equal(s4));
+    NL_TEST_ASSERT(inSuite, s5.data_equal(s0));
+    NL_TEST_ASSERT(inSuite, s0.data_equal(s5));
+}
+
+static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
+{
+    uint8_t arr[] = { 1, 2, 3 };
+
+    FixedByteSpan<3> s0 = FixedByteSpan<3>();
+    NL_TEST_ASSERT(inSuite, s0.data() == nullptr);
+    NL_TEST_ASSERT(inSuite, s0.size() == 3);
+    NL_TEST_ASSERT(inSuite, s0.empty());
+    NL_TEST_ASSERT(inSuite, s0.data_equal(s0));
+
+    FixedByteSpan<2> s1(arr);
+    NL_TEST_ASSERT(inSuite, s1.data() == arr);
+    NL_TEST_ASSERT(inSuite, s1.size() == 2);
+    NL_TEST_ASSERT(inSuite, !s1.empty());
+    NL_TEST_ASSERT(inSuite, s1.data_equal(s1));
+
+    FixedByteSpan<3> s2(arr);
+    NL_TEST_ASSERT(inSuite, s2.data() == arr);
+    NL_TEST_ASSERT(inSuite, s2.size() == 3);
+    NL_TEST_ASSERT(inSuite, s2.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s2.empty());
+    NL_TEST_ASSERT(inSuite, s2.data_equal(s2));
+
+    FixedByteSpan<3> s3 = s2;
+    NL_TEST_ASSERT(inSuite, s3.data() == arr);
+    NL_TEST_ASSERT(inSuite, s3.size() == 3);
+    NL_TEST_ASSERT(inSuite, s3.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s3.empty());
+    NL_TEST_ASSERT(inSuite, s3.data_equal(s2));
+
+    uint8_t arr2[] = { 3, 2, 1 };
+    FixedByteSpan<3> s4(arr2);
+    NL_TEST_ASSERT(inSuite, !s4.data_equal(s2));
 }
 
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(SpanConstructors), NL_TEST_SENTINEL() };
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan), NL_TEST_DEF_FN(TestFixedByteSpan), NL_TEST_SENTINEL() };
 
 int TestSpan(void)
 {


### PR DESCRIPTION
#### Problem
Currently Span and FixedSpan classes don't have compare operators and empty class.

#### Change overview
Added new operators and method.

#### Testing
Span class currently doesn't have tests.

Ticket: #7442 