### PR TITLE
Instrument log to correlate messages be sent and received within the …

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -194,6 +194,9 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
         *bufferRetainSlot = EncryptedPacketBufferHandle::MarkEncrypted(msgBuf.Retain());
     }
 
+    ChipLogProgress(Inet, "Send message of type %d and protocolId %" PRIu32 " on exchange %d", payloadHeader.GetMessageType(),
+                    payloadHeader.GetProtocolID().ToFullyQualifiedSpecForm(), payloadHeader.GetExchangeID());
+
     ChipLogProgress(Inet, "Sending msg from 0x" ChipLogFormatX64 " to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec",
                     ChipLogValueX64(localNodeId), ChipLogValueX64(state->GetPeerNodeId()), System::Layer::GetClock_MonotonicMS());
 


### PR DESCRIPTION
…same exchange

#### Problem
What is being fixed?  
Right now, we can only see message is sent from which node to which destination with msg ID from log. We need to correlate those message request and response by msg ID manually. It will be nice if we could instrument extra log to correlate messages be sent and received within the same exchange, which will help us debug the issue from protocol level.

* Fixes #7503 

#### Change overview
Instrument log to correlate messages be sent and received within the same exchange.

#### Testing
How was this tested? (at least one bullet point required)
Start ping test and check log.

```
Send echo request message to Node: 12344321
[1623344837.424109][155247] CHIP:IN: Secure message was encrypted: Msg ID 1
[1623344837.424114][155247] CHIP:IN: Send message of type 1 and protocolId 1 on exchange 39017          ---> Echo Request Message
[1623344837.424118][155247] CHIP:IN: Sending msg from 0x000000000001B669 to 0x0000000000BC5C01 at utc time: 47245488 msec
[1623344837.424122][155247] CHIP:IN: Sending secure msg on generic transport
[1623344837.424168][155247] CHIP:IN: Secure msg send status No Error
[1623344837.424447][155254] CHIP:IN: Secure transport received message destined to fabric 0, node 0x000000000001B669. Key ID 0
[1623344837.424461][155254] CHIP:IN: Setting fabricID BC5C01 on admin.
[1623344837.424465][155254] CHIP:IN: Since admin was modified, persisting changes to KVS
[1623344837.424469][155254] CHIP:EM: Received message of type 2 and protocolId 1 on exchange 39017 <--- Echo Response Message
[1623344837.424475][155254] CHIP:EM: Rxd Ack; Removing MsgId:00000001 from Retrans Table
[1623344837.424479][155254] CHIP:EM: Removed CHIP MsgId:00000001 from RetransTable
[1623344837.424486][155254] CHIP:EM: Sending Standalone Ack for MsgId:00000001
[1623344837.424494][155254] CHIP:IN: Secure message was encrypted: Msg ID 2
[1623344837.424498][155254] CHIP:IN: Send message of type 16 and protocolId 0 on exchange 39017
[1623344837.424502][155254] CHIP:IN: Sending msg from 0x000000000001B669 to 0x0000000000BC5C01 at utc time: 47245488 msec
[1623344837.424506][155254] CHIP:IN: Sending secure msg on generic transport
[1623344837.424524][155254] CHIP:IN: Secure msg send status No Error
[1623344837.424529][155254] CHIP:EM: Flushed pending ack for MsgId:00000001
Echo Response: 1/1(100.00%) len=15 time=0.000ms

```
