### PR TITLE
Fix chip-tool crash in case of commissioning ethernet device.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -170,11 +170,11 @@ CHIP_ERROR PairingCommand::SetupNetwork()
     switch (mNetworkType)
     {
     case PairingNetworkType::None:
+    case PairingNetworkType::Ethernet:
         // Nothing to do
         SetCommandExitStatus(err == CHIP_NO_ERROR);
         break;
     case PairingNetworkType::WiFi:
-    case PairingNetworkType::Ethernet:
     case PairingNetworkType::Thread:
         err = GetExecContext()->commissioner->GetDevice(mRemoteId, &mDevice);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Setup failure! No pairing for device: %" PRIu64, mRemoteId));


### PR DESCRIPTION
#### Problem
Fix chip-tool crash on commissioning Ethernet device:
```
./chip-tool pairing ethernet 21589380 3840 192.168.10.131 11097
...
[1623941639.843658][4510] CHIP:CTL: Device confirmed that it has received the root certificate
[1623941639.843700][4510] CHIP:CTL: Operational credentials provisioned on device 0xaaaaf127c778
[1623941639.847772][4510] CHIP:TOO: Secure Pairing Success
[1623941639.849808][4510] CHIP:TOO: Pairing Success
Segmentation fault (core dumped) 
```

#### Change overview
Need to figure out what SetupNetwork() should do in case of Ethernet device, for now move it to the case where is does nothing.

#### Testing
Was manually tested on Linux.
