### PR TITLE
Change mdns broadcast to allow treatement as success if sends

### DIFF
--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -263,6 +263,17 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
 
 CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, uint16_t port)
 {
+    // Broadcast requires sending data multiple times, each of which may error
+    // out, yet broadcast only has a single error code.
+    //
+    // The general logic of error handling is:
+    //   - if no send done at all, return error
+    //   - if at least one broadcast succeeds, assume success overall
+    //   + some internal consistency validations for state error.
+
+    bool hadSuccesfulSend = false;
+    CHIP_ERROR lastError  = CHIP_ERROR_NO_ENDPOINT;
+
     for (size_t i = 0; i < mEndpointCount; i++)
     {
         EndpointInfo * info = &mEndpoints[i];
@@ -291,20 +302,25 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
 #endif
         else
         {
+            // This is a general error of internal consistency: every address has a known type
+            // Fail completly otherwise.
             return CHIP_ERROR_INCORRECT_STATE;
         }
 
-        if (err == chip::System::MapErrorPOSIX(ENETUNREACH))
+        if (err == CHIP_NO_ERROR)
         {
-            // Send attempted to an unreachable network. Generally should not happen if
-            // interfaces are configured properly, however such a failure to broadcast
-            // may not be critical either.
-            ChipLogError(Discovery, "Attempt to mDNS broadcast to an unreachable destination.");
+            hadSuccesfulSend = true;
         }
-        else if (err != CHIP_NO_ERROR)
+        else
         {
-            return err;
+            ChipLogError(Discovery, "Attempt to mDNS broadcast failed:  %s", chip::ErrorStr(err));
+            lastError = err;
         }
+    }
+
+    if (!hadSuccesfulSend)
+    {
+        return lastError;
     }
 
     return CHIP_NO_ERROR;

--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -303,7 +303,7 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
         else
         {
             // This is a general error of internal consistency: every address has a known type
-            // Fail completly otherwise.
+            // Fail completely otherwise.
             return CHIP_ERROR_INCORRECT_STATE;
         }
 

--- a/src/lib/mdns/minimal/Server.cpp
+++ b/src/lib/mdns/minimal/Server.cpp
@@ -310,6 +310,7 @@ CHIP_ERROR ServerBase::BroadcastSend(chip::System::PacketBufferHandle && data, u
         if (err == CHIP_NO_ERROR)
         {
             hadSuccesfulSend = true;
+            ChipLogProgress(Discovery, "mDNS broadcast success");
         }
         else
         {


### PR DESCRIPTION
#### Problem
Broadcast send in minmdns errors out early if any broadcast succeeds. It tries to filter out some errors, but not all of them.

#### Change overview
Make sure an error is only if: cannot send anything at all (no endpoints or all error out) or if there is an internal inconsistency in address types.

#### Testing

Tried manually, saw error logs and still got data with minimal-mdns-client:

```sh
cd examples/miniman-mdns
gn gen out
ninja -C out
./out/minimal-mdns-client
```

```
...
[1623428512.066252][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2101 (0x00000835): Network is unreachable
[1623428512.066341][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2101 (0x00000835): Network is unreachable
[1623428512.066354][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2099 (0x00000833): Cannot assign requested address
[1623428512.066375][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2101 (0x00000835): Network is unreachable
[1623428512.066383][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2101 (0x00000835): Network is unreachable
[1623428512.066390][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2099 (0x00000833): Cannot assign requested address
[1623428512.066398][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2099 (0x00000833): Cannot assign requested address
[1623428512.066405][737854] CHIP:DIS: Attempt to mDNS broadcast failed:  OS Error 2099 (0x00000833): Cannot assign requested address
RESPONSE from: fe80::8c0e:8fff:fea0:188 on port 5353, via interface 4
RESPONSE: REPLY 4660 (0, 1, 0, 0):                                                                        
RESPONSE:     ANSWER PTR/IN ttl 3200: _services._dns-sd._udp.local.
RESPONSE:       PTR:  _uum._tcp.local.
...
```

fixes #7406