### PR TITLE
[test] Update log checking patten after log output update

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -76,7 +76,8 @@ class BaseTestHelper:
         except Exception as ex:
             self.logger.exception("Failed to send AddThreadNetwork command")
             return False
-        self.logger.info("Send EnableNetwork command to device {}".format(nodeid))
+        self.logger.info(
+            "Send EnableNetwork command to device {}".format(nodeid))
         try:
             self.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", nodeid, endpoint, group, {
                 "networkID": bytes.fromhex(network_id),
@@ -88,21 +89,21 @@ class BaseTestHelper:
         return True
 
     def TestOnOffCluster(self, nodeid: int, endpoint: int, group: int):
-        self.logger.info("Sending On/Off commands to device {}".format(nodeid))
-        try:
-            self.devCtrl.ZCLSend("OnOff", "On", nodeid, endpoint, group, {}, blocking=True)
-        except Exception as ex:
-            self.logger.exception("Failed to send On command")
+        self.logger.info(
+            "Sending On/Off commands to device {} endpoint {}".format(nodeid, endpoint))
+        err, code = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
+                                         endpoint, group, {}, blocking=True)
+        if err != 0 or code != 0:
             return False
-        try:
-            self.devCtrl.ZCLSend("OnOff", "Off", nodeid, endpoint, group, {}, blocking=True)
-        except Exception as ex:
-            self.logger.exception("Failed to send Off command")
+        err, code = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
+                                         endpoint, group, {}, blocking=True)
+        if err != 0 or code != 0:
             return False
         return True
 
     def TestResolve(self, fabricid, nodeid):
-        self.logger.info("Resolve {} with fabric id: {}".format(nodeid, fabricid))
+        self.logger.info(
+            "Resolve {} with fabric id: {}".format(nodeid, fabricid))
         try:
             self.devCtrl.ResolveNode(fabricid=fabricid, nodeid=nodeid)
         except Exception as ex:
@@ -136,6 +137,3 @@ class BaseTestHelper:
             self.logger.exception(f"Following attributes failed: {failed_zcl}")
             return False
         return True
-
-
-

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -91,13 +91,17 @@ class BaseTestHelper:
     def TestOnOffCluster(self, nodeid: int, endpoint: int, group: int):
         self.logger.info(
             "Sending On/Off commands to device {} endpoint {}".format(nodeid, endpoint))
-        err, code = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
+        err, resp = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
                                          endpoint, group, {}, blocking=True)
-        if err != 0 or code != 0:
+        if err != 0 or resp is None or resp.ProtocolCode != 0:
+            self.logger.error(
+                "failed to send OnOff.On: error is {} with im response{}".format(err, resp))
             return False
-        err, code = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
+        err, resp = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
                                          endpoint, group, {}, blocking=True)
-        if err != 0 or code != 0:
+        if err != 0 or resp is None or resp.ProtocolCode != 0:
+            self.logger.error(
+                "failed to send OnOff.Off: error is {} with im response {}".format(err, resp))
             return False
         return True
 

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -9,14 +9,14 @@ from base import TestTimeout, BaseTestHelper, FailIfNot, logger
 # The thread network dataset tlv for testing, splited into T-L-V.
 
 TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
-                "000300000c" + \
-                "35060004001fffe0" + \
-                "0208fedcba9876543210" + \
-                "0708fd00000000001234" + \
-                "0510ffeeddccbbaa99887766554433221100" + \
-                "030e54657374696e674e6574776f726b" + \
-                "0102d252" + \
-                "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
+    "000300000c" + \
+    "35060004001fffe0" + \
+    "0208fedcba9876543210" + \
+    "0708fd00000000001234" + \
+    "0510ffeeddccbbaa99887766554433221100" + \
+    "030e54657374696e674e6574776f726b" + \
+    "0102d252" + \
+    "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
 # Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
 TEST_THREAD_NETWORK_ID = "fedcba9876543210"
 
@@ -55,11 +55,13 @@ def main():
 
     test = BaseTestHelper(nodeid=112233)
 
+    logger.info("Testing key exchange")
     FailIfNot(test.TestKeyExchange(ip=options.deviceAddress,
                                    setuppin=20202021,
                                    nodeid=1),
               "Failed to finish key exchange")
 
+    logger.info("Testing network commissioning")
     FailIfNot(test.TestNetworkCommissioning(nodeid=1,
                                             endpoint=ENDPOINT_ID,
                                             group=GROUP_ID,
@@ -67,14 +69,17 @@ def main():
                                             network_id=TEST_THREAD_NETWORK_ID),
               "Failed to finish network commissioning")
 
+    logger.info("Testing on off cluster")
     FailIfNot(test.TestOnOffCluster(nodeid=1,
                                     endpoint=LIGHTING_ENDPOINT_ID,
                                     group=GROUP_ID), "Failed to test on off cluster")
 
-    FailIfNot(test.TestOnOffCluster(nodeid=1,
-                                    endpoint=233,
-                                    group=GROUP_ID), "Failed to test on off cluster on non-exist endpoint")
+    logger.info("Testing sending commands to non exist endpoint")
+    FailIfNot(not test.TestOnOffCluster(nodeid=1,
+                                        endpoint=233,
+                                        group=GROUP_ID), "Failed to test on off cluster on non-exist endpoint")
 
+    logger.info("Testing attribute reading")
     FailIfNot(test.TestReadBasicAttribiutes(nodeid=1,
                                             endpoint=ENDPOINT_ID,
                                             group=GROUP_ID),

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -77,14 +77,16 @@ class TestPythonController(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 /usr/bin/mobile-device-test.py -t 75 -a {}".format(ethernet_ip)
+        command = "gdb -return-child-result -q -ex run -ex bt --args python3 /usr/bin/mobile-device-test.py -t 75 -a {}".format(
+            ethernet_ip)
         ret = self.execute_device_cmd(req_device_id, command)
 
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
         # Check if the device is in thread network.
-        self.check_device_thread_state(server_ids[0], expected_role=['leader'], timeout=5)
+        self.check_device_thread_state(
+            server_ids[0], expected_role=['leader'], timeout=5)
 
         # Check if the device is attached to the correct thread network.
         for device_id in server_ids:
@@ -106,77 +108,51 @@ class TestPythonController(CHIPVirtualHome):
               "CHIP:ZCL:   value: {value}"
 
         for device_id in server_ids:
-            # VendorName
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0001',
-                                                           attr_type='0x42',
-                                                           value='TEST_VENDOR')]),
-                            "Vendor Name was not found {}".format(device_id))
+            matchContent = []
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0001',
+                                       attr_type='0x42',
+                                       value='TEST_VENDOR').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0002',
+                                       attr_type='0x21',
+                                       value='0x235a').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0003',
+                                       attr_type='0x42',
+                                       value='TEST_PRODUCT').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0004',
+                                       attr_type='0x21',
+                                       value='0xfeff').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0005',
+                                       attr_type='0x42',
+                                       value='').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0006',
+                                       attr_type='0x42',
+                                       value='').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0007',
+                                       attr_type='0x21',
+                                       value='0x0001').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0008',
+                                       attr_type='0x42',
+                                       value='TEST_VERSION').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x0009',
+                                       attr_type='0x23',
+                                       value='0x00000001').split("\n")
+            matchContent += fmt.format(cluster='0x0028',
+                                       attr='0x000a',
+                                       attr_type='0x42',
+                                       value='prerelease').split("\n")
 
-            # VendorID
             self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0002',
-                                                           attr_type='0x21',
-                                                           value='0x235a')]),
-                            "Vendor ID was not found {}".format(device_id))
-            # ProductName
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0003',
-                                                           attr_type='0x42',
-                                                           value='TEST_PRODUCT')]),
-                            "Product Name was not found {}".format(device_id))
-            # ProductID
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0004',
-                                                           attr_type='0x21',
-                                                           value='0xfeff')]),
-                            "ProductID was not found {}".format(device_id))
-            # UserLabel
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0005',
-                                                           attr_type='0x42',
-                                                           value='')]),
-                            "UserLabel was not found {}".format(device_id))
-            # Location
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0006',
-                                                           attr_type='0x42',
-                                                           value='')]),
-                            "Location was not found {}".format(device_id))
-            # HardwareVersion
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0007',
-                                                           attr_type='0x21',
-                                                           value='0x0001')]),
-                            "HardwareVersion was not found {}".format(device_id))
-            # HardwareVersionString
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0008',
-                                                           attr_type='0x42',
-                                                           value='TEST_VERSION')]),
-                            "HardwareVersionString was not found {}".format(device_id))
-            # SoftwareVersion
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x0009',
-                                                           attr_type='0x23',
-                                                           value='0x00000001')]),
-                            "SoftwareVersion was not found {}".format(device_id))
-            # SoftwareVersionString
-            self.assertTrue(self.sequenceMatch(ret['output'],
-                                               [fmt.format(cluster='0x0028',
-                                                           attr='0x000a',
-                                                           attr_type='0x42',
-                                                           value='prerelease')]),
-                            "SoftwareVersionString was not found {}".format(device_id))
+                                               matchContent),
+                            "Attribute reading response was not found {}".format(device_id))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Problem

- Issue #7417
- #7299 updates the log format of linux devices. However, the cirque which relies on the log parsing is not updated.
- The test case for testing response for non-exist command is not clear

#### Change overview

- Update the output format
- Update test for OnOff cluster

#### Testing

- Test script update
- Manual tested
  - Run chip-all-cluster-app on a device (assuming its ip is 10.123.123.123, and  
  - ```
    ./src/controller/python/test/test_scripts/mobile-device-test.py -a 10.123.123.123 -t 45
    ```
- The above test will be executed by Cirque after cirque is enabled.