### PR TITLE
[nrfconnect] Changed BT device names from Chip to Matter.

### DIFF
--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -48,7 +48,7 @@ Complete the following steps to perform DFU using mcumgr:
 > **_NOTE:_** In all of the commands listed in the following steps, replace
 > `ble-hci-number` with the Bluetooth hci integer value (for example, `0`) and
 > `ble-device-name` with the CHIP device name advertised over Bluetooth LE (for
-> example, `ChipLock`).
+> example, `MatterLock`).
 
 4.  Upload the firmware image to the device by running the following command in
     your example directory:

--- a/examples/lighting-app/nrfconnect/prj.conf
+++ b/examples/lighting-app/nrfconnect/prj.conf
@@ -29,7 +29,7 @@ CONFIG_OPENTHREAD_NETWORK_NAME="OpenThread"
 CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth overrides
-CONFIG_BT_DEVICE_NAME="ChipLight"
+CONFIG_BT_DEVICE_NAME="MatterLight"
 
 # Additional configs for debbugging experience.
 CONFIG_THREAD_NAME=y

--- a/examples/lock-app/nrfconnect/prj.conf
+++ b/examples/lock-app/nrfconnect/prj.conf
@@ -28,7 +28,7 @@ CONFIG_OPENTHREAD_NETWORK_NAME="OpenThread"
 CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth overrides
-CONFIG_BT_DEVICE_NAME="ChipLock"
+CONFIG_BT_DEVICE_NAME="MatterLock"
 
 # Additional configs for debbugging experience.
 CONFIG_THREAD_NAME=y


### PR DESCRIPTION
#### Change overview
Changed BT device names for lighting-app and lock-app from ChipLock/Light to MatterLock/Light.

#### Testing
Small change and not much to test, so verified only that after changing device name commissioning using Python CHIP controller is still working fine.
