### PR TITLE
[python] Raise exceptions when the controller failed to send commands

### DIFF
--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -958,7 +958,9 @@ class ChipClusters:
         if not func:
             raise UnknownCommand(cluster, command)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, groupid, **args))
+        res = funcCaller(lambda: func(device, endpoint, groupid, **args))
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
 
     def ReadAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, imEnabled):
         func = getattr(self, "Cluster{}_ReadAttribute{}".format(cluster, attribute), None)

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -50,7 +50,9 @@ class ChipClusters:
         if not func:
             raise UnknownCommand(cluster, command)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, groupid, **args))
+        res = funcCaller(lambda: func(device, endpoint, groupid, **args))
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
 
     def ReadAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, imEnabled):
         func = getattr(self, "Cluster{}_ReadAttribute{}".format(cluster, attribute), None)


### PR DESCRIPTION
#### Problem
The controller will hang due to desired response never comes when it failed to send a command.

#### Change overview
Raise an exception in this case

#### Testing
- This PR is for error handling, however, failed to send command is a rare case and hard to construct using python apis.
- @cjandhyala please verify if this PR can resolve the handing issue.
