### PR TITLE
Format Java files in generate.py

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -39,7 +39,12 @@ jobs:
               uses: actions/setup-node@v1
               with:
                 node-version: '12.x'
-
+            - name: Use Java 
+              uses: actions/setup-java@v2
+              with:
+                distribution: 'zulu'
+                java-version: '11'
+                java-package: jre
             - run: sudo apt-get update
             - run: sudo apt-get install --fix-missing libpixman-1-dev libcairo-dev libsdl-pango-dev libjpeg-dev libgif-dev
             - name: Setup ZAP

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -109,6 +109,7 @@ restylers:
           - "**/*.mm"
     - name: google-java-format
       enabled: true
+      # Update https://github.com/project-chip/connectedhomeip/blob/master/scripts/tools/zap/generate.py if this version changes.
       image: restyled/restyler-google-java-format:v1.6
       command:
           - google-java-format

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import urllib.request
 
 CHIP_ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../..'))
 
@@ -81,23 +82,49 @@ def runGeneration(zap_file, zcl_file, templates_file, output_dir):
     os.chdir(generator_dir)
     subprocess.check_call(['node', './src-script/zap-generate.js', '-z', zcl_file, '-g', templates_file, '-i', zap_file, '-o', output_dir])
 
-def runPrettifier(templates_file, output_dir):
+def runClangPrettifier(templates_file, output_dir):
     listOfSupportedFileExtensions = ['.js', '.h', '.c', '.hpp', '.cpp', '.m', '.mm']
 
     try:
         jsonData = json.loads(Path(templates_file).read_text())
         outputs = [(os.path.join(output_dir, template['output'])) for template in jsonData['templates']]
-        outputs = list(filter(lambda filepath: os.path.splitext(filepath)[1] in listOfSupportedFileExtensions, outputs))
-        os.system('clang-format -i ' + ' '.join(outputs))
+        clangOutputs = list(filter(lambda filepath: os.path.splitext(filepath)[1] in listOfSupportedFileExtensions, outputs))
+
+        if len(clangOutputs) > 0:
+            args = ['clang-format', '-i']
+            args.extend(clangOutputs)
+            subprocess.check_call(args)
     except Exception as err:
         print('clang-format error:', err)
+
+def runJavaPrettifier(templates_file, output_dir):
+    try:
+        jsonData = json.loads(Path(templates_file).read_text())
+        outputs = [(os.path.join(output_dir, template['output'])) for template in jsonData['templates']]
+        javaOutputs = list(filter(lambda filepath: os.path.splitext(filepath)[1] == ".java", outputs))
+
+        if len(javaOutputs) > 0:
+            # Keep this version in sync with what restyler uses (https://github.com/project-chip/connectedhomeip/blob/master/.restyled.yaml).
+            google_java_format_version = "1.6"
+            google_java_format_url = 'https://github.com/google/google-java-format/releases/download/google-java-format-' + google_java_format_version + '/'
+            google_java_format_jar = 'google-java-format-' + google_java_format_version + '-all-deps.jar'
+            jar_url = google_java_format_url + google_java_format_jar
+            
+            home = str(Path.home())
+            path, http_message = urllib.request.urlretrieve(jar_url, home + '/' + google_java_format_jar)
+            args = ['java', '-jar', path, '--replace']
+            args.extend(javaOutputs)
+            subprocess.check_call(args)
+    except Exception as err:
+        print('google-java-format error:', err)
 
 def main():
     checkPythonVersion()
 
     zap_file, zcl_file, templates_file, output_dir = runArgumentsParser()
     runGeneration(zap_file, zcl_file, templates_file, output_dir)
-    runPrettifier(templates_file, output_dir)
+    runClangPrettifier(templates_file, output_dir)
+    runJavaPrettifier(templates_file, output_dir)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
#### Problem
- `scripts/tools/zap/generate.py` does not support prettifying Java files
-  Consequently, the "ZAP templates" action will fail because it expects unformatted files

#### Change overview
- In `zap_templates.yaml`, add `actions/setup-java@v2` step so we can run `java -jar`
- In `generate.py`, download a `google-java-format` jar from https://github.com/google/google-java-format, and use that to in-place format `*.java` files

#### Testing
In this PR, added `test-javafile.zapt` which generates `Test.java`. This is just for providing a real Java template that the CI can run on, and will be removed after approvals are received.
