### PR TITLE
Move bootstrap earlier in darwin build

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -41,6 +41,9 @@ jobs:
                 ls -la /usr/local/Cellar/openssl@1.1
                 OPEN_SSL_VERSION=`ls -la /usr/local/Cellar/openssl@1.1 | cat | tail -n1 | awk '{print $NF}'`
                 ln -s /usr/local/Cellar/openssl@1.1/$OPEN_SSL_VERSION/lib/pkgconfig/* .
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
             - name: Run iOS Build
               timeout-minutes: 15
               working-directory: src/darwin/Framework
@@ -74,9 +77,6 @@ jobs:
             - name: Clean Build
               run: xcodebuild clean
               working-directory: src/darwin/Framework
-            - name: Bootstrap
-              timeout-minutes: 15
-              run: scripts/build/gn_bootstrap.sh
             - name: Run Build Test Server
               timeout-minutes: 10
               run: |


### PR DESCRIPTION
This will make it easier to account for time spent in bootstrap.