### PR TITLE
Updated CHIP Certs to Use Spans Instead of Pointer/Len Pairs

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -293,9 +293,7 @@ CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * 
             MutableByteSpan rootCertSpan(rootCert.Get(), kMaxCHIPDERCertLength);
             ReturnErrorOnFailure(mOperationalCredentialsDelegate->GetRootCACertificate(0, rootCertSpan));
             VerifyOrReturnError(CanCastTo<uint32_t>(rootCertSpan.size()), CHIP_ERROR_INVALID_ARGUMENT);
-            ReturnErrorOnFailure(ConvertX509CertToChipCert(rootCertSpan.data(), static_cast<uint32_t>(rootCertSpan.size()),
-                                                           chipCert.Get(), chipCertAllocatedLen, chipCertLen));
-
+            ReturnErrorOnFailure(ConvertX509CertToChipCert(rootCertSpan, chipCert.Get(), chipCertAllocatedLen, chipCertLen));
             ReturnErrorOnFailure(admin->SetRootCert(ByteSpan(chipCert.Get(), chipCertLen)));
         }
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -336,7 +336,7 @@ const ChipCertificateData * ChipCertificateSet::FindCert(const CertificateKeyId 
     for (uint8_t i = 0; i < mCertCount; i++)
     {
         ChipCertificateData & cert = mCerts[i];
-        if (cert.mSubjectKeyId.IsEqual(subjectKeyId))
+        if (cert.mSubjectKeyId.data_equal(subjectKeyId))
         {
             return &cert;
         }
@@ -392,12 +392,12 @@ CHIP_ERROR ChipCertificateSet::VerifySignature(const ChipCertificateData * cert,
     P256ECDSASignature signature;
     uint16_t derSigLen;
 
-    ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(cert->mSignature, cert->mSignatureLen, signature,
-                                                       static_cast<uint16_t>(signature.Capacity()), derSigLen));
+    ReturnErrorOnFailure(
+        ConvertECDSASignatureRawToDER(cert->mSignature, signature, static_cast<uint16_t>(signature.Capacity()), derSigLen));
 
     ReturnErrorOnFailure(signature.SetLength(derSigLen));
 
-    memcpy(caPublicKey, caCert->mPublicKey, caCert->mPublicKeyLen);
+    memcpy(caPublicKey, caCert->mPublicKey.data(), caCert->mPublicKey.size());
 
     ReturnErrorOnFailure(caPublicKey.ECDSA_validate_hash_signature(cert->mTBSHash, chip::Crypto::kSHA256_Hash_Length, signature));
 
@@ -495,7 +495,7 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
 
     // Fail validation if the certificate is self-signed. Since we don't trust this certificate (see the check above) and
     // it has no path we can follow to a trust anchor, it can't be considered valid.
-    if (cert->mIssuerDN.IsEqual(cert->mSubjectDN) && cert->mAuthKeyId.IsEqual(cert->mSubjectKeyId))
+    if (cert->mIssuerDN.IsEqual(cert->mSubjectDN) && cert->mAuthKeyId.data_equal(cert->mSubjectKeyId))
     {
         ExitNow(err = CHIP_ERROR_CERT_NOT_TRUSTED);
     }
@@ -536,7 +536,7 @@ CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const Cer
     err = (depth > 0) ? CHIP_ERROR_CA_CERT_NOT_FOUND : CHIP_ERROR_CERT_NOT_FOUND;
 
     // Fail immediately if neither of the input criteria are specified.
-    if (subjectDN.IsEmpty() && subjectKeyId.IsEmpty())
+    if (subjectDN.IsEmpty() && subjectKeyId.empty())
     {
         ExitNow();
     }
@@ -551,7 +551,7 @@ CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const Cer
         {
             continue;
         }
-        if (!subjectKeyId.IsEmpty() && !candidateCert->mSubjectKeyId.IsEqual(subjectKeyId))
+        if (!subjectKeyId.empty() && !candidateCert->mSubjectKeyId.data_equal(subjectKeyId))
         {
             continue;
         }
@@ -581,21 +581,20 @@ void ChipCertificateData::Clear()
 {
     mSubjectDN.Clear();
     mIssuerDN.Clear();
-    mSubjectKeyId.Clear();
-    mAuthKeyId.Clear();
-    mNotBeforeTime  = 0;
-    mNotAfterTime   = 0;
-    mPublicKey      = nullptr;
-    mPublicKeyLen   = 0;
-    mPubKeyCurveOID = 0;
-    mPubKeyAlgoOID  = 0;
-    mSigAlgoOID     = 0;
+    mSubjectKeyId      = CertificateKeyId();
+    mAuthKeyId         = CertificateKeyId();
+    mNotBeforeTime     = 0;
+    mNotAfterTime      = 0;
+    mPublicKey         = P256PublicKeySpan();
+    mPubKeyCurveOID    = 0;
+    mPubKeyAlgoOID     = 0;
+    mSigAlgoOID        = 0;
+    mPathLenConstraint = 0;
     mCertFlags.ClearAll();
     mKeyUsageFlags.ClearAll();
     mKeyPurposeFlags.ClearAll();
-    mPathLenConstraint = 0;
-    mSignature         = nullptr;
-    mSignatureLen      = 0;
+    mSignature = P256ECDSASignatureSpan();
+
     memset(mTBSHash, 0, sizeof(mTBSHash));
 }
 
@@ -603,14 +602,13 @@ bool ChipCertificateData::IsEqual(const ChipCertificateData & other) const
 {
     // TODO - Add an operator== on BitFlags class.
     return mSubjectDN.IsEqual(other.mSubjectDN) && mIssuerDN.IsEqual(other.mIssuerDN) &&
-        mSubjectKeyId.IsEqual(other.mSubjectKeyId) && mAuthKeyId.IsEqual(other.mAuthKeyId) &&
+        mSubjectKeyId.data_equal(other.mSubjectKeyId) && mAuthKeyId.data_equal(other.mAuthKeyId) &&
         (mNotBeforeTime == other.mNotBeforeTime) && (mNotAfterTime == other.mNotAfterTime) &&
-        (mPublicKeyLen == other.mPublicKeyLen) && (memcmp(mPublicKey, other.mPublicKey, mPublicKeyLen) == 0) &&
-        (mPubKeyCurveOID == other.mPubKeyCurveOID) && (mPubKeyAlgoOID == other.mPubKeyAlgoOID) &&
-        (mSigAlgoOID == other.mSigAlgoOID) && (mCertFlags.Raw() == other.mCertFlags.Raw()) &&
-        (mKeyUsageFlags.Raw() == other.mKeyUsageFlags.Raw()) && (mKeyPurposeFlags.Raw() == other.mKeyPurposeFlags.Raw()) &&
-        (mPathLenConstraint == other.mPathLenConstraint) && (mSignatureLen == other.mSignatureLen) &&
-        (memcmp(mSignature, other.mSignature, mSignatureLen) == 0) && (memcmp(mTBSHash, other.mTBSHash, sizeof(mTBSHash)) == 0);
+        mPublicKey.data_equal(other.mPublicKey) && (mPubKeyCurveOID == other.mPubKeyCurveOID) &&
+        (mPubKeyAlgoOID == other.mPubKeyAlgoOID) && (mSigAlgoOID == other.mSigAlgoOID) &&
+        (mCertFlags.Raw() == other.mCertFlags.Raw()) && (mKeyUsageFlags.Raw() == other.mKeyUsageFlags.Raw()) &&
+        (mKeyPurposeFlags.Raw() == other.mKeyPurposeFlags.Raw()) && (mPathLenConstraint == other.mPathLenConstraint) &&
+        mSignature.data_equal(other.mSignature) && (memcmp(mTBSHash, other.mTBSHash, sizeof(mTBSHash)) == 0);
 }
 
 void ValidationContext::Reset()
@@ -633,12 +631,11 @@ bool ChipRDN::IsEqual(const ChipRDN & other) const
 
     if (IsChipDNAttr(mAttrOID))
     {
-        return mAttrValue.mChipVal == other.mAttrValue.mChipVal;
+        return mChipVal == other.mChipVal;
     }
     else
     {
-        return (mAttrValue.mString.mLen == other.mAttrValue.mString.mLen &&
-                memcmp(mAttrValue.mString.mValue, other.mAttrValue.mString.mValue, mAttrValue.mString.mLen) == 0);
+        return mString.data_equal(other.mString);
     }
 }
 
@@ -671,39 +668,34 @@ uint8_t ChipDN::RDNCount() const
 
 CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, uint64_t val)
 {
-    CHIP_ERROR err   = CHIP_NO_ERROR;
     uint8_t rdnCount = RDNCount();
 
-    VerifyOrExit(rdnCount < CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES, err = CHIP_ERROR_NO_MEMORY);
-    VerifyOrExit(IsChipDNAttr(oid), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(rdnCount < CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(IsChipDNAttr(oid), CHIP_ERROR_INVALID_ARGUMENT);
 
     if (IsChip32bitDNAttr(oid))
     {
-        VerifyOrExit(val <= UINT32_MAX, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(val <= UINT32_MAX, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    rdn[rdnCount].mAttrOID            = oid;
-    rdn[rdnCount].mAttrValue.mChipVal = val;
+    rdn[rdnCount].mAttrOID = oid;
+    rdn[rdnCount].mChipVal = val;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, const uint8_t * val, uint32_t valLen)
+CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, ByteSpan val)
 {
-    CHIP_ERROR err   = CHIP_NO_ERROR;
     uint8_t rdnCount = RDNCount();
 
-    VerifyOrExit(rdnCount < CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES, err = CHIP_ERROR_NO_MEMORY);
-    VerifyOrExit(!IsChipDNAttr(oid), err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(oid != kOID_NotSpecified, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(rdnCount < CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(!IsChipDNAttr(oid), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(oid != kOID_NotSpecified, CHIP_ERROR_INVALID_ARGUMENT);
 
-    rdn[rdnCount].mAttrOID                  = oid;
-    rdn[rdnCount].mAttrValue.mString.mValue = val;
-    rdn[rdnCount].mAttrValue.mString.mLen   = valLen;
+    rdn[rdnCount].mAttrOID = oid;
+    rdn[rdnCount].mString  = val;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipDN::GetCertType(uint8_t & certType) const
@@ -777,7 +769,7 @@ CHIP_ERROR ChipDN::GetCertChipId(uint64_t & chipId) const
         case kOID_AttributeType_ChipFirmwareSigningId:
             VerifyOrReturnError(chipId == 0, CHIP_ERROR_WRONG_CERT_TYPE);
 
-            chipId = rdn[i].mAttrValue.mChipVal;
+            chipId = rdn[i].mChipVal;
             break;
         default:
             break;
@@ -802,11 +794,6 @@ bool ChipDN::IsEqual(const ChipDN & other) const
 
 exit:
     return res;
-}
-
-bool CertificateKeyId::IsEqual(const CertificateKeyId & other) const
-{
-    return mId != nullptr && other.mId != nullptr && mLen == other.mLen && memcmp(mId, other.mId, mLen) == 0;
 }
 
 DLL_EXPORT CHIP_ERROR ASN1ToChipEpochTime(const chip::ASN1::ASN1UniversalTime & asn1Time, uint32_t & epochTime)
@@ -856,16 +843,18 @@ DLL_EXPORT CHIP_ERROR ChipEpochToASN1Time(uint32_t epochTime, chip::ASN1::ASN1Un
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConvertIntegerDERToRaw(const uint8_t * derInt, uint16_t derIntLen, uint8_t * rawInt, const uint16_t rawIntLen)
+CHIP_ERROR ConvertIntegerDERToRaw(ByteSpan derInt, uint8_t * rawInt, const uint16_t rawIntLen)
 {
-    VerifyOrReturnError(derInt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(derIntLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!derInt.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(rawInt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    const uint8_t * derIntData = derInt.data();
+    size_t derIntLen           = derInt.size();
+
     /* one leading zero is allowed for positive integer in ASN1 DER format */
-    if (*derInt == 0)
+    if (*derIntData == 0)
     {
-        derInt++;
+        derIntData++;
         derIntLen--;
     }
 
@@ -873,31 +862,33 @@ CHIP_ERROR ConvertIntegerDERToRaw(const uint8_t * derInt, uint16_t derIntLen, ui
 
     if (derIntLen > 0)
     {
-        VerifyOrReturnError(*derInt != 0, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(*derIntData != 0, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     memset(rawInt, 0, (rawIntLen - derIntLen));
-    memcpy(rawInt + (rawIntLen - derIntLen), derInt, derIntLen);
+    memcpy(rawInt + (rawIntLen - derIntLen), derIntData, derIntLen);
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConvertIntegerRawToDER(const uint8_t * rawInt, uint16_t rawIntLen, uint8_t * derInt, const uint16_t derIntBufSize,
-                                  uint16_t & derIntLen)
+CHIP_ERROR ConvertIntegerRawToDER(P256IntegerSpan rawInt, uint8_t * derInt, const uint16_t derIntBufSize, uint16_t & derIntLen)
 {
-    VerifyOrReturnError(rawInt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(rawIntLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    static_assert(rawInt.size() <= UINT16_MAX - 1, "P256 raw integer doesn't fit in a uint16_t");
+
+    VerifyOrReturnError(!rawInt.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(derInt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    while (*rawInt == 0)
+    const uint8_t * rawIntData = rawInt.data();
+    size_t rawIntLen           = rawInt.size();
+
+    while (*rawIntData == 0)
     {
-        rawInt++;
+        rawIntData++;
         rawIntLen--;
     }
 
-    if (*rawInt & 0x80) /* Need Leading Zero */
+    if (*rawIntData & 0x80) /* Need Leading Zero */
     {
-        VerifyOrReturnError(rawIntLen <= UINT16_MAX - 1, CHIP_ERROR_BUFFER_TOO_SMALL);
         VerifyOrReturnError(derIntBufSize >= rawIntLen + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
 
         *derInt++ = 0;
@@ -907,26 +898,24 @@ CHIP_ERROR ConvertIntegerRawToDER(const uint8_t * rawInt, uint16_t rawIntLen, ui
     {
         VerifyOrReturnError(derIntBufSize >= rawIntLen, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-        derIntLen = rawIntLen;
+        derIntLen = static_cast<uint16_t>(rawIntLen);
     }
 
-    memcpy(derInt, rawInt, rawIntLen);
+    memcpy(derInt, rawIntData, rawIntLen);
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConvertECDSASignatureRawToDER(const uint8_t * rawSig, uint16_t rawSigLen, uint8_t * derSig, const uint16_t derSigBufSize,
+CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, uint8_t * derSig, const uint16_t derSigBufSize,
                                          uint16_t & derSigLen)
 {
     ASN1Writer writer;
 
-    VerifyOrReturnError(rawSig != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(rawSigLen > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(derSig != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     writer.Init(derSig, derSigBufSize);
 
-    ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(rawSig, rawSigLen, writer));
+    ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(rawSig, writer));
 
     ReturnErrorOnFailure(writer.Finalize());
 
@@ -935,24 +924,24 @@ CHIP_ERROR ConvertECDSASignatureRawToDER(const uint8_t * rawSig, uint16_t rawSig
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConvertECDSASignatureRawToDER(const uint8_t * rawSig, uint16_t rawSigLen, ASN1Writer & writer)
+CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, ASN1Writer & writer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t derInt[kP256_FE_Length + 1];
     uint16_t derIntLen;
 
-    VerifyOrReturnError(rawSig != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(rawSigLen == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!rawSig.empty(), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Ecdsa-Sig-Value ::= SEQUENCE
     ASN1_START_SEQUENCE
     {
         // r INTEGER
-        ReturnErrorOnFailure(ConvertIntegerRawToDER(rawSig, kP256_FE_Length, derInt, sizeof(derInt), derIntLen));
+        ReturnErrorOnFailure(ConvertIntegerRawToDER(P256IntegerSpan(rawSig.data()), derInt, sizeof(derInt), derIntLen));
         ReturnErrorOnFailure(writer.PutValue(kASN1TagClass_Universal, kASN1UniversalTag_Integer, false, derInt, derIntLen));
 
         // s INTEGER
-        ReturnErrorOnFailure(ConvertIntegerRawToDER(rawSig + kP256_FE_Length, kP256_FE_Length, derInt, sizeof(derInt), derIntLen));
+        ReturnErrorOnFailure(
+            ConvertIntegerRawToDER(P256IntegerSpan(rawSig.data() + kP256_FE_Length), derInt, sizeof(derInt), derIntLen));
         ReturnErrorOnFailure(writer.PutValue(kASN1TagClass_Universal, kASN1UniversalTag_Integer, false, derInt, derIntLen));
     }
     ASN1_END_SEQUENCE;

--- a/src/credentials/CHIPOperationalCredentials.h
+++ b/src/credentials/CHIPOperationalCredentials.h
@@ -35,8 +35,7 @@
 namespace chip {
 namespace Credentials {
 
-static constexpr size_t kOperationalCredentialsMax     = 5;
-static constexpr size_t kOperationalCertificateMaxSize = 400;
+static constexpr size_t kOperationalCredentialsMax = 5;
 
 using namespace Crypto;
 
@@ -49,13 +48,13 @@ struct NodeCredential
 struct OperationalCredentialSerializable
 {
     uint16_t mNodeCredentialLen;
-    uint8_t mNodeCredential[kOperationalCertificateMaxSize];
+    uint8_t mNodeCredential[kMaxCHIPCertLength];
     uint16_t mNodeKeypairLen;
     uint8_t mNodeKeypair[kP256_PublicKey_Length + kP256_PrivateKey_Length];
     uint16_t mRootCertificateLen;
-    uint8_t mRootCertificate[kOperationalCertificateMaxSize];
+    uint8_t mRootCertificate[kMaxCHIPCertLength];
     uint16_t mCACertificateLen;
-    uint8_t mCACertificate[kOperationalCertificateMaxSize];
+    uint8_t mCACertificate[kMaxCHIPCertLength];
 };
 
 struct NodeCredentialMap
@@ -153,7 +152,7 @@ public:
      *
      * @return A pointer to the Trusted Root ID on success. Otherwise, nullptr if no Trust Anchor is found.
      **/
-    const CertificateKeyId * GetTrustedRootId(uint16_t certSetIndex) const;
+    CertificateKeyId GetTrustedRootId(uint16_t certSetIndex) const;
 
     /**
      * @brief Check whether certificate set is in the operational credential set.

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -68,8 +68,7 @@ enum class TestCertLoadFlags : uint8_t
     kSetAppDefinedCertType = 0x20,
 };
 
-extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
-                              uint32_t & certDataLen);
+extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, ByteSpan & cert);
 extern const char * GetTestCertName(uint8_t certType);
 extern CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t *& certPubkey, uint32_t & certPubkeyLen);
 extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -47,17 +47,6 @@ using namespace chip::Crypto;
 enum
 {
     kStandardCertsCount = 3,
-
-    /**
-     * Maximum buffer size needed to hold any of the test certificates in CHIP TLV encoded form.
-     */
-    kTestCHIPCertBufSize = kOperationalCertificateMaxSize,
-
-    /**
-     * Maximum buffer size needed to hold any of the test certificates in DER encoded form.
-     * The same buffer size is also used when the certificate is decoded.
-     */
-    kTestDERCertBufSize = 600,
 };
 
 static const BitFlags<CertValidateFlags> sIgnoreNotBeforeFlag(CertValidateFlags::kIgnoreNotBefore);
@@ -148,52 +137,46 @@ static CHIP_ERROR SetEffectiveTime(ValidationContext & validContext, uint16_t ye
 static void TestChipCert_ChipToX509(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
-    const uint8_t * inCert;
-    uint32_t inCertLen;
-    const uint8_t * expectedOutCert;
-    uint32_t expectedOutCertLen;
-    uint8_t outCertBuf[kTestDERCertBufSize];
+    ByteSpan inCert;
+    ByteSpan expectedOutCert;
+    uint8_t outCertBuf[kMaxDERCertLength];
     uint32_t outCertLen;
 
     for (size_t i = 0; i < gNumTestCerts; i++)
     {
         uint8_t certType = gTestCerts[i];
 
-        err = GetTestCert(certType, sNullLoadFlag, inCert, inCertLen);
+        err = GetTestCert(certType, sNullLoadFlag, inCert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        err = GetTestCert(certType, sDerFormFlag, expectedOutCert, expectedOutCertLen);
+        err = GetTestCert(certType, sDerFormFlag, expectedOutCert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = ConvertChipCertToX509Cert(inCert, inCertLen, outCertBuf, sizeof(outCertBuf), outCertLen);
+        err = ConvertChipCertToX509Cert(inCert, outCertBuf, sizeof(outCertBuf), outCertLen);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, outCertLen == expectedOutCertLen);
-        NL_TEST_ASSERT(inSuite, memcmp(outCertBuf, expectedOutCert, outCertLen) == 0);
+        NL_TEST_ASSERT(inSuite, expectedOutCert.data_equal(ByteSpan(outCertBuf, outCertLen)));
     }
 }
 
 static void TestChipCert_X509ToChip(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
-    const uint8_t * inCert;
-    uint32_t inCertLen;
-    const uint8_t * expectedOutCert;
-    uint32_t expectedOutCertLen;
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    ByteSpan inCert;
+    ByteSpan expectedOutCert;
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     for (size_t i = 0; i < gNumTestCerts; i++)
     {
         uint8_t certType = gTestCerts[i];
 
-        err = GetTestCert(certType, sDerFormFlag, inCert, inCertLen);
+        err = GetTestCert(certType, sDerFormFlag, inCert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        err = GetTestCert(certType, sNullLoadFlag, expectedOutCert, expectedOutCertLen);
+        err = GetTestCert(certType, sNullLoadFlag, expectedOutCert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = ConvertX509CertToChipCert(inCert, inCertLen, outCertBuf, sizeof(outCertBuf), outCertLen);
+        err = ConvertX509CertToChipCert(inCert, outCertBuf, sizeof(outCertBuf), outCertLen);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, outCertLen == expectedOutCertLen);
-        NL_TEST_ASSERT(inSuite, memcmp(outCertBuf, expectedOutCert, outCertLen) == 0);
+        NL_TEST_ASSERT(inSuite, expectedOutCert.data_equal(ByteSpan(outCertBuf, outCertLen)));
     }
 }
 
@@ -367,7 +350,7 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
         const ValidationTestCase & testCase = sValidationTestCases[i];
 
         // Initialize the certificate set and load the specified test certificates.
-        certSet.Init(kMaxCertsPerTestCase, kTestDERCertBufSize);
+        certSet.Init(kMaxCertsPerTestCase, kMaxDERCertLength);
         for (size_t i2 = 0; i2 < kMaxCertsPerTestCase; i2++)
         {
             if (testCase.InputCerts[i2].Type != TestCert::kNone)
@@ -425,7 +408,7 @@ static void TestChipCert_CertValidTime(nlTestSuite * inSuite, void * inContext)
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
-    certSet.Init(kStandardCertsCount, kTestDERCertBufSize);
+    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
 
     err = LoadTestCertSet01(certSet);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -585,7 +568,7 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
     // clang-format on
     size_t sNumUsageTestCases = sizeof(sUsageTestCases) / sizeof(sUsageTestCases[0]);
 
-    certSet.Init(kStandardCertsCount, kTestDERCertBufSize);
+    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
 
     err = LoadTestCertSet01(certSet);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -641,7 +624,7 @@ static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
         uint8_t certType;
 
         // Initialize the certificate set and load the test certificate.
-        certSet.Init(1, kTestDERCertBufSize);
+        certSet.Init(1, kMaxDERCertLength);
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -688,7 +671,7 @@ static void TestChipCert_CertId(nlTestSuite * inSuite, void * inContext)
         uint64_t chipId;
 
         // Initialize the certificate set and load the test certificate.
-        certSet.Init(1, kTestDERCertBufSize);
+        certSet.Init(1, kMaxDERCertLength);
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -706,7 +689,7 @@ static void TestChipCert_LoadDuplicateCerts(nlTestSuite * inSuite, void * inCont
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
-    certSet.Init(kStandardCertsCount, kTestDERCertBufSize);
+    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
 
     // Let's load two distinct certificates, and make sure cert count is 2
     err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
@@ -738,7 +721,7 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signed_cert[kTestDERCertBufSize];
+    uint8_t signed_cert[kMaxDERCertLength];
     uint32_t signed_len = 0;
 
     ChipCertificateData certData;
@@ -747,11 +730,12 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
 
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert, sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(signed_cert, signed_len, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
@@ -775,12 +759,12 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signed_cert[kTestDERCertBufSize];
+    uint8_t signed_cert[kMaxDERCertLength];
     uint32_t signed_len = 0;
 
     ChipCertificateData certData;
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     X509CertRequestParams root_params_fabric = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0xabcd, false, 0 };
@@ -789,7 +773,8 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
                    NewRootX509Cert(root_params_fabric, keypair, signed_cert, sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(signed_cert, signed_len, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 }
@@ -800,10 +785,10 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signed_cert[kTestDERCertBufSize];
+    uint8_t signed_cert[kMaxDERCertLength];
     uint32_t signed_len = 0;
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     ChipCertificateData certData;
@@ -817,7 +802,8 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
                        CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(signed_cert, signed_len, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
@@ -841,10 +827,10 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signed_cert[kTestDERCertBufSize];
+    uint8_t signed_cert[kMaxDERCertLength];
     uint32_t signed_len = 0;
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     ChipCertificateData certData;
@@ -858,7 +844,8 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
                                               sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(signed_cert, signed_len, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
@@ -890,10 +877,10 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    uint8_t signed_cert[kTestDERCertBufSize];
+    uint8_t signed_cert[kMaxDERCertLength];
     uint32_t signed_len = 0;
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize];
+    uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     ChipCertificateData certData;
@@ -907,7 +894,8 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
                                               sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(signed_cert, signed_len, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 }
@@ -918,13 +906,13 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t ica_cert[kTestDERCertBufSize];
+    static uint8_t ica_cert[kMaxDERCertLength];
     uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
@@ -935,7 +923,7 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
                    NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
                        CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -947,15 +935,16 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestDERCertBufSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
 
-    static uint8_t rootCertBuf[kTestCHIPCertBufSize];
-    static uint8_t icaCertBuf[kTestCHIPCertBufSize];
-    static uint8_t nocCertBuf[kTestCHIPCertBufSize];
+    static uint8_t rootCertBuf[kMaxCHIPCertLength];
+    static uint8_t icaCertBuf[kMaxCHIPCertLength];
+    static uint8_t nocCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(
         inSuite,
         certSet.LoadCert(rootCertBuf, outCertLen,
@@ -963,13 +952,15 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
             CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ica_cert, ica_len, icaCertBuf, sizeof(icaCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(ica_cert, ica_len), icaCertBuf, sizeof(icaCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCert(icaCertBuf, outCertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) ==
                        CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(noc_cert, noc_len, nocCertBuf, sizeof(nocCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(noc_cert, noc_len), nocCertBuf, sizeof(nocCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCert(nocCertBuf, outCertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) ==
                        CHIP_NO_ERROR);
@@ -996,13 +987,13 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t ica_cert[kTestDERCertBufSize];
+    static uint8_t ica_cert[kMaxDERCertLength];
     uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
@@ -1013,7 +1004,7 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
                    NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
                        CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -1024,7 +1015,7 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize * 2];
+    uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     NL_TEST_ASSERT(inSuite,
                    ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCert) ==
@@ -1032,17 +1023,18 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestDERCertBufSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCerts(outCert.data(), static_cast<uint32_t>(outCert.size()),
                                      BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) == CHIP_NO_ERROR);
 
-    static uint8_t rootCertBuf[kTestCHIPCertBufSize];
+    static uint8_t rootCertBuf[kMaxCHIPCertLength];
 
     uint32_t outCertLen;
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(
         inSuite,
         certSet.LoadCert(rootCertBuf, outCertLen,
@@ -1071,13 +1063,13 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -1088,7 +1080,7 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize * 2];
+    uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     NL_TEST_ASSERT(inSuite,
@@ -1096,16 +1088,17 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestDERCertBufSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCerts(outCert.data(), static_cast<uint32_t>(outCert.size()),
                                      BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) == CHIP_NO_ERROR);
 
-    static uint8_t rootCertBuf[kTestCHIPCertBufSize];
+    static uint8_t rootCertBuf[kMaxCHIPCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(
         inSuite,
         certSet.LoadCert(rootCertBuf, outCertLen,
@@ -1134,13 +1127,13 @@ static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, vo
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t ica_cert[kTestDERCertBufSize];
+    static uint8_t ica_cert[kMaxDERCertLength];
     uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
@@ -1151,7 +1144,7 @@ static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, vo
                    NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
                        CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -1162,7 +1155,7 @@ static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, vo
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize * 2];
+    uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     // Test that NOC is mandatory
     NL_TEST_ASSERT(inSuite,
@@ -1191,13 +1184,13 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t ica_cert[kTestDERCertBufSize];
+    static uint8_t ica_cert[kMaxDERCertLength];
     uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
@@ -1208,7 +1201,7 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
                    NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
                        CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -1219,7 +1212,7 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize * 2];
+    uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     NL_TEST_ASSERT(inSuite,
@@ -1231,7 +1224,7 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, ExtractCertsFromCertArray(outCert, noc_chip_cert, ica_chip_cert) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestCHIPCertBufSize * 3) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCert(noc_chip_cert.data(), static_cast<uint32_t>(noc_chip_cert.size()),
@@ -1241,10 +1234,11 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
                    certSet.LoadCert(ica_chip_cert.data(), static_cast<uint32_t>(ica_chip_cert.size()),
                                     BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) == CHIP_NO_ERROR);
 
-    static uint8_t rootCertBuf[kTestCHIPCertBufSize];
+    static uint8_t rootCertBuf[kMaxDERCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(
         inSuite,
         certSet.LoadCert(rootCertBuf, outCertLen,
@@ -1272,13 +1266,13 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
     P256Keypair keypair;
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    static uint8_t root_cert[kTestDERCertBufSize];
+    static uint8_t root_cert[kMaxDERCertLength];
     uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
 
-    static uint8_t noc_cert[kTestDERCertBufSize];
+    static uint8_t noc_cert[kMaxDERCertLength];
     uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
@@ -1289,7 +1283,7 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
                    NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert,
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
-    uint8_t outCertBuf[kTestCHIPCertBufSize * 2];
+    uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     NL_TEST_ASSERT(inSuite,
@@ -1302,16 +1296,17 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, ica_chip_cert.data() == nullptr && ica_chip_cert.size() == 0);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kTestCHIPCertBufSize * 3) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCert(noc_chip_cert.data(), static_cast<uint32_t>(noc_chip_cert.size()),
                                     BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)) == CHIP_NO_ERROR);
 
-    static uint8_t rootCertBuf[kTestCHIPCertBufSize];
+    static uint8_t rootCertBuf[kMaxDERCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(root_cert, root_len, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
+                       CHIP_NO_ERROR);
     NL_TEST_ASSERT(
         inSuite,
         certSet.LoadCert(rootCertBuf, outCertLen,

--- a/src/credentials/tests/TestChipOperationalCredentials.cpp
+++ b/src/credentials/tests/TestChipOperationalCredentials.cpp
@@ -209,8 +209,8 @@ static void TestChipOperationalCredentials_Serialization(nlTestSuite * inSuite, 
     NL_TEST_ASSERT(inSuite, opCredSet.Init(&certSet, 1) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, opCredSet2.Init(1) == CHIP_NO_ERROR);
 
-    const CertificateKeyId * trustedRootId = opCredSet.GetTrustedRootId(static_cast<uint16_t>(opCredSet.GetCertCount() - 1));
-    NL_TEST_ASSERT(inSuite, trustedRootId != nullptr);
+    CertificateKeyId trustedRootId = opCredSet.GetTrustedRootId(static_cast<uint16_t>(opCredSet.GetCertCount() - 1));
+    NL_TEST_ASSERT(inSuite, !trustedRootId.empty());
 
     NL_TEST_ASSERT(inSuite,
                    serializedKeypair.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len) ==
@@ -222,19 +222,19 @@ static void TestChipOperationalCredentials_Serialization(nlTestSuite * inSuite, 
 
     NL_TEST_ASSERT(inSuite, keypair.Deserialize(serializedKeypair) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, opCredSet.SetDevOpCredKeypair(*trustedRootId, &keypair) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opCredSet.SetDevOpCredKeypair(trustedRootId, &keypair) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   opCredSet.SetDevOpCred(*trustedRootId, sTestCert_Node01_01_Chip,
+                   opCredSet.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
                                           static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, opCredSet.ToSerializable(*trustedRootId, sSerialized) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opCredSet.ToSerializable(trustedRootId, sSerialized) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, opCredSet2.FromSerializable(sSerialized) == CHIP_NO_ERROR);
 
-    const CertificateKeyId * trustedRootId2 = opCredSet2.GetTrustedRootId(static_cast<uint16_t>(opCredSet2.GetCertCount() - 1));
-    NL_TEST_ASSERT(inSuite, trustedRootId2->IsEqual(*trustedRootId));
+    CertificateKeyId trustedRootId2 = opCredSet2.GetTrustedRootId(static_cast<uint16_t>(opCredSet2.GetCertCount() - 1));
+    NL_TEST_ASSERT(inSuite, trustedRootId2.data_equal(trustedRootId));
 
-    NL_TEST_ASSERT(inSuite, opCredSet2.ToSerializable(*trustedRootId2, sSerialized2) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, opCredSet2.ToSerializable(trustedRootId2, sSerialized2) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    strncmp(reinterpret_cast<const char *>(&sSerialized), reinterpret_cast<const char *>(&sSerialized2),

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1463,8 +1463,7 @@ static void TestPubkey_x509Extraction(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     P256PublicKey publicKey;
 
-    const uint8_t * cert;
-    uint32_t certLen;
+    ByteSpan cert;
     const uint8_t * certPubkey;
     uint32_t certPubkeyLen;
 
@@ -1472,12 +1471,12 @@ static void TestPubkey_x509Extraction(nlTestSuite * inSuite, void * inContext)
     {
         uint8_t certType = TestCerts::gTestCerts[i];
 
-        err = GetTestCert(certType, TestCertLoadFlags::kDERForm, cert, certLen);
+        err = GetTestCert(certType, TestCertLoadFlags::kDERForm, cert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         err = GetTestCertPubkey(certType, certPubkey, certPubkeyLen);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        err = ExtractPubkeyFromX509Cert(ByteSpan(cert, certLen), publicKey);
+        err = ExtractPubkeyFromX509Cert(cert, publicKey);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(publicKey, certPubkey, certPubkeyLen) == 0);
     }

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -43,8 +43,8 @@ public:
     {}
 
     constexpr pointer data() const { return mDataBuf; }
-    size_t size() const { return mDataLen; }
-    bool empty() const { return size() == 0; }
+    constexpr size_t size() const { return mDataLen; }
+    constexpr bool empty() const { return size() == 0; }
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>
@@ -89,8 +89,8 @@ public:
     constexpr explicit FixedSpan(pointer databuf) : mDataBuf(databuf) {}
 
     constexpr pointer data() const { return mDataBuf; }
-    size_t size() const { return N; }
-    bool empty() const { return data() == nullptr; }
+    constexpr size_t size() const { return N; }
+    constexpr bool empty() const { return data() == nullptr; }
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -72,7 +72,7 @@ static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = 10000;
 
 CASESession::CASESession()
 {
-    mTrustedRootId.mId = nullptr;
+    mTrustedRootId = CertificateKeyId();
     // dummy initialization REMOVE LATER
     for (size_t i = 0; i < mFabricSecret.Capacity(); i++)
     {
@@ -95,10 +95,10 @@ void CASESession::Clear()
     mCommissioningHash.Clear();
     mPairingComplete = false;
     mConnectionState.Reset();
-    if (mTrustedRootId.mId != nullptr)
+    if (!mTrustedRootId.empty())
     {
-        chip::Platform::MemoryFree(const_cast<uint8_t *>(mTrustedRootId.mId));
-        mTrustedRootId.mId = nullptr;
+        chip::Platform::MemoryFree(const_cast<uint8_t *>(mTrustedRootId.data()));
+        mTrustedRootId = CertificateKeyId();
     }
 
     CloseExchange();
@@ -332,9 +332,10 @@ CHIP_ERROR CASESession::SendSigmaR1()
         bbuf.Put16(n_trusted_roots);
         for (uint16_t i = 0; i < n_trusted_roots; ++i)
         {
-            if (mOpCredSet->GetTrustedRootId(i) != nullptr && mOpCredSet->GetTrustedRootId(i)->mId != nullptr)
+            CertificateKeyId trustedRootId = mOpCredSet->GetTrustedRootId(i);
+            if (!trustedRootId.empty())
             {
-                bbuf.Put(mOpCredSet->GetTrustedRootId(i)->mId, kTrustedRootIdSize);
+                bbuf.Put(trustedRootId.data(), trustedRootId.size());
             }
         }
         bbuf.Put(mEphemeralKey.Pubkey(), mEphemeralKey.Pubkey().Length());
@@ -530,7 +531,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         // Responder's session ID
         bbuf.Put16(mConnectionState.GetLocalKeyID());
         // Step 2
-        bbuf.Put(mTrustedRootId.mId, mTrustedRootId.mLen);
+        bbuf.Put(mTrustedRootId.data(), mTrustedRootId.size());
         bbuf.Put(mEphemeralKey.Pubkey(), mEphemeralKey.Pubkey().Length());
         bbuf.Put(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len);
         bbuf.Put(tag, sizeof(tag));
@@ -948,27 +949,25 @@ CHIP_ERROR CASESession::FindValidTrustedRoot(const uint8_t ** msgIterator, uint3
 
     for (uint32_t i = 0; i < nTrustedRoots; ++i)
     {
-        trustedRoot[i].mId  = *msgIterator;
-        trustedRoot[i].mLen = kTrustedRootIdSize;
+        trustedRoot[i] = CertificateKeyId(*msgIterator);
         *msgIterator += kTrustedRootIdSize;
 
         if (mOpCredSet->IsTrustedRootIn(trustedRoot[i]))
         {
-            if (mTrustedRootId.mId != nullptr)
+            if (!mTrustedRootId.empty())
             {
-                chip::Platform::MemoryFree(const_cast<uint8_t *>(mTrustedRootId.mId));
-                mTrustedRootId.mId = nullptr;
+                chip::Platform::MemoryFree(const_cast<uint8_t *>(mTrustedRootId.data()));
+                mTrustedRootId = CertificateKeyId();
             }
-            mTrustedRootId.mId = reinterpret_cast<const uint8_t *>(chip::Platform::MemoryAlloc(kTrustedRootIdSize));
-            VerifyOrReturnError(mTrustedRootId.mId != nullptr, CHIP_ERROR_NO_MEMORY);
+            mTrustedRootId = CertificateKeyId(reinterpret_cast<const uint8_t *>(chip::Platform::MemoryAlloc(kTrustedRootIdSize)));
+            VerifyOrReturnError(!mTrustedRootId.empty(), CHIP_ERROR_NO_MEMORY);
 
-            memcpy(const_cast<uint8_t *>(mTrustedRootId.mId), trustedRoot[i].mId, trustedRoot[i].mLen);
-            mTrustedRootId.mLen = trustedRoot[i].mLen;
+            memcpy(const_cast<uint8_t *>(mTrustedRootId.data()), trustedRoot[i].data(), trustedRoot[i].size());
 
             break;
         }
     }
-    VerifyOrReturnError(mTrustedRootId.mId != nullptr, CHIP_ERROR_CERT_NOT_TRUSTED);
+    VerifyOrReturnError(!mTrustedRootId.empty(), CHIP_ERROR_CERT_NOT_TRUSTED);
 
     return CHIP_NO_ERROR;
 }
@@ -1015,7 +1014,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t ** msgIte
 
     ChipCertificateSet certSet;
     // Certificate set can contain up to 3 certs (NOC, ICA cert, and Root CA cert)
-    ReturnErrorOnFailure(certSet.Init(3, kMaxCHIPCertLength * 3));
+    ReturnErrorOnFailure(certSet.Init(3, kMaxDERCertLength));
 
     responderOpCertLen = chip::Encoding::LittleEndian::Read16(*msgIterator);
     *responderOpCert   = *msgIterator;
@@ -1025,7 +1024,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t ** msgIte
     ReturnErrorOnFailure(
         certSet.LoadCerts(*responderOpCert, responderOpCertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
 
-    bbuf.Put(certSet.GetCertSet()[0].mPublicKey, certSet.GetCertSet()[0].mPublicKeyLen);
+    bbuf.Put(certSet.GetCertSet()[0].mPublicKey.data(), certSet.GetCertSet()[0].mPublicKey.size());
 
     VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -49,7 +49,7 @@ namespace chip {
 constexpr uint16_t kAEADKeySize = 16;
 
 constexpr uint16_t kSigmaParamRandomNumberSize = 32;
-constexpr uint16_t kTrustedRootIdSize          = 20;
+constexpr uint16_t kTrustedRootIdSize          = Credentials::kKeyIdentifierLength;
 constexpr uint16_t kMaxTrustedRootIds          = 5;
 
 constexpr uint16_t kIPKSize = 16;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -108,7 +108,7 @@ public:
 
 static CHIP_ERROR InitCredentialSets()
 {
-    CertificateKeyId trustedRootId = { .mId = sTestCert_Root01_SubjectKeyId, .mLen = sTestCert_Root01_SubjectKeyId_Len };
+    CertificateKeyId trustedRootId = CertificateKeyId(sTestCert_Root01_SubjectKeyId);
 
     commissionerDevOpCred.Release();
     accessoryDevOpCred.Release();

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -295,8 +295,8 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'c':
-        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, reinterpret_cast<const uint8_t *>(arg),
-                                      static_cast<uint32_t>(strlen(arg)));
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName,
+                                      chip::ByteSpan(reinterpret_cast<const uint8_t *>(arg), strlen(arg)));
         if (err != CHIP_NO_ERROR)
         {
             fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -92,9 +92,7 @@ OptionSet * gCmdOptionSets[] =
 
 enum
 {
-    kMaxCerts        = 16,
-    kTestCertBufSize = 1024, // Size of buffer needed to hold any of the test certificates
-                             // (in either CHIP or DER form), or to decode the certificates.
+    kMaxCerts = 16,
 };
 
 const char * gTargetCertFileName = nullptr;
@@ -148,7 +146,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     const ChipCertificateData * certToBeValidated;
     ChipCertificateData * validatedCert;
     ValidationContext context;
-    uint8_t certsBuf[kMaxCerts * kMaxChipCertBufSize];
+    uint8_t certsBuf[kMaxCerts * kMaxCHIPCertLength];
 
     context.Reset();
 
@@ -161,7 +159,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
     VerifyTrueOrExit(res);
 
-    err = certSet.Init(kMaxCerts, kTestCertBufSize);
+    err = certSet.Init(kMaxCerts, kMaxDERCertLength);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));
@@ -170,13 +168,12 @@ bool Cmd_ValidateCert(int argc, char * argv[])
 
     for (size_t i = 0; i < gNumCertFileNames; i++)
     {
-        res = LoadChipCert(gCACertFileNames[i], gCACertIsTrusted[i], certSet, &certsBuf[i * kMaxChipCertBufSize],
-                           kMaxChipCertBufSize);
+        res =
+            LoadChipCert(gCACertFileNames[i], gCACertIsTrusted[i], certSet, &certsBuf[i * kMaxCHIPCertLength], kMaxCHIPCertLength);
         VerifyTrueOrExit(res);
     }
 
-    res =
-        LoadChipCert(gTargetCertFileName, false, certSet, &certsBuf[gNumCertFileNames * kMaxChipCertBufSize], kMaxChipCertBufSize);
+    res = LoadChipCert(gTargetCertFileName, false, certSet, &certsBuf[gNumCertFileNames * kMaxCHIPCertLength], kMaxCHIPCertLength);
     VerifyTrueOrExit(res);
 
     certToBeValidated = certSet.GetLastCert();

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -61,6 +61,7 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
+#include <support/SafeInt.h>
 #include <support/TimeUtils.h>
 
 using chip::ASN1::OID;
@@ -86,12 +87,6 @@ enum KeyFormat
     kKeyFormat_X509_PUBKEY_PEM,
     kKeyFormat_Chip_Raw,
     kKeyFormat_Chip_Base64
-};
-
-enum
-{
-    kMaxChipCertBufSize = 400, // Maximum size of a buffer needed to hold CHIP TLV encoded certificates.
-    kMaxX509CertBufSize = 600, // Maximum size of a buffer needed to hold/encode X.509 certificates in DER form.
 };
 
 struct FutureExtension

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -362,9 +362,7 @@ CHIP_ERROR AdminPairingInfo::GetCredentials(OperationalCredentialSet & credentia
     credentials.Release();
     ReturnErrorOnFailure(credentials.Init(&certificates, 1));
 
-    const CertificateKeyId * id = credentials.GetTrustedRootId(0);
-    rootKeyId.mId               = id->mId;
-    rootKeyId.mLen              = id->mLen;
+    rootKeyId = credentials.GetTrustedRootId(0);
 
     ReturnErrorOnFailure(credentials.SetDevOpCred(rootKeyId, mNOCCert, mNOCCertLen));
     ReturnErrorOnFailure(credentials.SetDevOpCredKeypair(rootKeyId, mOperationalKey));


### PR DESCRIPTION
#### Problem
Currently CHIP Cert implementation is using data pointer/len pairs to represent some data structures. It should be more convenient and cleaner to use ByteSpan and FixedByteSpan types for that.

#### Change overview
Updated CHIP Certs Implementation to Use Spans Instead of Pointer/Len Pairs

Specifically, added the following FixedSpan types:
  - CertificateKeyId
  - P256ECDSASignatureSpan
  - P256PublicKeySpan
Also redefined mString member in the ChipRDN structure to be ByteSpan.

#### Testing
CHIP Cert Unit Testing

Ticket: #7458 
