### PR TITLE
Update the path of chip-all-clusters-app into scripts/tests/test_suit…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
             - name: Build all clusters app
               timeout-minutes: 5
               run: |
-                  scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug chip_config_network_layer_ble=false
+                  scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone/ chip_config_network_layer_ble=false
             - name: Build chip-tool
               timeout-minutes: 5
               run: |
@@ -136,7 +136,7 @@ jobs:
             - name: Run Build Test Server
               timeout-minutes: 5
               run: |
-                  scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug chip_config_network_layer_ble=false
+                  scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone/ chip_config_network_layer_ble=false
             - name: Build chip-tool
               timeout-minutes: 5
               run: |

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -75,7 +75,7 @@ for j in "${iter_array[@]}"; do
         rm -rf /tmp/all-clusters-log
         rm -rf /tmp/pid
         (
-            stdbuf -o0 out/debug/chip-all-clusters-app &
+            stdbuf -o0 out/debug/standalone/chip-all-clusters-app &
             echo $! >&3
         ) 3>/tmp/pid | tee /tmp/all-clusters-log &
         while ! grep -q "Server Listening" /tmp/all-clusters-log; do


### PR DESCRIPTION
…es.sh so it can either be runned from CI or from a build from ./gn_build.sh

#### Problem

`./scripts/tests/test_suites.sh` uses `out/debug/chip-all-clusters-app` for the path of the server. Building with `./gn_build.sh` usually results into `out/debug/standalone/chip-all-clusters-app`. 


#### Change overview
 * This PR update the path of the bash script to make it easier to run the tests suite locally.

#### Testing
 * This was tested locally by running `./scripts/tests/test_suites.sh`.
 * The CI changed will be tested by the CI
