### PR TITLE
Controller error no device layer inet system shutdown

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -301,8 +301,8 @@ CHIP_ERROR DeviceController::Shutdown()
     //
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
 #else
-    mInetLayer->Shutdown();
-    mSystemLayer->Shutdown();
+    VerifyOrReturnError(mInetLayer->Shutdown() == INET_NO_ERROR, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(mSystemLayer->Shutdown() == CHIP_SYSTEM_NO_ERROR, CHIP_ERROR_INTERNAL);
     chip::Platform::Delete(mInetLayer);
     chip::Platform::Delete(mSystemLayer);
 #endif // CONFIG_DEVICE_LAYER


### PR DESCRIPTION
#### Problem

Errors into inet/system does not propagate into `CHIPDeviceController::Shutdown` if no device layer is used.

#### Change overview
 * Propage the error

#### Testing
 * No testing was added since this change affects mostly Android and I expect the tests into `src/app/tests/suites/` to generate some tests for it at some point.
