### PR TITLE
Remove chip_stack_lock_tracking for Darwin since it has been added ba…

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -61,7 +61,7 @@ if (chip_device_platform != "none") {
   }
 
   if (chip_stack_lock_tracking == "auto") {
-    if (chip_device_platform == "linux" || chip_device_platform == "darwin") {
+    if (chip_device_platform == "linux") {
       # TODO: should be fatal for development. Change once bugs are fixed
       chip_stack_lock_tracking = "log"
     } else {


### PR DESCRIPTION
…ck by #7575

#### Problem

`chip_stack_log_tracking` has been re-enabled for darwin in #7575. Since Darwin does not uses locking, this is just noisy.


#### Change overview
 * Revert back to the previous value before #7575

#### Testing
 * This was manually tested on darwin, looking for the log in the console.
