### PR TITLE
ESP32: Add RPC service to lock-app.

### DIFF
--- a/examples/lock-app/esp32/CMakeLists.txt
+++ b/examples/lock-app/esp32/CMakeLists.txt
@@ -27,5 +27,18 @@ set(EXTRA_COMPONENT_DIRS
 )
 
 project(chip-lock-app)
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=c++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+# C++17 is required for RPC build.
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=c++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+if (CONFIG_ENABLE_PW_RPC)
+get_filename_component(CHIP_ROOT ./third_party/connectedhomeip REALPATH)
+include(third_party/connectedhomeip/third_party/pigweed/repo/pw_build/pigweed.cmake)
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert pw_assert_log)
+pw_set_backend(pw_sys_io pw_sys_io.esp32)
+
+add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
+add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
+add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
+endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/lock-app/esp32/main/CMakeLists.txt
+++ b/examples/lock-app/esp32/main/CMakeLists.txt
@@ -15,6 +15,123 @@
 #    limitations under the License.
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+
+if (CONFIG_ENABLE_PW_RPC)
+idf_component_register(INCLUDE_DIRS
+                     "${CMAKE_CURRENT_LIST_DIR}"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_bytes/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_checksum/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_containers/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_hdlc/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/standard_library_public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/nanopb/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/raw/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_protobuf/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_status/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_stream/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_result/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_varint/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_preprocessor/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/system_server/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/nanopb/repo"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/lock-common"
+                     "${CMAKE_CURRENT_LIST_DIR}/include"
+                     "${IDF_PATH}/components/freertos/include/freertos"
+                      SRC_DIRS
+                     "${CMAKE_CURRENT_LIST_DIR}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/lock-common/gen"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/on-off-server"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
+                     PRIV_REQUIRES bt chip QRCode tft spidriver screen-framework)
+
+idf_component_get_property(chip_lib chip COMPONENT_LIB)
+
+set(WRAP_FUNCTIONS esp_log_write)
+target_link_libraries(${chip_lib} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
+
+get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
+include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
+set(dir_pw_third_party_nanopb "${CHIP_ROOT}/third_party/nanopb/repo" CACHE STRING "" FORCE)
+
+pw_proto_library(device_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.options
+  PREFIX
+    device_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(button_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/button_service.proto
+  PREFIX
+    button_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(locking_service
+  SOURCES
+    ${CHIP_ROOT}/examples/lock-app/esp32/main/locking_service.proto
+  PREFIX
+    locking_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/lock-app/esp32/main
+  DEPS
+    pw_protobuf.common_protos
+)
+
+target_link_libraries(${COMPONENT_LIB} PUBLIC
+  device_service.nanopb_rpc
+  button_service.nanopb_rpc
+  locking_service.nanopb_rpc
+)
+
+set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})
+target_include_directories(${chip_lib} PUBLIC
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb")
+
+else (CONFIG_ENABLE_PW_RPC)
 idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/lock-common"
@@ -33,5 +150,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
                       PRIV_REQUIRES chip QRCode tft spidriver bt screen-framework)
 
-set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14) 
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 17)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
+
+endif (CONFIG_ENABLE_PW_RPC)

--- a/examples/lock-app/esp32/main/Kconfig.projbuild
+++ b/examples/lock-app/esp32/main/Kconfig.projbuild
@@ -92,3 +92,37 @@ menu "Demo"
 
 
 endmenu
+
+menu "PW RPC Debug channel"
+    config EXAMPLE_UART_PORT_NUM
+        int "UART port number"
+        range 0 2 if IDF_TARGET_ESP32
+        default 0 if IDF_TARGET_ESP32
+        help
+            UART communication port number for the example.
+            See UART documentation for available port numbers.
+
+    config EXAMPLE_UART_BAUD_RATE
+        int "UART communication speed"
+        range 1200 115200
+        default 115200
+        help
+            UART communication speed for Modbus example.
+
+    config EXAMPLE_UART_RXD
+        int "UART RXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        default 3
+        help
+            GPIO number for UART RX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+    config EXAMPLE_UART_TXD
+        int "UART TXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        default 1
+        help
+            GPIO number for UART TX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+endmenu

--- a/examples/lock-app/esp32/main/Rpc.cpp
+++ b/examples/lock-app/esp32/main/Rpc.cpp
@@ -1,0 +1,152 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "sdkconfig.h"
+#if CONFIG_ENABLE_PW_RPC
+#include "AppTask.h"
+#include "PigweedLoggerMutex.h"
+#include "RpcService.h"
+#include "button_service/button_service.rpc.pb.h"
+#include "device_service/device_service.rpc.pb.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "locking_service/locking_service.rpc.pb.h"
+#include "pw_log/log.h"
+#include "pw_rpc/server.h"
+#include "pw_sys_io/sys_io.h"
+#include <support/logging/CHIPLogging.h>
+
+const char * TAG = "RPC";
+
+using chip::DeviceLayer::ConfigurationMgr;
+
+static bool uartInitialised;
+
+extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, const char * format, ...)
+{
+    va_list v;
+    va_start(v, format);
+#ifndef CONFIG_LOG_DEFAULT_LEVEL_NONE
+    if (uartInitialised)
+    {
+        char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+        size_t len = vsnprintf(formattedMsg, sizeof formattedMsg, format, v);
+        if (len >= sizeof formattedMsg)
+        {
+            len = sizeof formattedMsg - 1;
+        }
+        PigweedLogger::putString(formattedMsg, len);
+    }
+#endif
+    va_end(v);
+}
+
+namespace chip {
+namespace rpc {
+
+class Locking final : public generated::Locking<Locking>
+{
+
+public:
+    pw::Status Set(ServerContext &, const chip_rpc_LockingState & request, pw_protobuf_Empty & response)
+    {
+        BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock,
+                                     request.locked ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
+        return pw::OkStatus();
+    }
+
+    pw::Status Get(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_LockingState & response)
+    {
+        response.locked = BoltLockMgr().IsUnlocked();
+        return pw::OkStatus();
+    }
+};
+
+class Button final : public generated::Button<Button>
+{
+public:
+    pw::Status Event(ServerContext &, const chip_rpc_ButtonEvent & request, pw_protobuf_Empty & response)
+    {
+        GetAppTask().ButtonEventHandler(request.idx, request.pushed);
+        return pw::OkStatus();
+    }
+};
+
+class Device final : public generated::Device<Device>
+{
+public:
+    pw::Status FactoryReset(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        ConfigurationMgr().InitiateFactoryReset();
+        return pw::OkStatus();
+    }
+    pw::Status Reboot(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        return pw::OkStatus();
+    }
+    pw::Status TriggerOta(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        // TODO: auto err = DeviceLayer::SoftwareUpdateMgr().CheckNow();
+        return pw::Status::Unimplemented();
+    }
+    pw::Status GetDeviceInfo(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_DeviceInfo & response)
+    {
+        response.vendor_id        = 1234;
+        response.product_id       = 5678;
+        response.software_version = 0;
+        return pw::OkStatus();
+    }
+};
+
+constexpr size_t kRpcStackSizeBytes = (4 * 1024);
+constexpr uint8_t kRpcTaskPriority  = 5;
+
+TaskHandle_t rpcTaskHandle;
+
+Button button_service;
+Locking locking_service;
+Device device_service;
+
+void RegisterServices(pw::rpc::Server & server)
+{
+    server.RegisterService(locking_service);
+    server.RegisterService(button_service);
+    server.RegisterService(device_service);
+}
+
+void RunRpcService(void *)
+{
+    Start(RegisterServices, &logger_mutex);
+}
+
+void Init()
+{
+    PigweedLogger::init();
+    uartInitialised = true;
+
+    ESP_LOGI(TAG, "----------- esp32-pigweed-service starting -----------");
+
+    xTaskCreate(RunRpcService, "RPC", kRpcStackSizeBytes / sizeof(StackType_t), nullptr, kRpcTaskPriority, &rpcTaskHandle);
+}
+
+} // namespace rpc
+} // namespace chip
+
+#endif

--- a/examples/lock-app/esp32/main/include/Rpc.h
+++ b/examples/lock-app/esp32/main/include/Rpc.h
@@ -1,0 +1,27 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace rpc {
+
+void Init();
+void RunRpcService(void *);
+
+} // namespace rpc
+} // namespace chip

--- a/examples/lock-app/esp32/main/locking_service.proto
+++ b/examples/lock-app/esp32/main/locking_service.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+import 'pw_protobuf_protos/common.proto';
+
+package chip.rpc;
+
+message LockingState {
+  bool locked = 1;
+}
+
+service Locking {
+  // Set will return OK if all supported fields are successfully applied, any
+  // unsupported fields will be ignored.
+  // Get can be used to determine which fields are supported.
+  rpc Set(LockingState) returns (pw.protobuf.Empty){}
+
+  // Get will populate all of the supported locking state fields with the
+  // current values. This can be used to discover the devices supported
+  // locking features.
+  rpc Get(pw.protobuf.Empty) returns (LockingState){}
+}

--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -35,6 +35,12 @@
 #include <vector>
 
 #include <support/ErrorStr.h>
+
+#if CONFIG_ENABLE_PW_RPC
+#include "PigweedLogger.h"
+#include "Rpc.h"
+#endif
+
 using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
@@ -53,6 +59,10 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "nvs_flash_init() failed: %s", ErrorStr(err));
         return;
     }
+
+#if CONFIG_ENABLE_PW_RPC
+    chip::rpc::Init();
+#endif
 
     ESP_LOGI(TAG, "==================================================");
     ESP_LOGI(TAG, "chip-esp32-lock-example starting");
@@ -74,10 +84,5 @@ extern "C" void app_main()
     if (err != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "GetAppTask().Init() failed");
-    }
-
-    while (true)
-    {
-        vTaskDelay(500 / portTICK_PERIOD_MS);
     }
 }

--- a/examples/platform/esp32/pw_sys_io/CMakeLists.txt
+++ b/examples/platform/esp32/pw_sys_io/CMakeLists.txt
@@ -1,0 +1,10 @@
+include($ENV{PW_ROOT}/pw_build/pigweed.cmake)
+
+# This is compiled in gn build, just provide headers and let linker sort it out.
+pw_add_module_library(pw_sys_io.esp32
+    SOURCES
+    PRIVATE_DEPS
+      pw_sys_io
+    HEADERS
+      public
+)


### PR DESCRIPTION
#### Problem
* Lighting example is not present for esp32.
* Lighting example in CHIP is equivalent to lock-app example.
* Lighting example has RPC communication. 
* Hence in order to avoid redundancy by replicating the example, just add RPC communication feature to lock-app esp32.

#### Change overview
Added the necessary changes for pigweed in lock-app esp32.

#### Testing
* Using a pigweed RPC console, perform actions on device_service, locking_service, and button_service.
