### PR TITLE
Restrict Responder sub types for QueryResponder

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -144,7 +144,7 @@ private:
     /// interfaces on which the mDNS server is listening
     bool ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr);
 
-    QueryResponderSettings AddAllocatedResponder(Responder * responder)
+    QueryResponderSettings AddAllocatedResponder(RecordResponder * responder)
     {
         if (responder == nullptr)
         {
@@ -230,7 +230,7 @@ private:
     uint32_t mMessageId                             = 0;
 
     // dynamically allocated items
-    Responder * mAllocatedResponders[kMaxAllocatedResponders];
+    RecordResponder * mAllocatedResponders[kMaxAllocatedResponders];
     void * mAllocatedQNameParts[kMaxAllocatedQNameData];
 
     const char * mEmptyTextEntries[1] = {

--- a/src/lib/mdns/minimal/responders/BUILD.gn
+++ b/src/lib/mdns/minimal/responders/BUILD.gn
@@ -21,6 +21,7 @@ static_library("responders") {
     "Ptr.h",
     "QueryResponder.cpp",
     "QueryResponder.h",
+    "RecordResponder.h",
     "ReplyFilter.h",
     "Responder.h",
     "Srv.h",

--- a/src/lib/mdns/minimal/responders/Ptr.h
+++ b/src/lib/mdns/minimal/responders/Ptr.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #include <mdns/minimal/records/Ptr.h>
-#include <mdns/minimal/responders/Responder.h>
+#include <mdns/minimal/responders/RecordResponder.h>
 
 namespace mdns {
 namespace Minimal {
 
-class PtrResponder : public Responder
+class PtrResponder : public RecordResponder
 {
 public:
-    PtrResponder(const FullQName & qname, const FullQName & target) : Responder(QType::PTR, qname), mTarget(target) {}
+    PtrResponder(const FullQName & qname, const FullQName & target) : RecordResponder(QType::PTR, qname), mTarget(target) {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
     {

--- a/src/lib/mdns/minimal/responders/QueryResponder.cpp
+++ b/src/lib/mdns/minimal/responders/QueryResponder.cpp
@@ -50,7 +50,7 @@ void QueryResponderBase::Init()
     }
 }
 
-QueryResponderSettings QueryResponderBase::AddResponder(Responder * responder)
+QueryResponderSettings QueryResponderBase::AddResponder(RecordResponder * responder)
 {
     if (responder == nullptr)
     {

--- a/src/lib/mdns/minimal/responders/QueryResponder.h
+++ b/src/lib/mdns/minimal/responders/QueryResponder.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "RecordResponder.h"
 #include "ReplyFilter.h"
 #include "Responder.h"
 
@@ -245,7 +246,7 @@ public:
     /// Add a new responder to be processed
     ///
     /// Return valid QueryResponderSettings on add success.
-    QueryResponderSettings AddResponder(Responder * responder);
+    QueryResponderSettings AddResponder(RecordResponder * responder);
 
     /// Implementation of the responder delegate.
     ///

--- a/src/lib/mdns/minimal/responders/RecordResponder.h
+++ b/src/lib/mdns/minimal/responders/RecordResponder.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,25 +17,16 @@
 
 #pragma once
 
-#include <mdns/minimal/responders/RecordResponder.h>
-
+#include <mdns/minimal/responders/Responder.h>
 namespace mdns {
 namespace Minimal {
 
-class IPv4Responder : public RecordResponder
+// This is a container class for the various record responders (PTR, SRV, TXT, A, AAAA etc.)
+// This class is used to restrict the set of possible responders added to a QueryResponder.
+class RecordResponder : public Responder
 {
 public:
-    IPv4Responder(const FullQName & qname) : RecordResponder(QType::A, qname) {}
-
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override;
-};
-
-class IPv6Responder : public RecordResponder
-{
-public:
-    IPv6Responder(const FullQName & qname) : RecordResponder(QType::AAAA, qname) {}
-
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override;
+    RecordResponder(QType qType, const FullQName & qName) : Responder(qType, qName) {}
 };
 
 } // namespace Minimal

--- a/src/lib/mdns/minimal/responders/Srv.h
+++ b/src/lib/mdns/minimal/responders/Srv.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #include <mdns/minimal/records/Srv.h>
-#include <mdns/minimal/responders/Responder.h>
+#include <mdns/minimal/responders/RecordResponder.h>
 
 namespace mdns {
 namespace Minimal {
 
-class SrvResponder : public Responder
+class SrvResponder : public RecordResponder
 {
 public:
-    SrvResponder(const SrvResourceRecord & record) : Responder(QType::SRV, record.GetName()), mRecord(record) {}
+    SrvResponder(const SrvResourceRecord & record) : RecordResponder(QType::SRV, record.GetName()), mRecord(record) {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
     {

--- a/src/lib/mdns/minimal/responders/Txt.h
+++ b/src/lib/mdns/minimal/responders/Txt.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #include <mdns/minimal/records/Txt.h>
-#include <mdns/minimal/responders/Responder.h>
+#include <mdns/minimal/responders/RecordResponder.h>
 
 namespace mdns {
 namespace Minimal {
 
-class TxtResponder : public Responder
+class TxtResponder : public RecordResponder
 {
 public:
-    TxtResponder(const TxtResourceRecord & record) : Responder(QType::TXT, record.GetName()), mRecord(record) {}
+    TxtResponder(const TxtResourceRecord & record) : RecordResponder(QType::TXT, record.GetName()), mRecord(record) {}
 
     void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
     {

--- a/src/lib/mdns/minimal/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/mdns/minimal/responders/tests/TestQueryResponder.cpp
@@ -34,10 +34,10 @@ const QNamePart kDnsSdname[] = { "_services", "_dns-sd", "_udp", "local" };
 const QNamePart kName1[] = { "some", "test" };
 const QNamePart kName2[] = { "some", "other", "test" };
 
-class EmptyResponder : public Responder
+class EmptyResponder : public RecordResponder
 {
 public:
-    EmptyResponder(const FullQName & qName) : Responder(QType::NULLVALUE, qName) {}
+    EmptyResponder(const FullQName & qName) : RecordResponder(QType::NULLVALUE, qName) {}
     void AddAllResponses(const chip::Inet::IPPacketInfo *, ResponderDelegate *) override {}
 };
 


### PR DESCRIPTION
#### Problem
QueryResponder is derived from Responder, and has an AddResponder
function that looks like it can take other QueryResponders as
arguments. In reality, it's expecting one of IP/TXT/SRV/PTR Responders.

#### Change overview
This add a subclass over the IP/TXT/SRV/PTR responder classes to
clarify the required function arguments for AddResponder.

#### Testing
Query responder unit tests still pass, checked device adverts on commissionable and operational using discover -all in chip-device-ctrl.

