### PR TITLE
[TE4] Add get-fabricid command in Python Device Controller

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -514,6 +514,16 @@ CHIP_ERROR DeviceController::ServiceEventSignal()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DeviceController::GetFabricId(uint64_t & fabricId)
+{
+    Transport::AdminPairingInfo * admin = mAdmins.FindAdminWithId(mAdminId);
+    VerifyOrReturnError(admin != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    fabricId = admin->GetFabricId();
+
+    return CHIP_NO_ERROR;
+}
+
 void DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
                                          const PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf)
 {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -266,6 +266,15 @@ public:
      */
     CHIP_ERROR ServiceEventSignal();
 
+    /**
+     * @brief Get the Fabric ID assigned to the device.
+     *
+     * @param[out] fabricId   Fabric ID of the device.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    CHIP_ERROR GetFabricId(uint64_t & fabricId);
+
 protected:
     enum class State
     {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -88,6 +88,7 @@ CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::Controller::Devi
 CHIP_ERROR
 pychip_DeviceController_GetAddressAndPort(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId, char * outAddress,
                                           uint64_t maxAddressLen, uint16_t * outPort);
+CHIP_ERROR pychip_DeviceController_GetFabricId(chip::Controller::DeviceCommissioner * devCtrl, uint64_t * outFabricId);
 
 // Rendezvous
 CHIP_ERROR pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissioner * devCtrl, uint16_t discriminator,
@@ -181,6 +182,11 @@ CHIP_ERROR pychip_DeviceController_GetAddressAndPort(chip::Controller::DeviceCom
     VerifyOrReturnError(address.ToString(outAddress, maxAddressLen), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR pychip_DeviceController_GetFabricId(chip::Controller::DeviceCommissioner * devCtrl, uint64_t * outFabricId)
+{
+    return devCtrl->GetFabricId(*outFabricId);
 }
 
 const char * pychip_DeviceController_ErrorToString(CHIP_ERROR err)

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -195,6 +195,8 @@ class DeviceMgrCmd(Cmd):
 
         "set-pairing-wifi-credential",
         "set-pairing-thread-credential",
+
+        "get-fabricid",
     ]
 
     def parseline(self, line):
@@ -685,6 +687,28 @@ class DeviceMgrCmd(Cmd):
         Removed, use network commissioning cluster instead.
         """
         print("Pairing Thread Credential is nolonger available, use NetworkCommissioning cluster instead.")
+
+    def do_getfabricid(self, line):
+        """
+          get-fabricid
+
+          Read the current Fabric Id of the controller device, return 0 if not available.
+        """
+        try:
+            args = shlex.split(line)
+
+            if (len(args) > 0):
+                print("Unexpected argument: " + args[1])
+                return
+
+            fabricid = self.devCtrl.GetFabricId()
+        except exceptions.ChipStackException as ex:
+            print("An exception occurred during reading FabricID:")
+            print(str(ex))
+            return
+
+        print("Get fabric ID complete")
+        print("Fabric ID: " + hex(fabricid))
 
     def do_history(self, line):
         """

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -205,6 +205,19 @@ class ChipDeviceController(object):
             lambda: self._dmLib.pychip_DeviceController_DiscoverAllCommissioning(self.devCtrl)
         )
 
+    def GetFabricId(self):
+        fabricid = c_uint64(0)
+
+        error = self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_GetFabricId(
+                self.devCtrl, pointer(fabricid))
+        )
+
+        if error == 0:
+            return fabricid.value
+        else:
+            return 0
+
     def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args, blocking=False):
         device = c_void_p(None)
         res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
@@ -325,3 +338,6 @@ class ChipDeviceController(object):
 
             self._dmLib.pychip_GetCommandSenderHandle.argtypes = [c_void_p]
             self._dmLib.pychip_GetCommandSenderHandle.restype = c_uint64
+
+            self._dmLib.pychip_DeviceController_GetFabricId.argtypes = [c_void_p, POINTER(c_uint64)]
+            self._dmLib.pychip_DeviceController_GetFabricId.restype = c_uint32


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
FR requested by CSG, python controller needs to support command to getFabricId for the test script to query.

* Fixes #6985 

#### Change overview
Add get-fabricid command in Python Device Controller

#### Testing
How was this tested? (at least one bullet point required)
1. Run chip-device-ctrl
2. Run chip-device-ctrl> get-fabricid and the result should be 0

```
Get fabric ID complete
Fabric ID: 0
chip-device-ctrl >  
```

3. Connect to a device chip-device-ctrl > connect -ip 192.168.86.157 20202021 12344321
4. Run chip-device-ctrl > get-fabric-id and confirm the Fabric ID is returned.

```
Get fabric ID complete
Fabric ID: 0xbc5c01
chip-device-ctrl >  
```