### PR TITLE
Darwin - Pass the port advertised by mdns in network bytes order

### DIFF
--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -322,8 +322,8 @@ CHIP_ERROR Register(uint32_t interfaceId, const char * type, const char * name, 
     }
 
     sdCtx = chip::Platform::New<RegisterContext>(type, nullptr);
-    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDomain, NULL, port, recordLen, recordBytesPtr,
-                             OnRegister, sdCtx);
+    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDomain, NULL, ntohs(port), recordLen,
+                             recordBytesPtr, OnRegister, sdCtx);
     TXTRecordDeallocate(recordRef);
 
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
#### Problem

On Darwin, mdns advertisement is advertising port `22827` instead of `11097`. This is due to the API expecting the port to be passed in network byte order.

#### Change overview
 * Pass the port using the correct format

#### Testing
 * It was tested under darwin by running `chip-all-clusters-app` and using `chip-tool discover resolve 12344321 0` to get the result from `mdns`
 * I have not added tests yet, because this is what I would like to achieve with this PR and a few others. Adding tests that exercise `mdns`.