### PR TITLE
Add closeContainer check for CheckSchemaValidity

### DIFF
--- a/src/app/MessageDef/AttributeDataElement.cpp
+++ b/src/app/MessageDef/AttributeDataElement.cpp
@@ -43,9 +43,7 @@ CHIP_ERROR AttributeDataElement::Parser::Init(const chip::TLV::TLVReader & aRead
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -322,6 +320,8 @@ CHIP_ERROR AttributeDataElement::Parser::CheckSchemaValidity() const
             err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_DATA_ELEMENT;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributeDataList.cpp
+++ b/src/app/MessageDef/AttributeDataList.cpp
@@ -78,6 +78,8 @@ CHIP_ERROR AttributeDataList::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributeDataVersionList.cpp
+++ b/src/app/MessageDef/AttributeDataVersionList.cpp
@@ -78,6 +78,8 @@ CHIP_ERROR AttributeDataVersionList::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -42,11 +42,7 @@ CHIP_ERROR AttributePath::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_List == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType dummyContainerType;
-    // enter into the Path
-    err = mReader.EnterContainer(dummyContainerType);
-    SuccessOrExit(err);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -161,7 +157,9 @@ CHIP_ERROR AttributePath::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+
     SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributePathList.cpp
+++ b/src/app/MessageDef/AttributePathList.cpp
@@ -72,6 +72,8 @@ CHIP_ERROR AttributePathList::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributeStatusElement.cpp
+++ b/src/app/MessageDef/AttributeStatusElement.cpp
@@ -77,9 +77,7 @@ CHIP_ERROR AttributeStatusElement::Parser::Init(const chip::TLV::TLVReader & aRe
     mReader.Init(aReader);
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -155,6 +153,8 @@ CHIP_ERROR AttributeStatusElement::Parser::CheckSchemaValidity() const
             err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_STATUS_ELEMENT;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/AttributeStatusList.cpp
+++ b/src/app/MessageDef/AttributeStatusList.cpp
@@ -102,6 +102,8 @@ CHIP_ERROR AttributeStatusList::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/CommandDataElement.cpp
+++ b/src/app/MessageDef/CommandDataElement.cpp
@@ -43,9 +43,7 @@ CHIP_ERROR CommandDataElement::Parser::Init(const chip::TLV::TLVReader & aReader
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -317,6 +315,8 @@ CHIP_ERROR CommandDataElement::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/CommandList.cpp
+++ b/src/app/MessageDef/CommandList.cpp
@@ -79,6 +79,8 @@ CHIP_ERROR CommandList::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -43,11 +43,7 @@ CHIP_ERROR CommandPath::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_List == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType dummyContainerType;
-    // enter into the Path
-    err = mReader.EnterContainer(dummyContainerType);
-    SuccessOrExit(err);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -147,6 +143,8 @@ CHIP_ERROR CommandPath::Parser::CheckSchemaValidity() const
         }
     }
     SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
+
 exit:
     ChipLogFunctError(err);
 

--- a/src/app/MessageDef/EventDataElement.cpp
+++ b/src/app/MessageDef/EventDataElement.cpp
@@ -43,9 +43,7 @@ CHIP_ERROR EventDataElement::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -389,6 +387,7 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
         }
     }
     SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/EventList.cpp
+++ b/src/app/MessageDef/EventList.cpp
@@ -84,6 +84,8 @@ CHIP_ERROR EventList::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -43,11 +43,7 @@ CHIP_ERROR EventPath::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_List == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType dummyContainerType;
-    // enter into the Path
-    err = mReader.EnterContainer(dummyContainerType);
-    SuccessOrExit(err);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -151,6 +147,7 @@ CHIP_ERROR EventPath::Parser::CheckSchemaValidity() const
         }
     }
     SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/EventPathList.cpp
+++ b/src/app/MessageDef/EventPathList.cpp
@@ -74,6 +74,8 @@ CHIP_ERROR EventPathList::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/InvokeCommand.cpp
+++ b/src/app/MessageDef/InvokeCommand.cpp
@@ -42,9 +42,7 @@ CHIP_ERROR InvokeCommand::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -103,6 +101,8 @@ CHIP_ERROR InvokeCommand::Parser::CheckSchemaValidity() const
             err = CHIP_NO_ERROR;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/ListParser.cpp
+++ b/src/app/MessageDef/ListParser.cpp
@@ -43,9 +43,7 @@ CHIP_ERROR ListParser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Array == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/ReadRequest.cpp
+++ b/src/app/MessageDef/ReadRequest.cpp
@@ -40,9 +40,7 @@ CHIP_ERROR ReadRequest::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -153,6 +151,8 @@ CHIP_ERROR ReadRequest::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/ReportData.cpp
+++ b/src/app/MessageDef/ReportData.cpp
@@ -43,9 +43,7 @@ CHIP_ERROR ReportData::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -157,6 +155,8 @@ CHIP_ERROR ReportData::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/StatusElement.cpp
+++ b/src/app/MessageDef/StatusElement.cpp
@@ -42,9 +42,7 @@ CHIP_ERROR StatusElement::Parser::Init(const chip::TLV::TLVReader & aReader)
     mReader.Init(aReader);
     VerifyOrExit(chip::TLV::kTLVType_Array == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -170,6 +168,8 @@ CHIP_ERROR StatusElement::Parser::CheckSchemaValidity() const
             err = CHIP_ERROR_IM_MALFORMED_STATUS_CODE;
         }
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/WriteRequest.cpp
+++ b/src/app/MessageDef/WriteRequest.cpp
@@ -39,9 +39,7 @@ CHIP_ERROR WriteRequest::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -134,6 +132,8 @@ CHIP_ERROR WriteRequest::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/WriteResponse.cpp
+++ b/src/app/MessageDef/WriteResponse.cpp
@@ -40,9 +40,7 @@ CHIP_ERROR WriteResponse::Parser::Init(const chip::TLV::TLVReader & aReader)
 
     VerifyOrExit(chip::TLV::kTLVType_Structure == mReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
-    // This is just a dummy, as we're not going to exit this container ever
-    chip::TLV::TLVType OuterContainerType;
-    err = mReader.EnterContainer(OuterContainerType);
+    err = mReader.EnterContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);
@@ -95,6 +93,8 @@ CHIP_ERROR WriteResponse::Parser::CheckSchemaValidity() const
     {
         err = CHIP_NO_ERROR;
     }
+    SuccessOrExit(err);
+    err = reader.ExitContainer(mOuterContainerType);
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -197,6 +197,10 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
     err = attributePathBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
+    attributePathListBuilder.EndOfAttributePathList();
+    err = attributePathListBuilder.GetError();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
     NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
     readRequestBuilder.EndOfReadRequest();
     NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -576,6 +576,10 @@ CHIP_ERROR TLVReader::ReadElement()
     if (err != CHIP_NO_ERROR)
         return err;
 
+    if (mReadPoint == nullptr)
+    {
+        return CHIP_ERROR_INVALID_TLV_ELEMENT;
+    }
     // Get the element's control byte.
     mControlByte = *mReadPoint;
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Before this change, if we forget to close Container in IM data model, the
checkSchemaValidity would show pass. 


#### Change overview
* With this change, it would report
the CHIP_ERROR_INVALID_TLV_ELEMENT if we forgot to add closeContainer.
* Fix one test which forgot to close container.

#### Testing
The existing test cover this, fix one test break this check
