### PR TITLE
Do not use an undefined node id for mdns advertising

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -48,7 +48,7 @@ NodeId GetCurrentNodeId()
 
     // Search for one admin pairing and use its node id.
     auto pairing = GetGlobalAdminPairingTable().cbegin();
-    if (pairing != GetGlobalAdminPairingTable().cend())
+    if (pairing != GetGlobalAdminPairingTable().cend() && pairing->GetNodeId() != kUndefinedNodeId)
     {
         ChipLogProgress(Discovery, "Found admin pairing for admin %" PRIX16 ", node 0x" ChipLogFormatX64, pairing->GetAdminId(),
                         ChipLogValueX64(pairing->GetNodeId()));


### PR DESCRIPTION
#### Problem

If an accessory already connected to the network and without any admin pairing is on the network, the mdns advertisement is `0000000000000000-0000000000000000` instead of beeing (for example): `0000000000000000-0000000000BC5C01` if the node id is `12344321`.

#### Change overview
 * Do not use an undefined node id from the admin pairing table

#### Testing
 * It was tested on Mac with `chip-all-clusters-app`,  with `chip_config_network_layer_ble=false`, advertising over mdns on the local network.
 * Similarly to #7487, I'm trying to get mdns advertisement working in order to have a working test.
