### PR TITLE
Check CSR Nonce before processing CSR

### DIFF
--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -347,7 +347,7 @@ public:
 
     CHIP_ERROR GenerateCSRNonce() { return Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce)); }
 
-    const ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
+    ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
 
 private:
     enum class ConnectionState

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -59,6 +59,7 @@ class DeviceStatusDelegate;
 struct SerializedDevice;
 
 constexpr size_t kMaxBlePendingPackets = 1;
+constexpr uint32_t kOpCSRNonceLength   = 32;
 
 using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
 #if INET_CONFIG_ENABLE_IPV4
@@ -344,6 +345,15 @@ public:
 
     CASESession & GetCASESession() { return mCASESession; }
 
+    CHIP_ERROR GenerateCSRNonce(ByteSpan & nonce)
+    {
+        ReturnErrorOnFailure(Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce)));
+        nonce = ByteSpan(mCSRNonce, sizeof(mCSRNonce));
+        return CHIP_NO_ERROR;
+    }
+
+    const ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
+
 private:
     enum class ConnectionState
     {
@@ -426,6 +436,8 @@ private:
     Credentials::OperationalCredentialSet * mCredentials = nullptr;
 
     PersistentStorageDelegate * mStorageDelegate = nullptr;
+
+    uint8_t mCSRNonce[kOpCSRNonceLength];
 };
 
 /**

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -345,12 +345,7 @@ public:
 
     CASESession & GetCASESession() { return mCASESession; }
 
-    CHIP_ERROR GenerateCSRNonce(ByteSpan & nonce)
-    {
-        ReturnErrorOnFailure(Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce)));
-        nonce = ByteSpan(mCSRNonce, sizeof(mCSRNonce));
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR GenerateCSRNonce() { return Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce)); }
 
     const ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1124,9 +1124,8 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(D
     Callback::Cancelable * successCallback = mOpCSRResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCSRFailureCallback.Cancel();
 
-    ByteSpan nonce;
-    ReturnErrorOnFailure(device->GenerateCSRNonce(nonce));
-    ReturnErrorOnFailure(cluster.OpCSRRequest(successCallback, failureCallback, nonce));
+    ReturnErrorOnFailure(device->GenerateCSRNonce());
+    ReturnErrorOnFailure(cluster.OpCSRRequest(successCallback, failureCallback, device->GetCSRNonce()));
     ChipLogDetail(Controller, "Sent OpCSR request, waiting for the CSR");
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
The nonce received in OpCSR from the device must match with the nonce sent by commissioner when it requested OpCSR.
The check is missing in the code. 

#### Change overview
Added the nonce check.

#### Testing
Tested the commissioning flow using Python, and chip-tool commissioning apps.
