### PR TITLE
Fix data race on mTestIndex.

### DIFF
--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -24,7 +24,7 @@
 class TestCluster : public TestCommand
 {
 public:
-    TestCluster() : TestCommand("TestCluster") {}
+    TestCluster() : TestCommand("TestCluster"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
     CHIP_ERROR NextTest() override
@@ -37,7 +37,11 @@ public:
             SetCommandExitStatus(true);
         }
 
-        switch (mTestIndex)
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
         {
         case 0:
             err = TestSendClusterTestClusterCommandTest_0();
@@ -55,7 +59,6 @@ public:
             err = TestSendClusterTestClusterCommandReadAttribute_4();
             break;
         }
-        mTestIndex++;
 
         if (CHIP_NO_ERROR != err)
         {
@@ -67,8 +70,8 @@ public:
     }
 
 private:
-    uint16_t mTestIndex = 0;
-    uint16_t mTestCount = 5;
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 5;
 
     //
     // Tests methods
@@ -437,7 +440,7 @@ private:
 class OnOffCluster : public TestCommand
 {
 public:
-    OnOffCluster() : TestCommand("OnOffCluster") {}
+    OnOffCluster() : TestCommand("OnOffCluster"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
     CHIP_ERROR NextTest() override
@@ -450,7 +453,11 @@ public:
             SetCommandExitStatus(true);
         }
 
-        switch (mTestIndex)
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
         {
         case 0:
             err = TestSendClusterOnOffCommandReadAttribute_0();
@@ -468,7 +475,6 @@ public:
             err = TestSendClusterOnOffCommandReadAttribute_4();
             break;
         }
-        mTestIndex++;
 
         if (CHIP_NO_ERROR != err)
         {
@@ -480,8 +486,8 @@ public:
     }
 
 private:
-    uint16_t mTestIndex = 0;
-    uint16_t mTestCount = 5;
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 5;
 
     //
     // Tests methods

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -2,7 +2,7 @@
 class {{asCamelCased filename false}}: public TestCommand
 {
   public:
-    {{asCamelCased filename false}}(): TestCommand("{{filename}}") {}
+    {{asCamelCased filename false}}(): TestCommand("{{filename}}"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
     CHIP_ERROR NextTest() override
@@ -15,7 +15,11 @@ class {{asCamelCased filename false}}: public TestCommand
           SetCommandExitStatus(true);
       }
 
-      switch (mTestIndex)
+      // Ensure we increment mTestIndex before we start running the relevant
+      // command.  That way if we lose the timeslice after we send the message
+      // but before our function call returns, we won't end up with an
+      // incorrect mTestIndex value observed when we get the response.
+      switch (mTestIndex++)
       {
         {{#chip_tests_items}}
         case {{index}}:
@@ -23,7 +27,6 @@ class {{asCamelCased filename false}}: public TestCommand
           break;
         {{/chip_tests_items}}
       }
-      mTestIndex++;
 
       if (CHIP_NO_ERROR != err)
       {
@@ -36,8 +39,8 @@ class {{asCamelCased filename false}}: public TestCommand
 
 
   private:
-    uint16_t mTestIndex = 0;
-    uint16_t mTestCount = {{totalTests}};
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = {{totalTests}};
 
     //
     // Tests methods


### PR DESCRIPTION
We could end up sending a message and getting a response to it before
we ever incremented mTestIndex (if our call into NextTest() was on a
thread other than the message thread).  If that happened, we would end
up running some subtest twice, and then later whenever we
incrememented mTestIndex would end up skipping some subtest.

Fixes https://github.com/project-chip/connectedhomeip/issues/7493

#### Problem
Random test failures due to the data race.

#### Change overview
Eliminate the data race.

#### Testing
Manually ran `scripts/tests/test_suites.sh` but realistically without some sort of race simulator or instrumenting the code to sleep before the increment on mainthread only it's hard to figure out how to test this reasonably.