### PR TITLE
Propagate pairing errors out as chip-tool exit values.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -55,6 +55,12 @@ CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, Node
 exit:
     mCommissioner.ServiceEventSignal();
     mCommissioner.Shutdown();
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
+    }
+
     return err;
 }
 


### PR DESCRIPTION
Without this, running 'chip-tool pairing ...' can log a failure but
the process will have successful exit status, which makes it hard to
use in shell things.

#### Problem
Can run chip-tool and have it fail to pair but it will exit successfully.

#### Change overview
Make sure to check our command status.

#### Testing
Manually tested that if pairing fails the exit value tests false for `&&` and `||` shell pipeline purposes.