### PR TITLE
Fix Werror=format build error on EFR32, K32W, QPG6100

### DIFF
--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -627,6 +627,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
     }
 }

--- a/examples/lighting-app/qpg6100/src/AppTask.cpp
+++ b/examples/lighting-app/qpg6100/src/AppTask.cpp
@@ -438,7 +438,7 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
     }
 
     ChipLogProgress(NotSpecified, "UpdateClusterState");
@@ -449,6 +449,6 @@ void AppTask::UpdateClusterState(void)
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating level %x", status);
+        ChipLogError(NotSpecified, "ERR: updating level %" PRIx32, status);
     }
 }

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -635,6 +635,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
     }
 }

--- a/examples/lock-app/qpg6100/src/AppTask.cpp
+++ b/examples/lock-app/qpg6100/src/AppTask.cpp
@@ -490,6 +490,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
     }
 }

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -145,7 +145,7 @@ EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddThreadNetwork: %d", err);
+    ChipLogDetail(Zcl, "AddThreadNetwork: %" PRIu32, err);
     return err;
 #else
     // The target does not supports ThreadNetwork. We should not add AddThreadNetwork command in that case then the upper layer will
@@ -203,7 +203,7 @@ EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Co
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddWiFiNetwork: %d", err);
+    ChipLogDetail(Zcl, "AddWiFiNetwork: %" PRIu32, err);
     return err;
 #else
     // The target does not supports WiFiNetwork.


### PR DESCRIPTION
#### Problem
Building EFR32, K32W and QPG6100 fails with -Werror=format= error on master
Not sure how the change that caused those error passed the CI the first time but it now catches them.

Here is the errors on EFR32
```
../../../examples/lock-app/efr32/third_party/connectedhomeip/src/app/clusters/network-commissioning/network-commissioning.cpp:148:24: error: format '%d' expects argument of type 'int', but argument 4 has type 'long unsigned int' [-Werror=format=]
  148 |     ChipLogDetail(Zcl, "AddThreadNetwork: %d", err);
      |                        ^~~~~~~~~~~~~~~~~~~~~~  ~~~
      |                                                |
      |                                                long unsigned int

../../../examples/lock-app/efr32/third_party/connectedhomeip/src/app/clusters/network-commissioning/network-commissioning.cpp:206:24: error: format '%d' expects argument of type 'int', but argument 4 has type 'long unsigned int' [-Werror=format=]
  206 |     ChipLogDetail(Zcl, "AddWiFiNetwork: %d", err);
      |                        ^~~~~~~~~~~~~~~~~~~~  ~~~
      |                                              |
      |                                              long unsigned int
```

#### Change overview
Replace the print format %d to % PRIu32 and %x to PRIx32 in the errors caught as it is portable to all platforms.

#### Testing
Running ./gn_build.sh currently fails for me on MAC with some errors in tv-app. 
So I did manual builds for 
EFR32
` ./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app BRD4164A` and ran on EFR32MG12 device the newly build firmware
Build K32W with
`./scripts/examples/k32w_example.sh`
Build QPG6100
`scripts/examples/gn_build_example.sh examples/lock-app/qpg6100 out/qpg6100_lock_app`
