### PR TITLE
Disallow copy-construction of Device objects.

### DIFF
--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -89,6 +89,8 @@ class DLL_EXPORT Device : public Messaging::ExchangeDelegate, public SessionEsta
 {
 public:
     ~Device();
+    Device()               = default;
+    Device(const Device &) = delete;
 
     enum class PairingWindowOption
     {


### PR DESCRIPTION
The lifetime of these objects is entirely managed by DeviceController
and copy-constructing them does not make any sense.

#### Problem
If someone copies a Device, as @msandstedt noted, they can end up having it outlive the objects its members point to, and then bad things will happen.

#### Change overview
Disallow copying Device, because that's not a thing that makes sense.

#### Testing
Manual testing that attempting to copy fails.  We don't really have a way to test "this should not compile" yet...