### PR TITLE
Add support for Clang's Thread Sanitizer (Tsan)

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -274,13 +274,10 @@ config("sanitize_address") {
 }
 
 config("sanitize_thread") {
-  cflags = [
-    "-fsanitize=thread",
-  ]
+  cflags = [ "-fsanitize=thread" ]
 
   ldflags = cflags
 }
-
 
 config("sanitize_memory") {
   cflags = [
@@ -313,7 +310,7 @@ config("sanitize_default") {
   configs = []
 
   if (is_tsan) {
-      configs += [ ":sanitize_thread" ]
+    configs += [ ":sanitize_thread" ]
   }
 
   if (is_asan) {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -248,6 +248,9 @@ config("runtime_default") {
 #
 
 declare_args() {
+  # Enable Thread sanitizer
+  is_tsan = false
+
   # Enable address sanitizer
   is_asan = false
 
@@ -269,6 +272,15 @@ config("sanitize_address") {
   ]
   ldflags = cflags
 }
+
+config("sanitize_thread") {
+  cflags = [
+    "-fsanitize=thread",
+  ]
+
+  ldflags = cflags
+}
+
 
 config("sanitize_memory") {
   cflags = [
@@ -299,6 +311,10 @@ config("sanitize_recover_all") {
 
 config("sanitize_default") {
   configs = []
+
+  if (is_tsan) {
+      configs += [ ":sanitize_thread" ]
+  }
 
   if (is_asan) {
     configs += [ ":sanitize_address" ]


### PR DESCRIPTION
#### Problem
* Fix #7452 

#### Change overview
* Add a build arg to platform/BUILD.gn 'is_tsan' to enable Tsan.

#### Testing
* Ran chip-tool and it was able to detect and uncover quite a few races.