### PR TITLE
[Tests] Throw an error if an argument name for a command can not be f…

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -66,7 +66,7 @@ class {{filename}}: public TestCommand
         CHIP_ERROR err = CHIP_NO_ERROR;
 
         {{#if isCommand}}
-        err = cluster.{{asCamelCased command false}}(mOnSuccessCallback_{{index}}->Cancel(), mOnFailureCallback_{{index}}->Cancel());
+        err = cluster.{{asCamelCased command false}}(mOnSuccessCallback_{{index}}->Cancel(), mOnFailureCallback_{{index}}->Cancel(){{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});
         {{else if isReadAttribute}}
         err = cluster.ReadAttribute{{asCamelCased attribute false}}(mOnSuccessCallback_{{index}}->Cancel(), mOnFailureCallback_{{index}}->Cancel());
         {{else if isWriteAttribute}}

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -224,7 +224,12 @@ function chip_tests_item_parameters(options)
     const commands    = commandArgs.map(commandArg => {
       commandArg = JSON.parse(JSON.stringify(commandArg));
 
-      const expected          = commandValues.find(value => value.name.toLowerCase() == commandArg.name.toLowerCase());
+      const expected = commandValues.find(value => value.name.toLowerCase() == commandArg.name.toLowerCase());
+      if (!expected) {
+        printErrorAndExit(this,
+            'Missing "' + commandArg.name + '" in arguments list: \n\t* '
+                + commandValues.map(command => command.name).join('\n\t* '));
+      }
       commandArg.definedValue = expected.value;
 
       return commandArg;


### PR DESCRIPTION
…ound in the arguments list for this command

#### Problem
 When writing tests for `src/app/tests/suites/`, throw a comprehensive error message when an argument name is misspelled.

#### Change overview
 * Throw an error message with the name of the command argument and the possible names with values configured into the yaml file
 * Pass arguments to the `chip-tool` partials when generating commands

#### Testing
 * This was tested writing yaml files. This has no effects unless someone writes a test and makes a typo.