### PR TITLE
[K32W] Increase IM timeout

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -59,7 +59,8 @@ namespace chip {
 namespace app {
 
 constexpr size_t kMaxSecureSduLengthBytes = 1024;
-constexpr uint32_t kImMessageTimeoutMsec  = 6000;
+/* TODO: https://github.com/project-chip/connectedhomeip/issues/7489 */
+constexpr uint32_t kImMessageTimeoutMsec  = 12000;
 constexpr FieldId kRootFieldId            = 0;
 
 /**

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -60,8 +60,8 @@ namespace app {
 
 constexpr size_t kMaxSecureSduLengthBytes = 1024;
 /* TODO: https://github.com/project-chip/connectedhomeip/issues/7489 */
-constexpr uint32_t kImMessageTimeoutMsec  = 12000;
-constexpr FieldId kRootFieldId            = 0;
+constexpr uint32_t kImMessageTimeoutMsec = 12000;
+constexpr FieldId kRootFieldId           = 0;
 
 /**
  * @class InteractionModelEngine


### PR DESCRIPTION
#### Problem
chip-device-ctrl times out waiting for the OpCSR response:
https://github.com/project-chip/connectedhomeip/issues/7320.

#### Change overview
Double the IM timer timeout.

#### Testing
* tested manually the end-to-end flow between K32W elock app and chip-device-ctrl.