### PR TITLE
Darwin - Start/Stop events on StartEventLoop/StopEventLoop

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -85,8 +85,6 @@ exit:
     // since the CHIP thread and event queue have been stopped, preventing any thread
     // races.
     //
-    // TODO: This doesn't hold true on Darwin, issue #7557 tracks the problem.
-    //
     mController.Shutdown();
 
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -119,11 +119,11 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 - (BOOL)shutdown
 {
     dispatch_async(_chipWorkQueue, ^{
-        if (_cppCommissioner) {
+        if (self->_cppCommissioner) {
             CHIP_LOG_DEBUG("%@", kInfoStackShutdown);
-            _cppCommissioner->Shutdown();
-            delete _cppCommissioner;
-            _cppCommissioner = nullptr;
+            self->_cppCommissioner->Shutdown();
+            delete self->_cppCommissioner;
+            self->_cppCommissioner = nullptr;
         }
     });
 

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -48,6 +48,7 @@ public:
         if (mWorkQueue == nullptr)
         {
             mWorkQueue = dispatch_queue_create(CHIP_CONTROLLER_QUEUE, DISPATCH_QUEUE_SERIAL);
+            dispatch_suspend(mWorkQueue);
         }
         return mWorkQueue;
     }
@@ -58,9 +59,9 @@ private:
     CHIP_ERROR _Shutdown();
 
     CHIP_ERROR _StartChipTimer(int64_t aMilliseconds) { return CHIP_ERROR_NOT_IMPLEMENTED; };
-    CHIP_ERROR _StartEventLoopTask() { return CHIP_NO_ERROR; };
-    CHIP_ERROR _StopEventLoopTask() { return CHIP_NO_ERROR; };
-    void _RunEventLoop(){};
+    CHIP_ERROR _StartEventLoopTask();
+    CHIP_ERROR _StopEventLoopTask();
+    void _RunEventLoop();
     void _LockChipStack(){};
     bool _TryLockChipStack() { return false; };
     void _UnlockChipStack(){};

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -80,6 +80,7 @@ private:
     static PlatformManagerImpl sInstance;
 
     dispatch_queue_t mWorkQueue = nullptr;
+    bool mIsWorkQueueRunning    = false;
 
     inline ImplClass * Impl() { return static_cast<PlatformManagerImpl *>(this); }
 };


### PR DESCRIPTION
#### Problem

`chip-tool` under Darwin may crash if `DeviceController::Shutdown` is called.

#### Change overview
 * Start/Stop event queue processing when `StartEventLoopTask/StopEventLoopTask` is called.
 * `dispatch_sync` into `StopEventLoopTask` to make sure that processing inside the stack is finished when this method is called.

#### Testing
 * This was manually tested under darwin by running: `time bash -c "for i in {1..1000}; do ./out/debug/standalone/chip-tool tests OnOffCluster; done"`
 * This is a tentative to fix some CI crashes with the combo `chip-tool`/`darwin`
