### PR TITLE
CASE spec refresh

### DIFF
--- a/src/channel/Channel.h
+++ b/src/channel/Channel.h
@@ -107,6 +107,13 @@ public:
         return *this;
     }
 
+    Credentials::CertificateKeyId & GetTrustedRootId() const { return *mCaseParameters.mTrustedRootId; }
+    ChannelBuilder & SetTrustedRootId(Credentials::CertificateKeyId * trustedRootId)
+    {
+        mCaseParameters.mTrustedRootId = trustedRootId;
+        return *this;
+    }
+
     Optional<Inet::IPAddress> GetForcePeerAddress() const { return mForcePeerAddr; }
     ChannelBuilder & SetForcePeerAddress(Inet::IPAddress peerAddr)
     {
@@ -121,6 +128,7 @@ private:
     {
         uint16_t mPeerKeyId;
         Credentials::OperationalCredentialSet * mOperationalCredentialSet;
+        Credentials::CertificateKeyId * mTrustedRootId;
     } mCaseParameters;
 
     Optional<Inet::IPAddress> mForcePeerAddr;

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -264,9 +264,9 @@ void ChannelContext::EnterCasePairingState()
     // TODO: currently only supports IP/UDP paring
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(prepare.mAddress);
-    CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(addr, &prepare.mBuilder.GetOperationalCredentialSet(),
-                                                                   prepare.mBuilder.GetPeerNodeId(),
-                                                                   mExchangeManager->GetNextKeyId(), ctxt, this);
+    CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(
+        addr, &prepare.mBuilder.GetOperationalCredentialSet(), prepare.mBuilder.GetTrustedRootId(),
+        prepare.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -497,7 +497,8 @@ CHIP_ERROR Device::EstablishCASESession()
     ReturnErrorOnFailure(mCASESession.MessageDispatch().Init(mSessionManager->GetTransportManager()));
     mCASESession.MessageDispatch().SetPeerAddress(mDeviceAddress);
 
-    ReturnErrorOnFailure(mCASESession.EstablishSession(mDeviceAddress, mCredentials, mDeviceId, 0, exchange, this));
+    ReturnErrorOnFailure(
+        mCASESession.EstablishSession(mDeviceAddress, mCredentials, *mTrustedRootId, mDeviceId, 0, exchange, this));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -80,6 +80,7 @@ struct ControllerDeviceInitParams
     Inet::InetLayer * inetLayer                         = nullptr;
     PersistentStorageDelegate * storageDelegate         = nullptr;
     Credentials::OperationalCredentialSet * credentials = nullptr;
+    Credentials::CertificateKeyId * trustedRoot         = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * bleLayer = nullptr;
 #endif
@@ -173,6 +174,7 @@ public:
         mAdminId         = admin;
         mStorageDelegate = params.storageDelegate;
         mCredentials     = params.credentials;
+        mTrustedRootId   = params.trustedRoot;
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
@@ -429,6 +431,7 @@ private:
     uint16_t mCASESessionKeyId = 0;
 
     Credentials::OperationalCredentialSet * mCredentials = nullptr;
+    Credentials::CertificateKeyId * mTrustedRootId       = nullptr;
 
     PersistentStorageDelegate * mStorageDelegate = nullptr;
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -775,6 +775,28 @@ CHIP_ERROR ChipDN::GetCertChipId(uint64_t & chipId) const
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipDN::GetCertFabricId(uint64_t & fabricId) const
+{
+    uint8_t rdnCount = RDNCount();
+
+    fabricId = 0;
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        switch (rdn[i].mAttrOID)
+        {
+        case kOID_AttributeType_ChipFabricId:
+            VerifyOrReturnError(fabricId == 0, CHIP_ERROR_WRONG_CERT_TYPE);
+            fabricId = rdn[i].mAttrValue.mChipVal;
+            break;
+        default:
+            return CHIP_ERROR_WRONG_CERT_TYPE;
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 bool ChipDN::IsEqual(const ChipDN & other) const
 {
     bool res         = true;

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -256,6 +256,15 @@ public:
      **/
     CHIP_ERROR GetCertChipId(uint64_t & chipId) const;
 
+    /**
+     * @brief Retrieve the Fabric ID of a CHIP certificate.
+     *
+     * @param certId  A reference to the certificate Fabric ID value.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR GetCertFabricId(uint64_t & fabricId) const;
+
     bool IsEqual(const ChipDN & other) const;
 
     /**

--- a/src/credentials/CHIPOperationalCredentials.cpp
+++ b/src/credentials/CHIPOperationalCredentials.cpp
@@ -377,5 +377,24 @@ P256Keypair * OperationalCredentialSet::GetNodeKeypairAt(const CertificateKeyId 
     return nullptr;
 }
 
+const ChipCertificateData * OperationalCredentialSet::GetRootCertificate(const CertificateKeyId & trustedRootId) const
+{
+    for (uint8_t i = 0; i < mOpCredCount; i++)
+    {
+        ChipCertificateSet * certSet = &mOpCreds[i];
+
+        for (uint8_t j = 0; j < certSet->GetCertCount(); j++)
+        {
+            const ChipCertificateData * cert = &certSet->GetCertSet()[j];
+            if (cert->mCertFlags.Has(CertFlags::kIsTrustAnchor) && cert->mAuthKeyId.IsEqual(trustedRootId))
+            {
+                return cert;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
 } // namespace Credentials
 } // namespace chip

--- a/src/credentials/CHIPOperationalCredentials.h
+++ b/src/credentials/CHIPOperationalCredentials.h
@@ -253,6 +253,8 @@ public:
 
     CHIP_ERROR SetDevOpCredKeypair(const CertificateKeyId & trustedRootId, P256Keypair * newKeypair);
 
+    const ChipCertificateData * GetRootCertificate(const CertificateKeyId & trustedRootId) const;
+
 private:
     ChipCertificateSet * mOpCreds;     /**< Pointer to an array of certificate data. */
     uint8_t mOpCredCount;              /**< Number of certificates in mOpCreds


### PR DESCRIPTION
#### Problem
The current CASE logic is not up to date with 0.7 spec.

#### Change overview
- Replaced BoundBuf with TLV. 
- Cleanup SigmaR1/2/3
- Added new method to OperationalCredentialSet to retrieve RootCertificate indexed by TrustedRootId
- Updated GenerateDestinationID method to use Root Certificate's public key instead of the leaf certificate
- Addresses #5934

#### Testing
- TestCaseSession.cpp tests were updated to reflect changes.

