### PR TITLE
Fix XML comments in opcreds cluster

### DIFF
--- a/src/app/zap-templates/zcl/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/operational-credentials-cluster.xml
@@ -19,27 +19,27 @@ limitations under the License.
   <cluster>
     <domain>General</domain>
     <name>Operational Credentials</name>
-    <code>0x003E</code> // Change to correct clusterID once it is decided in the spec #2396
+    <code>0x003E</code>
     <define>OPERATIONAL_CREDENTIALS_CLUSTER</define>
     <description>This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated Fabrics.</description>
 
     <attribute side="server" code="0x0001" define="FABRICS" type="ARRAY" entryType="FabricDescriptor" length="254" writable="false" optional="false">fabrics list</attribute>
 
-    /* 
-    * Temporary flow for fabric management until addOptCert + fabric index are implemented:
-    * 1) When Commissioner pairs with CHIP device, store device nodeId in Admin Pairing table as NodeId 
-    *    and store commissioner nodeId in Admin Pairing table as FabricId (This is temporary until AddOptCert is implemented and Fabrics are implemented correctely)
-    * 2) When pairing is complete, commissioner calls SetFabric to set the vendorId on the newly created fabric. The corresponding fabric is found by looking
-    *    in admin pairing table and finding a fabric that has the matching commissioner node ID as fabricId + device nodeId as nodeId and an uninitialized vendorId.
-    * 3) RemoveFabric uses the passed in fabricId, nodeId, vendorID to find matching entry and remove it from admin pairing table. Once fabricIndex is implemented, it should use that instead.
-    */
+    <!-- 
+      Temporary flow for fabric management until AddOpCert + fabric index are implemented:
+      1) When Commissioner pairs with CHIP device, store device nodeId in Admin Pairing table as NodeId 
+         and store commissioner nodeId in Admin Pairing table as FabricId (This is temporary until AddOptCert is implemented and Fabrics are implemented correctely)
+      2) When pairing is complete, commissioner calls SetFabric to set the vendorId on the newly created fabric. The corresponding fabric is found by looking
+         in admin pairing table and finding a fabric that has the matching commissioner node ID as fabricId + device nodeId as nodeId and an uninitialized vendorId.
+      3) RemoveFabric uses the passed in fabricId, nodeId, vendorID to find matching entry and remove it from admin pairing table. Once fabricIndex is implemented, it should use that instead.
+    -->
     
     <command source="client" code="0x09" name="UpdateFabricLabel" optional="false">
       <description>This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by entries in the Fabrics attribute.</description>
       <arg name="Label" type="CHAR_STRING" length="32"/>
     </command>
 
-    // TODO: Once FabricIndex is implemented, have RemoveFabric take an index instead of vid+fabricId+nopeId
+    <!-- TODO: Once FabricIndex is implemented, have RemoveFabric take an index instead of vid+fabricId+nopeId -->
     <command source="client" code="0x0a" name="RemoveFabric" optional="false">
       <description>This command is used by Administrative Nodes to remove a given Fabric and delete all associated
 fabric-scoped data.</description>
@@ -48,7 +48,7 @@ fabric-scoped data.</description>
       <arg name="VendorId" type="INT16U"/>
     </command>
 
-    // TODO: Remove SetFabric + SetFabricResponse once addOptCert command is implemented
+    <!-- TODO: Remove SetFabric + SetFabricResponse once AddOpCert command is implemented -->
     <command source="client" code="0x00" name="SetFabric" optional="false">
       <description>Sets the vendorID of the fabric and returns the fabricId of newly created fabric.</description>
       <arg name="VendorId" type="INT16U"/>
@@ -59,7 +59,7 @@ fabric-scoped data.</description>
       <arg name="FabricId" type="FABRIC_ID"/>
     </command>
 
-    // Up for discussion in Multi-Admin TT: chip-spec:#2891
+    <!-- Up for discussion in Multi-Admin TT: chip-spec:#2891 -->
     <command source="client" code="0x0b" name="RemoveAllFabrics" optional="false">
       <description>Removes all fabrics.</description>
     </command>
@@ -69,6 +69,7 @@ fabric-scoped data.</description>
       <arg name="CSRNonce" type="OCTET_STRING"/>
     </command>
 
+    <!-- TODO: Fix to match chip-spec:#3346 -->
     <command source="server" code="0x05" name="OpCSRResponse" optional="false">
       <description>A certificate signing request (CSR) from the server.</description>
       <arg name="CSR" type="OCTET_STRING"/>


### PR DESCRIPTION
#### Problem
Comments in OpCreds cluster XML use C++ style rather than XML style

#### Change overview
- Fix comments to use XML comments
- Remove a TODO that is fixed.
- Add TODO about CSR format

#### Testing
- XML syntax verified using XML plugin in IDE