### PR TITLE
Always use python3 for zap_cluster_list.py

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/lib/core/core.gni")
@@ -119,10 +120,11 @@ template("chip_data_model") {
       _cluster_sources = invoker.cluster_sources
     } else if (defined(invoker.zap_file)) {
       _zap_path = rebase_path(invoker.zap_file, root_build_dir)
+      _script_path = rebase_path(_zap_cluster_list_script, root_build_dir)
       _script_args = [ "--zap_file=" + _zap_path ]
 
-      _cluster_sources = exec_script(_zap_cluster_list_script,
-                                     _script_args,
+      _cluster_sources = exec_script("${build_root}/gn_run_binary.py",
+                                     [ _script_path ] + _script_args,
                                      "list lines",
                                      [ invoker.zap_file ])
     }


### PR DESCRIPTION
### Problem

Unfortunately python is still python2 on some systems and this becomes
the default python interpreter for exec_script(). If we run
zap_cluster_list.py with python2, it's a parse error due to use of
python 3 only optional typing syntax.

If we instead execute the script via gn_run_binary.py, the shebang line
(#!/usr/bin/env python3) in the script will be respected. This is more
likely to work until python2 is dead everywhere...

### Change overview

...so do that.

### Testing

Tested by building as a subproject of a project that uses the default
script_executable in GN on a system with /usr/bin/python as python2.