### PR TITLE
[esp32] Support level control cluster in ESP32 all cluster app

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -73,7 +73,7 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         break;
     }
 
-    ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
+    ESP_LOGI(TAG, "Current free heap: %zu\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }
 
 void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
@@ -92,12 +92,16 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
         OnIdentifyPostAttributeChangeCallback(endpointId, attributeId, value);
         break;
 
+    case ZCL_LEVEL_CONTROL_CLUSTER_ID:
+        OnLevelControlAttributeChangeCallback(endpointId, attributeId, value);
+        break;
+
     default:
         ESP_LOGI(TAG, "Unhandled cluster ID: %d", clusterId);
         break;
     }
 
-    ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
+    ESP_LOGI(TAG, "Current free heap: %zu\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }
 
 void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event)
@@ -138,7 +142,22 @@ void DeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, 
     VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
 
     // At this point we can assume that value points to a bool value.
-    endpointId == 1 ? statusLED1.Set(*value) : statusLED2.Set(*value);
+    mEndpointOnOffState[endpointId - 1] = *value;
+
+exit:
+    return;
+}
+
+void DeviceCallbacks::OnLevelControlAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
+{
+    bool onOffState    = mEndpointOnOffState[endpointId - 1];
+    uint8_t brightness = onOffState ? *value : 0;
+
+    VerifyOrExit(attributeId == ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, ESP_LOGI(TAG, "Unhandled Attribute ID: '0x%04x", attributeId));
+    VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
+
+    // At this point we can assume that value points to a bool value.
+    endpointId == 1 ? statusLED1.SetBrightness(brightness) : statusLED2.SetBrightness(brightness);
 
 exit:
     return;

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -41,5 +41,8 @@ private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+    void OnLevelControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+
+    bool mEndpointOnOffState[2];
 };

--- a/examples/all-clusters-app/esp32/main/include/LEDWidget.h
+++ b/examples/all-clusters-app/esp32/main/include/LEDWidget.h
@@ -31,11 +31,21 @@ class LEDWidget
 {
 public:
     void Init(gpio_num_t gpioNum);
+
     void Set(bool state);
+
+    void SetStateMask(bool state);
+
+    void SetBrightness(uint8_t brightness);
+
     void Blink(uint32_t changeRateMS);
+
     void Blink(uint32_t onTimeMS, uint32_t offTimeMS);
+
     void BlinkOnError();
+
     void Animate();
+
 #if CONFIG_HAVE_DISPLAY
     void SetVLED(int id1, int id2);
 #endif
@@ -44,6 +54,7 @@ private:
     int64_t mLastChangeTimeUS;
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
+    uint8_t mDefaultOnBrightness;
     gpio_num_t mGPIONum;
     int mVLED1;
     int mVLED2;

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 
+#include <app/common/gen/att-storage.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
@@ -49,6 +50,8 @@
 #include <app/server/Mdns.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
+#include <app/util/af-types.h>
+#include <app/util/af.h>
 #include <lib/shell/Engine.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -363,6 +366,16 @@ public:
 
 #endif // CONFIG_DEVICE_TYPE_M5STACK
 
+void SetupInitialLevelControlValues(chip::EndpointId endpointId)
+{
+    uint8_t level = UINT8_MAX;
+
+    emberAfWriteAttribute(endpointId, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
+                          ZCL_DATA8_ATTRIBUTE_TYPE);
+    emberAfWriteAttribute(endpointId, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_ON_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
+                          ZCL_DATA8_ATTRIBUTE_TYPE);
+}
+
 void SetupPretendDevices()
 {
     AddDevice("Watch");
@@ -380,9 +393,13 @@ void SetupPretendDevices()
     AddEndpoint("1");
     AddCluster("OnOff");
     AddAttribute("OnOff", "Off");
+    AddCluster("Level Control");
+    AddAttribute("Current Level", "255");
     AddEndpoint("2");
     AddCluster("OnOff");
     AddAttribute("OnOff", "Off");
+    AddCluster("Level Control");
+    AddAttribute("Current Level", "255");
 
     AddDevice("Thermometer");
     AddEndpoint("External");
@@ -612,6 +629,8 @@ extern "C" void app_main()
 #endif
 
     SetupPretendDevices();
+    SetupInitialLevelControlValues(/* endpointId = */ 1);
+    SetupInitialLevelControlValues(/* endpointId = */ 2);
 
     std::string qrCodeText = createSetupPayload();
     ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.c_str());


### PR DESCRIPTION
#### Problem

* Fix level control cluster handlers missing in esp32 all-cluster-app.

#### Change overview

* Add `LEDWidget::SetBrightness`
* Add level control handling logic and coexistence with On/Off cluster.

#### Testing

Manually paired with `chip-dev-ctrl` then tested with:

```
zcl OnOff On 12344321 1 1
zcl LevelControl MoveToLevel 12344321 1 1 level=10 transitionTime=0 optionMask=0 optionOverride=0
zcl OnOff Off 12344321 1 1
zcl OnOff Toggle 12344321 1 1
zcl LevelControl MoveToLevel 12344321 1 1 level=255 transitionTime=0 optionMask=0 optionOverride=0
```