### PR TITLE
Shut down InteractionModelEngine during DeviceController shutdown.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -312,6 +312,10 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mState = State::NotInitialized;
 
+    // Shut down the interaction model before we try shuttting down the exchange
+    // manager.
+    app::InteractionModelEngine::GetInstance()->Shutdown();
+
     // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
     // if (mExchangeMgr != nullptr)
     // {


### PR DESCRIPTION
Otherwise if we have an IM action in flight at shutdown time we will
effectively leak the object managing it, and after a few
shutdown/restart cycles for the stack not be able to send any more IM
actions.

#### Problem
If I shut down and restart DeviceController a few times, and the shutdowns happen to come while there is a CommandSender outstanding (in that we sent a command and a response has not come back), then eventually we run out of CommandSenders.

#### Change overview
Make sure to shut down CommandSenders when we shut down DeviceController.

#### Testing
Manual testing with a bug added to chip-all-clusters-app that causes it to shut down the DeviceController while CommandSenders are life.  Will try to add some automated tests too.