### PR TITLE
Update platform manager state on shutdown

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
 		9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9956064326420367000C28DE /* CHIPSetupPayload_Internal.h */; };
+		99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 99C65E0F267282F1003402F6 /* CHIPControllerTests.m */; };
 		B20252972459E34F00F97062 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* CHIP.framework */; };
 		B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */ = {isa = PBXBuildFile; fileRef = B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */; };
@@ -122,6 +123,7 @@
 		991DC0872475F47D00C13860 /* CHIPDeviceController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceController.mm; sourceTree = "<group>"; };
 		991DC08A247704DC00C13860 /* CHIPLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPLogging.h; sourceTree = "<group>"; };
 		9956064326420367000C28DE /* CHIPSetupPayload_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPSetupPayload_Internal.h; sourceTree = "<group>"; };
+		99C65E0F267282F1003402F6 /* CHIPControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPControllerTests.m; sourceTree = "<group>"; };
 		B202528D2459E34F00F97062 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20252912459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B20252962459E34F00F97062 /* CHIPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CHIPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -264,6 +266,7 @@
 			isa = PBXGroup;
 			children = (
 				1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */,
+				99C65E0F267282F1003402F6 /* CHIPControllerTests.m */,
 				B2F53AF1245B0DCF0010745E /* CHIPSetupPayloadParserTests.m */,
 				B202529D2459E34F00F97062 /* Info.plist */,
 			);
@@ -470,6 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1EB41B7B263C4CC60048E4C1 /* CHIPClustersTests.m in Sources */,
+				99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */,
 				B2F53AF2245B0DCF0010745E /* CHIPSetupPayloadParserTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -178,9 +178,10 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 
         // Start the IO pump
         self.cppCommissioner->ServiceEvents();
+        commissionerInitialized = YES;
     });
 
-    return YES;
+    return commissionerInitialized;
 }
 
 - (NSNumber *)getControllerNodeId

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -31,7 +31,7 @@
 
 - (void)testControllerLifecycle
 {
-    CHIPDeviceController *controller = [CHIPDeviceController sharedController];
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     XCTAssertTrue([controller startup:nil]);
     XCTAssertTrue([controller shutdown]);
 

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -1,0 +1,43 @@
+//
+//  CHIPControllerTests.m
+//  CHIPControllerTests
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <CHIP/CHIP.h>
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+@interface CHIPControllerTests : XCTestCase
+
+@end
+
+@implementation CHIPControllerTests
+
+- (void)testControllerLifecycle
+{
+    CHIPDeviceController *controller = [CHIPDeviceController sharedController];
+    XCTAssertTrue([controller startup:nil]);
+    XCTAssertTrue([controller shutdown]);
+
+    // now try to restart the controller
+    XCTAssertTrue([controller startup:nil]);
+    XCTAssertTrue([controller shutdown]);
+}
+
+@end

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -270,6 +270,7 @@ inline CHIP_ERROR PlatformManager::StartChipTimer(uint32_t durationMS)
 
 inline CHIP_ERROR PlatformManager::Shutdown()
 {
+    mInitialized = false;
     return static_cast<ImplClass *>(this)->_Shutdown();
 }
 


### PR DESCRIPTION
#### Problem
* The CHIPDeviceController does not fail if the underlying init fails. 
* Restarting the CHIP stack via a startup -> shutdown -> startup  doesn't work. 
#### Change overview
* Updated the CHIPDeviceController to return the correct init status. 
* Reset the state variable in `PlatformManager.h` on shutdown.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
Added a test to restart the Matter stack and ensure it correctly comes back up. 