### PR TITLE
Add PID to Darwin/Linux Log Lines

### DIFF
--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -29,7 +29,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     pthread_threadid_np(NULL, &ktid);
 
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [0x%" PRIx64 "] CHIP: [%s] ", ms, ktid, module);
+    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [%lld:%lld] CHIP: [%s] ", ms, (long long)getpid(), (long long)ktid, module);
     static os_log_t log = os_log_create("com.zigbee.chip", "all");
     if (prefixLen < 0)
     {

--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -29,7 +29,8 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     pthread_threadid_np(NULL, &ktid);
 
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [%lld:%lld] CHIP: [%s] ", ms, (long long)getpid(), (long long)ktid, module);
+    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [%lld:%lld] CHIP: [%s] ", ms, (long long) getpid(),
+                                 (long long) ktid, module);
     static os_log_t log = os_log_create("com.zigbee.chip", "all");
     if (prefixLen < 0)
     {

--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -35,8 +35,8 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     // indicate the error occurred during getting time.
     gettimeofday(&tv, nullptr);
 
-    printf("[%" PRIu64 ".%06" PRIu64 "][%ld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
-           static_cast<long>(syscall(SYS_gettid)), module);
+    printf("[%" PRIu64 ".%06" PRIu64 "][%lld:%lld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
+           static_cast<long long>(syscall(SYS_getpid)), static_cast<long long>(syscall(SYS_gettid)), module);
     vprintf(msg, v);
     printf("\n");
     fflush(stdout);


### PR DESCRIPTION
Problem:
- Debugging test failures that involve multiple instances of
  applications is difficult when the log lines don't indicate which
  process/application they're coming from.

Solution:
- Added PID to the log lines on Darwin & Linux minimally to aid in
  debugging.

Testing:
- Ran chip-tool on both platforms.