### PR TITLE
Fix shutdown ordering in Echo requester/responder

### DIFF
--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -30,7 +30,7 @@
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <support/ErrorStr.h>
 
-// The ExchangeManager global object.
+chip::SecureSessionMgr gSessionManager;
 chip::Messaging::ExchangeManager gExchangeManager;
 chip::secure_channel::MessageCounterManager gMessageCounterManager;
 
@@ -58,6 +58,8 @@ exit:
 
 void ShutdownChip(void)
 {
-    gExchangeManager.Shutdown();
     chip::DeviceLayer::PlatformMgr().Shutdown();
+    gMessageCounterManager.Shutdown();
+    gExchangeManager.Shutdown();
+    gSessionManager.Shutdown();
 }

--- a/src/messaging/tests/echo/common.h
+++ b/src/messaging/tests/echo/common.h
@@ -26,11 +26,13 @@
 
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/SecureSessionMgr.h>
 
 constexpr size_t kMaxTcpActiveConnectionCount = 4;
 constexpr size_t kMaxTcpPendingPackets        = 4;
 constexpr size_t kNetworkSleepTimeMsecs       = (100 * 1000);
 
+extern chip::SecureSessionMgr gSessionManager;
 extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -35,7 +35,6 @@
 #include <protocols/secure_channel/PASESession.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecureSessionMgr.h>
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>
 
@@ -60,7 +59,6 @@ chip::Protocols::Echo::EchoClient gEchoClient;
 
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecureSessionMgr gSessionManager;
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Echo was attempted to be sent.

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -35,7 +35,6 @@
 #include <protocols/secure_channel/PASESession.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecureSessionMgr.h>
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>
 
@@ -45,7 +44,6 @@ namespace {
 chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
 
 // Callback handler when a CHIP EchoRequest is received.


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Similar to #7469, we also need to adjust the showdown ordering in Echo requester/responder to prevent exchange leak during Cirque Echo test.

#### Change overview
Fix shutdown ordering in Echo requester/responder.

#### Testing
How was this tested? (at least one bullet point required)
1.  Run ./chip-echo-responder on server node
2.  Run ./chip-echo-requester 192.168.86.171 on Linux station
3. Confirm all echo responses are successfully received
`Echo Response: 3/3(100.00%) len=15 time=0.002ms`
