### PR TITLE
esp32 mdns server (re)start on connectivity change

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -33,10 +33,8 @@
 #include <app/Command.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/cluster-id.h>
-#include <app/server/Mdns.h>
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
-#include <lib/mdns/Advertiser.h>
 #include <support/CodeUtils.h>
 
 static const char * TAG = "app-devicecallbacks";
@@ -59,17 +57,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
 
     case DeviceEventType::kSessionEstablished:
         OnSessionEstablished(event);
-        break;
-    case DeviceEventType::kInterfaceIpAddressChanged:
-        if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
-            (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
-        {
-            // MDNS server restart on any ip assignment: if link local ipv6 is configured, that
-            // will not trigger a 'internet connectivity change' as there is no internet
-            // connectivity. MDNS still wants to refresh its listening interfaces to include the
-            // newly selected address.
-            chip::app::Mdns::StartServer();
-        }
         break;
     }
 
@@ -110,7 +97,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     {
         ESP_LOGI(TAG, "Server ready at: %s:%d", event->InternetConnectivityChange.address, CHIP_PORT);
         wifiLED.Set(true);
-        chip::app::Mdns::StartServer();
     }
     else if (event->InternetConnectivityChange.IPv4 == kConnectivity_Lost)
     {
@@ -120,7 +106,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     if (event->InternetConnectivityChange.IPv6 == kConnectivity_Established)
     {
         ESP_LOGI(TAG, "IPv6 Server ready...");
-        chip::app::Mdns::StartServer();
     }
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -272,6 +272,33 @@ void StartServer()
     }
 }
 
+void NetworkChangeEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t)
+{
+    switch (event->Type)
+    {
+    case chip::DeviceLayer::DeviceEventType::kInternetConnectivityChange:
+        if ((event->InternetConnectivityChange.IPv4 == chip::DeviceLayer::kConnectivity_Established) ||
+            (event->InternetConnectivityChange.IPv6 == chip::DeviceLayer::kConnectivity_Established))
+        {
+            chip::app::Mdns::StartServer();
+        }
+        break;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    case chip::DeviceLayer::DeviceEventType::kThreadStateChange:
+        VerifyOrReturn(event->ThreadStateChange.AddressChanged);
+        chip::app::Mdns::StartServer();
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+void StartServerOnNetworkChange()
+{
+    chip::DeviceLayer::PlatformMgr().AddEventHandler(NetworkChangeEventHandler, {});
+}
+
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize)
 {

--- a/src/app/server/Mdns.h
+++ b/src/app/server/Mdns.h
@@ -40,6 +40,9 @@ CHIP_ERROR Advertise(bool commissionableNode);
 /// (Re-)starts the minmdns server
 void StartServer();
 
+/// (Re-)starts the minmdns server on network change
+void StartServerOnNetworkChange();
+
 CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize);
 
 } // namespace Mdns

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -530,6 +530,8 @@ void InitServer(AppDelegate * delegate)
 // ESP32 examples have a custom logic for enabling DNS-SD
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !CHIP_DEVICE_LAYER_TARGET_ESP32
     app::Mdns::StartServer();
+#elif CHIP_DEVICE_CONFIG_ENABLE_MDNS && CHIP_DEVICE_LAYER_TARGET_ESP32
+    app::Mdns::StartServerOnNetworkChange();
 #endif
 
     gCallbacks.SetSessionMgr(&gSessions);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #7705 chip-device-ctrl - resolve command hangs with lock-app.

#### Change overview
esp32 mdns server (re)start on connectivity change
Alternative solution of https://github.com/project-chip/connectedhomeip/pull/7723
Worked with @DamKast for this change.

#### Testing
How was this tested? (at least one bullet point required)
* using lock-app on esp32