### PR TITLE
Enable IM schema check for all supported platform

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -24,9 +24,9 @@ declare_args() {
 
 config("app_config") {
   if (chip_enable_schema_check) {
-    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=1" ]
+    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK_LOGGING=1" ]
   } else {
-    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=0" ]
+    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK_LOGGING=0" ]
   }
 }
 

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -92,10 +92,9 @@ CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle && payload,
     err = invokeCommandParser.Init(reader);
     SuccessOrExit(err);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = invokeCommandParser.CheckSchemaValidity();
     SuccessOrExit(err);
-#endif
+
     err = invokeCommandParser.GetCommandList(&commandListParser);
     SuccessOrExit(err);
 

--- a/src/app/MessageDef/AttributeDataElement.cpp
+++ b/src/app/MessageDef/AttributeDataElement.cpp
@@ -214,7 +214,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributeDataElement::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -328,7 +327,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR AttributeDataElement::Parser::GetAttributePath(AttributePath::Parser * const apAttributePath) const
 {

--- a/src/app/MessageDef/AttributeDataElement.h
+++ b/src/app/MessageDef/AttributeDataElement.h
@@ -55,7 +55,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -70,7 +69,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the AttributePath. Next() must be called before accessing them.

--- a/src/app/MessageDef/AttributeDataList.cpp
+++ b/src/app/MessageDef/AttributeDataList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributeDataList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
@@ -86,7 +85,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 AttributeDataElement::Builder & AttributeDataList::Builder::CreateAttributeDataElementBuilder()
 {

--- a/src/app/MessageDef/AttributeDataList.h
+++ b/src/app/MessageDef/AttributeDataList.h
@@ -38,7 +38,6 @@ namespace AttributeDataList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -53,7 +52,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/AttributeDataVersionList.cpp
+++ b/src/app/MessageDef/AttributeDataVersionList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributeDataVersionList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -86,7 +85,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 // 1) current element is anonymous
 // 2) current element is either unsigned integer or NULL

--- a/src/app/MessageDef/AttributeDataVersionList.h
+++ b/src/app/MessageDef/AttributeDataVersionList.h
@@ -39,7 +39,6 @@ namespace AttributeDataVersionList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -54,7 +53,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Check if this element is valid

--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -50,7 +50,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributePath::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -166,7 +165,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR AttributePath::Parser::GetNodeId(chip::NodeId * const apNodeId) const
 {

--- a/src/app/MessageDef/AttributePath.h
+++ b/src/app/MessageDef/AttributePath.h
@@ -55,7 +55,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -70,7 +69,7 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
+
     /**
      *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them.
      *

--- a/src/app/MessageDef/AttributePathList.cpp
+++ b/src/app/MessageDef/AttributePathList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributePathList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -80,7 +79,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 // Re-initialize the shared PathBuilder with anonymous tag
 AttributePath::Builder & AttributePathList::Builder::CreateAttributePathBuilder()

--- a/src/app/MessageDef/AttributePathList.h
+++ b/src/app/MessageDef/AttributePathList.h
@@ -39,7 +39,6 @@ namespace AttributePathList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -54,7 +53,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/AttributeStatusElement.cpp
+++ b/src/app/MessageDef/AttributeStatusElement.cpp
@@ -84,7 +84,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributeStatusElement::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -161,7 +160,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR AttributeStatusElement::Parser::GetAttributePath(AttributePath::Parser * const apAttributePath) const
 {

--- a/src/app/MessageDef/AttributeStatusElement.h
+++ b/src/app/MessageDef/AttributeStatusElement.h
@@ -91,7 +91,7 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -106,7 +106,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the AttributePath. Next() must be called before accessing them.

--- a/src/app/MessageDef/AttributeStatusList.cpp
+++ b/src/app/MessageDef/AttributeStatusList.cpp
@@ -53,7 +53,7 @@ AttributeStatusList::Builder & AttributeStatusList::Builder::EndOfAttributeStatu
     EndOfContainer();
     return *this;
 }
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
 CHIP_ERROR AttributeStatusList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err                  = CHIP_NO_ERROR;
@@ -110,6 +110,6 @@ exit:
 
     return err;
 }
-#endif
+
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/AttributeStatusList.h
+++ b/src/app/MessageDef/AttributeStatusList.h
@@ -60,7 +60,6 @@ private:
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -75,7 +74,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 }; // namespace AttributeStatusList
 

--- a/src/app/MessageDef/CommandDataElement.cpp
+++ b/src/app/MessageDef/CommandDataElement.cpp
@@ -222,7 +222,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR CommandDataElement::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -322,7 +321,6 @@ exit:
     ChipLogFunctError(err);
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR CommandDataElement::Parser::GetCommandPath(CommandPath::Parser * const apCommandPath) const
 {

--- a/src/app/MessageDef/CommandDataElement.h
+++ b/src/app/MessageDef/CommandDataElement.h
@@ -56,7 +56,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -71,7 +70,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the CommandPath. Next() must be called before accessing them.

--- a/src/app/MessageDef/CommandList.cpp
+++ b/src/app/MessageDef/CommandList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR CommandList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
@@ -87,7 +86,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CommandDataElement::Builder & CommandList::Builder::CreateCommandDataElementBuilder()
 {

--- a/src/app/MessageDef/CommandList.h
+++ b/src/app/MessageDef/CommandList.h
@@ -39,7 +39,6 @@ namespace CommandList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -54,7 +53,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -51,7 +51,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR CommandPath::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -150,7 +149,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR CommandPath::Parser::GetEndpointId(chip::EndpointId * const apEndpointID) const
 {

--- a/src/app/MessageDef/CommandPath.h
+++ b/src/app/MessageDef/CommandPath.h
@@ -54,7 +54,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -69,7 +68,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the EndpointId. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventDataElement.cpp
+++ b/src/app/MessageDef/EventDataElement.cpp
@@ -214,7 +214,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -394,7 +393,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR EventDataElement::Parser::GetEventPath(EventPath::Parser * const apEventPath)
 {

--- a/src/app/MessageDef/EventDataElement.h
+++ b/src/app/MessageDef/EventDataElement.h
@@ -60,7 +60,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -75,7 +74,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the EventPath. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventList.cpp
+++ b/src/app/MessageDef/EventList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR EventList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
@@ -92,7 +91,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 EventDataElement::Builder & EventList::Builder::CreateEventBuilder()
 {

--- a/src/app/MessageDef/EventList.h
+++ b/src/app/MessageDef/EventList.h
@@ -39,7 +39,6 @@ namespace EventList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -54,7 +53,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -51,7 +51,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR EventPath::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -154,7 +153,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR EventPath::Parser::GetNodeId(chip::NodeId * const apNodeId) const
 {

--- a/src/app/MessageDef/EventPath.h
+++ b/src/app/MessageDef/EventPath.h
@@ -54,7 +54,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -69,7 +68,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventPathList.cpp
+++ b/src/app/MessageDef/EventPathList.cpp
@@ -34,7 +34,6 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR EventPathList::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -82,7 +81,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 EventPath::Builder & EventPathList::Builder::CreateEventPathBuilder()
 {

--- a/src/app/MessageDef/EventPathList.h
+++ b/src/app/MessageDef/EventPathList.h
@@ -40,7 +40,6 @@ namespace EventPathList {
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -55,7 +54,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/InvokeCommand.cpp
+++ b/src/app/MessageDef/InvokeCommand.cpp
@@ -50,7 +50,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR InvokeCommand::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -109,7 +108,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR InvokeCommand::Parser::GetCommandList(CommandList::Parser * const apCommandList) const
 {

--- a/src/app/MessageDef/InvokeCommand.h
+++ b/src/app/MessageDef/InvokeCommand.h
@@ -54,7 +54,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -69,7 +68,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a parser for a CommandList.

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -31,7 +31,7 @@
 namespace chip {
 namespace app {
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK_LOGGING
 // this is used to run in signle thread for IM message debug purpose
 namespace {
 uint32_t gPrettyPrintingDepthLevel = 0;

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -30,7 +30,7 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK_LOGGING
 void PrettyPrintIM(bool aIsNewLine, const char * aFmt, ...);
 void IncreaseDepth();
 void DecreaseDepth();

--- a/src/app/MessageDef/ReadRequest.cpp
+++ b/src/app/MessageDef/ReadRequest.cpp
@@ -48,7 +48,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR ReadRequest::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -159,7 +158,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR ReadRequest::Parser::GetAttributePathList(AttributePathList::Parser * const apAttributePathList) const
 {

--- a/src/app/MessageDef/ReadRequest.h
+++ b/src/app/MessageDef/ReadRequest.h
@@ -57,7 +57,7 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -72,7 +72,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Get a TLVReader for the AttributePathList. Next() must be called before accessing them.

--- a/src/app/MessageDef/ReportData.cpp
+++ b/src/app/MessageDef/ReportData.cpp
@@ -51,7 +51,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR ReportData::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -163,7 +162,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR ReportData::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/ReportData.h
+++ b/src/app/MessageDef/ReportData.h
@@ -58,7 +58,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -73,7 +72,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
      *  @brief Check whether a response (a StatusReponse specifically) is to be sent back to the request.

--- a/src/app/MessageDef/StatusElement.cpp
+++ b/src/app/MessageDef/StatusElement.cpp
@@ -82,7 +82,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR StatusElement::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -176,7 +175,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR StatusElement::Builder::Init(chip::TLV::TLVWriter * const apWriter)
 {

--- a/src/app/MessageDef/StatusElement.h
+++ b/src/app/MessageDef/StatusElement.h
@@ -56,7 +56,6 @@ public:
      */
     CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     /**
      *  @brief Roughly verify the message is correctly formed
      *   1) all mandatory tags are present
@@ -71,7 +70,6 @@ public:
      *  @return #CHIP_NO_ERROR on success
      */
     CHIP_ERROR CheckSchemaValidity() const;
-#endif
 
     /**
     `* Read the GeneralCode, ProtocolId, ProtocolCode, ClusterId

--- a/src/app/MessageDef/WriteRequest.cpp
+++ b/src/app/MessageDef/WriteRequest.cpp
@@ -47,7 +47,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR WriteRequest::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -139,7 +138,6 @@ exit:
     ChipLogFunctError(err);
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR WriteRequest::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/WriteResponse.cpp
+++ b/src/app/MessageDef/WriteResponse.cpp
@@ -48,7 +48,6 @@ exit:
     return err;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR WriteResponse::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err           = CHIP_NO_ERROR;
@@ -101,7 +100,6 @@ exit:
 
     return err;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
 CHIP_ERROR WriteResponse::Parser::GetAttributeStatusList(AttributeStatusList::Parser * const apAttributeStatusList) const
 {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -256,10 +256,8 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     err = report.Init(reader);
     SuccessOrExit(err);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = report.CheckSchemaValidity();
     SuccessOrExit(err);
-#endif
 
     err = report.GetSuppressResponse(&suppressResponse);
     if (CHIP_END_OF_TLV == err)

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -118,10 +118,9 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
 
     err = readRequestParser.Init(reader);
     SuccessOrExit(err);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = readRequestParser.CheckSchemaValidity();
     SuccessOrExit(err);
-#endif
 
     err = readRequestParser.GetAttributePathList(&attributePathListParser);
     if (err == CHIP_END_OF_TLV)

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -257,23 +257,6 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
     err = reportDataWriter.Finalize(&bufHandle);
     SuccessOrExit(err);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    {
-        ChipLogDetail(DataManagement, "<RE> Dumping report data...");
-        chip::System::PacketBufferTLVReader reader;
-        ReportData::Parser report;
-
-        reader.Init(bufHandle.Retain());
-        reader.Next();
-
-        err = report.Init(reader);
-        SuccessOrExit(err);
-
-        err = report.CheckSchemaValidity();
-        SuccessOrExit(err);
-    }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-
     ChipLogDetail(DataManagement, "<RE> Sending report...");
     err = SendReport(apReadHandler, std::move(bufHandle));
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DataManagement, "<RE> Error sending out report data with %" PRId32 "!", err));

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -334,7 +334,6 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     err = commandHandler.FinalizeCommandsMessage();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     chip::System::PacketBufferTLVReader reader;
     InvokeCommand::Parser invokeCommandParser;
     reader.Init(std::move(commandHandler.mCommandMessageBuf));
@@ -344,7 +343,6 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = invokeCommandParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData(nlTestSuite * apSuite, void * apContext)

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -87,10 +87,9 @@ void ParseAttributePath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = attributePathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = attributePathParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = attributePathParser.GetNodeId(&nodeId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && nodeId == 1);
 
@@ -126,10 +125,8 @@ void ParseAttributePathList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     err = attributePathListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = attributePathListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildEventPath(nlTestSuite * apSuite, EventPath::Builder & aEventPathBuilder)
@@ -148,10 +145,9 @@ void ParseEventPath(nlTestSuite * apSuite, EventPath::Parser & aEventPathParser)
     chip::ClusterId clusterId   = 3;
     chip::EventId eventId       = 4;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = aEventPathParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aEventPathParser.GetNodeId(&nodeId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && nodeId == 1);
 
@@ -182,10 +178,8 @@ void ParseEventPathList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventPathListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = eventPathListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildCommandPath(nlTestSuite * apSuite, CommandPath::Builder & aCommandPathBuilder)
@@ -205,10 +199,9 @@ void ParseCommandPath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = commandPathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = commandPathParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = commandPathParser.GetEndpointId(&endpointId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && endpointId == 1);
 
@@ -263,10 +256,9 @@ void ParseEventDataElement(nlTestSuite * apSuite, EventDataElement::Parser & aEv
     uint64_t deltaUTCTimestamp    = 0;
     uint64_t deltaSystemTimestamp = 0;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = aEventDataElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     {
         {
             EventPath::Parser eventPath;
@@ -323,10 +315,9 @@ void ParseEventList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = eventListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildStatusElement(nlTestSuite * apSuite, StatusElement::Builder & aStatusElementBuilder)
@@ -348,10 +339,9 @@ void ParseStatusElement(nlTestSuite * apSuite, StatusElement::Parser & aStatusEl
     uint32_t protocolId                                           = 0;
     uint16_t protocolCode                                         = 0;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = aStatusElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aStatusElementParser.DecodeStatusElement(&generalCode, &protocolId, &protocolCode);
     NL_TEST_ASSERT(apSuite,
                    err == CHIP_NO_ERROR &&
@@ -380,10 +370,9 @@ void ParseAttributeStatusElement(nlTestSuite * apSuite, AttributeStatusElement::
     AttributePath::Parser attributePathParser;
     StatusElement::Parser statusElementParser;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = aAttributeStatusElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aAttributeStatusElementParser.GetAttributePath(&attributePathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -409,10 +398,8 @@ void ParseAttributeStatusList(nlTestSuite * apSuite, chip::TLV::TLVReader & aRea
     err = attributeStatusParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = attributeStatusParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildAttributeDataElement(nlTestSuite * apSuite, AttributeDataElement::Builder & aAttributeDataElementBuilder)
@@ -457,10 +444,10 @@ void ParseAttributeDataElement(nlTestSuite * apSuite, AttributeDataElement::Pars
     StatusElement::Parser statusElementParser;
     chip::DataVersion version = 0;
     bool moreClusterDataFlag  = false;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = aAttributeDataElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aAttributeDataElementParser.GetAttributePath(&attributePathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -506,10 +493,9 @@ void ParseAttributeDataList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
 
     err = attributeDataListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = attributeDataListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildAttributeDataVersionList(nlTestSuite * apSuite, AttributeDataVersionList::Builder & aAttributeDataVersionListBuilder)
@@ -529,10 +515,9 @@ void ParseAttributeDataVersionList(nlTestSuite * apSuite, chip::TLV::TLVReader &
     err = attributeDataVersionListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = attributeDataVersionListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     attributeDataVersionListParser.GetVersion(&version);
 }
 
@@ -567,10 +552,10 @@ void ParseCommandDataElement(nlTestSuite * apSuite, CommandDataElement::Parser &
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandPath::Parser commandPathParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = aCommandDataElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aCommandDataElementParser.GetCommandPath(&commandPathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -612,10 +597,10 @@ void ParseCommandDataElementWithStatusCode(nlTestSuite * apSuite, CommandDataEle
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandPath::Parser commandPathParser;
     StatusElement::Parser statusElementParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = aCommandDataElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = aCommandDataElementParser.GetCommandPath(&commandPathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -640,10 +625,8 @@ void ParseCommandList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = commandListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = commandListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
 }
 
 void BuildReportData(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
@@ -684,10 +667,9 @@ void ParseReportData(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     bool moreChunkedMessages = false;
     reportDataParser.Init(aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = reportDataParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = reportDataParser.GetSuppressResponse(&suppressResponse);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && suppressResponse);
 
@@ -730,10 +712,9 @@ void ParseInvokeCommand(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = invokeCommandParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = invokeCommandParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = invokeCommandParser.GetCommandList(&commandListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
@@ -777,10 +758,10 @@ void ParseReadRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = readRequestParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = readRequestParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = readRequestParser.GetAttributePathList(&attributePathListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -832,10 +813,10 @@ void ParseWriteRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = writeRequestParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = writeRequestParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = writeRequestParser.GetSuppressResponse(&suppressResponse);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && suppressResponse);
 
@@ -873,10 +854,10 @@ void ParseWriteResponse(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     AttributeStatusList::Parser attributeStatusListParser;
     err = writeResponseParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
     err = writeResponseParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     err = writeResponseParser.GetAttributeStatusList(&attributeStatusListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
@@ -1388,10 +1369,9 @@ void CheckPointRollbackTest(nlTestSuite * apSuite, void * apContext)
     err = attributeDataListParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     err = attributeDataListParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#endif
+
     while (CHIP_NO_ERROR == (err = attributeDataListParser.Next()))
     {
         ++NumDataElement;


### PR DESCRIPTION
Summary of Changes:
#### Problem
currently this schema check is only enabled in linux and mac, other platform also need this check.

#### Change overview
--Enable IM schema check for all supported platform, and only enable its
verbose logging in linux and mac

#### Testing
The existing tests cover this