### PR TITLE
Adding request-commissioning CHIPTool command

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -27,6 +27,7 @@ executable("chip-tool") {
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
     "commands/pairing/PairingCommand.cpp",
+    "commands/pairing/RequestCommissioningCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/reporting/ReportingCommand.cpp",

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "PairingCommand.h"
-
+#include "RequestCommissioningCommand.h"
 class Unpair : public PairingCommand
 {
 public:
@@ -67,8 +67,10 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),     make_unique<PairBypass>(), make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
-        make_unique<PairSoftAP>(), make_unique<Ethernet>(),   make_unique<PairOnNetwork>(),
+        make_unique<Unpair>(),        make_unique<PairBypass>(),
+        make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
+        make_unique<PairSoftAP>(),    make_unique<Ethernet>(),
+        make_unique<PairOnNetwork>(), make_unique<RequestCommissioningCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/RequestCommissioningCommand.cpp
+++ b/examples/chip-tool/commands/pairing/RequestCommissioningCommand.cpp
@@ -1,0 +1,27 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "RequestCommissioningCommand.h"
+
+using namespace ::chip;
+
+CHIP_ERROR RequestCommissioningCommand::Run()
+{
+    ChipLogProgress(chipTool, "Announcing commissionable node for %d sec", GetWaitDurationInSeconds());
+    return mCommissionableNodeController.AdvertiseCommissionableNode();
+}

--- a/examples/chip-tool/commands/pairing/RequestCommissioningCommand.h
+++ b/examples/chip-tool/commands/pairing/RequestCommissioningCommand.h
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (c) 2020 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/Command.h"
+#include <controller/CHIPCommissionableNodeController.h>
+
+/**
+ *    @brief
+ *      RequestCommissioningCommand, when issued by the user, will request a
+ *      user selected Commissioner to begin commissioning the requesting device
+ *      (i.e. a Commissionee). This will involve the Commissionee entering
+ *      commissioning mode, displaying an onboarding payload to the user,
+ *      initiating a User directed commissioning request and Advertising itself
+ *      as a Commissionable Node over DNS-SD.
+ */
+class RequestCommissioningCommand : public Command
+{
+public:
+    RequestCommissioningCommand() : Command("request-commissioning") {}
+    CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 3 * 60; }
+
+private:
+    chip::Controller::CommissionableNodeController mCommissionableNodeController;
+};

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -18,6 +18,9 @@ static_library("controller") {
   output_name = "libChipController"
 
   sources = [
+    "${chip_root}/src/app/server/Mdns.cpp",
+    "${chip_root}/src/app/server/Mdns.h",
+    "${chip_root}/src/app/server/Server.h",
     "AbstractMdnsDiscoveryController.cpp",
     "CHIPCluster.cpp",
     "CHIPCluster.h",

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -19,6 +19,11 @@
 // module header, comes first
 #include <controller/CHIPCommissionableNodeController.h>
 
+#include <app/server/Mdns.h>
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+#include <mdns/Advertiser.h>
 #include <support/CodeUtils.h>
 
 namespace chip {
@@ -33,6 +38,23 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Mdns::DiscoveryFi
 const Mdns::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)
 {
     return GetDiscoveredNode(idx);
+}
+
+CHIP_ERROR CommissionableNodeController::AdvertiseCommissionableNode()
+{
+#if CONFIG_DEVICE_LAYER
+    ReturnErrorOnFailure(chip::Mdns::ServiceAdvertiser::Instance().Start(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort));
+    return app::Mdns::AdvertiseCommissionableNode();
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+CHIP_ERROR CommissionableNodeController::SendUserDirectedCommissioningRequest(chip::Inet::IPAddress commissioner, uint16_t port)
+{
+    // TODO: integrate with Server:SendUserDirectedCommissioningRequest()
+    ChipLogError(Controller, "Unsupported operation CommissionableNodeController::SendUserDirectedCommissioningRequest");
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 } // namespace Controller

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -20,7 +20,6 @@
 
 #include <controller/AbstractMdnsDiscoveryController.h>
 #include <mdns/Resolver.h>
-#include <platform/CHIPDeviceConfig.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -53,6 +52,10 @@ public:
     {
         ChipLogError(Controller, "Unsupported operation CommissionableNodeController::OnNodeIdResolutionFailed");
     }
+
+    CHIP_ERROR AdvertiseCommissionableNode();
+
+    CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Inet::IPAddress commissioner, uint16_t port);
 
 protected:
     Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mDiscoveredCommissioners; }


### PR DESCRIPTION
#### Problem
Support for [Initializing setup via "commissioner-discovery-from-an-on-network-device"](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/rendezvous/InitiatingSetup.adoc#24-commissioner-discovery-from-an-on-network-device) is pending implementation of commands for Steps 7-12. 

Note: Steps 3-5 were previously implemented as a discover-commissioner command in the CHIPTool  (see [PR](https://github.com/project-chip/connectedhomeip/pull/7193))

What is being fixed?  
* Implementation of Commissionable Node advertisement in the new request-commissioning CHIPTool command.

#### Change overview
* This PR adds the basic skeleton for the request-commissioning command on the CLI CHIPTool and initiates advertisement of the tool as a Commissionable Node. 
* More actions like sending a UDC request, entering commissioning mode, etc. will be implemented as part of the same command later on, in separate PRs.

#### Testing
Tested by running the new request-commissioning command on the CHIPTool and verifying using minimal-mdns-client that a commissionable node is advertised. See outputs below from each command:

```
$> ./chip-tool pairing request-commissioning
[1623962271.779161][33013] CHIP:IN: TransportMgr initialized
[1623962271.779210][33013] CHIP:DIS: Init admin pairing table with server storage
[1623962271.779507][33013] CHIP:IN: Loading certs from KVS
[1623962271.779555][33013] CHIP:IN: local node id is 0x000000000001B669
[1623962271.780311][33013] CHIP:ZCL: Using ZAP configuration...
[1623962271.780371][33013] CHIP:ZCL: deactivate report event
[1623962271.780435][33013] CHIP:CTL: Getting operational keys
[1623962271.780447][33013] CHIP:CTL: Generating credentials
[1623962271.780577][33013] CHIP:CTL: Loaded credentials successfully
[1623962271.781020][33013] CHIP:DIS: CHIP minimal mDNS started advertising.
[1623962271.781126][33013] CHIP:DIS: Replying to DNS-SD service listing request
[1623962271.781183][33013] CHIP:DIS: Replying to DNS-SD service listing request
[1623962271.781216][33013] CHIP:DIS: Replying to DNS-SD service listing request
[1623962271.781248][33013] CHIP:DIS: Replying to DNS-SD service listing request
[1623962271.781281][33013] CHIP:DIS: Replying to DNS-SD service listing request
[1623962271.781295][33013] CHIP:DL: wpa_supplicant: _IsWiFiStationProvisioned: interface not connected
[1623962271.784222][33013] CHIP:DIS: Using wifi MAC for hostname
[1623962271.784364][33013] CHIP:DL: rotatingDeviceId: 0000490C1FF0DB5910AD14994F162DB850F3
[1623962271.784378][33013] CHIP:DIS: Advertise commission parameter vendorID=9050 productID=65279 discriminator=2976/160
[1623962271.784405][33013] CHIP:DIS: CHIP minimal mDNS configured as 'Commissionable node device'.
[1623962271.784417][33013] CHIP:TOO: Waiting for 30 sec
[1623962271.781380][33018] CHIP:DL: CHIP task running
[1623962288.933834][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962288.935128][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962288.936404][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962288.937910][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962288.939446][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962288.942679][33018] CHIP:DIS: Directly sending mDns reply to peer on port 5388
[1623962301.785356][33013] CHIP:TOO: No response from device
[1623962301.786065][33013] CHIP:CTL: Shutting down the commissioner
[1623962301.786123][33013] CHIP:CTL: Shutting down the controller
[1623962301.786139][33013] CHIP:DL: Inet Layer shutdown
[1623962301.786232][33013] CHIP:DL: BLE layer shutdown
[1623962301.786248][33013] CHIP:DL: System Layer shutdown

$> ./minimal-mdns-client -q _chipc._udp.local
Running...
Usable interface: eth0 (2)
Usable interface: services1 (5)
Usable interface: docker0 (7)
[1623962288.932292][33112] CHIP:DIS: Attempt to mDNS broadcast to an unreachable destination.
RESPONSE from: fe80::50:ff:fe00:1 on port 5353, via interface 2
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::50:ff:fe00:1
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.3
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
RESPONSE from: fe80::50:ff:fe00:1 on port 5353, via interface 2
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::50:ff:fe00:1
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.3
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
RESPONSE from: fe80::50:ff:fe00:1 on port 5353, via interface 2
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::50:ff:fe00:1
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.3
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
RESPONSE from: fe80::f0c6:79ff:fe6e:4308 on port 5353, via interface 5
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::f0c6:79ff:fe6e:4308
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.4
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
RESPONSE from: fe80::f0c6:79ff:fe6e:4308 on port 5353, via interface 5
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::f0c6:79ff:fe6e:4308
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.4
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
RESPONSE from: fe80::f0c6:79ff:fe6e:4308 on port 5353, via interface 5
RESPONSE: REPLY 4660 (1, 1, 0, 4):
RESPONSE:     QUERY ANY/IN UNICAST: _chipc._udp.local.
RESPONSE:     ANSWER PTR/IN ttl 120: _chipc._udp.local.
RESPONSE:       PTR:  1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     ADDITIONAL SRV/IN ttl 120: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:       SRV on port 11097, priority 0, weight 0:  025000000001.local.
RESPONSE:     ADDITIONAL AAAA/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  fe80::f0c6:79ff:fe6e:4308
RESPONSE:     ADDITIONAL A/IN ttl 120: 025000000001.local.
RESPONSE:       IP:  192.168.65.4
RESPONSE:     ADDITIONAL TXT/IN ttl 4500: 1F2958EC944A5CFF._chipc._udp.local.
RESPONSE:     TXT:  'VP' = '9050+65279'
RESPONSE:     TXT:  'D' = '2976'
RESPONSE:     TXT:  'CM' = '1'
RESPONSE:     TXT:  'RI' = '0000490C1FF0DB5910AD14994F162DB850F3'
RESPONSE:     TXT:  'PH' = '33'
RESPONSE:     TXT:  'PI' = ''
[1623962289.434855][33112] CHIP:DL: Inet Layer shutdown
[1623962289.435056][33112] CHIP:DL: BLE layer shutdown
[1623962289.435087][33112] CHIP:DL: System Layer shutdown
Done...
```