### PR TITLE
Bump Raspberry Pi Ubuntu Server version to 21.04

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -73,9 +73,9 @@ dependency.
 
 #### How to install prerequisites on Raspberry Pi 4
 
-Using `rpi-imager`, install the Ubuntu _20.10_ LTS 64-bit _server_ OS for arm64
-architectures on a micro SD card. This release will have bluez 5.55 which is
-required for BLE functionality.
+Using `rpi-imager`, install the Ubuntu _21.04_ 64-bit _server_ OS for arm64
+architectures on a micro SD card. This release will have bluez 5.55 or newer
+which is required for BLE functionality.
 
 Boot the SD card, login with the default user account "ubuntu" and password
 "ubuntu", then proceed with "How to install prerequisites on Linux".


### PR DESCRIPTION
#### Problem

Ubuntu 20.10 is out of support and furthermore, the Raspberry Pi imaging
tool no longer includes this version. 

#### Change overview

Bump the version to the current one (21.04). Either version should work fine.

#### Testing

Ran the build on Ubuntu 21.04 server aarch64.