### PR TITLE
Print pin code and long discriminator on QR screen

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -669,6 +669,16 @@ extern "C" void app_main()
                    [=]() {
                        ESP_LOGI(TAG, "Opening QR code screen");
                        ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.c_str());
+                       uint16_t discriminator;
+                       if (ConfigurationMgr().GetSetupDiscriminator(discriminator) == CHIP_NO_ERROR)
+                       {
+                           ESP_LOGI(TAG, "Setup discriminator: %u (0x%x)", discriminator, discriminator);
+                       }
+                       uint32_t setupPINCode;
+                       if (ConfigurationMgr().GetSetupPinCode(setupPINCode) == CHIP_NO_ERROR)
+                       {
+                           ESP_LOGI(TAG, "Setup PIN code: %u (0x%x)", setupPINCode, setupPINCode);
+                       }
                        ScreenManager::PushScreen(chip::Platform::New<QRCodeScreen>(qrCodeText));
                    })
             ->Item("Setup",

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -445,6 +445,7 @@ std::string createSetupPayload()
         ESP_LOGE(TAG, "Couldn't get discriminator: %s", ErrorStr(err));
         return result;
     }
+    ESP_LOGI(TAG, "Setup discriminator: %u (0x%x)", discriminator, discriminator);
 
     uint32_t setupPINCode;
     err = ConfigurationMgr().GetSetupPinCode(setupPINCode);
@@ -453,6 +454,7 @@ std::string createSetupPayload()
         ESP_LOGE(TAG, "Couldn't get setupPINCode: %s", ErrorStr(err));
         return result;
     }
+    ESP_LOGI(TAG, "Setup PIN code: %u (0x%x)", setupPINCode, setupPINCode);
 
     uint16_t vendorId;
     err = ConfigurationMgr().GetVendorId(vendorId);


### PR DESCRIPTION
This is very helpful info, and it's already part of the QR code
string anyway.

#### Problem
Setup PIN code is hard to find. It's part of the QR code, but that's hard to parse as a human.

#### Change overview
M5 all cluster app only - Prints setup pin code and long discriminator when you go to the QR code screen.

#### Testing
Manual - went to QR code screen, saw prints.
