### PR TITLE
Fix: Inserting VP into txtFields in Advertiser_ImplMinimalMdns

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -568,13 +568,15 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
     size_t numTxtFields = 0;
 
     char txtVidPid[chip::Mdns::kKeyVendorProductMaxLength + 4];
-    if (params.GetProductId().HasValue())
+    if (params.GetProductId().HasValue() && params.GetVendorId().HasValue())
     {
         sprintf(txtVidPid, "VP=%d+%d", params.GetVendorId().Value(), params.GetProductId().Value());
+        txtFields[numTxtFields++] = txtVidPid;
     }
-    else
+    else if (params.GetVendorId().HasValue())
     {
         sprintf(txtVidPid, "VP=%d", params.GetVendorId().Value());
+        txtFields[numTxtFields++] = txtVidPid;
     }
 
     char txtDeviceType[chip::Mdns::kKeyDeviceTypeMaxLength + 4];


### PR DESCRIPTION
#### Problem
* VP was not being inserted into the array of txtFields in the mDNS Advertiser
* VendorId's presence was not being checked before setting the value of VP

#### Change overview
Inserted VP's value into txtFields and checked vendorId's presence

#### Testing
* Tested by running chip-lighting-app for linux and querying using avahi-browse -ar to see that VP field is advertised now.