### PR TITLE
Upload logs after bootstrap

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -48,6 +48,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build libs
               timeout-minutes: 2
               run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Setup Build
               run: |
                   case $BUILD_TYPE in

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -44,6 +44,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 15
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Run iOS Build
               timeout-minutes: 15
               working-directory: src/darwin/Framework

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -46,6 +46,17 @@ jobs:
 #               uses: github/codeql-action/init@v1
 #               with:
 #                   languages: "cpp, python"
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example EFR32 Lock App for BRD4161A
               timeout-minutes: 5
               run:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -47,6 +47,17 @@ jobs:
 #               uses: github/codeql-action/init@v1
 #               with:
 #                   languages: "cpp, python"
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example All Clusters App
               timeout-minutes: 15
               run: scripts/examples/esp_example.sh all-clusters-app

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -46,6 +46,17 @@ jobs:
 #              with:
 #                  languages: "cpp"
 #                  queries: +security-and-quality
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example K32W Lock App
               timeout-minutes: 5
               run: scripts/examples/k32w_example.sh

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -49,6 +49,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example Standalone Echo Client
               timeout-minutes: 5
               run:

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -42,6 +42,17 @@ jobs:
               with:
                   fetch-depth: 0
                   submodules: true
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Update nRF Connect SDK revision to the currently recommended.
               timeout-minutes: 5
               run: scripts/run_in_build_env.sh "python3 scripts/setup/nrfconnect/update_ncs.py --update"

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -45,6 +45,17 @@ jobs:
 #               uses: github/codeql-action/init@v1
 #               with:
 #                   languages: "cpp"
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example QPG6100 Lock App
               timeout-minutes: 5
               run: scripts/examples/gn_build_example.sh

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -39,6 +39,17 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example All Clusters App
               timeout-minutes: 15
               run: scripts/examples/esp_example.sh all-clusters-app

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -37,6 +37,17 @@ jobs:
               with:
                   submodules: true
                   ref: "${{ github.event.inputs.releaseTag }}"
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build
               run: scripts/examples/esp_example.sh all-clusters-app
 
@@ -66,6 +77,17 @@ jobs:
               with:
                   submodules: true
                   ref: "${{ github.event.inputs.releaseTag }}"
+            - name: Bootstrap
+              timeout-minutes: 15
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build example EFR32 Lock App
               run:
                   scripts/examples/gn_efr32_example.sh examples/lock-app/efr32/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Build all clusters app
               timeout-minutes: 5
               run: |
@@ -78,6 +86,14 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 15
               run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Run Build Test Server
               timeout-minutes: 5
               run: |

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -54,6 +54,14 @@ jobs:
                   scripts/tests/happy_tests.sh install_packages ;
                   scripts/tests/happy_tests.sh bootstrap ;
                   scripts/build/gn_bootstrap.sh ;
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
             - name: Artifact suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0


### PR DESCRIPTION
Currently the bootstrap logs are discarded. Upload them to allow
diagnosis of any bootstrap problems.