### PR TITLE
[Darwin] Fix hangs in CHIPDeviceController when it is already shutdown

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		1E85732C26551A490050A4D9 /* DataModelHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731C26551A490050A4D9 /* DataModelHandler.cpp */; };
 		1E85732D26551A490050A4D9 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731D26551A490050A4D9 /* util.cpp */; };
 		1E85732E26551A490050A4D9 /* ember-print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731E26551A490050A4D9 /* ember-print.cpp */; };
-		1E85732F26551A490050A4D9 /* attribute-size.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731F26551A490050A4D9 /* attribute-size.cpp */; };
+		1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85731F26551A490050A4D9 /* attribute-size-util.cpp */; };
 		1E85733026551A490050A4D9 /* process-cluster-message.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85732026551A490050A4D9 /* process-cluster-message.cpp */; };
 		1E85733126551A490050A4D9 /* chip-message-send.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85732126551A490050A4D9 /* chip-message-send.cpp */; };
 		1E85733426551A700050A4D9 /* reporting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E85733226551A700050A4D9 /* reporting.cpp */; };
@@ -98,7 +98,7 @@
 		1E85731C26551A490050A4D9 /* DataModelHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DataModelHandler.cpp; path = ../../../app/util/DataModelHandler.cpp; sourceTree = "<group>"; };
 		1E85731D26551A490050A4D9 /* util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = util.cpp; path = ../../../app/util/util.cpp; sourceTree = "<group>"; };
 		1E85731E26551A490050A4D9 /* ember-print.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ember-print.cpp"; path = "../../../app/util/ember-print.cpp"; sourceTree = "<group>"; };
-		1E85731F26551A490050A4D9 /* attribute-size.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-size-util.cpp"; path = "../../../app/util/attribute-size-util.cpp"; sourceTree = "<group>"; };
+		1E85731F26551A490050A4D9 /* attribute-size-util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-size-util.cpp"; path = "../../../app/util/attribute-size-util.cpp"; sourceTree = "<group>"; };
 		1E85732026551A490050A4D9 /* process-cluster-message.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "process-cluster-message.cpp"; path = "../../../app/util/process-cluster-message.cpp"; sourceTree = "<group>"; };
 		1E85732126551A490050A4D9 /* chip-message-send.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "chip-message-send.cpp"; path = "../../../app/util/chip-message-send.cpp"; sourceTree = "<group>"; };
 		1E85733226551A700050A4D9 /* reporting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = reporting.cpp; path = ../../../app/reporting/reporting.cpp; sourceTree = "<group>"; };
@@ -173,7 +173,7 @@
 				1E85731926551A490050A4D9 /* af-event.cpp */,
 				1E85731B26551A490050A4D9 /* af-main-common.cpp */,
 				1E85731426551A490050A4D9 /* attribute-list-byte-span.cpp */,
-				1E85731F26551A490050A4D9 /* attribute-size.cpp */,
+				1E85731F26551A490050A4D9 /* attribute-size-util.cpp */,
 				1E85731626551A490050A4D9 /* attribute-storage.cpp */,
 				1E85731826551A490050A4D9 /* attribute-table.cpp */,
 				1E85731226551A490050A4D9 /* binding-table.cpp */,
@@ -453,7 +453,7 @@
 				1E85732B26551A490050A4D9 /* af-main-common.cpp in Sources */,
 				1E85732A26551A490050A4D9 /* ember-compatibility-functions.cpp in Sources */,
 				B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */,
-				1E85732F26551A490050A4D9 /* attribute-size.cpp in Sources */,
+				1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */,
 				2C1B027A2641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm in Sources */,
 				1E85733526551A700050A4D9 /* reporting-default-configuration.cpp in Sources */,
 				1E85732926551A490050A4D9 /* af-event.cpp in Sources */,

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -130,8 +130,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
 
     __block BOOL commissionerInitialized = NO;
-    if ([self isRunning])
-    {
+    if ([self isRunning]) {
         CHIP_LOG_DEBUG("Ignoring duplicate call to startup, Controller already started...");
         return YES;
     }
@@ -217,8 +216,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         success = ![self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return success;
     }
@@ -244,8 +242,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         success = ![self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return success;
     }
@@ -274,8 +271,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         success = ![self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return success;
     }
@@ -317,8 +313,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         success = ![self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return success;
     }
@@ -336,8 +331,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     __block BOOL success = NO;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         success = ![self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return success;
     }
@@ -355,8 +349,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 {
     __block CHIPDevice * chipDevice = nil;
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         [self checkForError:errorCode logMsg:kErrorNotRunning error:error];
         return chipDevice;
     }
@@ -385,8 +378,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 - (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId
 {
     __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
-    if (![self isRunning])
-    {
+    if (![self isRunning]) {
         [self checkForError:errorCode logMsg:kErrorNotRunning error:nil];
         return;
     }

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -40,4 +40,35 @@
     XCTAssertTrue([controller shutdown]);
 }
 
+- (void)testControllerMultipleStartup
+{
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    for (int i=0; i < 5; i++)
+    {
+        XCTAssertTrue([controller startup:nil]);
+    }
+    XCTAssertTrue([controller shutdown]);
+}
+
+- (void)testControllerMultipleShutdown
+{
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    XCTAssertTrue([controller startup:nil]);
+    for (int i=0; i < 5; i++)
+    {
+        XCTAssertTrue([controller shutdown]);
+    }
+}
+
+- (void)testControllerInvalidAccess
+{
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    NSError *error;
+    XCTAssertFalse([controller isRunning]);
+    XCTAssertNil([controller getPairedDevice:1234 error:&error]);
+    XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
+    XCTAssertFalse([controller unpairDevice:1 error:&error]);
+    XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
+}
+
 @end

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -43,8 +43,7 @@
 - (void)testControllerMultipleStartup
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    for (int i=0; i < 5; i++)
-    {
+    for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller startup:nil]);
     }
     XCTAssertTrue([controller shutdown]);
@@ -54,8 +53,7 @@
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     XCTAssertTrue([controller startup:nil]);
-    for (int i=0; i < 5; i++)
-    {
+    for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller shutdown]);
     }
 }
@@ -63,7 +61,7 @@
 - (void)testControllerInvalidAccess
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    NSError *error;
+    NSError * error;
     XCTAssertFalse([controller isRunning]);
     XCTAssertNil([controller getPairedDevice:1234 error:&error]);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);


### PR DESCRIPTION
#### Problem
What is being fixed?
* As of #7651, the CHIP workqueue is suspended when the Controller is shutdown or not running. This means almost any API on the CHIPDeviceController will hang because we are using the work queue to serialize access to the CHIPDeviceController's members. This includes APIs to check whether the Controller is even "running".  

#### Change overview
The main thing to enable here is an early return if the controller is not "running", this can be done by making the `isRunning` API directly rely on the "atomic" member variable `cppCommissioner`. 
Now we can check whether the controller is running without queuing up requests synchronously on the stopped workqueue. 

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
Added unit tests to start the controller repeatedly, stop the controller repeatedly, and access APIs in the controller while it's not running. These tests hang without this fix.