### PR TITLE
Stop installing rsync in our test, since our docker image now provides it

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,8 +44,6 @@ jobs:
                   submodules: true
             - name: Try to ensure the directories for core dumping exist and we can write them.
               run: |
-                  apt-get update
-                  apt-get -y install --fix-missing rsync
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
                   mkdir objdir-clone || true


### PR DESCRIPTION
#### Problem
We don't need to install rsync in the workflow anymore.

#### Change overview
Stop installing it.

#### Testing
Made sure the workflow still correctly uploads a Linux objdir on crash.