### PR TITLE
all-clusters-app/esp32: add missing onoff vled side effect

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -143,6 +143,7 @@ void DeviceCallbacks::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, 
 
     // At this point we can assume that value points to a bool value.
     mEndpointOnOffState[endpointId - 1] = *value;
+    endpointId == 1 ? statusLED1.Set(*value) : statusLED2.Set(*value);
 
 exit:
     return;


### PR DESCRIPTION
#### Problem
What is being fixed?
* all-clusters-app sample vleds don't update on `onoff` commands

#### Change overview

* add missing vleds control to the device callbacks for `onoff` attributes changes.

#### Testing
How was this tested? (at least one bullet point required)
* tested on m5stack:
```
./out/debug/chip-tool onoff toggle 1
```
triggers `green` vled.

```
./out/debug/chip-tool onoff toggle 2
```
triggers `cyan` vled.