### PR TITLE
Fix various compile failures with is_debug=false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -218,7 +218,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_efr32_lock_app_build = enable_efr32_builds
 
     # Build the qpg6100 lock app example.
-    enable_qpg6100_lock_app_build = enable_qpg6100_builds
+    enable_qpg6100_lock_app_build = enable_qpg6100_builds && !is_debug
 
     # Build the efr32 lighting app example.
     enable_efr32_lighting_app_build = enable_efr32_builds

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -54,17 +54,19 @@ echo 'To re-create the build environment from scratch, run:'
 echo source "$CHIP_ROOT/scripts/bootstrap.sh"
 
 echo
-echo 'To build a debug build:'
-echo gn gen "$CHIP_ROOT/out/debug" --args=\''target_os="all"'"$extra_args"\'
+echo 'To compile the generated debug build:'
 echo ninja -C "$CHIP_ROOT/out/debug"
 
 echo
-echo 'To run tests (idempotent):'
+echo 'To test the generated debug build (idempotent):'
 echo ninja -C "$CHIP_ROOT/out/debug" check
 
 echo
-echo 'To build & test an optimized build:'
-echo gn gen "$CHIP_ROOT/out/release" --args=\''target_os="all" is_debug=false'"$extra_args"\'
+echo 'To compile the generated release build':
+echo ninja -C "$CHIP_ROOT/out/release"
+
+echo
+echo 'To test the generated release build (idempotent):'
 echo ninja -C "$CHIP_ROOT/out/release" check
 
 echo

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -248,7 +248,7 @@ exit:
 
 bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command * commandObj, uint8_t groupCount, uint8_t * groupList)
 {
-    EmberStatus status;
+    EmberStatus status = EMBER_ZCL_STATUS_FAILURE;
     uint8_t i, j;
     uint8_t count = 0;
     uint8_t list[EMBER_BINDING_TABLE_SIZE << 1];

--- a/src/lwip/cc13x2_26x2/arch/cc.h
+++ b/src/lwip/cc13x2_26x2/arch/cc.h
@@ -27,6 +27,7 @@
 #ifndef CHIP_LWIP_FREERTOS_ARCH_CC_H
 #define CHIP_LWIP_FREERTOS_ARCH_CC_H
 
+#include <assert.h>
 #include <errno.h>
 #include <malloc.h>
 #include <stddef.h>
@@ -43,11 +44,7 @@ extern "C" {
 #endif
 
 #ifndef LWIP_NOASSERT
-#ifdef DEBUG
 #define LWIP_PLATFORM_ASSERT(MSG) assert(0)
-#else
-#define LWIP_PLATFORM_ASSERT(MSG) assert(0)
-#endif
 #else
 #define LWIP_PLATFORM_ASSERT(message)
 #endif


### PR DESCRIPTION
- Missing #include <assert.h> in src/lwip/cc13x2_26x2/arch/cc.h:

  ```
  ../../third_party/lwip/repo/lwip/src/api/api_msg.c: In function 'recv_udp':
  ../../src/lwip/cc13x2_26x2/arch/cc.h:49:35: error: implicit declaration of function 'assert' [-Werror=implicit-function-declaration]
     49 | #define LWIP_PLATFORM_ASSERT(MSG) assert(0)
        |                                   ^~~~~~
  ../../third_party/lwip/repo/lwip/src/include/lwip/debug.h:117:3: note: in expansion of macro 'LWIP_PLATFORM_ASSERT'
    117 |   LWIP_PLATFORM_ASSERT(message); }} while(0)
        |   ^~~~~~~~~~~~~~~~~~~~
  ../../third_party/lwip/repo/lwip/src/api/api_msg.c:177:3: note: in expansion of macro 'LWIP_ASSERT'
    177 |   LWIP_ASSERT("recv_udp must have a pcb argument", pcb != NULL);
        |   ^~~~~~~~~~~
  ../../third_party/lwip/repo/lwip/src/api/api_msg.c:58:1: note: 'assert' is defined in header '<assert.h>'; did you forget to '#include <assert.h>'?
     57 | #include <string.h>
    +++ |+#include <assert.h>
     58 |
  ```

  Add the missing #include.

- Potentially uninitialized variable in groups-server:

  ```
  In file included from ../../src/app/util/af.h:72,
                   from ../../src/app/clusters/groups-server/groups-server.cpp:55:
  ../../src/app/util/debug-printing.h: In function ‘bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command*, uint8_t, uint8_t*)’:
  ../../src/app/util/debug-printing.h:137:56: error: ‘status’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
    137 | #define emberAfGroupsClusterPrintln(...) emberAfPrintln(EMBER_AF_PRINT_GROUPS_CLUSTER, __VA_ARGS__)
        |                                                        ^
  ../../src/app/clusters/groups-server/groups-server.cpp:251:17: note: ‘status’ was declared here
    251 |     EmberStatus status;
        |                 ^~~~~~
  ```

  Initialize the variable.

- Also remove qpg6100 generation in unified debug as this this platform
  now forces an optimized build due to space constraints.

- Finally, make the instructions output by gn_build.sh not override the
  provided arguments. This script already generates output directories
  for both debug and release builds.

Tested by
```
  ./gn_build.sh enable_efr32_builds=true enable_qpg6100_builds=true
  ninja -C out/release
```