### PR TITLE
Enable CASE session establishment

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -39,11 +39,11 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
 CHIP_ERROR WaitForSessionSetup(chip::Controller::Device * device)
 {
-    constexpr time_t kWaitPerIteration = 1;
-    constexpr uint16_t kIterationCount = 5;
+    constexpr time_t kWaitPerIterationSec = 1;
+    constexpr uint16_t kIterationCount    = 5;
 
     struct timespec sleep_time;
-    sleep_time.tv_sec  = kWaitPerIteration;
+    sleep_time.tv_sec  = kWaitPerIterationSec;
     sleep_time.tv_nsec = 0;
 
     for (uint32_t i = 0; i < kIterationCount && device->IsSessionSetupInProgress(); i++)
@@ -73,12 +73,12 @@ CHIP_ERROR ModelCommand::Run(NodeId localId, NodeId remoteId)
         err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
 
-        if (mDevice->IsSessionSetupInProgress())
-        {
-            err = WaitForSessionSetup(mDevice);
-            VerifyOrExit(err == CHIP_NO_ERROR,
-                         ChipLogError(chipTool, "Timed out while waiting for session setup for device: %" PRIu64, localId));
-        }
+        // TODO - Implement notification from device object when the secure session is available.
+        // Current code is polling the device object to check for secure session availability. This should
+        // be updated to a notification/callback mechanism.
+        err = WaitForSessionSetup(mDevice);
+        VerifyOrExit(err == CHIP_NO_ERROR,
+                     ChipLogError(chipTool, "Timed out while waiting for session setup for device: %" PRIu64, localId));
 
         err = SendCommand(mDevice, mEndPointId);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Failed to send message: %s", ErrorStr(err)));

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -31,7 +31,10 @@
 class ModelCommand : public Command
 {
 public:
-    ModelCommand(const char * commandName) : Command(commandName) {}
+    ModelCommand(const char * commandName) :
+        Command(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    {}
 
     void AddArguments() { AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId); }
 
@@ -41,6 +44,11 @@ public:
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 
 private:
-    ChipDevice * mDevice;
     uint8_t mEndPointId;
+
+    static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
+    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+
+    chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 };

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -66,10 +66,8 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ChipDevice * device;
-        ReturnErrorOnFailure(GetExecContext()->commissioner->GetDevice(remoteId, &device));
         ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
-        return GetExecContext()->commissioner->UpdateDevice(device, fabricId);
+        return GetExecContext()->commissioner->UpdateDevice(remoteId, fabricId);
     }
 
     /////////// DeviceAddressUpdateDelegate Interface /////////

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -103,6 +103,7 @@ public:
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
+    void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
 
     /////////// DeviceAddressUpdateDelegate Interface /////////
     void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override;

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -184,9 +184,12 @@ void RendezvousServer::OnSessionEstablished()
     VerifyOrReturn(connection.StoreIntoKVS(*mStorage) == CHIP_NO_ERROR,
                    ChipLogError(AppServer, "Failed to store the connection state"));
 
-    uint16_t keyID = 0;
-    mIDAllocator->Peek(keyID);
-
+    // The Peek() is used to find the highest key ID that's been assigned to any session.
+    // This value is persisted, and on reboot, it is used to revive any previously
+    // active secure sessions.
+    // We support one active PASE session at any time. So the key ID should not be updated
+    // in another thread, while we retrieve it here.
+    uint16_t keyID = mIDAllocator->Peek();
     mStorage->SyncSetKeyValue(kStorablePeerConnectionCountKey, &keyID, sizeof(keyID));
 }
 } // namespace chip

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -184,7 +184,7 @@ void RendezvousServer::OnSessionEstablished()
     VerifyOrReturn(connection.StoreIntoKVS(*mStorage) == CHIP_NO_ERROR,
                    ChipLogError(AppServer, "Failed to store the connection state"));
 
-    // The Peek() is used to find the highest key ID that's been assigned to any session.
+    // The Peek() is used to find the smallest key ID that's not been assigned to any session.
     // This value is persisted, and on reboot, it is used to revive any previously
     // active secure sessions.
     // We support one active PASE session at any time. So the key ID should not be updated

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -22,6 +22,7 @@
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
+#include <protocols/secure_channel/SessionIDAllocator.h>
 
 namespace chip {
 
@@ -31,11 +32,12 @@ public:
     CHIP_ERROR WaitForPairing(const RendezvousParameters & params, Messaging::ExchangeManager * exchangeManager,
                               TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr, Transport::AdminPairingInfo * admin);
 
-    CHIP_ERROR Init(AppDelegate * delegate, PersistentStorageDelegate * storage)
+    CHIP_ERROR Init(AppDelegate * delegate, PersistentStorageDelegate * storage, SessionIDAllocator * idAllocator)
     {
         VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        mDelegate = delegate;
-        mStorage  = storage;
+        mDelegate    = delegate;
+        mStorage     = storage;
+        mIDAllocator = idAllocator;
         return CHIP_NO_ERROR;
     }
 
@@ -45,8 +47,6 @@ public:
 
     void Cleanup();
 
-    uint16_t GetNextKeyId() const { return mNextKeyId; }
-    void SetNextKeyId(uint16_t id) { mNextKeyId = id; }
     void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event);
 
 private:
@@ -55,10 +55,11 @@ private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 
     PASESession mPairingSession;
-    uint16_t mNextKeyId            = 0;
     SecureSessionMgr * mSessionMgr = nullptr;
 
     Transport::AdminPairingInfo * mAdmin = nullptr;
+
+    SessionIDAllocator * mIDAllocator = nullptr;
 
     const RendezvousAdvertisementDelegate * mAdvDelegate;
 

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -35,9 +35,14 @@ public:
     CHIP_ERROR Init(AppDelegate * delegate, PersistentStorageDelegate * storage, SessionIDAllocator * idAllocator)
     {
         VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        mDelegate    = delegate;
-        mStorage     = storage;
+        mStorage = storage;
+
+        VerifyOrReturnError(idAllocator != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         mIDAllocator = idAllocator;
+
+        // The caller may chose to not provide a delegate object. The RendezvousServer checks for null delegate before calling
+        // it's methods.
+        mDelegate = delegate;
         return CHIP_NO_ERROR;
     }
 

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -41,7 +41,7 @@ public:
         mIDAllocator = idAllocator;
 
         // The caller may chose to not provide a delegate object. The RendezvousServer checks for null delegate before calling
-        // it's methods.
+        // its methods.
         mDelegate = delegate;
         return CHIP_NO_ERROR;
     }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -179,7 +179,7 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr)
             }
             else
             {
-                ChipLogProgress(AppServer, "Session Key ID %d cannot be used. Skipping over this session", keyId);
+                ChipLogProgress(AppServer, "Session Key ID  %" PRIu16 " cannot be used. Skipping over this session", keyId);
             }
             session->Clear();
         }

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -164,9 +164,14 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     serializable.mAdminId    = Encoding::LittleEndian::HostSwap16(mAdminId);
 
     Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
-    VerifyOrReturnError(connectionState != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    const uint32_t localMessageCounter = connectionState->GetSessionMessageCounter().GetLocalMessageCounter().Value();
-    const uint32_t peerMessageCounter  = connectionState->GetSessionMessageCounter().GetPeerMessageCounter().GetCounter();
+
+    uint32_t localMessageCounter = 0;
+    uint32_t peerMessageCounter  = 0;
+    if (connectionState != nullptr)
+    {
+        localMessageCounter = connectionState->GetSessionMessageCounter().GetLocalMessageCounter().Value();
+        peerMessageCounter  = connectionState->GetSessionMessageCounter().GetPeerMessageCounter().GetCounter();
+    }
 
     serializable.mLocalMessageCounter = Encoding::LittleEndian::HostSwap32(localMessageCounter);
     serializable.mPeerMessageCounter  = Encoding::LittleEndian::HostSwap32(peerMessageCounter);

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -488,6 +488,8 @@ void Device::OperationalCertProvisioned()
     ChipLogDetail(Controller, "Enabling CASE session establishment for the device");
     mDeviceOperationalCertProvisioned = true;
 
+    Persist();
+
     if (mState == ConnectionState::SecureConnected)
     {
         mSessionManager->ExpirePairing(mSecureSession);

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -352,6 +352,14 @@ public:
 
     ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
 
+    /**
+     * @brief
+     *   This function triggers CASE session setup if the device has been provisioned with
+     *   operational credentials, and there is no currently active session.
+     *
+     * @return CHIP_NO_ERROR if the session setup was triggered or a session is already available.
+     */
+
     CHIP_ERROR WarmupCASESession();
 
 private:

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -314,6 +314,8 @@ public:
 
     bool IsSecureConnected() const { return IsActive() && mState == ConnectionState::SecureConnected; }
 
+    bool IsSessionSetupInProgress() const { return IsActive() && mState == ConnectionState::Connecting; }
+
     void Reset();
 
     NodeId GetDeviceId() const { return mDeviceId; }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -479,7 +479,6 @@ CHIP_ERROR DeviceController::GetConnectedDevice(NodeId deviceId, Callback::Callb
 
     if (device->IsSecureConnected())
     {
-        // Call onConnectedDevice
         onConnection->mCall(onConnection->mContext, device);
         return CHIP_NO_ERROR;
     }
@@ -1554,12 +1553,20 @@ void DeviceCommissioner::OnNodeIdResolutionFailed(const chip::PeerId & peer, CHI
 void DeviceCommissioner::OnDeviceConnectedFn(void * context, Device * device)
 {
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
+    VerifyOrReturn(commissioner != nullptr, ChipLogProgress(Controller, "Device connected callback with null context. Ignoring"));
+    VerifyOrReturn(commissioner->mPairingDelegate != nullptr,
+                   ChipLogProgress(Controller, "Device connected callback with null pairing delegate. Ignoring"));
     commissioner->mPairingDelegate->OnCommissioningComplete(device->GetDeviceId(), CHIP_NO_ERROR);
 }
 
 void DeviceCommissioner::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error)
 {
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
+    ChipLogProgress(Controller, "Device connection failed. Error %s", ErrorStr(error));
+    VerifyOrReturn(commissioner != nullptr,
+                   ChipLogProgress(Controller, "Device connection failure callback with null context. Ignoring"));
+    VerifyOrReturn(commissioner->mPairingDelegate != nullptr,
+                   ChipLogProgress(Controller, "Device connection failure callback with null pairing delegate. Ignoring"));
     commissioner->mPairingDelegate->OnCommissioningComplete(deviceId, error);
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -815,10 +815,7 @@ CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, CommissionerInitParams
     {
         nextKeyID = 0;
     }
-    for (uint16_t i = 0; i < nextKeyID; i++)
-    {
-        ReturnErrorOnFailure(mIDAllocator.Reserve(i));
-    }
+    ReturnErrorOnFailure(mIDAllocator.ReserveUpTo(nextKeyID));
     mPairingDelegate = params.pairingDelegate;
 
     return CHIP_NO_ERROR;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -348,8 +348,7 @@ protected:
     // array can contain up to two certificates (node operational certificate, and ICA certificate).
     // If the certificate issuer doesn't require an ICA (i.e. NOC is signed by the root CA), the array
     // will have only one certificate (node operational certificate).
-    CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, uint8_t * certBuf, uint32_t certBufSize,
-                                               uint32_t & outCertLen);
+    CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, MutableByteSpan & cert);
 
 private:
     //////////// ExchangeDelegate Implementation ///////////////
@@ -454,13 +453,12 @@ public:
     CHIP_ERROR UnpairDevice(NodeId remoteDeviceId);
 
     /**
-     * @brief
-     *   This function is called by the commissioner application when a device (being paired) is
-     *   discovered on the operational network.
+     *   This function call indicates that the device has been provisioned with operational
+     *   credentials, and is reachable on operational network. At this point, the device is
+     *   available for CASE session establishment.
      *
-     * @param[in] remoteDeviceId        The remote device Id.
-     *
-     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
+     *   The function updates the state of device proxy object such that all subsequent messages
+     *   will use secure session established via CASE handshake.
      */
     CHIP_ERROR OperationalDiscoveryComplete(NodeId remoteDeviceId);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -334,7 +334,7 @@ protected:
     Credentials::OperationalCredentialSet mCredentials;
     Credentials::CertificateKeyId mRootKeyId;
 
-    uint16_t mNextKeyId = 0;
+    SessionIDAllocator mIDAllocator;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     //////////// ResolverDelegate Implementation ///////////////
@@ -342,6 +342,9 @@ protected:
     void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
     Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mCommissionableNodes; }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
+    CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, uint8_t * certBuf, uint32_t certBufSize,
+                                               uint32_t & outCertLen);
 
 private:
     //////////// ExchangeDelegate Implementation ///////////////
@@ -444,6 +447,17 @@ public:
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR UnpairDevice(NodeId remoteDeviceId);
+
+    /**
+     * @brief
+     *   This function is called by the commissioner application when a device (being paired) is
+     *   discovered on the operational network.
+     *
+     * @param[in] remoteDeviceId        The remote device Id.
+     *
+     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
+     */
+    CHIP_ERROR OperationalDiscoveryComplete(NodeId remoteDeviceId);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -343,6 +343,11 @@ protected:
     Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mCommissionableNodes; }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
+    // This function uses `OperationalCredentialsDelegate` to generate the operational certificates
+    // for the given device. The output is a TLV encoded array of compressed CHIP certificates. The
+    // array can contain up to two certificates (node operational certificate, and ICA certificate).
+    // If the certificate issuer doesn't require an ICA (i.e. NOC is signed by the root CA), the array
+    // will have only one certificate (node operational certificate).
     CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, uint8_t * certBuf, uint32_t certBufSize,
                                                uint32_t & outCertLen);
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -18,6 +18,7 @@
 
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/CHIPCert.h>
+#include <support/CHIPMem.h>
 
 namespace chip {
 namespace Controller {
@@ -29,6 +30,16 @@ using namespace Crypto;
 
 CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDelegate & storage)
 {
+    using namespace ASN1;
+    ASN1UniversalTime effectiveTime;
+
+    // Initializing the default start validity to start of 2021. The default validity duration is 10 years.
+    CHIP_ZERO_AT(effectiveTime);
+    effectiveTime.Year  = 2021;
+    effectiveTime.Month = 1;
+    effectiveTime.Day   = 1;
+    ReturnErrorOnFailure(ASN1ToChipEpochTime(effectiveTime, mNow));
+
     Crypto::P256SerializedKeypair serializedKey;
     uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -44,6 +44,9 @@ static constexpr uint32_t kChip32bitAttrUTF8Length             = 8;
 static constexpr uint32_t kChip64bitAttrUTF8Length             = 16;
 static constexpr uint16_t kX509NoWellDefinedExpirationDateYear = 9999;
 
+// As per specifications (section 6.3.7. Trusted Root CA Certificates)
+static constexpr uint32_t kMaxCHIPCertLength = 400;
+
 /** Data Element Tags for the CHIP Certificate
  */
 enum

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -645,16 +645,13 @@ CHIP_ERROR ConvertX509CertToChipCert(const uint8_t * x509Cert, uint32_t x509Cert
  *
  *        The API enforces that the NOC is issued by ICA (if ICA is provided).
  *
- * @param x509NOC              Node operational credentials certificate in X.509 DER encoding.
- * @param x509ICAC             Intermediate CA certificate in X.509 DER encoding.
- * @param chipCertArrayBuf     Buffer to store converted certificates in CHIP format.
- * @param chipCertArrayBufSize The size of the buffer to store converted certificates.
- * @param chipCertBufLen       The length of the converted certificates.
+ * @param x509NOC           Node operational credentials certificate in X.509 DER encoding.
+ * @param x509ICAC          Intermediate CA certificate in X.509 DER encoding.
+ * @param chipCertArray     Buffer to store converted certificates in CHIP format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509NOC, const ByteSpan & x509ICAC, uint8_t * chipCertArrayBuf,
-                                           uint32_t chipCertArrayBufSize, uint32_t & chipCertBufLen);
+CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509NOC, const ByteSpan & x509ICAC, MutableByteSpan & chipCertArray);
 
 /**
  * @brief Convert CHIP certificate to the standard X.509 DER encoded certificate.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -383,17 +383,10 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         return;
     }
     dispatch_sync(_chipWorkQueue, ^{
-        chip::Controller::Device * device = nullptr;
-
         if ([self isRunning]) {
-            errorCode = self.cppCommissioner->GetDevice(deviceID, &device);
+            errorCode = self.cppCommissioner->UpdateDevice(deviceID, fabricId);
+            CHIP_LOG_ERROR("Update device address returned: %d", errorCode);
         }
-
-        if (errorCode != CHIP_NO_ERROR) {
-            return;
-        }
-
-        errorCode = self.cppCommissioner->UpdateDevice(device, fabricId);
     });
 }
 

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -14,6 +14,8 @@ static_library("secure_channel") {
     "SessionEstablishmentDelegate.h",
     "SessionEstablishmentExchangeDispatch.cpp",
     "SessionEstablishmentExchangeDispatch.h",
+    "SessionIDAllocator.cpp",
+    "SessionIDAllocator.h",
     "StatusReport.cpp",
     "StatusReport.h",
   ]

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -112,6 +112,8 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
+    mSessionMgr->ExpireAllPairings(mPairingSession.PeerConnection().GetPeerNodeId(), mAdminId);
+
     CHIP_ERROR err =
         mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
                                 mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -62,9 +62,13 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     //    ReturnErrorCodeIf(mAdminId == Transport::kUndefinedAdminId, CHIP_ERROR_INVALID_ARGUMENT);
     mAdminId = 0;
 
-    mAdmins->LoadFromStorage(mAdminId);
-
     Transport::AdminPairingInfo * admin = mAdmins->FindAdminWithId(mAdminId);
+
+    if (admin == nullptr)
+    {
+        ReturnErrorOnFailure(mAdmins->LoadFromStorage(mAdminId));
+        admin = mAdmins->FindAdminWithId(mAdminId);
+    }
     ReturnErrorCodeIf(admin == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ReturnErrorOnFailure(admin->GetCredentials(mCredentials, mCertificates, mRootKeyId));
@@ -100,6 +104,7 @@ void CASEServer::Cleanup()
     mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1, this);
     mAdminId = Transport::kUndefinedAdminId;
     mCredentials.Release();
+    mCertificates.Release();
 }
 
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -55,6 +55,8 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
 {
     ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    Cleanup();
+
     // TODO - Use PK of the root CA for the initiator to figure out the admin.
     mAdminId = ec->GetSecureSession().GetAdminId();
 
@@ -93,18 +95,15 @@ void CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
     mPairingSession.OnMessageReceived(ec, packetHeader, payloadHeader, std::move(payload));
 
     // TODO - Enable multiple concurrent CASE session establishment
-    // This will prevent CASEServer to process another CASE session establishment request until the current
-    // one completes (successfully or failed)
-    mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1);
 }
 
 void CASEServer::Cleanup()
 {
     // Let's re-register for CASE SigmaR1 message, so that the next CASE session setup request can be processed.
-    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1, this);
     mAdminId = Transport::kUndefinedAdminId;
     mCredentials.Release();
     mCertificates.Release();
+    mPairingSession.Clear();
 }
 
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -30,7 +30,8 @@ using namespace ::chip::Credentials;
 namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                                     SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins)
+                                                     SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins,
+                                                     SessionIDAllocator * idAllocator)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -40,6 +41,7 @@ CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager 
     mSessionMgr      = sessionMgr;
     mAdmins          = admins;
     mExchangeManager = exchangeManager;
+    mIDAllocator     = idAllocator;
 
     ReturnErrorOnFailure(mPairingSession.MessageDispatch().Init(transportMgr));
 
@@ -67,8 +69,10 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
 
     ReturnErrorOnFailure(admin->GetCredentials(mCredentials, mCertificates, mRootKeyId));
 
+    ReturnErrorOnFailure(mIDAllocator->Allocate(mSessionKeyId));
+
     // Setup CASE state machine using the credentials for the current admin.
-    ReturnErrorOnFailure(mPairingSession.ListenForSessionEstablishment(&mCredentials, mNextKeyId++, this));
+    ReturnErrorOnFailure(mPairingSession.ListenForSessionEstablishment(&mCredentials, mSessionKeyId, this));
 
     // Hand over the exchange context to the CASE session.
     ec->SetDelegate(&mPairingSession);
@@ -101,23 +105,23 @@ void CASEServer::Cleanup()
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     ChipLogProgress(Inet, "CASE Session establishment failed: %s", ErrorStr(err));
+    mIDAllocator->Free(mSessionKeyId);
     Cleanup();
 }
 
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    // TODO - enable use of secure session established via CASE
-    // CHIP_ERROR err =
-    //     mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-    //                             mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
-    //                             SecureSession::SessionRole::kResponder, mAdminId, nullptr);
-    // if (err != CHIP_NO_ERROR)
-    // {
-    //     ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));
-    //     OnSessionEstablishmentError(err);
-    //     return;
-    // }
+    CHIP_ERROR err =
+        mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
+                                mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
+                                SecureSession::SessionRole::kResponder, mAdminId, nullptr);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        OnSessionEstablishmentError(err);
+        return;
+    }
 
     ChipLogProgress(Inet, "CASE secure channel is available now.");
     Cleanup();

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -20,6 +20,7 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/CASESession.h>
+#include <protocols/secure_channel/SessionIDAllocator.h>
 
 namespace chip {
 
@@ -38,7 +39,8 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins);
+                                             SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins,
+                                             SessionIDAllocator * idAllocator);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -58,7 +60,7 @@ private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 
     CASESession mPairingSession;
-    uint16_t mNextKeyId            = 0;
+    uint16_t mSessionKeyId         = 0;
     SecureSessionMgr * mSessionMgr = nullptr;
 
     Transport::AdminId mAdminId = Transport::kUndefinedAdminId;
@@ -69,6 +71,8 @@ private:
     Credentials::CertificateKeyId mRootKeyId;
 
     CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
+
+    SessionIDAllocator * mIDAllocator = nullptr;
 
     void Cleanup();
 };

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -55,8 +55,7 @@ constexpr uint8_t kIVSR2[] = { 0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0
 constexpr uint8_t kIVSR3[] = { 0x4e, 0x43, 0x41, 0x53, 0x45, 0x5f, 0x53, 0x69, 0x67, 0x6d, 0x61, 0x52, 0x33 };
 constexpr size_t kIVLength = sizeof(kIVSR2);
 
-constexpr size_t kTAGSize               = 16;
-constexpr uint32_t kMaxCHIPOpCertLength = 1024;
+constexpr size_t kTAGSize = 16;
 
 using namespace Crypto;
 using namespace Credentials;
@@ -1026,7 +1025,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t ** msgIte
 
     ChipCertificateSet certSet;
     // Certificate set can contain up to 3 certs (NOC, ICA cert, and Root CA cert)
-    ReturnErrorOnFailure(certSet.Init(3, kMaxCHIPOpCertLength * 3));
+    ReturnErrorOnFailure(certSet.Init(3, kMaxCHIPCertLength * 3));
 
     responderOpCertLen = chip::Encoding::LittleEndian::Read16(*msgIterator);
     *responderOpCert   = *msgIterator;

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -67,10 +67,10 @@ using HKDF_sha_crypto = HKDF_shaHSM;
 using HKDF_sha_crypto = HKDF_sha;
 #endif
 
-// Wait at most 30 seconds for the response from the peer.
+// Wait at most 10 seconds for the response from the peer.
 // This timeout value assumes the underlying transport is reliable.
 // The session establishment fails if the response is not received within timeout window.
-static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = 30000;
+static constexpr ExchangeContext::Timeout kSigma_Response_Timeout = 10000;
 
 CASESession::CASESession()
 {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -969,6 +969,11 @@ CHIP_ERROR CASESession::FindValidTrustedRoot(const uint8_t ** msgIterator, uint3
 
         if (mOpCredSet->IsTrustedRootIn(trustedRoot[i]))
         {
+            if (mTrustedRootId.mId != nullptr)
+            {
+                chip::Platform::MemoryFree(const_cast<uint8_t *>(mTrustedRootId.mId));
+                mTrustedRootId.mId = nullptr;
+            }
             mTrustedRootId.mId = reinterpret_cast<const uint8_t *>(chip::Platform::MemoryAlloc(kTrustedRootIdSize));
             VerifyOrReturnError(mTrustedRootId.mId != nullptr, CHIP_ERROR_NO_MEMORY);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -188,6 +188,10 @@ public:
         return &mMessageDispatch;
     }
 
+    /** @brief This function zeroes out and resets the memory used by the object.
+     **/
+    void Clear();
+
 private:
     enum SigmaErrorType : uint8_t
     {
@@ -234,8 +238,6 @@ private:
 
     // TODO: Remove this and replace with system method to retrieve current time
     CHIP_ERROR SetEffectiveTime(void);
-
-    void Clear();
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
                                        const PayloadHeader & payloadHeader, System::PacketBufferHandle & msg);

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
 
 void SessionIDAllocator::Free(uint16_t id)
 {
-    if (mNextAvailable == id && mNextAvailable > 0)
+    if (mNextAvailable > 0 && (mNextAvailable - 1) == id)
     {
         mNextAvailable--;
     }
@@ -48,6 +48,8 @@ CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
         mNextAvailable = id;
         mNextAvailable++;
     }
+
+    // TODO - Check if ID is already allocated in SessionIDAllocator::Reserve()
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -1,0 +1,64 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <protocols/secure_channel/SessionIDAllocator.h>
+
+#include <support/CodeUtils.h>
+
+namespace chip {
+
+CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
+{
+    VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    id = mNextAvailable;
+
+    // TODO - Update SessionID allocator to use freed session IDs
+    mNextAvailable++;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SessionIDAllocator::Free(uint16_t id)
+{
+    if (mNextAvailable == id && mNextAvailable > 0)
+    {
+        mNextAvailable--;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
+{
+    VerifyOrReturnError(id < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    if (id >= mNextAvailable)
+    {
+        mNextAvailable = id;
+        mNextAvailable++;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SessionIDAllocator::Peek(uint16_t & id)
+{
+    VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    id = mNextAvailable;
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -32,13 +32,12 @@ CHIP_ERROR SessionIDAllocator::Allocate(uint16_t & id)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SessionIDAllocator::Free(uint16_t id)
+void SessionIDAllocator::Free(uint16_t id)
 {
     if (mNextAvailable == id && mNextAvailable > 0)
     {
         mNextAvailable--;
     }
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
@@ -53,12 +52,9 @@ CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SessionIDAllocator::Peek(uint16_t & id)
+uint16_t SessionIDAllocator::Peek()
 {
-    VerifyOrReturnError(mNextAvailable < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
-    id = mNextAvailable;
-
-    return CHIP_NO_ERROR;
+    return mNextAvailable;
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/SessionIDAllocator.cpp
@@ -54,6 +54,23 @@ CHIP_ERROR SessionIDAllocator::Reserve(uint16_t id)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR SessionIDAllocator::ReserveUpTo(uint16_t id)
+{
+    VerifyOrReturnError(id < kMaxSessionID, CHIP_ERROR_NO_MEMORY);
+    if (id >= mNextAvailable)
+    {
+        mNextAvailable = id;
+        mNextAvailable++;
+    }
+
+    // TODO - Update ReserveUpTo to mark all IDs in use
+    // Current SessionIDAllocator only tracks the smallest unused session ID.
+    // If/when we change it to track all in use IDs, we should also update ReserveUpTo
+    // to reserve all individual session IDs, instead of just setting the mNextAvailable.
+
+    return CHIP_NO_ERROR;
+}
+
 uint16_t SessionIDAllocator::Peek()
 {
     return mNextAvailable;

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -28,9 +28,9 @@ public:
     ~SessionIDAllocator() {}
 
     CHIP_ERROR Allocate(uint16_t & id);
-    CHIP_ERROR Free(uint16_t id);
+    void Free(uint16_t id);
     CHIP_ERROR Reserve(uint16_t id);
-    CHIP_ERROR Peek(uint16_t & id);
+    uint16_t Peek();
 
 private:
     // Session ID is a 15 bit value (16th bit indicates unicast/group key)

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPError.h>
+
+namespace chip {
+
+class SessionIDAllocator
+{
+public:
+    SessionIDAllocator() {}
+    ~SessionIDAllocator() {}
+
+    CHIP_ERROR Allocate(uint16_t & id);
+    CHIP_ERROR Free(uint16_t id);
+    CHIP_ERROR Reserve(uint16_t id);
+    CHIP_ERROR Peek(uint16_t & id);
+
+private:
+    // Session ID is a 15 bit value (16th bit indicates unicast/group key)
+    static constexpr uint16_t kMaxSessionID = (1 << 15) - 1;
+    uint16_t mNextAvailable                 = 0;
+};
+
+} // namespace chip

--- a/src/protocols/secure_channel/SessionIDAllocator.h
+++ b/src/protocols/secure_channel/SessionIDAllocator.h
@@ -30,6 +30,7 @@ public:
     CHIP_ERROR Allocate(uint16_t & id);
     void Free(uint16_t id);
     CHIP_ERROR Reserve(uint16_t id);
+    CHIP_ERROR ReserveUpTo(uint16_t id);
     uint16_t Peek();
 
 private:

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -12,6 +12,7 @@ chip_test_suite("tests") {
     "TestCASESession.cpp",
     "TestMessageCounterManager.cpp",
     "TestPASESession.cpp",
+    "TestSessionIDAllocator.cpp",
     "TestStatusReport.cpp",
   ]
 

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -88,6 +88,14 @@ void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, allocator.Peek() == 101);
 }
 
+void TestSessionIDAllocator_ReserveUpTo(nlTestSuite * inSuite, void * inContext)
+{
+    SessionIDAllocator allocator;
+
+    allocator.ReserveUpTo(100);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 101);
+}
+
 // Test Suite
 
 /**
@@ -99,6 +107,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("SessionIDAllocator_Allocate", TestSessionIDAllocator_Allocate),
     NL_TEST_DEF("SessionIDAllocator_Free", TestSessionIDAllocator_Free),
     NL_TEST_DEF("SessionIDAllocator_Reserve", TestSessionIDAllocator_Reserve),
+    NL_TEST_DEF("SessionIDAllocator_ReserveUpTo", TestSessionIDAllocator_ReserveUpTo),
 
     NL_TEST_SENTINEL()
 };

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -24,7 +24,7 @@
 
 using namespace chip;
 
-void TestStatusReport_Allocate(nlTestSuite * inSuite, void * inContext)
+void TestSessionIDAllocator_Allocate(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
 
@@ -41,7 +41,7 @@ void TestStatusReport_Allocate(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-void TestStatusReport_Free(nlTestSuite * inSuite, void * inContext)
+void TestSessionIDAllocator_Free(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
 
@@ -70,7 +70,7 @@ void TestStatusReport_Free(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, allocator.Peek() == 15);
 }
 
-void TestStatusReport_Reserve(nlTestSuite * inSuite, void * inContext)
+void TestSessionIDAllocator_Reserve(nlTestSuite * inSuite, void * inContext)
 {
     SessionIDAllocator allocator;
 
@@ -96,9 +96,9 @@ void TestStatusReport_Reserve(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 static const nlTest sTests[] =
 {
-    NL_TEST_DEF("SessionIDAllocator_Allocate", TestStatusReport_Allocate),
-    NL_TEST_DEF("SessionIDAllocator_Free", TestStatusReport_Free),
-    NL_TEST_DEF("SessionIDAllocator_Reserve", TestStatusReport_Reserve),
+    NL_TEST_DEF("SessionIDAllocator_Allocate", TestSessionIDAllocator_Allocate),
+    NL_TEST_DEF("SessionIDAllocator_Free", TestSessionIDAllocator_Free),
+    NL_TEST_DEF("SessionIDAllocator_Reserve", TestSessionIDAllocator_Reserve),
 
     NL_TEST_SENTINEL()
 };
@@ -137,7 +137,7 @@ static nlTestSuite sSuite =
 /**
  *  Main
  */
-int TestStatusReport()
+int TestSessionIDAllocator()
 {
     // Run test suit against one context
     nlTestRunner(&sSuite, nullptr);
@@ -145,4 +145,4 @@ int TestStatusReport()
     return (nlTestRunnerStats(&sSuite));
 }
 
-CHIP_REGISTER_TEST_SUITE(TestStatusReport)
+CHIP_REGISTER_TEST_SUITE(TestSessionIDAllocator)

--- a/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
+++ b/src/protocols/secure_channel/tests/TestSessionIDAllocator.cpp
@@ -1,0 +1,148 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <protocols/secure_channel/SessionIDAllocator.h>
+#include <support/CHIPMem.h>
+#include <support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+void TestStatusReport_Allocate(nlTestSuite * inSuite, void * inContext)
+{
+    SessionIDAllocator allocator;
+
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 0);
+
+    uint16_t id;
+
+    for (uint16_t i = 0; i < 16; i++)
+    {
+        CHIP_ERROR err = allocator.Allocate(id);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+    }
+}
+
+void TestStatusReport_Free(nlTestSuite * inSuite, void * inContext)
+{
+    SessionIDAllocator allocator;
+
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 0);
+
+    uint16_t id;
+
+    for (uint16_t i = 0; i < 16; i++)
+    {
+        CHIP_ERROR err = allocator.Allocate(id);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+    }
+
+    // Free an intermediate ID
+    allocator.Free(10);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 16);
+
+    // Free the last allocated ID
+    allocator.Free(15);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 15);
+
+    // Free some random unallocated ID
+    allocator.Free(100);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 15);
+}
+
+void TestStatusReport_Reserve(nlTestSuite * inSuite, void * inContext)
+{
+    SessionIDAllocator allocator;
+
+    uint16_t id;
+
+    for (uint16_t i = 0; i < 16; i++)
+    {
+        CHIP_ERROR err = allocator.Allocate(id);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, id == i);
+        NL_TEST_ASSERT(inSuite, allocator.Peek() == i + 1);
+    }
+
+    allocator.Reserve(100);
+    NL_TEST_ASSERT(inSuite, allocator.Peek() == 101);
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("SessionIDAllocator_Allocate", TestStatusReport_Allocate),
+    NL_TEST_DEF("SessionIDAllocator_Free", TestStatusReport_Free),
+    NL_TEST_DEF("SessionIDAllocator_Reserve", TestStatusReport_Reserve),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+/**
+ *  Set up the test suite.
+ */
+static int TestSetup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+static int TestTeardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+// clang-format off
+static nlTestSuite sSuite =
+{
+    "Test-CHIP-SessionIDAllocator",
+    &sTests[0],
+    TestSetup,
+    TestTeardown,
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int TestStatusReport()
+{
+    // Run test suit against one context
+    nlTestRunner(&sSuite, nullptr);
+
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestStatusReport)

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR AdminPairingInfo::SetRootCert(const ByteSpan & cert)
         return CHIP_NO_ERROR;
     }
 
-    VerifyOrReturnError(cert.size() <= kMaxChipCertSize, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(cert.size() <= kMaxCHIPCertLength, CHIP_ERROR_INVALID_ARGUMENT);
     if (mRootCertLen != 0 && mRootCertAllocatedLen < cert.size())
     {
         ReleaseRootCert();
@@ -252,7 +252,7 @@ CHIP_ERROR AdminPairingInfo::SetOperationalCert(const ByteSpan & cert)
     }
 
     // There could be two certs in the set -> ICA and NOC
-    VerifyOrReturnError(cert.size() <= kMaxChipCertSize * 2, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(cert.size() <= kMaxCHIPCertLength * 2, CHIP_ERROR_INVALID_ARGUMENT);
     if (mOpCertLen != 0 && mOpCertAllocatedLen < cert.size())
     {
         ReleaseOperationalCert();
@@ -275,7 +275,7 @@ CHIP_ERROR AdminPairingInfo::GetCredentials(OperationalCredentialSet & credentia
                                             CertificateKeyId & rootKeyId)
 {
     constexpr uint8_t kMaxNumCertsInOpCreds = 3;
-    ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds, kMaxChipCertSize * kMaxNumCertsInOpCreds));
+    ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds, kMaxCHIPCertLength * kMaxNumCertsInOpCreds));
 
     ReturnErrorOnFailure(
         certificates.LoadCert(mRootCert, mRootCertLen,

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -43,8 +43,6 @@ static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 constexpr char kAdminTableKeyPrefix[] = "CHIPAdmin";
 constexpr char kAdminTableCountKey[]  = "CHIPAdminNextId";
 
-constexpr uint16_t kMaxChipCertSize = 600;
-
 struct AccessControlList
 {
     uint32_t placeholder;
@@ -193,9 +191,9 @@ private:
         uint16_t mOpCertLen;   /* This field is serialized in LittleEndian byte order */
 
         Crypto::P256SerializedKeypair mOperationalKey;
-        uint8_t mRootCert[kMaxChipCertSize];
+        uint8_t mRootCert[Credentials::kMaxCHIPCertLength];
         // The operationa credentials set can have up to two certs -> ICAC and NOC
-        uint8_t mOperationalCert[kMaxChipCertSize * 2];
+        uint8_t mOperationalCert[Credentials::kMaxCHIPCertLength * 2];
         char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
     };
 };

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -214,6 +214,16 @@ exit:
     return err;
 }
 
+void SecureSessionMgr::ExpirePairing(SecureSessionHandle session)
+{
+    PeerConnectionState * state = GetPeerConnectionState(session);
+    if (state != nullptr)
+    {
+        mPeerConnections.MarkConnectionExpired(
+            state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
+    }
+}
+
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, Transport::AdminId admin,
                                         Transport::Base * transport)

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -224,6 +224,24 @@ void SecureSessionMgr::ExpirePairing(SecureSessionHandle session)
     }
 }
 
+void SecureSessionMgr::ExpireAllPairings(NodeId peerNodeId, Transport::AdminId admin)
+{
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
+    while (state != nullptr)
+    {
+        if (admin == state->GetAdminId())
+        {
+            mPeerConnections.MarkConnectionExpired(
+                state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
+            state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
+        }
+        else
+        {
+            state = mPeerConnections.FindPeerConnectionState(peerNodeId, state);
+        }
+    }
+}
+
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, Transport::AdminId admin,
                                         Transport::Base * transport)

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -221,6 +221,7 @@ public:
                           SecureSession::SessionRole direction, Transport::AdminId admin, Transport::Base * transport = nullptr);
 
     void ExpirePairing(SecureSessionHandle session);
+    void ExpireAllPairings(NodeId peerNodeId, Transport::AdminId admin);
 
     /**
      * @brief

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -220,6 +220,8 @@ public:
     CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PairingSession * pairing,
                           SecureSession::SessionRole direction, Transport::AdminId admin, Transport::Base * transport = nullptr);
 
+    void ExpirePairing(SecureSessionHandle session);
+
     /**
      * @brief
      *   Return the System Layer pointer used by current SecureSessionMgr.


### PR DESCRIPTION
#### Problem
We are currently using secure sessions established via PASE for non commissioning cluster messages. This needs to be changed to CASE sessions.

#### Change overview
1. Update CASESession code to use array of certs as operational certificates.
2. Trigger CASE session establishment after the device has been discovered on operational network.
3. Move session key ID assignment to a common class (as session ID space is shared by PASE and CASE sessions).
4. Expire the secure session established via PASE while triggering the CASE sessions.
5. Use secure sessions established via CASE for further messaging.

#### Testing
Tested flow using Python controller, chip-tool, and iOS CHIP Tool applications.
