### PR TITLE
Remove linux clang_experimental build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,6 @@ jobs:
                      "gcc_release") GN_ARGS='is_debug=false';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
-                     "clang_experimental") GN_ARGS='is_clang=true chip_enable_interaction_model=true';;
                      *) ;;
                   esac
 

--- a/scripts/build/gn_gen.sh
+++ b/scripts/build/gn_gen.sh
@@ -28,4 +28,4 @@ set -x
 
 env
 
-gn --root="$CHIP_ROOT" gen --check "$CHIP_ROOT/out/$BUILD_TYPE" "$@"
+gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/$BUILD_TYPE" "$@"


### PR DESCRIPTION
As of 80120a20 ("[im] Always use interaction model to send commands
(#5945)"), this build is equivalent to the clang build. Add
--fail-on-unused-args to gn_gen.sh to avoid this happening again.
