### PR TITLE
Fix more usage of C++ comments in XML comments

### DIFF
--- a/src/app/zap-templates/zcl/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/audio-output-cluster.xml
@@ -44,7 +44,7 @@ limitations under the License.
   <struct name="AudioOutputInfo">
     <item name="index" type="INT8U"/>
     <item name="outputType" type="AudioOutputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
+    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 
   <enum name="AudioOutputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/custom-types.xml
+++ b/src/app/zap-templates/zcl/custom-types.xml
@@ -32,8 +32,8 @@ limitations under the License.
     <item name="WiFi" value="0x01"/>
     <item name="Ethernet" value="0x02"/>
     <item name="Cellular" value="0x03"/>
-    <item name="Thread" value="0x04"/>    
-  </enum> 
+    <item name="Thread" value="0x04"/>
+  </enum>
   <struct name="GroupState">
     <item name="VendorId" type="INT16U"/>
     <item name="VendorGroupId" type="INT16U"/>
@@ -44,33 +44,33 @@ limitations under the License.
     <item name="GroupKeyIndex" type="INT16U"/>
     <item name="GroupKeyRoot" type="OCTET_STRING" length="16"/>
     <item name="GroupKeyEpochStartTime" type="INT64U"/>
-    <item name="GroupKeySecurityPolicy" type="GroupKeySecurityPolicy"/>    
+    <item name="GroupKeySecurityPolicy" type="GroupKeySecurityPolicy"/>
   </struct>
   <struct name="DeviceType">
     <item name="type" type="DEVICE_TYPE_ID"/>
     <item name="revision" type="INT16U"/>
   </struct>
   <struct name="LabelStruct">
-    <item name="label" type="OCTET_STRING" length="16"/> // TODO: Change this to CHAR_STRING once it is supported #6112
-    <item name="value" type="OCTET_STRING" length="16"/> // TODO: Change this to CHAR_STRING once it is supported #6112
+    <item name="label" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="value" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
   <struct name="FabricDescriptor">
      <item name="FabricId" type="FABRIC_ID"/>
-     <item name="VendorId" type="INT16U"/> // Change INT16U to new type VendorID #2395
+     <item name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
      <item name="NodeId" type="NODE_ID"/>
-     <item name="Label" type="OCTET_STRING" length="32"/>// TODO: Add Label once CHAR_STRING or OCTET_STRING works
+     <item name="Label" type="OCTET_STRING" length="32"/><!-- TODO: Add Label once CHAR_STRING or OCTET_STRING works -->
    </struct>
    <struct name="TestListStructOctet">
      <item name="fabricIndex" type="INT64U"/>
      <item name="operationalCert" type="OCTET_STRING" length="32"/>
    </struct>
   <struct name="NetworkInterfaceType">
-    // TODO: CHAR_STRING not supported yet in structs.
+    <!-- TODO: CHAR_STRING not supported yet in structs. -->
     <item name="Name" type="OCTET_STRING" length="32"/>
     <item name="FabricConnected" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv4" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN"/>
     <item name="HardwareAddress" type="IEEE_ADDRESS"/>
-    <item name="Type" type="ENUM8"/>            
-  </struct>   
+    <item name="Type" type="ENUM8"/>
+  </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/media-input-cluster.xml
@@ -52,8 +52,8 @@ limitations under the License.
   <struct name="MediaInputInfo">
     <item name="index" type="INT8U"/>
     <item name="inputType" type="MediaInputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
-    <item name="description" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
+    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="description" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 
   <enum name="MediaInputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/software-diagnostics-cluster.xml
@@ -18,11 +18,11 @@ limitations under the License.
   <domain name="CHIP"/>
   <struct name="ThreadMetrics">
     <item name="Id" type="INT64U"/>
-    // TODO: CHAR_STRING not supported yet in structs.
+    <!-- TODO: CHAR_STRING not supported yet in structs. -->
     <item name="Name" type="OCTET_STRING" length="8"/>
     <item name="StackFreeCurrent" type="INT32U"/>
     <item name="StackFreeMinimum" type="INT32U"/>
-    <item name="StackSize" type="INT32U"/>                
+    <item name="StackSize" type="INT32U"/>
   </struct>
   <cluster>
     <domain>General</domain>
@@ -33,9 +33,9 @@ limitations under the License.
     <attribute side="server" code="0x00" define="THREAD_METRICS" type="ARRAY" entryType="ThreadMetrics" length="254" writable="false" optional="true">ThreadMetrics</attribute>
     <attribute side="server" code="0x01" define="CURRENT_HEAP_FREE" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapFree</attribute>
     <attribute side="server" code="0x02" define="CURRENT_HEAP_USED" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapUsed</attribute>
-    <attribute side="server" code="0x03" define="CURRENT_HEAP_HIGH_WATERMARK" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">CurrentHeapHighWatermark</attribute>                  
+    <attribute side="server" code="0x03" define="CURRENT_HEAP_HIGH_WATERMARK" type="INT64U" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="false">CurrentHeapHighWatermark</attribute>
     <command source="client" code="0x00" name="ResetWatermarks" optional="false" cli="chip software_diagnostics resetwatermarks">
       <description>Reception of this command SHALL reset the values: The StackFreeMinimum field of the ThreadMetrics attribute, CurrentHeapHighWaterMark attribute</description>
-    </command>           
+    </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/target-navigator-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
       <arg name="data" type="CHAR_STRING"/>
     </command>
   </cluster>
-  
+
   <enum name="NavigateTargetStatus" type="ENUM8">
       <item name="Success" value="0x00"/>
       <item name="AppNotAvailable" value="0x01"/>
@@ -49,6 +49,6 @@ limitations under the License.
 
   <struct name="NavigateTargetTargetInfo">
       <item name="identifier" type="INT8U"/>
-      <item name="name" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
+      <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/tv-channel-cluster.xml
+++ b/src/app/zap-templates/zcl/tv-channel-cluster.xml
@@ -58,9 +58,9 @@ limitations under the License.
   <struct name="TvChannelInfo">
     <item name="majorNumber" type="INT16U"/>
     <item name="minorNumber" type="INT16U"/>
-    <item name="name" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
-    <item name="callSign" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
-    <item name="affiliateCallSign" type="OCTET_STRING" length="32"/> // Change this to CHAR_STRING once it is supported #6112
+    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="callSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="affiliateCallSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 
   <struct name="TvChannelLineupInfo">


### PR DESCRIPTION
#### Problem
- Some cluster XML use C++ style comments

#### Change overview
- Change those to XML comments

#### Testing
- IDE checks of XML syntax validity