### PR TITLE
Remove PacketHandle in IM command

### DIFF
--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -90,7 +90,7 @@ public:
      * @return CHIP_ERROR
      *
      */
-    CHIP_ERROR FinalizeCommandsMessage();
+    CHIP_ERROR FinalizeCommandsMessage(System::PacketBufferHandle & commandPacket);
 
     CHIP_ERROR PrepareCommand(const CommandPathParams & aCommandPathParams, bool aIsStatus = false);
     TLV::TLVWriter * GetCommandDataElementTLVWriter();
@@ -130,9 +130,8 @@ protected:
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
-    chip::System::PacketBufferHandle mCommandMessageBuf;
-    uint8_t mCommandIndex = 0;
-    CommandState mState   = CommandState::Uninitialized;
+    uint8_t mCommandIndex                      = 0;
+    CommandState mState                        = CommandState::Uninitialized;
 
 private:
     friend class TestCommandInteraction;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -56,14 +56,15 @@ exit:
 CHIP_ERROR CommandHandler::SendCommandResponse()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle commandPacket;
 
     VerifyOrExit(mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = FinalizeCommandsMessage();
+    err = FinalizeCommandsMessage(commandPacket);
     SuccessOrExit(err);
 
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandResponse, std::move(mCommandMessageBuf));
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandResponse, std::move(commandPacket));
     SuccessOrExit(err);
 
     MoveToState(CommandState::Sending);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -37,10 +37,11 @@ namespace app {
 CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle commandPacket;
 
     VerifyOrExit(mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = FinalizeCommandsMessage();
+    err = FinalizeCommandsMessage(commandPacket);
     SuccessOrExit(err);
 
     // Discard any existing exchange context. Effectively we can only have one exchange per CommandSender
@@ -62,7 +63,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(
-        Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(mCommandMessageBuf),
+        Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(commandPacket),
         Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse).Set(Messaging::SendMessageFlags::kNoAutoRequestAck));
     SuccessOrExit(err);
     MoveToState(CommandState::Sending);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -312,6 +312,7 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
+    System::PacketBufferHandle commandPacket;
     err = commandHandler.Init(&chip::gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -320,13 +321,13 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
 
     AddCommandDataElement(apSuite, apContext, &commandHandler, aNeedStatusCode);
-    err = commandHandler.FinalizeCommandsMessage();
+    err = commandHandler.FinalizeCommandsMessage(commandPacket);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     chip::System::PacketBufferTLVReader reader;
     InvokeCommand::Parser invokeCommandParser;
-    reader.Init(std::move(commandHandler.mCommandMessageBuf));
+    reader.Init(std::move(commandPacket));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeCommandParser.Init(reader);


### PR DESCRIPTION
#### Problem
#7498

#### Change overview
* Remove `mCommandMessageBuf` in `app::Command`
* `Command::FinalizeCommandsMessage` will return a packet from the TLVBbuilder

This should fix #7498, but it doesn't address its root cause, #7478 may address to root cause.
This PR is not a workaround, it reduces the lifespan of the command packet, saves about 1K runtime memory, and also avoids the racing problem.

#### Testing
* Manually verified using unit test
* Manually verified using IM-req/res