### PR TITLE
[EFR32] Heap fragmentation issue cause AddOpCert request to fail

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -67,7 +67,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(13 * 1024)",
+    "SL_HEAP_SIZE=(16 * 1024)",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -59,7 +59,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(13 * 1024)",
+    "SL_HEAP_SIZE=(16 * 1024)",
   ]
 }
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -45,7 +45,7 @@ efr32_sdk("sdk") {
     "HAL_VCOM_ENABLE=1",
     "EFR32_LOG_ENABLED=1",
     "PW_RPC_ENABLED",
-    "SL_HEAP_SIZE=(10 * 1024)",
+    "SL_HEAP_SIZE=(16 * 1024)",
   ]
 }
 

--- a/examples/shell/efr32/BUILD.gn
+++ b/examples/shell/efr32/BUILD.gn
@@ -48,7 +48,7 @@ efr32_sdk("sdk") {
 
   defines = [
     "BOARD_ID=${efr32_board}",
-    "SL_HEAP_SIZE=(12 * 1024)",
+    "SL_HEAP_SIZE=(16 * 1024)",
     "OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE",
     "ENABLE_CHIP_SHELL",
   ]

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -60,7 +60,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(12 * 1024)",
+    "SL_HEAP_SIZE=(16 * 1024)",
   ]
 }
 


### PR DESCRIPTION
#### Problem
EFR32 examples fail Secure session establisment with a failure when adding OpCert

```
00> <info  > [ZCL] OpCreds: Failed AddOpCert request.
```

The error happend when trying to store the OperationCertificate for this admin, the creation of a new `StorableAdminPairingInfo` does a malloc of 1976 that fails.

```
CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
{
    CHIP_ERROR err = CHIP_NO_ERROR;

    char key[KeySize()];
    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));

    StorableAdminPairingInfo * info = chip::Platform::New<StorableAdminPairingInfo>();
    ReturnErrorCodeIf(info == nullptr, CHIP_ERROR_NO_MEMORY);
```

The whole process does multiples mallocs of rather large size. #7695

After analysing the heap usage, There was enough free heap but not a big enough block for the StorableAdminPairingInfo

#### Change overview
Quick band AID fix: Adding 3k to the heap of efr32 examples helps with the current fragmentation issues. 
Could Add more heap to the MG12 MCU family but MG21 is already starving for RAM. 

TODO: refactor efr32 example to use heap4 for FreeRTOS and wrap all allocs to the freeRTOS api. Improve heap monitor and tracking to better analyse and optimize the heap usage.

#### Testing
Manual tests with python controller on the differents examples
`connect -ble 3840 73141520 1234`
confirm `Secure Session to Device Established`

Fixes #7390