### PR TITLE
Align header include paths between Release and Debug configuration

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -56,6 +56,10 @@ jobs:
               timeout-minutes: 15
               working-directory: src/darwin/Framework
               run: xcodebuild -target "CHIP" -sdk iphoneos
+            - name: Run iOS Build (Release)
+              timeout-minutes: 15
+              working-directory: src/darwin/Framework
+              run: xcodebuild -target "CHIP" -sdk iphoneos -configuration Release
             - name: Clean Build
               run: xcodebuild clean
               working-directory: src/darwin/Framework

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -52,11 +52,11 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Run iOS Build
+            - name: Run iOS Build Debug
               timeout-minutes: 15
               working-directory: src/darwin/Framework
               run: xcodebuild -target "CHIP" -sdk iphoneos
-            - name: Run iOS Build (Release)
+            - name: Run iOS Build Release
               timeout-minutes: 15
               working-directory: src/darwin/Framework
               run: xcodebuild -target "CHIP" -sdk iphoneos -configuration Release

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -19,8 +19,8 @@
  * @file Basic implementation of a binding table.
  */
 
-#include <gen/gen_config.h>
 #include <app/util/binding-table.h>
+#include <gen/gen_config.h>
 
 static EmberBindingTableEntry bindingTable[EMBER_BINDING_TABLE_SIZE];
 

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -19,7 +19,7 @@
  * @file Basic implementation of a binding table.
  */
 
-#include "gen/gen_config.h"
+#include <gen/gen_config.h>
 #include <app/util/binding-table.h>
 
 static EmberBindingTableEntry bindingTable[EMBER_BINDING_TABLE_SIZE];

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -724,8 +724,11 @@
 					"$(CHIP_ROOT)/src/app",
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
-					.,
+					"$(CHIP_ROOT)/src/darwin/Framework/CHIP/",
+					"$(CHIP_ROOT)/src/app/util",
+					"$(CHIP_ROOT)/third_party/nlio/repo/include",
 					"$(TEMP_DIR)/out/gen/include",
+					"$(CHIP_ROOT)/src/controller/data_model",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Xcode release mode builds of CHIP Framework fail

#### Change overview
Align the includes between debug and release builds and fixup an include. 

#### Testing
How was this tested? (at least one bullet point required)
* Added a step in CI to also build CHIP Framework in release mode on iOS.
