### PR TITLE
Add a fixit rotation script and a workflow (for official runs)

### DIFF
--- a/.github/workflows/fixit_rotation.yaml
+++ b/.github/workflows/fixit_rotation.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build release artifacts
+
+on:
+    workflow_dispatch:
+
+jobs:
+    shuffle_names:
+        name: Shuffle names
+        runs-on: ubuntu-latest
+        container:
+            image: connectedhomeip/chip-build-esp32:latest
+
+        steps:
+            - name: Pick fixit rotation order
+              run: scripts/fixit_rotation.py
+

--- a/.github/workflows/fixit_rotation.yaml
+++ b/.github/workflows/fixit_rotation.yaml
@@ -22,7 +22,7 @@ jobs:
         name: Shuffle names
         runs-on: ubuntu-latest
         container:
-            image: connectedhomeip/chip-build-esp32:latest
+            image: connectedhomeip/chip-build:latest
 
         steps:
             - name: Pick fixit rotation order

--- a/scripts/fixit_rotation.py
+++ b/scripts/fixit_rotation.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import random
+
+ROTATION_CHOICES = [
+  'Andrei (Google)',
+  'Boris (Apple)',
+  'Cecille (Google)',
+  'Damian (Nordic)',
+  'Etienne (Silabs)',
+  'Junior (Silabs)',
+  'Kamil (Nordic)',
+  'Kevin (Google)',
+  # 'Martin (Google)', # TO be enabled July 2021
+  'Michael (Google)',
+  'Mingjie (Google)',
+  'Pankaj (Apple)',
+  'Ricardo (Silabs)',
+  'Rob (Google)',
+  'Song (Google)',
+  'Victor (Samsung)',
+  'Vivien (Apple)',
+  'Yufeng (Google)',
+  'Yunhan (Google)',
+]
+
+
+def main():
+  """Main task if executed standalone."""
+  print("Rolling dice....")
+
+  results = ROTATION_CHOICES[:]
+  random.shuffle(results)
+
+  print("Results: ")
+  for idx, name in enumerate(results):
+    print("    %2d: %s" % (idx +1, name))
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
#### Problem
Need to pick fixit rotation assignment in a fair manner.

#### Change overview
A script + a workflow action to trigger the script run (so it is logged and viewable globally)

#### Testing
Ran script manually and saw random order outputs.