### PR TITLE
Improve usability of spans for outparams.

### DIFF
--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -70,6 +70,74 @@ static void TestByteSpan(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !s5.data_equal(s4));
     NL_TEST_ASSERT(inSuite, s5.data_equal(s0));
     NL_TEST_ASSERT(inSuite, s0.data_equal(s5));
+
+    ByteSpan s6(arr2);
+    s6.reduce_size(2);
+    NL_TEST_ASSERT(inSuite, s6.size() == 2);
+    ByteSpan s7(arr2, 2);
+    NL_TEST_ASSERT(inSuite, s6.data_equal(s7));
+    NL_TEST_ASSERT(inSuite, s7.data_equal(s6));
+}
+
+static void TestMutableByteSpan(nlTestSuite * inSuite, void * inContext)
+{
+    uint8_t arr[] = { 1, 2, 3 };
+
+    MutableByteSpan s0 = MutableByteSpan();
+    NL_TEST_ASSERT(inSuite, s0.data() == nullptr);
+    NL_TEST_ASSERT(inSuite, s0.size() == 0);
+    NL_TEST_ASSERT(inSuite, s0.empty());
+    NL_TEST_ASSERT(inSuite, s0.data_equal(s0));
+
+    MutableByteSpan s1(arr, 2);
+    NL_TEST_ASSERT(inSuite, s1.data() == arr);
+    NL_TEST_ASSERT(inSuite, s1.size() == 2);
+    NL_TEST_ASSERT(inSuite, !s1.empty());
+    NL_TEST_ASSERT(inSuite, s1.data_equal(s1));
+    NL_TEST_ASSERT(inSuite, !s1.data_equal(s0));
+
+    MutableByteSpan s2(arr);
+    NL_TEST_ASSERT(inSuite, s2.data() == arr);
+    NL_TEST_ASSERT(inSuite, s2.size() == 3);
+    NL_TEST_ASSERT(inSuite, s2.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s2.empty());
+    NL_TEST_ASSERT(inSuite, s2.data_equal(s2));
+    NL_TEST_ASSERT(inSuite, !s2.data_equal(s1));
+
+    MutableByteSpan s3 = s2;
+    NL_TEST_ASSERT(inSuite, s3.data() == arr);
+    NL_TEST_ASSERT(inSuite, s3.size() == 3);
+    NL_TEST_ASSERT(inSuite, s3.data()[2] == 3);
+    NL_TEST_ASSERT(inSuite, !s3.empty());
+    NL_TEST_ASSERT(inSuite, s3.data_equal(s2));
+
+    uint8_t arr2[] = { 3, 2, 1 };
+    MutableByteSpan s4(arr2);
+    NL_TEST_ASSERT(inSuite, !s4.data_equal(s2));
+
+    MutableByteSpan s5(arr2, 0);
+    NL_TEST_ASSERT(inSuite, s5.data() != nullptr);
+    NL_TEST_ASSERT(inSuite, !s5.data_equal(s4));
+    NL_TEST_ASSERT(inSuite, s5.data_equal(s0));
+    NL_TEST_ASSERT(inSuite, s0.data_equal(s5));
+
+    MutableByteSpan s6(arr2);
+    s6.reduce_size(2);
+    NL_TEST_ASSERT(inSuite, s6.size() == 2);
+    MutableByteSpan s7(arr2, 2);
+    NL_TEST_ASSERT(inSuite, s6.data_equal(s7));
+    NL_TEST_ASSERT(inSuite, s7.data_equal(s6));
+
+    uint8_t arr3[] = { 1, 2, 3 };
+    MutableByteSpan s8(arr3);
+    NL_TEST_ASSERT(inSuite, arr3[1] == 2);
+    s8.data()[1] = 3;
+    NL_TEST_ASSERT(inSuite, arr3[1] == 3);
+
+    // Not mutable span on purpose, to test conversion.
+    ByteSpan s9 = s8;
+    NL_TEST_ASSERT(inSuite, s9.data_equal(s8));
+    NL_TEST_ASSERT(inSuite, s8.data_equal(s9));
 }
 
 static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
@@ -111,7 +179,8 @@ static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan), NL_TEST_DEF_FN(TestFixedByteSpan), NL_TEST_SENTINEL() };
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestByteSpan), NL_TEST_DEF_FN(TestMutableByteSpan),
+                                 NL_TEST_DEF_FN(TestFixedByteSpan), NL_TEST_SENTINEL() };
 
 int TestSpan(void)
 {


### PR DESCRIPTION
A few changes here:

1) Allow setting the size of a Span (to a value no larger than its current size).  This enables use of a Span over a non-const type as an outparam that you fill with data and then set the size of the data.

2) Allow converting a `Span<T>` to a `Span<const T>`, so once you fill such a non-const-type Span with data you can pass it to functions expecting a Span over a const type without having to manually create one.

3) Change data_equal to allow comparing `Span<T>` to `Span<const T>`.

#### Problem
Hard to use Span where we want to.  See https://github.com/project-chip/connectedhomeip/pull/7666#discussion_r653053393

#### Change overview
Address the shortcomings that comment pointed out.

#### Testing
Some automated tests included.  I also did some manual tests that various things that should not compile do not:

1. `Span<uint8_t>().data_equal(Span<uint16_t>())`
2. `MutableByteSpan s = ByteSpan()`

Wish we had automated ways to test "this should not compile"....