### PR TITLE
Increase timeout for bootstrap running.

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -46,7 +46,7 @@ jobs:
               with:
                   submodules: true
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
             - name: Build libs
               timeout-minutes: 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
                   languages: "cpp"
 
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
             - name: Setup Build
               run: |

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -75,7 +75,7 @@ jobs:
               run: xcodebuild clean
               working-directory: src/darwin/Framework
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 15
               run: scripts/build/gn_bootstrap.sh
             - name: Run Build Test Server
               timeout-minutes: 10

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -47,7 +47,7 @@ jobs:
 #               with:
 #                   languages: "cpp, python"
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
             - name: Build example Standalone Echo Client
               timeout-minutes: 5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
               with:
                   submodules: true
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
             - name: Build all clusters app
               timeout-minutes: 5
@@ -76,7 +76,7 @@ jobs:
                   OPEN_SSL_VERSION=`ls -la /usr/local/Cellar/openssl@1.1 | cat | tail -n1 | awk '{print $NF}'`
                   ln -s /usr/local/Cellar/openssl@1.1/$OPEN_SSL_VERSION/lib/pkgconfig/* .
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 15
               run: scripts/build/gn_bootstrap.sh
             - name: Run Build Test Server
               timeout-minutes: 5
@@ -90,3 +90,4 @@ jobs:
               timeout-minutes: 5
               run: |
                   scripts/tests/test_suites.sh
+

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -47,7 +47,7 @@ jobs:
               with:
                   submodules: true
             - name: Bootstrap
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: |
                   mkdir -p /tmp/happy_test_logs ;
                   mkdir -p /tmp/log_output ;


### PR DESCRIPTION
#### Problem
CI timeouts during "bootstrap'. Seems to mainly happen on darwin tests, assuming GH hardware or network connectivity slower for macs.

#### Change overview
Change timeouts from 5 to 10 minutes (and 15 minutes for darwin)

#### Testing
Could not manual test, expect CI itself to serve as a test bed.