### PR TITLE
K32W: Fix header paths breaking --check builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -226,8 +226,14 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     # Build the efr32 window app example.
     enable_efr32_window_app_build = enable_efr32_builds
 
+    # Build the k32w lighting app example.
+    enable_k32w_lighting_app_build = enable_k32w_builds
+
     # Build the k32w lock app example.
     enable_k32w_lock_app_build = enable_k32w_builds
+
+    # Build the k32w shell app example.
+    enable_k32w_shell_app_build = enable_k32w_builds
   }
 
   if (enable_host_clang_build) {
@@ -348,9 +354,21 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
   }
 
+  if (enable_k32w_lighting_app_build) {
+    group("k32w_lighting_app") {
+      deps = [ "${chip_root}/examples/lighting-app/k32w(${chip_root}/config/k32w/toolchain:k32w_lighting_app)" ]
+    }
+  }
+
   if (enable_k32w_lock_app_build) {
     group("k32w_lock_app") {
       deps = [ "${chip_root}/examples/lock-app/k32w(${chip_root}/config/k32w/toolchain:k32w_lock_app)" ]
+    }
+  }
+
+  if (enable_k32w_shell_app_build) {
+    group("k32w_shell_app") {
+      deps = [ "${chip_root}/examples/shell/k32w(${chip_root}/config/k32w/toolchain:k32w_shell_app)" ]
     }
   }
 
@@ -403,8 +421,14 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     if (enable_efr32_window_app_build) {
       deps += [ ":efr32_window_app" ]
     }
+    if (enable_k32w_lighting_app_build) {
+      deps += [ ":k32w_lighting_app" ]
+    }
     if (enable_k32w_lock_app_build) {
       deps += [ ":k32w_lock_app" ]
+    }
+    if (enable_k32w_shell_app_build) {
+      deps += [ ":k32w_shell_app" ]
     }
     if (enable_qpg6100_lock_app_build) {
       deps += [ ":qpg6100_lock_app" ]

--- a/config/k32w/toolchain/BUILD.gn
+++ b/config/k32w/toolchain/BUILD.gn
@@ -17,9 +17,23 @@ import("//build_overrides/chip.gni")
 
 import("${build_root}/toolchain/arm_gcc/arm_toolchain.gni")
 
+arm_toolchain("k32w_lighting_app") {
+  toolchain_args = {
+    current_os = "freertos"
+    import("${chip_root}/examples/lighting-app/k32w/args.gni")
+  }
+}
+
 arm_toolchain("k32w_lock_app") {
   toolchain_args = {
     current_os = "freertos"
     import("${chip_root}/examples/lock-app/k32w/args.gni")
+  }
+}
+
+arm_toolchain("k32w_shell_app") {
+  toolchain_args = {
+    current_os = "freertos"
+    import("${chip_root}/examples/shell/k32w/args.gni")
   }
 }

--- a/examples/lighting-app/k32w/BUILD.gn
+++ b/examples/lighting-app/k32w/BUILD.gn
@@ -25,7 +25,7 @@ k32w_platform_dir = "${chip_root}/examples/platform/k32w"
 
 k32w_sdk("sdk") {
   sources = [
-    "${k32w_platform_dir}/OpenThreadConfig.h",
+    "${k32w_platform_dir}/app/project_include/OpenThreadConfig.h",
     "include/CHIPProjectConfig.h",
     "include/FreeRTOSConfig.h",
     "main/include/app_config.h",

--- a/examples/lock-app/k32w/BUILD.gn
+++ b/examples/lock-app/k32w/BUILD.gn
@@ -26,7 +26,7 @@ k32w_platform_dir = "${chip_root}/examples/platform/k32w"
 
 k32w_sdk("sdk") {
   sources = [
-    "${k32w_platform_dir}/OpenThreadConfig.h",
+    "${k32w_platform_dir}/app/project_include/OpenThreadConfig.h",
     "include/CHIPProjectConfig.h",
     "include/FreeRTOSConfig.h",
     "main/include/app_config.h",

--- a/examples/shell/efr32/args.gni
+++ b/examples/shell/efr32/args.gni
@@ -21,4 +21,3 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
-chip_build_shell_lib = true

--- a/examples/shell/k32w/BUILD.gn
+++ b/examples/shell/k32w/BUILD.gn
@@ -26,7 +26,7 @@ k32w_platform_dir = "${chip_root}/examples/platform/k32w"
 
 k32w_sdk("sdk") {
   sources = [
-    "${k32w_platform_dir}/OpenThreadConfig.h",
+    "${k32w_platform_dir}/app/project_include/OpenThreadConfig.h",
     "include/CHIPProjectConfig.h",
     "include/FreeRTOSConfig.h",
     "main/include/app_config.h",

--- a/examples/shell/k32w/args.gni
+++ b/examples/shell/k32w/args.gni
@@ -18,7 +18,3 @@ import("${chip_root}/examples/platform/k32w/args.gni")
 import("${chip_root}/src/platform/K32W/args.gni")
 
 k32w_sdk_target = get_label_info(":sdk", "label_no_toolchain")
-
-pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
-pw_assert_BACKEND = "$dir_pw_assert_log"
-chip_build_shell_lib = true

--- a/scripts/examples/k32w_example.sh
+++ b/scripts/examples/k32w_example.sh
@@ -27,5 +27,5 @@ env
 
 "$(dirname "$0")"/../../third_party/k32w_sdk/sdk_fixes/patch_k32w_sdk.sh
 
-gn gen --root="$1" "$2" --args="k32w_sdk_root=\"$K32W061_SDK_ROOT\" is_debug=false"
+gn gen --check --fail-on-unused-args --root="$1" "$2" --args="k32w_sdk_root=\"$K32W061_SDK_ROOT\" is_debug=false"
 ninja -C "$2"


### PR DESCRIPTION
#### Problem

Some header paths are specified incorrectly. This is only an error
when generating the build with the --check option:

```
ERROR at //third_party/k32w_sdk/k32w_sdk.gni:218:3: Source file not found.
  source_set(sdk_target_name) {
  ^----------------------------
The target:
  //examples/lock-app/k32w:sdk
has a source file:
  //examples/platform/k32w/OpenThreadConfig.h
which was not found.
```
#### Change overview

Fix the paths and enable --check.

#### Testing
Tested by:

`(cd ./examples/lock-app/k32w; gn gen --check out/debug --args='k32w_sdk_root="/home/spang/sdk/k32w_sdk"'; ninja -C out/debug)`