### PR TITLE
Move nulling out of CHIPDeviceController members closer to where they are shut down.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -306,6 +306,9 @@ CHIP_ERROR DeviceController::Shutdown()
     chip::Platform::Delete(mSystemLayer);
 #endif // CONFIG_DEVICE_LAYER
 
+    mSystemLayer = nullptr;
+    mInetLayer   = nullptr;
+
     mState = State::NotInitialized;
 
     // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
@@ -318,8 +321,6 @@ CHIP_ERROR DeviceController::Shutdown()
         mSessionMgr->Shutdown();
     }
 
-    mSystemLayer     = nullptr;
-    mInetLayer       = nullptr;
     mStorageDelegate = nullptr;
 
     ReleaseAllDevices();


### PR DESCRIPTION
#### Problem
We shut down some members, then do some other shutdowns before nulling out the relevant pointers.

I thought I had fixed this in https://github.com/project-chip/connectedhomeip/pull/7430/files but apparently I missed it there.

#### Change overview
Move the "set to null" bits to right after shutdown.

#### Testing
This should not really change behavior at the moment, so I don't know how to test it.  This is just a safety precaution in case some of the other shutdown bits call into this class.