### PR TITLE
Fixed updating SRP services

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -980,7 +980,7 @@ exit:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
-static_assert(OPENTHREAD_API_VERSION >= 80, "SRP Client requires a more recent OpenThread version");
+static_assert(OPENTHREAD_API_VERSION >= 120, "SRP Client requires a more recent OpenThread version");
 
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnSrpClientNotification(otError aError,
@@ -1092,8 +1092,14 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AddSrpService(c
         }
         else
         {
-            VerifyOrExit((strcmp(service.mInstanceName, aInstanceName) != 0) || (strcmp(service.mName, aName) != 0),
-                         error = MapOpenThreadError(OT_ERROR_DUPLICATED));
+            if ((strcmp(service.mInstanceName, aInstanceName) == 0) && (strcmp(service.mName, aName) == 0))
+            {
+                VerifyOrExit(MapOpenThreadError(otSrpClientClearService(mOTInst, &(service.mService))) == CHIP_NO_ERROR,
+                             error = MapOpenThreadError(OT_ERROR_FAILED));
+
+                // Free memory immediately, as OnSrpClientNotification will not be called.
+                memset(&service, 0, sizeof(service));
+            }
         }
     }
 

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -51,12 +51,6 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
     char serviceType[chip::Mdns::kMdnsTypeAndProtocolMaxSize + 1];
     snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
 
-    // Try to remove service before adding it, as SRP doesn't allow to update existing services.
-    result = ThreadStackMgr().RemoveSrpService(service->mName, serviceType);
-
-    // Service should be successfully removed or not found (not exists).
-    VerifyOrExit((result == CHIP_NO_ERROR) || (result == Internal::MapOpenThreadError(OT_ERROR_NOT_FOUND)), );
-
     result =
         ThreadStackMgr().AddSrpService(service->mName, serviceType, service->mPort, service->mTextEntries, service->mTextEntrySize);
 


### PR DESCRIPTION
#### Problem
So far SRP services were updated following remove-readd pattern due to lack of SRP update functionality. This way needs sending two messages per each service update, while in the newest OpenThread version better method is available. That is clearing services locally and readding again that results in sending only one SRP update message.

#### Change overview
* Added clearing SRP service in case it already exists in the AddSrpService method implementation.
* Updated OpenThread submodule.

#### Testing
It was tested on nrfconnect platform using Python CHIP Controller and OpenThread Border Router with the following procedure:
1. Commissioning and provisioning using Python CHIP Controller.
2. Verified that device requests Operational Discovery record successfully and it's available on OTBR (using `ot-ctl srp server service` command).
3. Verified that Python CHIP Controller is able to resolve address successfully.
4. Verified that Python CHIP Controller is able to reach device using `zcl OnOff` command.
5. Changed OTBR prefix to trigger device IP address change and Operational Discovery record update by calling:
`ot-ctl prefix remove <prefix (e.g. fd11:22::/64)>`
`ot-ctl prefix add  <prefix (e.g. fd11:33::/64)>`
`ot-ctl netdata register`
6. Verified that device changes IP address and requests Operational Discovery record update successfully (using `ot-ctl srp server service` command).
7. Verified that Python CHIP Controller is able to resolve address successfully again.
8. Verified that Python CHIP Controller is still able to reach device using `zcl OnOff` command.
9. Repeated 5-8 steps few times.

#### Fixes: #6733 