### PR TITLE
Enable CRMP on the client

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -62,9 +62,8 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
-    err = mpExchangeCtx->SendMessage(
-        Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(commandPacket),
-        Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse).Set(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(commandPacket),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
     SuccessOrExit(err);
     MoveToState(CommandState::Sending);
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -85,9 +85,7 @@ CHIP_ERROR Device::SendMessage(Protocols::Id protocolId, uint8_t msgType, System
     // TODO(#5675): This code is temporary, and must be updated to use the IM API. Currently, we use a temporary Protocol
     // TempZCL to carry over legacy ZCL messages.  We need to set flag kFromInitiator to allow receiver to deliver message to
     // corresponding unsolicited message handler.
-    //
-    // TODO: Also, disable CRMP for now because it just doesn't seem to work
-    sendFlags.Set(Messaging::SendMessageFlags::kFromInitiator).Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
+    sendFlags.Set(Messaging::SendMessageFlags::kFromInitiator);
     exchange->SetDelegate(this);
 
     CHIP_ERROR err = exchange->SendMessage(protocolId, msgType, std::move(buffer), sendFlags);


### PR DESCRIPTION
#### Problem
We don't currently send commands as reliable messages from controllers to servers.

#### Change overview
Send commands as reliable messages.

#### Testing
Manually verified that if the server is unreachable we now do several retransmits.  Haven't figured out a good way to do an automated test for this yet.  The existing TestCommandInteraction tests don't seem to do any actual sending/receiving of commands, unfortunately.