### PR TITLE
Call Shutdown() if SendEchoRequest failed within  the timer handler 

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -179,6 +179,7 @@ void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, chip::
         if (err != CHIP_NO_ERROR)
         {
             streamer_printf(streamer_get(), "Send request failed: %s\n", ErrorStr(err));
+            Shutdown();
         }
     }
     else


### PR DESCRIPTION

#### Problem
What is being fixed?  Examples:
This is the follow-up of review comment in #7544.

After making shell ping command asynchronous, the following ping will be scheduled in the timer handler. I instrumented hack logic within the EchoTimerHandler to make SendEchoRequet fail on purpose, I found neither the echo client is shutdown nor the  
CancelTimer is called in this case.
 
```
> ping 192.168.86.171
IP address: 192.168.86.171
....
Establish secure session succeeded
-->: SendEchoRequest

Send echo request message with payload size: 32 bytes to Node: 12344321
....
Echo Response: 1/1(100.00%) len=32 time=0.002ms
--> EchoTimerHandler
Send request failed: CHIP Error 4011 (0x00000FAB): No memory

> quit
Error quit: CHIP Error 4047 (0x00000FCF): Invalid argument
```


#### Change overview
Call Shutdown() if SendEchoRequest failed within  the timer handler 

#### Testing
How was this tested? (at least one bullet point required)

Instrumented hack logic within the EchoTimerHandler to make SendEchoRequet fail on purpose, ping echo server from chip-shell.

```
> ping 192.168.86.171
....
Establish secure session succeeded
-->: SendEchoRequest

Send echo request message with payload size: 32 bytes to Node: 12344321
.....
-->: EchoTimerHandler
Send request failed: CHIP Error 4011 (0x00000FAB): No memory
-->: Shutdown

> 
> quit

```