### PR TITLE
Reduce iteration count for Darwin test for now.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,7 +116,8 @@ jobs:
             - name: Run Test Suites
               timeout-minutes: 5
               run: |
-                  scripts/tests/test_suites.sh
+                  # Force 1 iteration for now until we sort out our threading issues.
+                  scripts/tests/test_suites.sh 1
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }}


### PR DESCRIPTION
This is failing a lot more in the last few days due to thread
synchronization problems.  We are addressing those, but in the
meantime doing fewer iterations will make this less likely to fail on
random unrelated PRs.

#### Problem
Darwin "Tests" CI fails a lot after the combination of #7478 and  #7405.

#### Change overview
Run fewer iterations for now so the chance of hitting a thread race is lower.

#### Testing
Verified that workflow does the right thing in my fork.