### PR TITLE
[esp32] Remove ON_LEVEL attribute access in examples

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -372,8 +372,6 @@ void SetupInitialLevelControlValues(chip::EndpointId endpointId)
 
     emberAfWriteAttribute(endpointId, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
                           ZCL_DATA8_ATTRIBUTE_TYPE);
-    emberAfWriteAttribute(endpointId, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_ON_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
-                          ZCL_DATA8_ATTRIBUTE_TYPE);
 }
 
 void SetupPretendDevices()


### PR DESCRIPTION

#### Problem

The esp32 all cluster app is accessing `ZCL_ON_LEVEL_ATTRIBUTE_ID` which is not implemented for now.

#### Change overview

Remove the access.

#### Testing

Tested manually with chip-device-ctrl.