### PR TITLE
API to generate array of CHIP Certs for op creds

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -258,9 +258,9 @@ CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chi
 
     VerifyOrExit(
         (type == kTLVType_Structure &&
-             (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate) || tag == AnonymousTag) ||
-         (type == kTLVType_Array &&
-          (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificateArray) || tag == AnonymousTag))),
+         (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate) || tag == AnonymousTag)) ||
+            (type == kTLVType_Array &&
+             (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificateArray) || tag == AnonymousTag)),
         err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     err = LoadCerts(reader, decodeFlags);

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -257,8 +257,10 @@ CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chi
     tag  = reader.GetTag();
 
     VerifyOrExit(
-        (type == kTLVType_Structure && tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate)) ||
-            (type == kTLVType_Array && tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificateArray)),
+        (type == kTLVType_Structure &&
+             (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate) || tag == AnonymousTag) ||
+         (type == kTLVType_Array &&
+          (tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificateArray) || tag == AnonymousTag))),
         err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     err = LoadCerts(reader, decodeFlags);

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -633,6 +633,22 @@ CHIP_ERROR ConvertX509CertToChipCert(const uint8_t * x509Cert, uint32_t x509Cert
                                      uint32_t chipCertBufSize, uint32_t & chipCertLen);
 
 /**
+ * @brief Convert standard X.509 certificates to CHIP certificate array.
+ *        This function takes upto two X.509 certificates (e.g. NOC, and ICA cert) and
+ *        encodes into kTag_ChipCertificateArray container type array.
+ *
+ * @param x509Cert1            First X.509 DER encoded certificate.
+ * @param x509Cert2            Second X.509 DER encoded certificate.
+ * @param chipCertArrayBuf     Buffer to store converted certificates in CHIP format.
+ * @param chipCertArrayBufSize The size of the buffer to store converted certificates.
+ * @param chipCertBufLen       The length of the converted certificates.
+ *
+ * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+ **/
+CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509Cert1, const ByteSpan & x509Cert2, uint8_t * chipCertArrayBuf,
+                                           uint32_t chipCertArrayBufSize, uint32_t & chipCertBufLen);
+
+/**
  * @brief Convert CHIP certificate to the standard X.509 DER encoded certificate.
  *
  * @param chipCert        Buffer containing CHIP certificate.

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -634,18 +634,23 @@ CHIP_ERROR ConvertX509CertToChipCert(const uint8_t * x509Cert, uint32_t x509Cert
 
 /**
  * @brief Convert standard X.509 certificates to CHIP certificate array.
- *        This function takes upto two X.509 certificates (e.g. NOC, and ICA cert) and
- *        encodes into kTag_ChipCertificateArray container type array.
+ *        This function takes NOC, and ICA cert X.509 certificates and
+ *        encodes into CHIP certificate array.
  *
- * @param x509Cert1            First X.509 DER encoded certificate.
- * @param x509Cert2            Second X.509 DER encoded certificate.
+ *        NOC certificate must be provided.
+ *        ICA certificate is optional. It can be omitted by providing a 0 length ByteSpan.
+ *
+ *        The API enforces that the NOC is issued by ICA (if ICA is provided).
+ *
+ * @param x509NOC              Node operational credentials certificate in X.509 DER encoding.
+ * @param x509ICAC             Intermediate CA certificate in X.509 DER encoding.
  * @param chipCertArrayBuf     Buffer to store converted certificates in CHIP format.
  * @param chipCertArrayBufSize The size of the buffer to store converted certificates.
  * @param chipCertBufLen       The length of the converted certificates.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509Cert1, const ByteSpan & x509Cert2, uint8_t * chipCertArrayBuf,
+CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509NOC, const ByteSpan & x509ICAC, uint8_t * chipCertArrayBuf,
                                            uint32_t chipCertArrayBufSize, uint32_t & chipCertBufLen);
 
 /**

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -646,7 +646,7 @@ CHIP_ERROR ConvertX509CertToChipCert(const uint8_t * x509Cert, uint32_t x509Cert
  * @param x509ICAC             Intermediate CA certificate in X.509 DER encoding.
  * @param chipCertArrayBuf     Buffer to store converted certificates in CHIP format.
  * @param chipCertArrayBufSize The size of the buffer to store converted certificates.
- * @param chipCertBufLen       The length of the converted certificates.
+ * @param chipCertBufLen[out]  The length of the converted certificates.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -152,7 +152,7 @@ static CHIP_ERROR ConvertDistinguishedName(ASN1Reader & reader, TLVWriter & writ
                         //      Subject = kOID_AttributeType_ChipRootId
                         //
                         // This function is called first for the Issuer DN, and later for Subject DN.
-                        // Since, the caller knows if Issuer or Subject DN is being parsed, it's left up to
+                        // Since the caller knows if Issuer or Subject DN is being parsed, it's left up to
                         // the caller to use the returned value (subjectOrIssuer) appropriately.
                         if (attrOID == chip::ASN1::kOID_AttributeType_ChipNodeId ||
                             attrOID == chip::ASN1::kOID_AttributeType_ChipICAId ||

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1152,6 +1152,16 @@ static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, vo
     NL_TEST_ASSERT(inSuite,
                    ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(root_cert, root_len), outCertBuf,
                                                    sizeof(outCertBuf), outCertLen) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    X509CertRequestParams ica_params_wrong_fabric = { 1234, 0xabcdabcd, 9876, 98790000, true, 0x9999, false, 0 };
+
+    NL_TEST_ASSERT(inSuite,
+                   NewICAX509Cert(ica_params_wrong_fabric, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert),
+                                  ica_len) == CHIP_NO_ERROR);
+    // Test that NOC fabric must match ICA fabric
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCertBuf,
+                                                   sizeof(outCertBuf), outCertLen) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 /**

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -1008,11 +1008,20 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
+    uint8_t outCertBuf[kTestCertBufSize * 2];
+    uint32_t outCertLen;
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCertBuf,
+                                                   sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+
     ChipCertificateSet certSet;
     NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestCertBufSize * 3) == CHIP_NO_ERROR);
 
+    NL_TEST_ASSERT(inSuite,
+                   certSet.LoadCerts(outCertBuf, outCertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) ==
+                       CHIP_NO_ERROR);
+
     static uint8_t rootCertBuf[kTestCertBufSize];
-    uint32_t outCertLen;
 
     NL_TEST_ASSERT(inSuite,
                    ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
@@ -1022,14 +1031,127 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor).Set(CertDecodeFlags::kGenerateTBSHash)) ==
             CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCertBufSize * 2];
+    ValidationContext validContext;
+
+    validContext.Reset();
+    NL_TEST_ASSERT(inSuite, SetEffectiveTime(validContext, 2022, 1, 1) == CHIP_NO_ERROR);
+    validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
+    validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
+
+    // Locate the subject DN and key id that will be used as input the FindValidCert() method.
+    const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
+    const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
+
+    ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+}
+
+static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inContext)
+{
+    // Generate a new keypair for cert signing
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    static uint8_t root_cert[kTestCertBufSize];
+    uint32_t root_len = 0;
+
+    X509CertRequestParams root_params = { 1234, 0xabcdabcd, 9876, 98790000, true, 0x8888, false, 0 };
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+
+    static uint8_t noc_cert[kTestCertBufSize];
+    uint32_t noc_len = 0;
+
+    X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 9876, 98790000, true, 0x8888, true, 0x1234 };
+    P256Keypair noc_keypair;
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(ica_cert, ica_len), ByteSpan(noc_cert, noc_len), outCertBuf,
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert,
+                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+
+    uint8_t outCertBuf[kTestCertBufSize * 2];
+    uint32_t outCertLen;
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(nullptr, 0), outCertBuf,
                                                    sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+
+    ChipCertificateSet certSet;
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestCertBufSize * 3) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCerts(outCertBuf, outCertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) ==
                        CHIP_NO_ERROR);
+
+    static uint8_t rootCertBuf[kTestCertBufSize];
+
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(
+        inSuite,
+        certSet.LoadCert(rootCertBuf, outCertLen,
+                         BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor).Set(CertDecodeFlags::kGenerateTBSHash)) ==
+            CHIP_NO_ERROR);
+
+    ValidationContext validContext;
+
+    validContext.Reset();
+    NL_TEST_ASSERT(inSuite, SetEffectiveTime(validContext, 2022, 1, 1) == CHIP_NO_ERROR);
+    validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
+    validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
+
+    // Locate the subject DN and key id that will be used as input the FindValidCert() method.
+    const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
+    const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
+
+    ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+}
+
+static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, void * inContext)
+{
+    // Generate a new keypair for cert signing
+    P256Keypair keypair;
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
+
+    static uint8_t root_cert[kTestCertBufSize];
+    uint32_t root_len = 0;
+
+    X509CertRequestParams root_params = { 1234, 0xabcdabcd, 9876, 98790000, true, 0x8888, false, 0 };
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+
+    static uint8_t ica_cert[kTestCertBufSize];
+    uint32_t ica_len = 0;
+
+    X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 9876, 98790000, true, 0x8888, false, 0 };
+    P256Keypair ica_keypair;
+    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite,
+                   NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
+                       CHIP_NO_ERROR);
+
+    static uint8_t noc_cert[kTestCertBufSize];
+    uint32_t noc_len = 0;
+
+    X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 9876, 98790000, true, 0x8888, true, 0x1234 };
+    P256Keypair noc_keypair;
+    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite,
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
+                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+
+    uint8_t outCertBuf[kTestCertBufSize * 2];
+    uint32_t outCertLen;
+    // Test that NOC is mandatory
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(nullptr, 0), ByteSpan(ica_cert, ica_len), outCertBuf,
+                                                   sizeof(outCertBuf), outCertLen) == CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Test that NOC issuer must match ICA
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(root_cert, root_len), outCertBuf,
+                                                   sizeof(outCertBuf), outCertLen) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 /**
@@ -1063,7 +1185,6 @@ int TestChipCert_Teardown(void * inContext)
 static const nlTest sTests[] = {
     NL_TEST_DEF("Test CHIP Certificate CHIP to X509 Conversion", TestChipCert_ChipToX509),
     NL_TEST_DEF("Test CHIP Certificate X509 to CHIP Conversion", TestChipCert_X509ToChip),
-    NL_TEST_DEF("Test CHIP Certificates X509 to CHIP Array Conversion", TestChipCert_X509ToChipArray),
     NL_TEST_DEF("Test CHIP Certificate Validation", TestChipCert_CertValidation),
     NL_TEST_DEF("Test CHIP Certificate Validation time", TestChipCert_CertValidTime),
     NL_TEST_DEF("Test CHIP Certificate Usage", TestChipCert_CertUsage),
@@ -1076,6 +1197,9 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test CHIP Generate NOC using Root", TestChipCert_GenerateNOCRoot),
     NL_TEST_DEF("Test CHIP Generate NOC using ICA", TestChipCert_GenerateNOCICA),
     NL_TEST_DEF("Test CHIP Verify Generated Cert Chain", TestChipCert_VerifyGeneratedCerts),
+    NL_TEST_DEF("Test CHIP Certificates X509 to CHIP Array Conversion", TestChipCert_X509ToChipArray),
+    NL_TEST_DEF("Test CHIP Certificates X509 No ICA to CHIP Array Conversion", TestChipCert_X509ToChipArrayNoICA),
+    NL_TEST_DEF("Test CHIP Certificates X509 to CHIP Array Conversion Error Scenarios", TestChipCert_X509ToChipArrayErrorScenarios),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -644,8 +644,7 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, ui
     else
     {
         uint32_t profileId = ProfileIdFromTag(tag);
-        if (mContainerType != kTLVType_NotSpecified && mContainerType != kTLVType_Structure && mContainerType != kTLVType_List &&
-            mContainerType != kTLVType_Array)
+        if (mContainerType != kTLVType_NotSpecified && mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
             return CHIP_ERROR_INVALID_TLV_TAG;
 
         if (profileId == kCommonProfileId)

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -644,6 +644,7 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, ui
     else
     {
         uint32_t profileId = ProfileIdFromTag(tag);
+
         if (mContainerType != kTLVType_NotSpecified && mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
             return CHIP_ERROR_INVALID_TLV_TAG;
 

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -644,8 +644,8 @@ CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, ui
     else
     {
         uint32_t profileId = ProfileIdFromTag(tag);
-
-        if (mContainerType != kTLVType_NotSpecified && mContainerType != kTLVType_Structure && mContainerType != kTLVType_List)
+        if (mContainerType != kTLVType_NotSpecified && mContainerType != kTLVType_Structure && mContainerType != kTLVType_List &&
+            mContainerType != kTLVType_Array)
             return CHIP_ERROR_INVALID_TLV_TAG;
 
         if (profileId == kCommonProfileId)


### PR DESCRIPTION
#### Problem
The commissioner should send device operational credentials as an array of NOC and ICA certs. Need a mechanism to generate correct TLV formatted array of certs. 

#### Change overview
Added API to generate an array of CHIP certs from the DER formatted ICA and NOC certs. Added a unit test to load and verify the certificate validity.

#### Testing
A unit test `TestChipCert_X509ToChipArray` for the added API.
