### PR TITLE
Remove CHIP buffer size check within shell and leave this it to lower layer

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -143,15 +143,12 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
 
     Messaging::SendFlags sendFlags;
     System::PacketBufferHandle payloadBuf;
-    char * requestData = nullptr;
+    char requestData[kMsgBufSize];
 
     uint32_t size = gPingArguments.GetEchoReqSize();
-    VerifyOrExit(size <= kMaxPayloadSize, err = CHIP_ERROR_MESSAGE_TOO_LONG);
+    VerifyOrExit(size >= kMsgBufSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
-    requestData = static_cast<char *>(chip::Platform::MemoryAlloc(size));
-    VerifyOrExit(requestData != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-    snprintf(requestData, size, "Echo Message %" PRIu64 "\n", gPingArguments.GetEchoCount());
+    snprintf(requestData, kMsgBufSize, "Echo Message %" PRIu64 "\n", gPingArguments.GetEchoCount());
 
     payloadBuf = MessagePacketBuffer::NewWithData(requestData, size);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
@@ -179,11 +176,6 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
     }
 
 exit:
-    if (requestData != nullptr)
-    {
-        chip::Platform::MemoryFree(requestData);
-    }
-
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Send echo request failed, err: %s\n", ErrorStr(err));

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -130,8 +130,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
 
     Messaging::SendFlags sendFlags;
     System::PacketBufferHandle payloadBuf;
-    char requestData[kMsgBufSize];
-    uint32_t size = 0;
+    uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
     // Discard any existing exchange context. Effectively we can only have one exchange with
     // a single node at any one time.
@@ -145,12 +144,11 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     gExchangeCtx = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gAdminId }, &gMockAppDelegate);
     VerifyOrExit(gExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    size = gSendArguments.GetPayloadSize();
-    VerifyOrExit(size >= kMsgBufSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-
-    snprintf(requestData, kMsgBufSize, "CHIP Message");
-    payloadBuf = MessagePacketBuffer::NewWithData(requestData, size);
+    payloadBuf = MessagePacketBuffer::New(payloadSize);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+    memset(payloadBuf->Start(), 0, payloadSize);
+    payloadBuf->SetDataLength(payloadSize);
 
     if (gSendArguments.IsUsingMRP())
     {
@@ -166,7 +164,8 @@ CHIP_ERROR SendMessage(streamer_t * stream)
 
     gSendArguments.SetLastSendTime(System::Timer::GetCurrentEpoch());
 
-    streamer_printf(stream, "\nSend CHIP message with payload size: %d bytes to Node: %" PRIu64 "\n", size, kTestDeviceNodeId);
+    streamer_printf(stream, "\nSend CHIP message with payload size: %d bytes to Node: %" PRIu64 "\n", payloadSize,
+                    kTestDeviceNodeId);
 
     err = gExchangeCtx->SendMessage(Protocols::Id(VendorId::Common, gSendArguments.GetProtocolId()),
                                     gSendArguments.GetMessageType(), std::move(payloadBuf), sendFlags);
@@ -309,7 +308,7 @@ void PrintUsage(streamer_t * stream)
     streamer_printf(stream, "  -T  <type>      message type\n");
     streamer_printf(stream, "  -p  <port>      server port number\n");
     streamer_printf(stream, "  -r  <1|0>       enable or disable MRP\n");
-    streamer_printf(stream, "  -s  <size>      payload size in bytes\n");
+    streamer_printf(stream, "  -s  <size>      application payload size in bytes\n");
 }
 
 int cmd_send(int argc, char ** argv)

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -130,8 +130,8 @@ CHIP_ERROR SendMessage(streamer_t * stream)
 
     Messaging::SendFlags sendFlags;
     System::PacketBufferHandle payloadBuf;
-    char * requestData = nullptr;
-    uint32_t size      = 0;
+    char requestData[kMsgBufSize];
+    uint32_t size = 0;
 
     // Discard any existing exchange context. Effectively we can only have one exchange with
     // a single node at any one time.
@@ -146,12 +146,9 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     VerifyOrExit(gExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     size = gSendArguments.GetPayloadSize();
-    VerifyOrExit(size <= kMaxPayloadSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(size >= kMsgBufSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
-    requestData = static_cast<char *>(chip::Platform::MemoryAlloc(size));
-    VerifyOrExit(requestData != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-    snprintf(requestData, size, "CHIP Message");
+    snprintf(requestData, kMsgBufSize, "CHIP Message");
     payloadBuf = MessagePacketBuffer::NewWithData(requestData, size);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
@@ -181,11 +178,6 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     }
 
 exit:
-    if (requestData != nullptr)
-    {
-        chip::Platform::MemoryFree(requestData);
-    }
-
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Send CHIP message failed, err: %s\n", ErrorStr(err));

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -28,7 +28,6 @@
 constexpr size_t kMaxTcpActiveConnectionCount = 4;
 constexpr size_t kMaxTcpPendingPackets        = 4;
 #endif
-constexpr size_t kMsgBufSize      = 32;
 constexpr size_t kResponseTimeOut = 1000;
 
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -28,7 +28,7 @@
 constexpr size_t kMaxTcpActiveConnectionCount = 4;
 constexpr size_t kMaxTcpPendingPackets        = 4;
 #endif
-constexpr size_t kMaxPayloadSize  = 1280;
+constexpr size_t kMsgBufSize      = 32;
 constexpr size_t kResponseTimeOut = 1000;
 
 extern chip::secure_channel::MessageCounterManager gMessageCounterManager;


### PR DESCRIPTION

#### Problem
What is being fixed? 

We should not take Payload size check within the shell application since it does not take default header size into account,

For example, I set the buffer size to 1279, which passed the payload size check within Shell, but still failed with CHIP Error 4004 
```
> send -s 1279 192.168.86.171
IP address: 192.168.86.171
CHIP:IN: TransportMgr initialized
CHIP:IN: TransportMgr initialized
CHIP:DL: writing settings to file (/tmp/chip_counters.ini.tmp)
CHIP:DL: failed to rename (/tmp/chip_counters.ini.tmp), Operation not permitted (1)
CHIP:IN: local node id is 0x000000000001b669
CHIP:IN: Connection from 'UDP:192.168.86.171:11097' expired
CHIP:IN: New pairing for device 0x0000000000bc5c01, key 0!!
Establish secure session succeeded

Send CHIP message with payload size: 1279 bytes to Node: 12344321
CHIP:EM: Failed to send message with err CHIP Error 4004 (0x00000FA4): Message too long
Send CHIP message failed, err: CHIP Error 4004 (0x00000FA4): Message too long
Send failed with error: CHIP Error 4004 (0x00000FA4): Message too long
Done
>
```

#### Change overview
1. Remove CHIP buffer size check within shell and leave this it to lower layer
2. Use stack buffer instead of dynamic memory to accommodate fixed length message.

#### Testing
How was this tested? (at least one bullet point required)
Set the Payload size to 1281 which exceed the previous kMaxPayloadSize

```
> ping -s 1281 192.168.86.171
IP address: 192.168.86.171
[1623341443.860683][150131] CHIP:IN: TransportMgr initialized
[1623341443.860804][150131] CHIP:IN: TransportMgr initialized
[1623341443.861217][150131] CHIP:DL: writing settings to file (/tmp/chip_counters.ini.tmp)
[1623341443.861499][150131] CHIP:DL: failed to rename (/tmp/chip_counters.ini.tmp), Operation not permitted (1)
[1623341443.861537][150131] CHIP:IN: local node id is 0x000000000001B669
[1623341443.861637][150131] CHIP:IN: Connection from 'UDP:192.168.86.171:11097' expired
[1623341443.861675][150131] CHIP:IN: New pairing for device 0x0000000000bc5c01, key 0!!
Establish secure session succeeded

Send echo request message with payload size: 1281 bytes to Node: 12344321
[1623341443.861834][150131] CHIP:EM: Failed to send message with err CHIP Error 4004 (0x00000FA4): Message too long
Send echo request failed, err: CHIP Error 4004 (0x00000FA4): Message too long
Send request failed: CHIP Error 4004 (0x00000FA4): Message too long
Ping failed with error: CHIP Error 4004 (0x00000FA4): Message too long
Done
>
``` 

Confirm the command send failed at lower layer due to "Message too long" 

