### PR TITLE
Add checkout step for the fixit rotation action

### DIFF
--- a/.github/workflows/fixit_rotation.yaml
+++ b/.github/workflows/fixit_rotation.yaml
@@ -25,6 +25,8 @@ jobs:
             image: connectedhomeip/chip-build:latest
 
         steps:
+            - name: Checkout
+              uses: actions/checkout@v2
             - name: Pick fixit rotation order
               run: scripts/fixit_rotation.py
 


### PR DESCRIPTION
#### Problem
Action failed with 'script not found' https://github.com/project-chip/connectedhomeip/runs/2820598055?check_suite_focus=true

which seems to be because we never checkout the script

#### Change overview
Added a checkout step to the fixit rotation script.

#### Testing
Not tested - github action.
