### PR TITLE
Fix shutdown ordering in IM integration test

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -33,7 +33,6 @@
 #include <core/CHIPCore.h>
 #include <mutex>
 #include <platform/CHIPDeviceLayer.h>
-#include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
@@ -55,9 +54,6 @@ constexpr chip::Transport::AdminId gAdminId       = 0;
 chip::app::ReadClient * gpReadClient = nullptr;
 
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-chip::SecureSessionMgr gSessionManager;
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
-
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Command was attempted to be sent.

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -35,7 +35,6 @@
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <platform/CHIPDeviceLayer.h>
-#include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
@@ -131,9 +130,7 @@ exit:
 
 namespace {
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
 LivenessEventGenerator gLivenessGenerator;
 
 uint8_t gDebugEventBuffer[2048];

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -30,8 +30,9 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <support/ErrorStr.h>
 
-// The ExchangeManager global object.
 chip::Messaging::ExchangeManager gExchangeManager;
+chip::SecureSessionMgr gSessionManager;
+chip::secure_channel::MessageCounterManager gMessageCounterManager;
 
 void InitializeChip(void)
 {
@@ -57,8 +58,10 @@ exit:
 
 void ShutdownChip(void)
 {
-    gExchangeManager.Shutdown();
     chip::DeviceLayer::PlatformMgr().Shutdown();
+    gMessageCounterManager.Shutdown();
+    gExchangeManager.Shutdown();
+    gSessionManager.Shutdown();
 }
 
 void TLVPrettyPrinter(const char * aFormat, ...)

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -26,11 +26,14 @@
 
 #include <app/util/basic-types.h>
 #include <messaging/ExchangeMgr.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
 
 #define MAX_MESSAGE_SOURCE_STR_LENGTH (100)
 #define NETWORK_SLEEP_TIME_MSECS (100 * 1000)
 
 extern chip::Messaging::ExchangeManager gExchangeManager;
+extern chip::SecureSessionMgr gSessionManager;
+extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
 
 constexpr chip::NodeId kTestNodeId           = 0x1ULL;
 constexpr chip::NodeId kTestNodeId1          = 0x2ULL;


### PR DESCRIPTION
#### Problem
What is being fixed? 

https://github.com/yunhanw-google/connectedhomeip/actions/runs/919262233

after 2877e1e, which adjust shutdown ordering, we still see shutdown crash for IM test,
[1623175629.106721][155] CHIP:EM: Sending Standalone Ack for MsgId:00000007
[1623175629.106735][155] CHIP:IN: Secure message was encrypted: Msg ID 14
[1623175629.106741][155] CHIP:IN: Sending msg from 0x000000000001B669 to 0x0000000000BC5C01 at utc time: 1231353 msec
[1623175629.106746][155] CHIP:IN: Sending secure msg on generic transport
[1623175629.106779][155] CHIP:IN: Secure msg send status No Error
[1623175629.106784][155] CHIP:EM: Flushed pending ack for MsgId:00000007
[1623175629.106789][155] CHIP:DMG: Client[0] moving to [INIT]
Read Response: 3/3(100.00%) time=0.808ms
[1623175629.106820][145] CHIP:DMG: Client[0] moving to [UNINIT]
[1623175629.106826][145] CHIP:DMG: Client[0] moving to [UNINIT]
[1623175629.106830][145] CHIP:DMG: IM RH moving to [Uninitialized]
chip-im-initiator: ../../../../../src/messaging/ExchangeMgr.cpp:102: chip::Messaging::ExchangeManager::Shutdown()::<lambda(auto:2*)> [with auto:2 = chip::Messaging::ExchangeContext]: Assertion `false' failed.

Thread 1 "chip-im-initiat" received signal SIGABRT, Aborted.
0x00007ffff756118b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#0 0x00007ffff756118b in raise () at /lib/x86_64-linux-gnu/libc.so.6
#1 0x00007ffff7540859 in abort () at /lib/x86_64-linux-gnu/libc.so.6
#2 0x00007ffff7540729 in () at /lib/x86_64-linux-gnu/libc.so.6
#3 0x00007ffff7551f36 in () at /lib/x86_64-linux-gnu/libc.so.6
#4 0x00005555555a2c35 in chip::Messaging::ExchangeManager::<lambda(auto:2*)>::operator()chip::Messaging::ExchangeContext(chip::Messaging::ExchangeContext ) const (__closure=0x7fffffffe417, ec=0x5555555e3e88 <gExchangeManager+360>)
at ../../../../../src/messaging/ExchangeMgr.cpp:102
#5 0x00005555555a2d49 in chip::BitMapObjectPool<chip::Messaging::ExchangeContext, 8>::ForEachActiveObject<chip::Messaging::ExchangeManager::Shutdown()::<lambda(auto:2)> >(chip::Messaging::ExchangeManager::<lambda(auto:2*)>)
(this=0x5555555e3e58 <gExchangeManager+312>, f=...)
at ../../../../../src/lib/support/Pool.h:140
#6 0x00005555555a2225 in chip::Messaging::ExchangeManager::Shutdown()
(this=0x5555555e3d20 )
at ../../../../../src/messaging/ExchangeMgr.cpp:100
#7 0x000055555556a078 in ShutdownChip() ()
at ../../../../../src/app/tests/integration/common.cpp:60
#8 0x0000555555568723 in main(int, char**) (argc=2, argv=0x7fffffffecf8)
at ../../../../../src/app/tests/integration/chip_im_initiator.cpp:458
(gdb) quit
A debugging session is active.

The reason is #7430 only adjust the shutdown ordering for controller, we need similar adjustment in IM integration test apps. 

Fixes #7466 

#### Change overview
Adjust the shutdown order and make sure network layer is shutdown first to prevent exchange manager still receive the messages while in a partially torn down state.

#### Testing
How was this tested? (at least one bullet point required)
1. Setting up cirque environment
git submodule update --init
./scripts/tests/cirque_tests.sh bootstrap

2. Run IM Cirque test
./scripts/tests/cirque_tests.sh run_test InteractionModelTest
