### PR TITLE
[nrfconnect] Fix build with Zephyr shell integration

### DIFF
--- a/src/platform/nrfconnect/shell/BUILD.gn
+++ b/src/platform/nrfconnect/shell/BUILD.gn
@@ -23,6 +23,4 @@ static_library("chip-zephyr-shell") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [ "${chip_root}/src/app/server" ]
-
-  complete_static_lib = true
 }


### PR DESCRIPTION
#### Problem
When building nRF Connect examples with CONFIG_CHIP_ZEPHYR_SHELL=y, files from src/app/server were needlessly linked into `libCHIPZephyrShell.a` causing linker errors 

#### Change overview
Don't link dependencies of `src/platform/nrfconnect/shell` into `libCHIPZephyrShell.a`. They will be included in other targets, be it `libCHIP.a` or an application itself.

#### Testing
Tested build of nRF Connect examples with `CONFIG_CHIP_ZEPHYR_SHELL=y`. Verified that CHIP commands appear in the Zephyr shell.

Fixes #7568