### PR TITLE
Don't shut down already-shutdown IM objects.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -68,22 +68,34 @@ void InteractionModelEngine::Shutdown()
 {
     for (auto & commandSender : mCommandSenderObjs)
     {
-        commandSender.Shutdown();
+        if (!commandSender.IsFree())
+        {
+            commandSender.Shutdown();
+        }
     }
 
     for (auto & commandHandler : mCommandHandlerObjs)
     {
-        commandHandler.Shutdown();
+        if (!commandHandler.IsFree())
+        {
+            commandHandler.Shutdown();
+        }
     }
 
     for (auto & readClient : mReadClients)
     {
-        readClient.Shutdown();
+        if (!readClient.IsFree())
+        {
+            readClient.Shutdown();
+        }
     }
 
     for (auto & readHandler : mReadHandlers)
     {
-        readHandler.Shutdown();
+        if (!readHandler.IsFree())
+        {
+            readHandler.Shutdown();
+        }
     }
 
     for (uint32_t index = 0; index < IM_SERVER_MAX_NUM_PATH_GROUPS; index++)


### PR DESCRIPTION
Shutting down things that are not in use already leads to pretty
confusing logging/debugging behavior.

#### Problem
I was logging allocation/shutdown of IM objects and was seeing a lot more shutdowns than allocations, because the IM shutdown code shuts down already-shutdown things.

#### Change overview
Only shut down things that are active.

#### Testing
Tested locally with my logs, allocations/shutdowns are now balanced.