### PR TITLE
Stop limiting Darwin test iterations.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -145,8 +145,7 @@ jobs:
             - name: Run Test Suites
               timeout-minutes: 5
               run: |
-                  # Force 1 iteration for now until we sort out our threading issues.
-                  scripts/tests/test_suites.sh 1
+                  scripts/tests/test_suites.sh
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }}


### PR DESCRIPTION
Now that https://github.com/project-chip/connectedhomeip/pull/7651 is merged,
this is reasonable again.

#### Problem
Darwin test iterations are being limited to 1 to reduce the chance of random failures.

#### Change overview
Remove the limitation, use default iteration count.

#### Testing
Ran the tests 7 times in CI on my fork with iterations set to 200, with no failures.  Ran another 6 times with this exact change (so at the 20 iterations default) with no failures.