### PR TITLE
Fix all detectable thread races in chip-tool

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -37,39 +37,31 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         "Default DispatchSingleClusterCommand is called, this should be replaced by actual dispatched for cluster commands");
 }
 
-CHIP_ERROR ModelCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR ModelCommand::Run(NodeId localId, NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Controller::CommissionerInitParams initParams;
-    initParams.storageDelegate = &storage;
-
-    err = mOpCredsIssuer.Initialize(storage);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
-
-    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
-
-    err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.Init(localId, initParams);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.ServiceEvents();
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Run Loop: %s", ErrorStr(err)));
-
-    err = mCommissioner.GetDevice(remoteId, &mDevice);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
-
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
     UpdateWaitForResponse(true);
-    err = SendCommand(mDevice, mEndPointId);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Failed to send message: %s", ErrorStr(err)));
+    
+    {
+        chip::DeviceLayer::StackLock lock;
+
+        err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
+
+        err = SendCommand(mDevice, mEndPointId);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Failed to send message: %s", ErrorStr(err)));
+    }
+
     WaitForResponse(kWaitDurationInSeconds);
 
     VerifyOrExit(GetCommandExitStatus(), err = CHIP_ERROR_INTERNAL);
 
 exit:
-    mCommissioner.ServiceEventSignal();
-    mCommissioner.Shutdown();
     return err;
 }

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR ModelCommand::Run(NodeId localId, NodeId remoteId)
     // set the variable to true, which will cause it to block indefinitely.
     //
     UpdateWaitForResponse(true);
-    
+
     {
         chip::DeviceLayer::StackLock lock;
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -36,13 +36,11 @@ public:
     void AddArguments() { AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId); }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 
 private:
-    ChipDeviceController mCommissioner;
     ChipDevice * mDevice;
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
     uint8_t mEndPointId;
 };

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -20,6 +20,7 @@
 
 #include "../../config/PersistentStorage.h"
 #include "Command.h"
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <map>
 
 class Commands
@@ -32,7 +33,7 @@ public:
     int Run(NodeId localId, NodeId remoteId, int argc, char ** argv);
 
 private:
-    CHIP_ERROR RunCommand(PersistentStorage & storage, NodeId localId, NodeId remoteId, int argc, char ** argv);
+    CHIP_ERROR RunCommand(NodeId localId, NodeId remoteId, int argc, char ** argv);
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);
     Command * GetGlobalCommand(CommandsVector & commands, std::string commandName, std::string attributeName);
@@ -44,4 +45,7 @@ private:
     void ShowCommand(std::string executable, std::string clusterName, Command * command);
 
     std::map<std::string, CommandsVector> mClusters;
+    chip::Controller::DeviceCommissioner mController;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+    PersistentStorage mStorage;
 };

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -66,9 +66,9 @@ public:
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
         ChipDevice * device;
-        ReturnErrorOnFailure(mCommissioner.GetDevice(remoteId, &device));
+        ReturnErrorOnFailure(GetExecContext()->commissioner->GetDevice(remoteId, &device));
         ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
-        return mCommissioner.UpdateDevice(device, fabricId);
+        return GetExecContext()->commissioner->UpdateDevice(device, fabricId);
     }
 
     /////////// DeviceAddressUpdateDelegate Interface /////////

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -20,27 +20,33 @@
 
 constexpr uint16_t kWaitDurationInSeconds = 30;
 
-CHIP_ERROR DiscoverCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR DiscoverCommand::Run(NodeId localId, NodeId remoteId)
 {
-    chip::Controller::CommissionerInitParams params;
+    CHIP_ERROR err;
 
-    params.storageDelegate                = &storage;
-    params.mDeviceAddressUpdateDelegate   = this;
-    params.operationalCredentialsDelegate = &mOpCredsIssuer;
-
-    ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
-    ReturnErrorOnFailure(mCommissioner.Init(localId, params));
-    ReturnErrorOnFailure(mCommissioner.ServiceEvents());
-
-    ReturnErrorOnFailure(RunCommand(mNodeId, mFabricId));
-
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
     UpdateWaitForResponse(true);
+    
+    {
+        chip::DeviceLayer::StackLock lock;
+
+        GetExecContext()->commissioner->RegisterDeviceAddressUpdateDelegate(this);
+        err = RunCommand(mNodeId, mFabricId);
+        SuccessOrExit(err);
+    }
+
     WaitForResponse(kWaitDurationInSeconds);
 
-    mCommissioner.ServiceEventSignal();
-    mCommissioner.Shutdown();
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
 
     VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
-
     return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -30,7 +30,7 @@ CHIP_ERROR DiscoverCommand::Run(NodeId localId, NodeId remoteId)
     // set the variable to true, which will cause it to block indefinitely.
     //
     UpdateWaitForResponse(true);
-    
+
     {
         chip::DeviceLayer::StackLock lock;
 

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -35,15 +35,11 @@ public:
     void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override{};
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
     virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;
-
-protected:
-    ChipDeviceCommissioner mCommissioner;
 
 private:
     chip::NodeId mNodeId;
     uint64_t mFabricId;
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "PairingCommand.h"
+#include "platform/PlatformManager.h"
 #include <lib/core/CHIPSafeCasts.h>
 
 using namespace ::chip;
@@ -26,35 +27,21 @@ constexpr uint64_t kBreadcrumb                = 0;
 constexpr uint32_t kTimeoutMs                 = 6000;
 constexpr uint8_t kTemporaryThreadNetworkId[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
 
-CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR PairingCommand::Run(NodeId localId, NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Controller::CommissionerInitParams params;
-    params.storageDelegate              = &storage;
-    params.mDeviceAddressUpdateDelegate = this;
-    params.pairingDelegate              = this;
+    {
+        chip::DeviceLayer::StackLock lock;
 
-    err = mOpCredsIssuer.Initialize(storage);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
-
-    params.operationalCredentialsDelegate = &mOpCredsIssuer;
-
-    err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.Init(localId, params);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.ServiceEvents();
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Run Loop: %s", ErrorStr(err)));
+        GetExecContext()->commissioner->RegisterDeviceAddressUpdateDelegate(this);
+        GetExecContext()->commissioner->RegisterPairingDelegate(this);
+    }
 
     err = RunInternal(remoteId);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init Failure! PairDevice: %s", ErrorStr(err)));
 
 exit:
-    mCommissioner.ServiceEventSignal();
-    mCommissioner.Shutdown();
 
     if (err == CHIP_NO_ERROR)
     {
@@ -71,26 +58,43 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     mRemoteId = remoteId;
 
     InitCallbacks();
+
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
     UpdateWaitForResponse(true);
-    switch (mPairingMode)
+
+    //
+    // We're about to call methods into the stack, so lock
+    // appropriately. None of the following calls below before the unlock are, nor should be,
+    // blocking.
+    //
     {
-    case PairingMode::None:
-        err = Unpair(remoteId);
-        break;
-    case PairingMode::Bypass:
-        err = PairWithoutSecurity(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
-        break;
-    case PairingMode::Ble:
-        err = Pair(remoteId, PeerAddress::BLE());
-        break;
-    case PairingMode::OnNetwork:
-    case PairingMode::SoftAP:
-        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
-        break;
-    case PairingMode::Ethernet:
-        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
-        break;
+        chip::DeviceLayer::StackLock lock;
+
+        switch (mPairingMode)
+        {
+        case PairingMode::None:
+            err = Unpair(remoteId);
+            break;
+        case PairingMode::Bypass:
+            err = PairWithoutSecurity(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+            break;
+        case PairingMode::Ble:
+            err = Pair(remoteId, PeerAddress::BLE());
+            break;
+        case PairingMode::OnNetwork:
+        case PairingMode::SoftAP:
+            err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+            break;
+        case PairingMode::Ethernet:
+            err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+            break;
+        }
     }
+
     WaitForResponse(kWaitDurationInSeconds);
     ReleaseCallbacks();
 
@@ -102,19 +106,19 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
     RendezvousParameters params =
         RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator).SetPeerAddress(address);
 
-    return mCommissioner.PairDevice(remoteId, params);
+    return GetExecContext()->commissioner->PairDevice(remoteId, params);
 }
 
 CHIP_ERROR PairingCommand::PairWithoutSecurity(NodeId remoteId, PeerAddress address)
 {
     ChipSerializedDevice serializedTestDevice;
-    return mCommissioner.PairTestDeviceWithoutSecurity(remoteId, address, serializedTestDevice);
+    return GetExecContext()->commissioner->PairTestDeviceWithoutSecurity(remoteId, address, serializedTestDevice);
 }
 
 CHIP_ERROR PairingCommand::Unpair(NodeId remoteId)
 {
     SetCommandExitStatus(true);
-    return mCommissioner.UnpairDevice(remoteId);
+    return GetExecContext()->commissioner->UnpairDevice(remoteId);
 }
 
 void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
@@ -172,7 +176,7 @@ CHIP_ERROR PairingCommand::SetupNetwork()
     case PairingNetworkType::WiFi:
     case PairingNetworkType::Ethernet:
     case PairingNetworkType::Thread:
-        err = mCommissioner.GetDevice(mRemoteId, &mDevice);
+        err = GetExecContext()->commissioner->GetDevice(mRemoteId, &mDevice);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Setup failure! No pairing for device: %" PRIu64, mRemoteId));
 
         mCluster.Associate(mDevice, mEndpointId);
@@ -312,9 +316,9 @@ void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, 
 
 CHIP_ERROR PairingCommand::UpdateNetworkAddress()
 {
-    ReturnErrorOnFailure(mCommissioner.GetDevice(mRemoteId, &mDevice));
+    ReturnErrorOnFailure(GetExecContext()->commissioner->GetDevice(mRemoteId, &mDevice));
     ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", mRemoteId, mFabricId);
-    return mCommissioner.UpdateDevice(mDevice, mFabricId);
+    return GetExecContext()->commissioner->UpdateDevice(mDevice, mFabricId);
 }
 
 void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -97,7 +97,7 @@ public:
     }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
@@ -143,7 +143,6 @@ private:
     chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback;
     chip::Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> * mOnEnableNetworkCallback;
     chip::Callback::Callback<DefaultFailureCallback> * mOnFailureCallback;
-    ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
     chip::Controller::NetworkCommissioningCluster mCluster;
     chip::EndpointId mEndpointId = 0;

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
@@ -24,7 +24,7 @@
 using namespace ::chip;
 using namespace ::chip::SetupPayloadData;
 
-CHIP_ERROR AdditionalDataParseCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR AdditionalDataParseCommand::Run(NodeId localId, NodeId remoteId)
 {
     std::vector<uint8_t> payloadData;
     AdditionalDataPayload resultPayload;
@@ -40,9 +40,12 @@ CHIP_ERROR AdditionalDataParseCommand::Run(PersistentStorage & storage, NodeId l
         uint8_t x = (uint8_t) stoi(str, 0, 16);
         payloadData.push_back(x);
     }
+
     err = AdditionalDataPayloadParser(payloadData.data(), (uint32_t) payloadData.size()).populatePayload(resultPayload);
     SuccessOrExit(err);
+
     ChipLogProgress(chipTool, "AdditionalDataParseCommand, RotatingDeviceId=%s", resultPayload.rotatingDeviceId.c_str());
+
 exit:
     return err;
 }

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
@@ -24,7 +24,7 @@ class AdditionalDataParseCommand : public Command
 {
 public:
     AdditionalDataParseCommand() : Command("parse-additional-data-payload") { AddArgument("payload", &mPayload); }
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
 private:
     char * mPayload;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -23,7 +23,7 @@
 
 using namespace ::chip;
 
-CHIP_ERROR SetupPayloadParseCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR SetupPayloadParseCommand::Run(NodeId localId, NodeId remoteId)
 {
     std::string codeString(mCode);
     SetupPayload payload;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
@@ -25,7 +25,7 @@ class SetupPayloadParseCommand : public Command
 {
 public:
     SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode); }
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
 private:
     char * mCode;

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -39,7 +39,7 @@ CHIP_ERROR ReportingCommand::Run(NodeId localId, NodeId remoteId)
     // set the variable to true, which will cause it to block indefinitely.
     //
     UpdateWaitForResponse(true);
-    
+
     {
         chip::DeviceLayer::StackLock lock;
 

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -28,43 +28,33 @@ namespace {
 constexpr uint16_t kWaitDurationInSeconds = UINT16_MAX;
 } // namespace
 
-CHIP_ERROR ReportingCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR ReportingCommand::Run(NodeId localId, NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
     chip::Controller::BasicCluster cluster;
-    chip::Controller::CommissionerInitParams initParams;
 
-    initParams.storageDelegate = &storage;
-
-    err = mOpCredsIssuer.Initialize(storage);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
-
-    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
-
-    err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.Init(localId, initParams);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
-
-    err = mCommissioner.ServiceEvents();
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Run Loop: %s", ErrorStr(err)));
-
-    err = mCommissioner.GetDevice(remoteId, &mDevice);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
-
-    AddReportCallbacks(mEndPointId);
-
-    cluster.Associate(mDevice, mEndPointId);
-    err = cluster.MfgSpecificPing(nullptr, nullptr);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
-
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
     UpdateWaitForResponse(true);
+    
+    {
+        chip::DeviceLayer::StackLock lock;
+
+        err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
+
+        AddReportCallbacks(mEndPointId);
+        cluster.Associate(mDevice, mEndPointId);
+
+        err = cluster.MfgSpecificPing(nullptr, nullptr);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
+    }
+
     WaitForResponse(kWaitDurationInSeconds);
 
 exit:
-    mCommissioner.ServiceEventSignal();
-    mCommissioner.Shutdown();
     return err;
 }

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -36,14 +36,11 @@ public:
     }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
     virtual void AddReportCallbacks(uint8_t endPointId) = 0;
 
 private:
     uint8_t mEndPointId;
-
-    ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -30,7 +30,7 @@ CHIP_ERROR TestCommand::Run(NodeId localId, NodeId remoteId)
     // set the variable to true, which will cause it to block indefinitely.
     //
     UpdateWaitForResponse(true);
-    
+
     {
         chip::DeviceLayer::StackLock lock;
 

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -20,30 +20,29 @@
 
 constexpr uint16_t kWaitDurationInSeconds = 30;
 
-CHIP_ERROR TestCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+CHIP_ERROR TestCommand::Run(NodeId localId, NodeId remoteId)
 {
-    ReturnErrorOnFailure(mOpCredsIssuer.Initialize(storage));
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Controller::CommissionerInitParams params;
-
-    params.storageDelegate                = &storage;
-    params.operationalCredentialsDelegate = &mOpCredsIssuer;
-
-    ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
-    ReturnErrorOnFailure(mCommissioner.Init(localId, params));
-    ReturnErrorOnFailure(mCommissioner.ServiceEvents());
-    ReturnErrorOnFailure(mCommissioner.GetDevice(remoteId, &mDevice));
-
-    ReturnErrorOnFailure(NextTest());
-
+    //
+    // Set this to true first BEFORE we send commands to ensure we don't
+    // end up in a situation where the response comes back faster than we can
+    // set the variable to true, which will cause it to block indefinitely.
+    //
     UpdateWaitForResponse(true);
+    
+    {
+        chip::DeviceLayer::StackLock lock;
+
+        err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
+        ReturnErrorOnFailure(err);
+
+        err = NextTest();
+        ReturnErrorOnFailure(err);
+    }
+
     WaitForResponse(kWaitDurationInSeconds);
 
-    mCommissioner.ServiceEventSignal();
-
-    mCommissioner.Shutdown();
-
     VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
-
     return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "../../config/PersistentStorage.h"
 #include "../common/Command.h"
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 
@@ -28,14 +27,10 @@ public:
     TestCommand(const char * commandName) : Command(commandName) {}
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
 
     virtual CHIP_ERROR NextTest() = 0;
 
 protected:
-    ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
-
-private:
-    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -2,7 +2,7 @@
 class {{asCamelCased filename false}}: public TestCommand
 {
   public:
-    {{asCamelCased filename false}}(): TestCommand("{{filename}}"), mTestIndex(0) {}
+    {{asCamelCased filename false}}(): TestCommand("{{filename}}") {}
 
     /////////// TestCommand Interface /////////
     CHIP_ERROR NextTest() override
@@ -15,11 +15,7 @@ class {{asCamelCased filename false}}: public TestCommand
           SetCommandExitStatus(true);
       }
 
-      // Ensure we increment mTestIndex before we start running the relevant
-      // command.  That way if we lose the timeslice after we send the message
-      // but before our function call returns, we won't end up with an
-      // incorrect mTestIndex value observed when we get the response.
-      switch (mTestIndex++)
+      switch (mTestIndex)
       {
         {{#chip_tests_items}}
         case {{index}}:
@@ -27,6 +23,7 @@ class {{asCamelCased filename false}}: public TestCommand
           break;
         {{/chip_tests_items}}
       }
+      mTestIndex++;
 
       if (CHIP_NO_ERROR != err)
       {
@@ -39,8 +36,8 @@ class {{asCamelCased filename false}}: public TestCommand
 
 
   private:
-    std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = {{totalTests}};
+    uint16_t mTestIndex = 0;
+    uint16_t mTestCount = {{totalTests}};
 
     //
     // Tests methods

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -2,7 +2,7 @@
 class {{asCamelCased filename false}}: public TestCommand
 {
   public:
-    {{asCamelCased filename false}}(): TestCommand("{{filename}}") {}
+    {{asCamelCased filename false}}(): TestCommand("{{filename}}"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
     CHIP_ERROR NextTest() override
@@ -15,7 +15,11 @@ class {{asCamelCased filename false}}: public TestCommand
           SetCommandExitStatus(true);
       }
 
-      switch (mTestIndex)
+      // Ensure we increment mTestIndex before we start running the relevant
+      // command.  That way if we lose the timeslice after we send the message
+      // but before our function call returns, we won't end up with an
+      // incorrect mTestIndex value observed when we get the response.
+      switch (mTestIndex++)
       {
         {{#chip_tests_items}}
         case {{index}}:
@@ -23,7 +27,6 @@ class {{asCamelCased filename false}}: public TestCommand
           break;
         {{/chip_tests_items}}
       }
-      mTestIndex++;
 
       if (CHIP_NO_ERROR != err)
       {
@@ -36,8 +39,8 @@ class {{asCamelCased filename false}}: public TestCommand
 
 
   private:
-    uint16_t mTestIndex = 0;
-    uint16_t mTestCount = {{totalTests}};
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = {{totalTests}};
 
     //
     // Tests methods

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -332,7 +332,12 @@ int main(int argc, char ** args)
     if (DeviceLayer::SystemLayer.NewTimer(timer) == CHIP_NO_ERROR)
     {
         timer->Start(
-            gOptions.runtimeMs, [](System::Layer *, void *, System::Error err) { DeviceLayer::PlatformMgr().Shutdown(); }, nullptr);
+            gOptions.runtimeMs,
+            [](System::Layer *, void *, System::Error err) {
+                DeviceLayer::PlatformMgr().StopEventLoopTask();
+                DeviceLayer::PlatformMgr().Shutdown();
+            },
+            nullptr);
     }
     else
     {

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -58,6 +58,7 @@ exit:
 
 void ShutdownChip(void)
 {
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -207,13 +207,11 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams par
     mExchangeMgr->SetDelegate(this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    if (params.mDeviceAddressUpdateDelegate != nullptr)
-    {
-        err = Mdns::Resolver::Instance().SetResolverDelegate(this);
-        SuccessOrExit(err);
+    err = Mdns::Resolver::Instance().SetResolverDelegate(this);
+    SuccessOrExit(err);
 
-        mDeviceAddressUpdateDelegate = params.mDeviceAddressUpdateDelegate;
-    }
+    RegisterDeviceAddressUpdateDelegate(params.mDeviceAddressUpdateDelegate);
+
     Mdns::Resolver::Instance().StartResolver(mInetLayer, kMdnsPort);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
@@ -293,11 +291,15 @@ CHIP_ERROR DeviceController::Shutdown()
     ChipLogDetail(Controller, "Shutting down the controller");
 
 #if CONFIG_DEVICE_LAYER
-    // Start by shutting down the PlatformManager.  This will ensure, with
-    // reasonable synchronization, that we stop processing of incoming messages
-    // before doing any other shutdown work.  Otherwise we can end up trying to
-    // process incoming messages in a partially shut down state, which is not
-    // great at all.
+    //
+    // We can safely call PlatformMgr().Shutdown(), which like DeviceController::Shutdown(),
+    // expects to be called with external thread synchronization and will not try to acquire the
+    // stack lock.
+    //
+    // Actually stopping the event queue is a separable call that applications will have to sequence.
+    // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling 
+    // DeviceController::Shutdown() in the CONFIG_DEVICE_LAYER configuration
+    //
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
 #else
     mInetLayer->Shutdown();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -297,7 +297,7 @@ CHIP_ERROR DeviceController::Shutdown()
     // stack lock.
     //
     // Actually stopping the event queue is a separable call that applications will have to sequence.
-    // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling 
+    // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling
     // DeviceController::Shutdown() in the CONFIG_DEVICE_LAYER configuration
     //
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -190,6 +190,15 @@ public:
 
     CHIP_ERROR Init(NodeId localDeviceId, ControllerInitParams params);
 
+    /**
+     * @brief
+     *  Tears down the entirety of the stack, including destructing key objects in the system.
+     *  This expects to be called with external thread synchronization, and will not internally
+     *  grab the CHIP stack lock.
+     *
+     *  This will also not stop the CHIP event queue / thread (if one exists).  Consumers are expected to
+     *  ensure this happend before calling this method.
+     */
     virtual CHIP_ERROR Shutdown();
 
     /**
@@ -236,6 +245,10 @@ public:
     CHIP_ERROR SetUdpListenPort(uint16_t listenPort);
 
     virtual void ReleaseDevice(Device * device);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    void RegisterDeviceAddressUpdateDelegate(DeviceAddressUpdateDelegate * delegate) { mDeviceAddressUpdateDelegate = delegate; }
+#endif
 
     // ----- IO -----
     /**
@@ -374,6 +387,13 @@ public:
      */
     CHIP_ERROR Init(NodeId localDeviceId, CommissionerInitParams params);
 
+    /**
+     * @brief
+     *  Tears down the entirety of the stack, including destructing key objects in the system.
+     *  This is not a thread-safe API, and should be called with external synchronization.
+     *
+     *  Please see implementation for more details.
+     */
     CHIP_ERROR Shutdown() override;
 
     // ----- Connection Management -----
@@ -470,6 +490,8 @@ public:
     void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
 
 #endif
+
+    void RegisterPairingDelegate(DevicePairingDelegate * pairingDelegate) { mPairingDelegate = pairingDelegate; }
 
 private:
     DevicePairingDelegate * mPairingDelegate;

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -91,6 +91,7 @@ public:
     void ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg = 0);
     void RunEventLoop();
     CHIP_ERROR StartEventLoopTask();
+    CHIP_ERROR StopEventLoopTask();
     void LockChipStack();
     bool TryLockChipStack();
     void UnlockChipStack();
@@ -171,6 +172,19 @@ extern PlatformManager & PlatformMgr();
  */
 extern PlatformManagerImpl & PlatformMgrImpl();
 
+/**
+ * @brief
+ * RAII locking for PlatformManager to simplify management of
+ * LockChipStack()/UnlockChipStack calls.
+ */
+class StackLock
+{
+public:
+    StackLock() { PlatformMgr().LockChipStack(); }
+
+    ~StackLock() { PlatformMgr().UnlockChipStack(); }
+};
+
 } // namespace DeviceLayer
 } // namespace chip
 
@@ -233,9 +247,47 @@ inline void PlatformManager::RunEventLoop()
     static_cast<ImplClass *>(this)->_RunEventLoop();
 }
 
+/**
+ * @brief
+ *  Starts the stack on its own task with an associated event queue
+ *  to dispatch and handle events posted to that task.
+ *
+ *  This is thread-safe.
+ *  This is *NOT SAFE* to call from within the CHIP event loop since it can grab the stack lock.
+ */
 inline CHIP_ERROR PlatformManager::StartEventLoopTask()
 {
     return static_cast<ImplClass *>(this)->_StartEventLoopTask();
+}
+
+/**
+ * @brief
+ *  This will trigger the event loop to exit and block till it has exited the loop.
+ *  This prevents the processing of any further events in the queue.
+ *
+ *  Additionally, this stops the CHIP task if the following criteria are met:
+ *      1. One was created earlier through a call to StartEventLoopTask
+ *      2. This call isn't being made from that task.
+ *
+ *  This is safe to call from any task.
+ *  This is safe to call from within the CHIP event loop.
+ *
+ */
+inline CHIP_ERROR PlatformManager::StopEventLoopTask()
+{
+    return static_cast<ImplClass *>(this)->_StopEventLoopTask();
+}
+
+/**
+ * @brief
+ *   Shuts down and cleans up the main objects in the CHIP stack.
+ *   This DOES NOT stop the chip thread or event queue from running.
+ *
+ */
+inline CHIP_ERROR PlatformManager::Shutdown()
+{
+    mInitialized = false;
+    return static_cast<ImplClass *>(this)->_Shutdown();
 }
 
 inline void PlatformManager::LockChipStack()
@@ -266,12 +318,6 @@ inline void PlatformManager::DispatchEvent(const ChipDeviceEvent * event)
 inline CHIP_ERROR PlatformManager::StartChipTimer(uint32_t durationMS)
 {
     return static_cast<ImplClass *>(this)->_StartChipTimer(durationMS);
-}
-
-inline CHIP_ERROR PlatformManager::Shutdown()
-{
-    mInitialized = false;
-    return static_cast<ImplClass *>(this)->_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
@@ -241,6 +241,14 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 {
+    VerifyOrDieWithMsg(false, DeviceLayer, "Shutdown is not implemented");
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StopEventLoopTask(void)
+{
+    VerifyOrDieWithMsg(false, DeviceLayer, "StopEventLoopTask is not implemented");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
@@ -71,6 +71,7 @@ protected:
     void _PostEvent(const ChipDeviceEvent * event);
     void _RunEventLoop(void);
     CHIP_ERROR _StartEventLoopTask(void);
+    CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(uint32_t durationMS);
     CHIP_ERROR _Shutdown(void);
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -24,6 +24,7 @@
 #ifndef GENERIC_PLATFORM_MANAGER_IMPL_POSIX_CPP
 #define GENERIC_PLATFORM_MANAGER_IMPL_POSIX_CPP
 
+#include "system/SystemError.h"
 #include <platform/PlatformManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.h>
@@ -64,6 +65,7 @@ template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    int ret        = 0;
 
     mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -73,7 +75,20 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
 
     mShouldRunEventLoop.store(true, std::memory_order_relaxed);
 
+    ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
+    SuccessOrExit(ret);
+
+    ret = pthread_mutex_init(&mStateLock, nullptr);
+    SuccessOrExit(ret);
+
+    mHasValidChipTask = false;
+
 exit:
+    if (ret != 0)
+    {
+        err = System::MapErrorPOSIX(ret);
+    }
+
     return err;
 }
 
@@ -220,6 +235,23 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::SysProcess()
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
 {
+    pthread_mutex_lock(&mStateLock);
+
+    //
+    // If we haven't set mHasValidChipTask by now, it means that the application did not call StartEventLoopTask
+    // and consequently, are running the event loop from their own, externally managed task.
+    // Let's track his appropriately since we need this info later when stopping the event queues.
+    //
+    if (!mHasValidChipTask)
+    {
+        mHasValidChipTask = true;
+        mChipTask         = pthread_self();
+        mTaskType         = kExternallyManagedTask;
+    }
+
+    mEventQueueHasStopped = false;
+    pthread_mutex_unlock(&mStateLock);
+
     Impl()->LockChipStack();
 
     do
@@ -229,6 +261,18 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
     } while (mShouldRunEventLoop.load(std::memory_order_relaxed));
 
     Impl()->UnlockChipStack();
+
+    pthread_mutex_lock(&mStateLock);
+    mEventQueueHasStopped = true;
+    pthread_mutex_unlock(&mStateLock);
+
+    //
+    // Wake up anyone blocked waiting for the event queue to stop in
+    // StopEventLoopTask().
+    //
+    pthread_cond_signal(&mEventQueueStoppedCond);
+
+    return;
 }
 
 template <class ImplClass>
@@ -250,27 +294,94 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
     SuccessOrExit(err);
     err = pthread_attr_setschedpolicy(&mChipTaskAttr, SCHED_RR);
     SuccessOrExit(err);
+
+    //
+    // We need to grab the lock here since we have to protect setting
+    // mHasValidChipTask, which will be read right away upon creating the
+    // thread below.
+    //
+    pthread_mutex_lock(&mStateLock);
+
     err = pthread_create(&mChipTask, &mChipTaskAttr, EventLoopTaskMain, this);
-    SuccessOrExit(err);
+    if (err == 0)
+    {
+        mHasValidChipTask = true;
+        mTaskType         = kInternallyManagedTask;
+    }
+
+    pthread_mutex_unlock(&mStateLock);
+
 exit:
+    return System::MapErrorPOSIX(err);
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
+{
+    int err = 0;
+
+    //
+    // Signal to the runloop to stop.
+    //
+    mShouldRunEventLoop.store(false, std::memory_order_relaxed);
+
+    pthread_mutex_lock(&mStateLock);
+
+    //
+    // If we're calling this from a different thread than the one running chip, then
+    // we need to wait till the event queue has completely stopped before proceeding.
+    //
+    if (mHasValidChipTask && (pthread_equal(pthread_self(), mChipTask) == 0))
+    {
+        pthread_mutex_unlock(&mStateLock);
+
+        //
+        // We need to grab the lock to protect critical sections accessed by the WakeSelect() call within
+        // SystemLayer.
+        //
+        Impl()->LockChipStack();
+        SystemLayer.WakeSelect();
+        Impl()->UnlockChipStack();
+
+        pthread_mutex_lock(&mStateLock);
+
+        while (!mEventQueueHasStopped)
+        {
+            err = pthread_cond_wait(&mEventQueueStoppedCond, &mStateLock);
+            SuccessOrExit(err);
+        }
+
+        pthread_mutex_unlock(&mStateLock);
+
+        //
+        // Wait further for the thread to terminate if we had previously created it.
+        //
+        if (mTaskType == kInternallyManagedTask)
+        {
+            err = pthread_join(mChipTask, nullptr);
+            SuccessOrExit(err);
+        }
+    }
+    else
+    {
+        pthread_mutex_unlock(&mStateLock);
+    }
+
+exit:
+    pthread_mutex_destroy(&mStateLock);
+    pthread_cond_destroy(&mEventQueueStoppedCond);
+    mHasValidChipTask = false;
     return System::MapErrorPOSIX(err);
 }
 
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
 {
-    int err = 0;
-    mShouldRunEventLoop.store(false, std::memory_order_relaxed);
-    if (mChipTask)
-    {
-        SystemLayer.WakeSelect();
-        SuccessOrExit(err = pthread_join(mChipTask, nullptr));
-    }
-    // Call up to the base class _Shutdown() to perform the bulk of the shutdown.
-    err = GenericPlatformManagerImpl<ImplClass>::_Shutdown();
-
-exit:
-    return System::MapErrorPOSIX(err);
+    //
+    // Call up to the base class _Shutdown() to perform the actual stack de-initialization
+    // and clean-up
+    //
+    return System::MapErrorPOSIX(GenericPlatformManagerImpl<ImplClass>::_Shutdown());
 }
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -63,7 +63,24 @@ protected:
     pthread_mutex_t mChipStackLock;
     std::queue<ChipDeviceEvent> mChipEventQueue;
 
+    enum TaskType
+    {
+        kExternallyManagedTask = 0,
+        kInternallyManagedTask = 1
+    };
+
     pthread_t mChipTask;
+    bool mHasValidChipTask = false;
+    TaskType mTaskType;
+    pthread_cond_t mEventQueueStoppedCond;
+    pthread_mutex_t mStateLock;
+
+    //
+    // TODO: This variable is very similar to mMainLoopIsStarted, track the
+    // cleanup and consolidation in this issue:
+    //
+    bool mEventQueueHasStopped = false;
+
     pthread_attr_t mChipTaskAttr;
     struct sched_param mChipTaskSchedParam;
 
@@ -83,6 +100,7 @@ protected:
     void _PostEvent(const ChipDeviceEvent * event);
     void _RunEventLoop();
     CHIP_ERROR _StartEventLoopTask();
+    CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(int64_t durationMS);
     CHIP_ERROR _Shutdown();
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -87,8 +87,16 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StartChipTimer(uint32_
 }
 
 template <class ImplClass>
+CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StopEventLoopTask(void)
+{
+    VerifyOrDieWithMsg(false, DeviceLayer, "StopEventLoopTask is not implemented");
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
 {
+    VerifyOrDieWithMsg(false, DeviceLayer, "Shutdown is not implemented");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
@@ -76,6 +76,7 @@ protected:
     void _PostEvent(const ChipDeviceEvent * event);
     void _RunEventLoop(void);
     CHIP_ERROR _StartEventLoopTask(void);
+    CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(uint32_t durationMS);
     CHIP_ERROR _Shutdown(void);
 

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -58,6 +58,7 @@ exit:
 
 void ShutdownChip(void)
 {
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -59,6 +59,7 @@ private:
 
     CHIP_ERROR _StartChipTimer(int64_t aMilliseconds) { return CHIP_ERROR_NOT_IMPLEMENTED; };
     CHIP_ERROR _StartEventLoopTask() { return CHIP_NO_ERROR; };
+    CHIP_ERROR _StopEventLoopTask() { return CHIP_NO_ERROR; };
     void _RunEventLoop(){};
     void _LockChipStack(){};
     bool _TryLockChipStack() { return false; };

--- a/src/platform/tests/TestMdns.cpp
+++ b/src/platform/tests/TestMdns.cpp
@@ -6,6 +6,7 @@
 
 #include "lib/mdns/platform/Mdns.h"
 #include "platform/CHIPDeviceLayer.h"
+#include "platform/PlatformManager.h"
 #include "support/CHIPMem.h"
 #include "support/UnitTestRegistration.h"
 
@@ -88,6 +89,7 @@ void TestMdnsPubSub(nlTestSuite * inSuite, void * inContext)
 
     ChipLogProgress(DeviceLayer, "Start EventLoop");
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    ChipLogProgress(DeviceLayer, "End EventLoop");
 }
 
 static const nlTest sTests[] = { NL_TEST_DEF("Test Mdns::PubSub", TestMdnsPubSub), NL_TEST_SENTINEL() };
@@ -132,13 +134,13 @@ int TestMdns()
         {
             fprintf(stderr, "mDNS test timeout, is avahi daemon running?\n");
 
-            chip::DeviceLayer::PlatformMgr().LockChipStack();
+            //
+            // This will stop the event loop above, and wait till it has actually stopped
+            // (i.e exited RunEventLoop()).
+            //
+            chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
             chip::DeviceLayer::PlatformMgr().Shutdown();
-            chip::DeviceLayer::SystemLayer.WakeSelect();
-            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-            // TODO: the above does not seem to actually reliably shut down the chip stack.
-            // Program will abort with core because chip thread will still run.
             doneCondition.wait_for(lock, std::chrono::seconds(1));
             if (!done)
             {


### PR DESCRIPTION
## Problem:
    
This PR fixes-up all detectable thread-races as detected by tsan in chip-tool.
    
## Change Overview:
    
* Following the pattern of 'external synchronization' as outlined in #6841, sprinkled `LockChipStack()` and `UnlockChipStack()` calls around key call sites that called into the stack from the various command logic in chip-tool that runs from the main thread.
* Removed `usleep()` and global instance hacks.
* Re-structured `Command::Run()` to now have the bulk of the stack initialization and shutdown be managed similarly for all commands before `Run()` is called in `Commands::Run()`, and an `ExecutionContext` object pointer be stashed inside the Command for convenient access to stack objects. This reduces the chances of people writing new commands of getting stack initialization wrong.
* Instead of sometimes using `chip::Controller::DeviceController` and sometimes `DeviceCommissioner`, just used the latter in all commands since that is the super-set class anyways.
* Added a new `PlatformMgr::StopEventLoopTask()` that is thread-safe, that is needed to be called by application logic before `DeviceController::Shutdown()` can be called with external synchronization.
* Fixed up TestMdns as well along the way.
    
## Testing:
    
* Enabled tsan using 'is_tsan' build arg and used that catch well over 10+ races, with not a single false-positive.
* Ran through all the chip-tool command groups (pairing, IM, discover, testcluster, payload, etc) 10x each to ensure no regressions in functionality as well as ensuring clean shutdown with tsan.