### PR TITLE
Upload core files as artifacts on Linux when crashes happen in the "Test Suites - Linux" test.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,13 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+            - name: Try to ensure the directories for core dumping exist and we can write them.
+              run: |
+                  apt-get update
+                  apt-get -y install --fix-missing rsync
+                  mkdir /tmp/cores || true
+                  sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
+                  mkdir objdir-clone || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -57,11 +64,32 @@ jobs:
               timeout-minutes: 5
               run: |
                   scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone/
+            - name: Copy objdir
+              run: |
+                  # The idea is to not upload our objdir unless builds have
+                  # actually succeeded, because that just wastes space.
+                  rsync -a out/debug/standalone/ objdir-clone || true
             - name: Run Tests
               timeout-minutes: 5
               run: |
                   ifconfig -a
                   scripts/tests/test_suites.sh
+            - name: Uploading core files
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }}
+              with:
+                  name: crash-core-linux
+                  path: /tmp/cores/
+                  # Cores are big; don't hold on to them too long.
+                  retention-days: 5
+            - name: Uploading objdir for debugging
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }}
+              with:
+                  name: crash-objdir-linux
+                  path: objdir-clone/
+                  # objdirs are big; don't hold on to them too long.
+                  retention-days: 5
     test_suites_darwin:
         name: Test Suites - Darwin
         timeout-minutes: 60
@@ -121,7 +149,7 @@ jobs:
               uses: actions/upload-artifact@v2
               if: ${{ failure() }}
               with:
-                  name: crash-core
+                  name: crash-core-darwin
                   path: /cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
@@ -129,13 +157,13 @@ jobs:
               uses: actions/upload-artifact@v2
               if: ${{ failure() }}
               with:
-                  name: crash-log
+                  name: crash-log-darwin
                   path: ~/Library/Logs/DiagnosticReports/
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
               if: ${{ failure() }}
               with:
-                  name: crash-objdir
+                  name: crash-objdir-darwin
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5


### PR DESCRIPTION
#### Problem
When the "Test Suites - Linux" test crashes it's hard to debug.

#### Change overview
Upload core file and objdir as artifacts

#### Testing
Tested the action in my fork.