### PR TITLE
Update WiFi SoftAP and BLE Device Name prefix to MATTER-

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -460,7 +460,7 @@ menu "CHIP Device Layer"
 
         config WIFI_AP_SSID_PREFIX
             string "WiFi AP SSID Prefix"
-            default "CHIP-"
+            default "MATTER-"
             help
                 A prefix string used in forming the WiFi soft-AP SSID.  The remainder of the SSID
                 consists of the final two bytes of the device's primary WiFi MAC address in hex.
@@ -510,7 +510,7 @@ menu "CHIP Device Layer"
 
         config BLE_DEVICE_NAME_PREFIX
             string "BLE Device Name Prefix"
-            default "CHIP-"
+            default "MATTER-"
             depends on ENABLE_CHIPOBLE
             help
                 A prefix string used in forming the BLE device name.  The remainder of the name

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -307,7 +307,7 @@
  * consists of the final two bytes of the device's primary WiFi MAC address in hex.
  */
 #ifndef CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX
-#define CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX "CHIP-"
+#define CHIP_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX "MATTER-"
 #endif
 
 /**
@@ -424,7 +424,7 @@
  * may need to be shorter.
  */
 #ifndef CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX
-#define CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX "CHIP-"
+#define CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX "MATTER-"
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
* WiFi SoftAP Prefix needs updating based on Matter branding. Issue https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/3349
* BLE DeviceName Prefix needs updating based on Matter branding.
* Implements the spec change found here:  https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/3350

#### Change overview
Update the user-visible WiFi SoftAP default prefix and BLE DeviceName prefix to `MATTER-` based on the new branding.

#### Testing
* Manually tested by compiling and checking advertisements
* This is a breaking change and requires all sides to update as the Prefix has changed