### PR TITLE
Remove `exit: return` idiom from some directories

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -126,7 +126,7 @@ exit:
 
 void Command::Shutdown()
 {
-    VerifyOrExit(mState != CommandState::Uninitialized, );
+    VerifyOrReturn(mState != CommandState::Uninitialized);
     mCommandMessageWriter.Reset();
 
     AbortExistingExchangeContext();
@@ -136,8 +136,6 @@ void Command::Shutdown()
     ClearState();
 
     mCommandIndex = 0;
-exit:
-    return;
 }
 
 CHIP_ERROR Command::PrepareCommand(const CommandPathParams & aCommandPathParams, bool aIsStatus)

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -668,15 +668,13 @@ CHIP_ERROR EventManagement::EventIterator(const TLVReader & aReader, size_t aDep
 
 CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aDepth, void * apContext)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    TLV::TLVWriter checkpoint;
-    EventLoadOutContext * loadOutContext = static_cast<EventLoadOutContext *>(apContext);
-    err                                  = EventIterator(aReader, aDepth, loadOutContext);
+    EventLoadOutContext * const loadOutContext = static_cast<EventLoadOutContext *>(apContext);
+    CHIP_ERROR err                             = EventIterator(aReader, aDepth, loadOutContext);
     loadOutContext->mCurrentEventNumber++;
     if (err == CHIP_EVENT_ID_FOUND)
     {
         // checkpoint the writer
-        checkpoint = loadOutContext->mWriter;
+        TLV::TLVWriter checkpoint = loadOutContext->mWriter;
 
         err = CopyEvent(aReader, loadOutContext->mWriter, loadOutContext);
 
@@ -684,13 +682,16 @@ CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aD
         // successful copy.  In all other cases, roll back the
         // writer state back to the checkpoint, i.e., the state
         // before we began the copy operation.
-        VerifyOrExit((err == CHIP_NO_ERROR) || (err == CHIP_END_OF_TLV), loadOutContext->mWriter = checkpoint);
+        if ((err != CHIP_NO_ERROR) && (err != CHIP_END_OF_TLV))
+        {
+            loadOutContext->mWriter = checkpoint;
+            return err;
+        }
 
         loadOutContext->mPreviousSystemTime.mValue = loadOutContext->mCurrentSystemTime.mValue;
         loadOutContext->mFirst                     = false;
     }
 
-exit:
     return err;
 }
 
@@ -734,86 +735,75 @@ exit:
 
 CHIP_ERROR EventManagement::GetEventReader(TLVReader & aReader, PriorityLevel aPriority, CircularEventBufferWrapper * apBufWrapper)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CircularEventReader reader;
     CircularEventBuffer * buffer = GetPriorityBuffer(aPriority);
-    VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     apBufWrapper->mpCurrent = buffer;
+
+    CircularEventReader reader;
     reader.Init(apBufWrapper);
     aReader.Init(reader);
-exit:
-    return err;
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR EventManagement::FetchEventParameters(const TLVReader & aReader, size_t aDepth, void * apContext)
 {
-    CHIP_ERROR err                  = CHIP_NO_ERROR;
-    EventEnvelopeContext * envelope = static_cast<EventEnvelopeContext *>(apContext);
+    EventEnvelopeContext * const envelope = static_cast<EventEnvelopeContext *>(apContext);
     TLVReader reader;
-    uint16_t extPriority; // Note: the type here matches the type case in EventManagement::LogEvent, priority section
     reader.Init(aReader);
 
     if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_EventPath))
     {
         EventPath::Parser path;
-        SuccessOrExit(err = path.Init(aReader));
-        SuccessOrExit(err = path.GetNodeId(&(envelope->mNodeId)));
-        SuccessOrExit(err = path.GetEndpointId(&(envelope->mEndpointId)));
-        SuccessOrExit(err = path.GetClusterId(&(envelope->mClusterId)));
-        SuccessOrExit(err = path.GetEventId(&(envelope->mEventId)));
+        ReturnErrorOnFailure(path.Init(aReader));
+        ReturnErrorOnFailure(path.GetNodeId(&(envelope->mNodeId)));
+        ReturnErrorOnFailure(path.GetEndpointId(&(envelope->mEndpointId)));
+        ReturnErrorOnFailure(path.GetClusterId(&(envelope->mClusterId)));
+        ReturnErrorOnFailure(path.GetEventId(&(envelope->mEventId)));
         envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_EventPath;
     }
 
     if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_PriorityLevel))
     {
-        err = reader.Get(extPriority);
-        SuccessOrExit(err);
+        uint16_t extPriority; // Note: the type here matches the type case in EventManagement::LogEvent, priority section
+        ReturnErrorOnFailure(reader.Get(extPriority));
         envelope->mPriority = static_cast<PriorityLevel>(extPriority);
         envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_PriorityLevel;
     }
 
     if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_DeltaSystemTimestamp))
     {
-        err = reader.Get(envelope->mDeltaSystemTime.mValue);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Get(envelope->mDeltaSystemTime.mValue));
 
         envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_DeltaSystemTimestamp;
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR EventManagement::EvictEvent(CHIPCircularTLVBuffer & apBuffer, void * apAppData, TLVReader & aReader)
 {
-    ReclaimEventCtx * ctx             = static_cast<ReclaimEventCtx *>(apAppData);
-    CircularEventBuffer * eventBuffer = ctx->mpEventBuffer;
-    TLVType containerType;
-    EventEnvelopeContext context;
-    const bool recurse = false;
-    CHIP_ERROR err;
-    PriorityLevel imp = PriorityLevel::Invalid;
-
     // pull out the delta time, pull out the priority
-    err = aReader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(aReader.Next());
 
-    err = aReader.EnterContainer(containerType);
-    SuccessOrExit(err);
+    TLVType containerType;
+    ReturnErrorOnFailure(aReader.EnterContainer(containerType));
 
-    err = TLV::Utilities::Iterate(aReader, FetchEventParameters, &context, recurse);
+    EventEnvelopeContext context;
+    constexpr bool recurse = false;
+    CHIP_ERROR err         = TLV::Utilities::Iterate(aReader, FetchEventParameters, &context, recurse);
     if (err == CHIP_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;
     }
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(err);
 
-    err = aReader.ExitContainer(containerType);
+    ReturnErrorOnFailure(aReader.ExitContainer(containerType));
 
-    SuccessOrExit(err);
+    const PriorityLevel imp = static_cast<PriorityLevel>(context.mPriority);
 
-    imp = static_cast<PriorityLevel>(context.mPriority);
-
+    ReclaimEventCtx * const ctx             = static_cast<ReclaimEventCtx *>(apAppData);
+    CircularEventBuffer * const eventBuffer = ctx->mpEventBuffer;
     if (eventBuffer->IsFinalDestinationForPriority(imp))
     {
         // event is getting dropped.  Increase the event number and first timestamp.
@@ -826,16 +816,12 @@ CHIP_ERROR EventManagement::EvictEvent(CHIPCircularTLVBuffer & apBuffer, void * 
             " };",
             static_cast<unsigned>(eventBuffer->GetPriorityLevel()), static_cast<unsigned>(imp), ChipLogValueX64(numEventsToDrop));
         ctx->mSpaceNeededForMovedEvent = 0;
-    }
-    else
-    {
-        // event is not getting dropped. Note how much space it requires, and return.
-        ctx->mSpaceNeededForMovedEvent = aReader.GetLengthRead();
-        err                            = CHIP_END_OF_TLV;
+        return CHIP_NO_ERROR;
     }
 
-exit:
-    return err;
+    // event is not getting dropped. Note how much space it requires, and return.
+    ctx->mSpaceNeededForMovedEvent = aReader.GetLengthRead();
+    return CHIP_END_OF_TLV;
 }
 
 CHIP_ERROR EventManagement::ScheduleFlushIfNeeded(EventOptions::Type aUrgent)

--- a/src/app/MessageDef/AttributeDataElement.cpp
+++ b/src/app/MessageDef/AttributeDataElement.cpp
@@ -393,27 +393,22 @@ exit:
 AttributeDataElement::Builder & AttributeDataElement::Builder::DataVersion(const chip::DataVersion aDataVersion)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DataVersion), aDataVersion);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DataVersion), aDataVersion);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributeDataElement::Builder & AttributeDataElement::Builder::MoreClusterData(const bool aMoreClusterData)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    if (aMoreClusterData)
+    if ((mError == CHIP_NO_ERROR) && aMoreClusterData)
     {
         mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreClusterDataFlag), true);
         ChipLogFunctError(mError);
     }
-
-exit:
     return *this;
 }
 

--- a/src/app/MessageDef/AttributeDataVersionList.cpp
+++ b/src/app/MessageDef/AttributeDataVersionList.cpp
@@ -137,24 +137,22 @@ CHIP_ERROR AttributeDataVersionList::Parser::GetVersion(chip::DataVersion * cons
 AttributeDataVersionList::Builder & AttributeDataVersionList::Builder::AddVersion(const uint64_t aVersion)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::AnonymousTag, aVersion);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::AnonymousTag, aVersion);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributeDataVersionList::Builder & AttributeDataVersionList::Builder::AddNull(void)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->PutNull(chip::TLV::AnonymousTag);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutNull(chip::TLV::AnonymousTag);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -217,61 +217,55 @@ CHIP_ERROR AttributePath::Builder::Init(chip::TLV::TLVWriter * const apWriter, c
 AttributePath::Builder & AttributePath::Builder::NodeId(const uint64_t aNodeId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NodeId), aNodeId);
-    ChipLogFunctError(mError);
-
-exit:
-
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NodeId), aNodeId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributePath::Builder & AttributePath::Builder::EndpointId(const chip::EndpointId aEndpointId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributePath::Builder & AttributePath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributePath::Builder & AttributePath::Builder::FieldId(const chip::FieldId aFieldId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FieldId), aFieldId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FieldId), aFieldId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributePath::Builder & AttributePath::Builder::ListIndex(const chip::ListIndex aListIndex)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ListIndex), aListIndex);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ListIndex), aListIndex);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -196,48 +196,44 @@ CHIP_ERROR CommandPath::Builder::Init(chip::TLV::TLVWriter * const apWriter, con
 CommandPath::Builder & CommandPath::Builder::EndpointId(const chip::EndpointId aEndpointId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 CommandPath::Builder & CommandPath::Builder::GroupId(const chip::GroupId aGroupId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_GroupId), aGroupId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_GroupId), aGroupId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 CommandPath::Builder & CommandPath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 CommandPath::Builder & CommandPath::Builder::CommandId(const chip::CommandId aCommandId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_CommandId), aCommandId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_CommandId), aCommandId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/EventDataElement.cpp
+++ b/src/app/MessageDef/EventDataElement.cpp
@@ -463,84 +463,81 @@ CHIP_ERROR EventDataElement::Builder::Init(chip::TLV::TLVWriter * const apWriter
 EventPath::Builder & EventDataElement::Builder::CreateEventPathBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mEventPathBuilder.ResetError(mError));
-
-    mError = mEventPathBuilder.Init(mpWriter, kCsTag_EventPath);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mEventPathBuilder.Init(mpWriter, kCsTag_EventPath);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mEventPathBuilder.ResetError(mError);
+    }
     return mEventPathBuilder;
 }
 
 EventDataElement::Builder EventDataElement::Builder::PriorityLevel(const uint8_t aPriorityLevel)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_PriorityLevel), aPriorityLevel);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_PriorityLevel), aPriorityLevel);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventDataElement::Builder EventDataElement::Builder::Number(const uint64_t aNumber)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_Number), aNumber);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_Number), aNumber);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventDataElement::Builder EventDataElement::Builder::UTCTimestamp(const uint64_t aUTCTimestamp)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_UTCTimestamp), aUTCTimestamp);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_UTCTimestamp), aUTCTimestamp);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventDataElement::Builder EventDataElement::Builder::SystemTimestamp(const uint64_t aSystemTimestamp)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_SystemTimestamp), aSystemTimestamp);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_SystemTimestamp), aSystemTimestamp);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventDataElement::Builder EventDataElement::Builder::DeltaUTCTimestamp(const uint64_t aDeltaUTCTimestamp)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DeltaUTCTimestamp), aDeltaUTCTimestamp);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DeltaUTCTimestamp), aDeltaUTCTimestamp);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventDataElement::Builder EventDataElement::Builder::DeltaSystemTimestamp(const uint64_t aDeltaSystemTimestamp)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DeltaSystemTimestamp), aDeltaSystemTimestamp);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_DeltaSystemTimestamp), aDeltaSystemTimestamp);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -200,48 +200,44 @@ CHIP_ERROR EventPath::Builder::Init(chip::TLV::TLVWriter * const apWriter, const
 EventPath::Builder & EventPath::Builder::NodeId(const uint64_t aNodeId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NodeId), aNodeId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NodeId), aNodeId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventPath::Builder & EventPath::Builder::EndpointId(const chip::EndpointId aEndpointId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EndpointId), aEndpointId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventPath::Builder & EventPath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 EventPath::Builder & EventPath::Builder::EventId(const chip::EventId aEventId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EventId), aEventId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EventId), aEventId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/ReadRequest.cpp
+++ b/src/app/MessageDef/ReadRequest.cpp
@@ -271,12 +271,11 @@ exit:
 ReadRequest::Builder & ReadRequest::Builder::EventNumber(const uint64_t aEventNumber)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EventNumber), aEventNumber);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EventNumber), aEventNumber);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/ReportData.cpp
+++ b/src/app/MessageDef/ReportData.cpp
@@ -237,48 +237,52 @@ exit:
 ReportData::Builder & ReportData::Builder::SubscriptionId(const uint64_t aSubscriptionId)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_SubscriptionId), aSubscriptionId);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_SubscriptionId), aSubscriptionId);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributeDataList::Builder & ReportData::Builder::CreateAttributeDataListBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mAttributeDataListBuilder.ResetError(mError));
-
-    mError = mAttributeDataListBuilder.Init(mpWriter, kCsTag_AttributeDataList);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributeDataListBuilder.Init(mpWriter, kCsTag_AttributeDataList);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mAttributeDataListBuilder.ResetError(mError);
+    }
     return mAttributeDataListBuilder;
 }
 
 EventList::Builder & ReportData::Builder::CreateEventDataListBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mAttributeDataListBuilder.ResetError(mError));
-
-    mError = mEventDataListBuilder.Init(mpWriter, kCsTag_EventDataList);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mEventDataListBuilder.Init(mpWriter, kCsTag_EventDataList);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mAttributeDataListBuilder.ResetError(mError);
+    }
     return mEventDataListBuilder;
 }
 
 ReportData::Builder & ReportData::Builder::MoreChunkedMessages(const bool aMoreChunkedMessages)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreChunkedMessages), aMoreChunkedMessages);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreChunkedMessages), aMoreChunkedMessages);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/WriteRequest.cpp
+++ b/src/app/MessageDef/WriteRequest.cpp
@@ -198,48 +198,53 @@ CHIP_ERROR WriteRequest::Builder::Init(chip::TLV::TLVWriter * const apWriter)
 WriteRequest::Builder & WriteRequest::Builder::SuppressResponse(const bool aSuppressResponse)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_SuppressResponse), aSuppressResponse);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_SuppressResponse), aSuppressResponse);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 
 AttributeDataList::Builder & WriteRequest::Builder::CreateAttributeDataListBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mAttributeDataListBuilder.ResetError(mError));
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributeDataListBuilder.Init(mpWriter, kCsTag_AttributeDataList);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mAttributeDataListBuilder.ResetError(mError);
+    }
 
-    mError = mAttributeDataListBuilder.Init(mpWriter, kCsTag_AttributeDataList);
-    ChipLogFunctError(mError);
-
-exit:
     return mAttributeDataListBuilder;
 }
 
 AttributeDataVersionList::Builder & WriteRequest::Builder::CreateAttributeDataVersionListBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mAttributeDataVersionListBuilder.ResetError(mError));
-
-    mError = mAttributeDataVersionListBuilder.Init(mpWriter, kCsTag_AttributeDataVersionList);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributeDataVersionListBuilder.Init(mpWriter, kCsTag_AttributeDataVersionList);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mAttributeDataVersionListBuilder.ResetError(mError);
+    }
     return mAttributeDataVersionListBuilder;
 }
 
 WriteRequest::Builder & WriteRequest::Builder::MoreChunkedMessages(const bool aMoreChunkedMessages)
 {
     // skip if error has already been set
-    SuccessOrExit(mError);
-
-    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreChunkedMessages), aMoreChunkedMessages);
-    ChipLogFunctError(mError);
-
-exit:
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreChunkedMessages), aMoreChunkedMessages);
+        ChipLogFunctError(mError);
+    }
     return *this;
 }
 

--- a/src/app/MessageDef/WriteResponse.cpp
+++ b/src/app/MessageDef/WriteResponse.cpp
@@ -130,12 +130,16 @@ CHIP_ERROR WriteResponse::Builder::Init(chip::TLV::TLVWriter * const apWriter)
 AttributeStatusList::Builder & WriteResponse::Builder::CreateAttributeStatusListBuilder()
 {
     // skip if error has already been set
-    VerifyOrExit(CHIP_NO_ERROR == mError, mAttributeStatusListBuilder.ResetError(mError));
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributeStatusListBuilder.Init(mpWriter, kCsTag_AttributeStatusList);
+        ChipLogFunctError(mError);
+    }
+    else
+    {
+        mAttributeStatusListBuilder.ResetError(mError);
+    }
 
-    mError = mAttributeStatusListBuilder.Init(mpWriter, kCsTag_AttributeStatusList);
-    ChipLogFunctError(mError);
-
-exit:
     return mAttributeStatusListBuilder;
 }
 

--- a/src/app/decoder.cpp
+++ b/src/app/decoder.cpp
@@ -41,22 +41,18 @@ uint16_t extractApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * 
 
     chip::DataModelReader reader(buffer, buf_length);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     // Skip first byte, because that's the always-0 frame control.
     uint8_t ignored;
-    err = reader.ReadOctet(&ignored)
-              .ReadClusterId(&outApsFrame->clusterId)
-              .ReadEndpointId(&outApsFrame->sourceEndpoint)
-              .ReadEndpointId(&outApsFrame->destinationEndpoint)
-              .Read16(&outApsFrame->options)
-              .ReadGroupId(&outApsFrame->groupId)
-              .ReadOctet(&outApsFrame->sequence)
-              .ReadOctet(&outApsFrame->radius)
-              .StatusCode();
-    SuccessOrExit(err);
+    const CHIP_ERROR err = reader.ReadOctet(&ignored)
+                               .ReadClusterId(&outApsFrame->clusterId)
+                               .ReadEndpointId(&outApsFrame->sourceEndpoint)
+                               .ReadEndpointId(&outApsFrame->destinationEndpoint)
+                               .Read16(&outApsFrame->options)
+                               .ReadGroupId(&outApsFrame->groupId)
+                               .ReadOctet(&outApsFrame->sequence)
+                               .ReadOctet(&outApsFrame->radius)
+                               .StatusCode();
 
-exit:
     return err == CHIP_NO_ERROR ? reader.OctetsRead() : 0;
 }
 

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -275,20 +275,17 @@ void StartServer()
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t rotatingDeviceIdHexBufferSize)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
     char serialNumber[chip::DeviceLayer::ConfigurationManager::kMaxSerialNumberLength + 1];
     size_t serialNumberSize                = 0;
     uint16_t lifetimeCounter               = 0;
     size_t rotatingDeviceIdValueOutputSize = 0;
 
-    SuccessOrExit(error =
-                      chip::DeviceLayer::ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber), serialNumberSize));
-    SuccessOrExit(error = chip::DeviceLayer::ConfigurationMgr().GetLifetimeCounter(lifetimeCounter));
-    SuccessOrExit(error = AdditionalDataPayloadGenerator().generateRotatingDeviceId(
-                      lifetimeCounter, serialNumber, serialNumberSize, rotatingDeviceIdHexBuffer, rotatingDeviceIdHexBufferSize,
-                      rotatingDeviceIdValueOutputSize));
-exit:
-    return error;
+    ReturnErrorOnFailure(
+        chip::DeviceLayer::ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber), serialNumberSize));
+    ReturnErrorOnFailure(chip::DeviceLayer::ConfigurationMgr().GetLifetimeCounter(lifetimeCounter));
+    return AdditionalDataPayloadGenerator().generateRotatingDeviceId(lifetimeCounter, serialNumber, serialNumberSize,
+                                                                     rotatingDeviceIdHexBuffer, rotatingDeviceIdHexBufferSize,
+                                                                     rotatingDeviceIdValueOutputSize);
 }
 #endif
 

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -85,76 +85,91 @@ CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousI
     aSetupPayload.rendezvousInformation = aRendezvousFlags;
 
     err = ConfigurationMgr().GetSetupPinCode(aSetupPayload.setUpPINCode);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupPinCode() failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupPinCode() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
     err = ConfigurationMgr().GetSetupDiscriminator(aSetupPayload.discriminator);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupDiscriminator() failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupDiscriminator() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
     err = ConfigurationMgr().GetVendorId(aSetupPayload.vendorID);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogProgress(AppServer, "ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
     err = ConfigurationMgr().GetProductId(aSetupPayload.productID);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogProgress(AppServer, "ConfigurationMgr().GetProductId() failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "ConfigurationMgr().GetProductId() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
-exit:
     return err;
 }
 
 CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     chip::SetupPayload payload;
 
-    err = GetSetupPayload(payload, aRendezvousFlags);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err)));
+    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
     // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
     // generating payload
     err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    int writtenDataSize;
+    VerifyOrReturnError(aQRCodeUrl, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(aUrlMaxSize >= (strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + aQRCode.size() + 1),
+                        CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    VerifyOrExit(aQRCodeUrl, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(aUrlMaxSize >= (strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + aQRCode.size() + 1),
-                 err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    const int writtenDataSize = snprintf(aQRCodeUrl, aUrlMaxSize, "%s%s", kQrCodeBaseUrl, kUrlDataAssignmentPhrase);
+    VerifyOrReturnError((writtenDataSize > 0) && (writtenDataSize < static_cast<int>(aUrlMaxSize)),
+                        CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    writtenDataSize = snprintf(aQRCodeUrl, aUrlMaxSize, "%s%s", kQrCodeBaseUrl, kUrlDataAssignmentPhrase);
-    VerifyOrExit((writtenDataSize > 0) && (writtenDataSize < static_cast<int>(aUrlMaxSize)),
-                 err = CHIP_ERROR_INVALID_STRING_LENGTH);
-
-    err = EncodeQRCodeToUrl(aQRCode.c_str(), aQRCode.size(), aQRCodeUrl + writtenDataSize, aUrlMaxSize - writtenDataSize);
-    VerifyOrExit(err == CHIP_NO_ERROR, );
-
-exit:
-    return err;
+    return EncodeQRCodeToUrl(aQRCode.c_str(), aQRCode.size(), aQRCodeUrl + writtenDataSize, aUrlMaxSize - writtenDataSize);
 }
 
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     chip::SetupPayload payload;
 
-    err = GetSetupPayload(payload, aRendezvousFlags);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err)));
+    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
     err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
-    VerifyOrExit(err == CHIP_NO_ERROR,
-                 ChipLogProgress(AppServer, "Generating Manual Pairing Code failed: %s", chip::ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(AppServer, "Generating Manual Pairing Code failed: %s", chip::ErrorStr(err));
+        return err;
+    }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 static inline bool isCharUnreservedInRfc3986(const char c)
@@ -165,10 +180,9 @@ static inline bool isCharUnreservedInRfc3986(const char c)
 CHIP_ERROR EncodeQRCodeToUrl(const char * aQRCode, size_t aLen, char * aUrl, size_t aMaxSize)
 {
     const char upperHexDigits[] = "0123456789ABCDEF";
-    CHIP_ERROR err              = CHIP_NO_ERROR;
     size_t i = 0, j = 0;
 
-    VerifyOrExit((aQRCode != nullptr) && (aUrl != nullptr), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError((aQRCode != nullptr) && (aUrl != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
 
     for (i = 0; i < aLen; ++i)
     {
@@ -176,14 +190,14 @@ CHIP_ERROR EncodeQRCodeToUrl(const char * aQRCode, size_t aLen, char * aUrl, siz
         if (isCharUnreservedInRfc3986(c))
         {
 
-            VerifyOrExit((j + 1) < aMaxSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+            VerifyOrReturnError((j + 1) < aMaxSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
             aUrl[j++] = c;
         }
         else
         {
 
-            VerifyOrExit((j + 3) < aMaxSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+            VerifyOrReturnError((j + 3) < aMaxSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
             aUrl[j++] = '%';
             aUrl[j++] = upperHexDigits[(c & 0xf0) >> 4];
@@ -193,6 +207,5 @@ CHIP_ERROR EncodeQRCodeToUrl(const char * aQRCode, size_t aLen, char * aUrl, siz
 
     aUrl[j] = '\0';
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -121,6 +121,7 @@ CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
     err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);
     SuccessOrExit(err);
 
+exit:
     if (err == CHIP_NO_ERROR)
     {
         gCommandCount++;
@@ -129,7 +130,6 @@ CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
     {
         printf("Send invoke command request failed, err: %s\n", chip::ErrorStr(err));
     }
-exit:
     return err;
 }
 
@@ -158,6 +158,7 @@ CHIP_ERROR SendBadCommandRequest(chip::app::CommandSender * commandSender)
     err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);
     SuccessOrExit(err);
 
+exit:
     if (err == CHIP_NO_ERROR)
     {
         gCommandCount++;
@@ -166,7 +167,6 @@ CHIP_ERROR SendBadCommandRequest(chip::app::CommandSender * commandSender)
     {
         printf("Send invoke command request failed, err: %s\n", chip::ErrorStr(err));
     }
-exit:
     return err;
 }
 
@@ -185,6 +185,7 @@ CHIP_ERROR SendReadRequest(void)
     err = gpReadClient->SendReadRequest(chip::kTestDeviceNodeId, gAdminId, &eventPathParams, 1, &attributePathParams, 1, number);
     SuccessOrExit(err);
 
+exit:
     if (err == CHIP_NO_ERROR)
     {
         gReadCount++;
@@ -193,7 +194,6 @@ CHIP_ERROR SendReadRequest(void)
     {
         printf("Send read request failed, err: %s\n", chip::ErrorStr(err));
     }
-exit:
     return err;
 }
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -53,7 +53,6 @@ bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCom
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {
-    CHIP_ERROR err                = CHIP_NO_ERROR;
     static bool statusCodeFlipper = false;
 
     if (aClusterId != kTestClusterId || aCommandId != kTestCommandId || aEndPointId != kTestEndpointId)
@@ -85,23 +84,16 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
         chip::TLV::TLVWriter * writer;
 
-        err = apCommandObj->PrepareCommand(commandPathParams);
-        SuccessOrExit(err);
+        ReturnOnFailure(apCommandObj->PrepareCommand(commandPathParams));
 
         writer = apCommandObj->GetCommandDataElementTLVWriter();
-        err    = writer->Put(chip::TLV::ContextTag(kTestFieldId1), kTestFieldValue1);
-        SuccessOrExit(err);
+        ReturnOnFailure(writer->Put(chip::TLV::ContextTag(kTestFieldId1), kTestFieldValue1));
 
-        err = writer->Put(chip::TLV::ContextTag(kTestFieldId2), kTestFieldValue2);
-        SuccessOrExit(err);
+        ReturnOnFailure(writer->Put(chip::TLV::ContextTag(kTestFieldId2), kTestFieldValue2));
 
-        err = apCommandObj->FinishCommand();
-        SuccessOrExit(err);
+        ReturnOnFailure(apCommandObj->FinishCommand());
     }
     statusCodeFlipper = !statusCodeFlipper;
-
-exit:
-    return;
 }
 
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter & aWriter)

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -76,13 +76,10 @@ exit:
 
 CHIP_ERROR ClusterBase::RequestAttributeReporting(AttributeId attributeId, Callback::Cancelable * onReportCallback)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(onReportCallback != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(onReportCallback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mDevice->AddReportHandler(mEndpoint, mClusterId, attributeId, onReportCallback);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Controller

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -672,14 +672,12 @@ JNI_ANDROID_CHIP_STACK_METHOD(void, handleWriteConfirmation)
 
     chip::Ble::ChipBleUUID svcUUID;
     chip::Ble::ChipBleUUID charUUID;
-    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
-                 ChipLogError(Controller, "handleWriteConfirmation() called with invalid service ID"));
-    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
-                 ChipLogError(Controller, "handleWriteConfirmation() called with invalid characteristic ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, svcId, svcUUID),
+                   ChipLogError(Controller, "handleWriteConfirmation() called with invalid service ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, charId, charUUID),
+                   ChipLogError(Controller, "handleWriteConfirmation() called with invalid characteristic ID"));
 
     sBleLayer.HandleWriteConfirmation(connObj, &svcUUID, &charUUID);
-exit:
-    return;
 }
 
 JNI_ANDROID_CHIP_STACK_METHOD(void, handleSubscribeComplete)
@@ -690,14 +688,12 @@ JNI_ANDROID_CHIP_STACK_METHOD(void, handleSubscribeComplete)
 
     chip::Ble::ChipBleUUID svcUUID;
     chip::Ble::ChipBleUUID charUUID;
-    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
-                 ChipLogError(Controller, "handleSubscribeComplete() called with invalid service ID"));
-    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
-                 ChipLogError(Controller, "handleSubscribeComplete() called with invalid characteristic ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, svcId, svcUUID),
+                   ChipLogError(Controller, "handleSubscribeComplete() called with invalid service ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, charId, charUUID),
+                   ChipLogError(Controller, "handleSubscribeComplete() called with invalid characteristic ID"));
 
     sBleLayer.HandleSubscribeComplete(connObj, &svcUUID, &charUUID);
-exit:
-    return;
 }
 
 JNI_ANDROID_CHIP_STACK_METHOD(void, handleUnsubscribeComplete)
@@ -708,14 +704,12 @@ JNI_ANDROID_CHIP_STACK_METHOD(void, handleUnsubscribeComplete)
 
     chip::Ble::ChipBleUUID svcUUID;
     chip::Ble::ChipBleUUID charUUID;
-    VerifyOrExit(JavaBytesToUUID(env, svcId, svcUUID),
-                 ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid service ID"));
-    VerifyOrExit(JavaBytesToUUID(env, charId, charUUID),
-                 ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid characteristic ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, svcId, svcUUID),
+                   ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid service ID"));
+    VerifyOrReturn(JavaBytesToUUID(env, charId, charUUID),
+                   ChipLogError(Controller, "handleUnsubscribeComplete() called with invalid characteristic ID"));
 
     sBleLayer.HandleUnsubscribeComplete(connObj, &svcUUID, &charUUID);
-exit:
-    return;
 }
 
 JNI_ANDROID_CHIP_STACK_METHOD(void, handleConnectionError)(JNIEnv * env, jobject self, jint conn)
@@ -1107,17 +1101,14 @@ void ThrowError(JNIEnv * env, CHIP_ERROR errToThrow)
 
 CHIP_ERROR N2J_ByteArray(JNIEnv * env, const uint8_t * inArray, uint32_t inArrayLen, jbyteArray & outArray)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     outArray = env->NewByteArray((int) inArrayLen);
-    VerifyOrExit(outArray != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(outArray != NULL, CHIP_ERROR_NO_MEMORY);
 
     env->ExceptionClear();
     env->SetByteArrayRegion(outArray, 0, inArrayLen, (jbyte *) inArray);
-    VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
+    VerifyOrReturnError(!env->ExceptionCheck(), CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx)

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -134,11 +134,8 @@ CHIP_ERROR pychip_BLEMgrImpl_ConfigureBle(uint32_t bluetoothAdapterId);
 CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl,
                                                        chip::NodeId localDeviceId)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CommissionerInitParams initParams;
-
     *outDevCtrl = new chip::Controller::DeviceCommissioner();
-    VerifyOrExit(*outDevCtrl != NULL, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(*outDevCtrl != NULL, CHIP_ERROR_NO_MEMORY);
 
     if (localDeviceId == chip::kUndefinedNodeId)
     {
@@ -147,17 +144,17 @@ CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceC
 
     ReturnErrorOnFailure(sOperationalCredentialsIssuer.Initialize(sStorageDelegate));
 
+    CommissionerInitParams initParams;
     initParams.storageDelegate                = &sStorageDelegate;
     initParams.mDeviceAddressUpdateDelegate   = &sDeviceAddressUpdateDelegate;
     initParams.pairingDelegate                = &sPairingDelegate;
     initParams.operationalCredentialsDelegate = &sOperationalCredentialsIssuer;
     initParams.imDelegate                     = &PythonInteractionModelDelegate::Instance();
 
-    SuccessOrExit(err = (*outDevCtrl)->Init(localDeviceId, initParams));
-    SuccessOrExit(err = (*outDevCtrl)->ServiceEvents());
+    ReturnErrorOnFailure((*outDevCtrl)->Init(localDeviceId, initParams));
+    ReturnErrorOnFailure((*outDevCtrl)->ServiceEvents());
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::Controller::DeviceCommissioner * devCtrl)

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -35,8 +35,7 @@ using HKDF_sha_crypto = HKDF_sha;
 
 CHIP_ERROR Spake2p::InternalHash(const uint8_t * in, size_t in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    uint64_t u64_len = in_len;
+    const uint64_t u64_len = in_len;
 
     uint8_t lb[8];
     lb[0] = static_cast<uint8_t>((u64_len >> 0) & 0xff);
@@ -48,17 +47,15 @@ CHIP_ERROR Spake2p::InternalHash(const uint8_t * in, size_t in_len)
     lb[6] = static_cast<uint8_t>((u64_len >> 48) & 0xff);
     lb[7] = static_cast<uint8_t>((u64_len >> 56) & 0xff);
 
-    error = Hash(lb, sizeof(lb));
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = Hash(lb, sizeof(lb));
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     if (in != nullptr)
     {
         error = Hash(in, in_len);
-        VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     }
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 Spake2p::Spake2p(size_t _fe_size, size_t _point_size, size_t _hash_size)
@@ -90,39 +87,32 @@ Spake2p::Spake2p(size_t _fe_size, size_t _point_size, size_t _hash_size)
 
 CHIP_ERROR Spake2p::Init(const uint8_t * context, size_t context_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    state            = CHIP_SPAKE2P_STATE::PREINIT;
+    state = CHIP_SPAKE2P_STATE::PREINIT;
 
-    error = InitImpl();
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = InitImpl();
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = PointLoad(spake2p_M_p256, sizeof(spake2p_M_p256), M);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = PointLoad(spake2p_N_p256, sizeof(spake2p_N_p256), N);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = InternalHash(context, context_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     state = CHIP_SPAKE2P_STATE::INIT;
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p::WriteMN()
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-
-    error = InternalHash(spake2p_M_p256, sizeof(spake2p_M_p256));
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = InternalHash(spake2p_M_p256, sizeof(spake2p_M_p256));
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     error = InternalHash(spake2p_N_p256, sizeof(spake2p_N_p256));
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p::BeginVerifier(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
@@ -130,27 +120,25 @@ CHIP_ERROR Spake2p::BeginVerifier(const uint8_t * my_identity, size_t my_identit
                                   size_t Lin_len)
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::INIT, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::INIT, CHIP_ERROR_INTERNAL);
 
     error = InternalHash(peer_identity, peer_identity_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = InternalHash(my_identity, my_identity_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = WriteMN();
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FELoad(w0in, w0in_len, w0);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = PointLoad(Lin, Lin_len, L);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::VERIFIER;
-    error = CHIP_NO_ERROR;
-exit:
     return error;
 }
 
@@ -158,31 +146,26 @@ CHIP_ERROR Spake2p::BeginProver(const uint8_t * my_identity, size_t my_identity_
                                 size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
                                 size_t w1in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::INIT, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::INIT, CHIP_ERROR_INTERNAL);
 
-    error = InternalHash(my_identity, my_identity_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = InternalHash(my_identity, my_identity_len);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = InternalHash(peer_identity, peer_identity_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = WriteMN();
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FELoad(w0in, w0in_len, w0);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FELoad(w1in, w1in_len, w1);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p::ComputeRoundOne(const uint8_t * pab, size_t pab_len, uint8_t * out, size_t * out_len)
@@ -331,28 +314,24 @@ exit:
 
 CHIP_ERROR Spake2p::GenerateKeys()
 {
-    CHIP_ERROR error                         = CHIP_ERROR_INTERNAL;
     static const uint8_t info_keyconfirm[16] = { 'C', 'o', 'n', 'f', 'i', 'r', 'm', 'a', 't', 'i', 'o', 'n', 'K', 'e', 'y', 's' };
 
-    error = HashFinalize(Kae);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = HashFinalize(Kae);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = KDF(Ka, hash_size / 2, nullptr, 0, info_keyconfirm, sizeof(info_keyconfirm), Kcab, hash_size);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p::KeyConfirm(const uint8_t * in, size_t in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
     uint8_t point_buffer[kP256_Point_Length];
     void * XY        = nullptr; // Choose X if a prover, Y if a verifier
     uint8_t * Kcaorb = nullptr; // Choose Kcb if a prover, Kca if a verifier
 
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::R2, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::R2, CHIP_ERROR_INTERNAL);
 
     if (role == CHIP_SPAKE2P_ROLE::PROVER)
     {
@@ -364,19 +343,17 @@ CHIP_ERROR Spake2p::KeyConfirm(const uint8_t * in, size_t in_len)
         XY     = Y;
         Kcaorb = Kca;
     }
-    VerifyOrExit(XY != nullptr, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(Kcaorb != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(XY != nullptr, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(Kcaorb != nullptr, CHIP_ERROR_INTERNAL);
 
-    error = PointWrite(XY, point_buffer, point_size);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = PointWrite(XY, point_buffer, point_size);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = MacVerify(Kcaorb, hash_size / 2, in, in_len, point_buffer, point_size);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     state = CHIP_SPAKE2P_STATE::KC;
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p::GetKeys(uint8_t * out, size_t * out_len)
@@ -395,56 +372,41 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitImpl()
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-
-    error = sha256_hash_ctx.Begin();
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = sha256_hash_ctx.Begin();
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = InitInternal();
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Hash(const uint8_t * in, size_t in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
+    CHIP_ERROR error = sha256_hash_ctx.AddData(in, in_len);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = sha256_hash_ctx.AddData(in, in_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::HashFinalize(uint8_t * out)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
+    CHIP_ERROR error = sha256_hash_ctx.Finish(out);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = sha256_hash_ctx.Finish(out);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::KDF(const uint8_t * ikm, const size_t ikm_len, const uint8_t * salt,
                                               const size_t salt_len, const uint8_t * info, const size_t info_len, uint8_t * out,
                                               size_t out_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
     HKDF_sha_crypto mHKDF;
 
-    error = mHKDF.HKDF_SHA256(ikm, ikm_len, salt, salt_len, info, info_len, out, out_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    CHIP_ERROR error = mHKDF.HKDF_SHA256(ikm, ikm_len, salt, salt_len, info, info_len, out, out_len);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Crypto

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -37,36 +37,36 @@
 namespace chip {
 namespace Crypto {
 
-const size_t kMax_x509_Certificate_Length = 600;
+constexpr size_t kMax_x509_Certificate_Length = 600;
 
 // TODO: Consider renaming these values to be closer to definisions in the spec:
 // CHIP_CRYPTO_GROUP_SIZE_BYTES
 // CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES
-const size_t kP256_FE_Length                  = 32;
-const size_t kP256_ECDSA_Signature_Length_Raw = (2 * kP256_FE_Length);
-const size_t kP256_Point_Length               = (2 * kP256_FE_Length + 1);
-const size_t kSHA256_Hash_Length              = 32;
+constexpr size_t kP256_FE_Length                  = 32;
+constexpr size_t kP256_ECDSA_Signature_Length_Raw = (2 * kP256_FE_Length);
+constexpr size_t kP256_Point_Length               = (2 * kP256_FE_Length + 1);
+constexpr size_t kSHA256_Hash_Length              = 32;
 
-const size_t kMax_ECDH_Secret_Length     = kP256_FE_Length;
-const size_t kMax_ECDSA_Signature_Length = 72;
-const size_t kMAX_FE_Length              = kP256_FE_Length;
-const size_t kMAX_Point_Length           = kP256_Point_Length;
-const size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
-const size_t kMAX_CSR_Length             = 512;
+constexpr size_t kMax_ECDH_Secret_Length     = kP256_FE_Length;
+constexpr size_t kMax_ECDSA_Signature_Length = 72;
+constexpr size_t kMAX_FE_Length              = kP256_FE_Length;
+constexpr size_t kMAX_Point_Length           = kP256_Point_Length;
+constexpr size_t kMAX_Hash_Length            = kSHA256_Hash_Length;
+constexpr size_t kMAX_CSR_Length             = 512;
 
-const size_t kMin_Salt_Length = 8;
-const size_t kMax_Salt_Length = 16;
+constexpr size_t kMin_Salt_Length = 8;
+constexpr size_t kMax_Salt_Length = 16;
 
-const size_t kP256_PrivateKey_Length = 32;
-const size_t kP256_PublicKey_Length  = 65;
+constexpr size_t kP256_PrivateKey_Length = 32;
+constexpr size_t kP256_PublicKey_Length  = 65;
 
 /* These sizes are hardcoded here to remove header dependency on underlying crypto library
  * in a public interface file. The validity of these sizes is verified by static_assert in
  * the implementation files.
  */
-const size_t kMAX_Spake2p_Context_Size     = 1024;
-const size_t kMAX_Hash_SHA256_Context_Size = 296;
-const size_t kMAX_P256Keypair_Context_Size = 512;
+constexpr size_t kMAX_Spake2p_Context_Size     = 1024;
+constexpr size_t kMAX_Hash_SHA256_Context_Size = 296;
+constexpr size_t kMAX_P256Keypair_Context_Size = 512;
 
 /**
  * Spake2+ parameters for P256
@@ -141,11 +141,9 @@ public:
      **/
     CHIP_ERROR SetLength(size_t len)
     {
-        CHIP_ERROR error = CHIP_NO_ERROR;
-        VerifyOrExit(len <= sizeof(bytes), error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(len <= sizeof(bytes), CHIP_ERROR_INVALID_ARGUMENT);
         length = len;
-    exit:
-        return error;
+        return CHIP_NO_ERROR;
     }
 
     /** @brief Returns current length of the buffer that's being used

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -285,16 +285,13 @@ exit:
 
 CHIP_ERROR Hash_SHA256(const uint8_t * data, const size_t data_length, uint8_t * out_buffer)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-
     // zero data length hash is supported.
 
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     SHA256(data, data_length, Uint8::to_uchar(out_buffer));
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA1(const uint8_t * data, const size_t data_length, uint8_t * out_buffer)
@@ -318,44 +315,32 @@ static inline SHA256_CTX * to_inner_hash_sha256_context(HashSHA256OpaqueContext 
 
 CHIP_ERROR Hash_SHA256_stream::Begin()
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 1;
+    SHA256_CTX * const context = to_inner_hash_sha256_context(&mContext);
 
-    SHA256_CTX * context = to_inner_hash_sha256_context(&mContext);
+    const int result = SHA256_Init(context);
+    VerifyOrReturnError(result == 1, CHIP_ERROR_INTERNAL);
 
-    result = SHA256_Init(context);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA256_stream::AddData(const uint8_t * data, const size_t data_length)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 1;
+    SHA256_CTX * const context = to_inner_hash_sha256_context(&mContext);
 
-    SHA256_CTX * context = to_inner_hash_sha256_context(&mContext);
+    const int result = SHA256_Update(context, Uint8::to_const_uchar(data), data_length);
+    VerifyOrReturnError(result == 1, CHIP_ERROR_INTERNAL);
 
-    result = SHA256_Update(context, Uint8::to_const_uchar(data), data_length);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA256_stream::Finish(uint8_t * out_buffer)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 1;
+    SHA256_CTX * const context = to_inner_hash_sha256_context(&mContext);
 
-    SHA256_CTX * context = to_inner_hash_sha256_context(&mContext);
+    const int result = SHA256_Final(Uint8::to_uchar(out_buffer), context);
+    VerifyOrReturnError(result == 1, CHIP_ERROR_INTERNAL);
 
-    result = SHA256_Final(Uint8::to_uchar(out_buffer), context);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 void Hash_SHA256_stream::Clear()
@@ -366,11 +351,10 @@ void Hash_SHA256_stream::Clear()
 CHIP_ERROR HKDF_sha::HKDF_SHA256(const uint8_t * secret, const size_t secret_length, const uint8_t * salt, const size_t salt_length,
                                  const uint8_t * info, const size_t info_length, uint8_t * out_buffer, size_t out_length)
 {
-    EVP_PKEY_CTX * context;
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 1;
 
-    context = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
+    EVP_PKEY_CTX * const context = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
     VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit(secret != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -467,18 +451,14 @@ CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t 
 
 CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<int>(out_length), CHIP_ERROR_INVALID_ARGUMENT);
+    const int result = RAND_priv_bytes(Uint8::to_uchar(out_buffer), static_cast<int>(out_length));
+    VerifyOrReturnError(result == 1, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(CanCastTo<int>(out_length), error = CHIP_ERROR_INVALID_ARGUMENT);
-    result = RAND_priv_bytes(Uint8::to_uchar(out_buffer), static_cast<int>(out_length));
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 ECName MapECName(SupportedECPKeyTypes keyType)
@@ -1198,14 +1178,14 @@ exit:
     do                                                                                                                             \
     {                                                                                                                              \
         _point_ = EC_POINT_new(context->curve);                                                                                    \
-        VerifyOrExit(_point_ != nullptr, error = CHIP_ERROR_INTERNAL);                                                             \
+        VerifyOrReturnError(_point_ != nullptr, CHIP_ERROR_INTERNAL);                                                              \
     } while (0)
 
 #define init_bn(_bn_)                                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
         _bn_ = BN_new();                                                                                                           \
-        VerifyOrExit(_bn_ != nullptr, error = CHIP_ERROR_INTERNAL);                                                                \
+        VerifyOrReturnError(_bn_ != nullptr, CHIP_ERROR_INTERNAL);                                                                 \
     } while (0)
 
 #define free_point(_point_)                                                                                                        \
@@ -1240,26 +1220,23 @@ static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * 
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal()
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
-
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
     context->curve   = nullptr;
     context->bn_ctx  = nullptr;
     context->md_info = nullptr;
 
     context->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
-    VerifyOrExit(context->curve != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(context->curve != nullptr, CHIP_ERROR_INTERNAL);
 
     G = EC_GROUP_get0_generator(context->curve);
-    VerifyOrExit(G != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(G != nullptr, CHIP_ERROR_INTERNAL);
 
     context->bn_ctx = BN_CTX_secure_new();
-    VerifyOrExit(context->bn_ctx != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(context->bn_ctx != nullptr, CHIP_ERROR_INTERNAL);
 
     context->md_info = EVP_sha256();
-    VerifyOrExit(context->md_info != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(context->md_info != nullptr, CHIP_ERROR_INTERNAL);
 
     init_point(M);
     init_point(N);
@@ -1274,17 +1251,15 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal()
     init_bn(tempbn);
     init_bn(order);
 
-    error_openssl = EC_GROUP_get_order(context->curve, static_cast<BIGNUM *>(order), context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
+    const int error_openssl = EC_GROUP_get_order(context->curve, static_cast<BIGNUM *>(order), context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl()
 {
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (context->curve != nullptr)
     {
@@ -1342,125 +1317,90 @@ exit:
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::MacVerify(const uint8_t * key, size_t key_len, const uint8_t * mac, size_t mac_len,
                                                     const uint8_t * in, size_t in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    VerifyOrExit(mac_len == kSHA256_Hash_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mac_len == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
 
     uint8_t computed_mac[kSHA256_Hash_Length];
-    error = Mac(key, key_len, in, in_len, computed_mac);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    const CHIP_ERROR error = Mac(key, key_len, in, in_len, computed_mac);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(CRYPTO_memcmp(mac, computed_mac, mac_len) == 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(CRYPTO_memcmp(mac, computed_mac, mac_len) == 0, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const uint8_t * in, size_t in_len, void * fe)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
-    BIGNUM * bn_fe    = static_cast<BIGNUM *>(fe);
+    BIGNUM * const bn_fe = static_cast<BIGNUM *>(fe);
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
-    VerifyOrExit(CanCastTo<int>(in_len), error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(CanCastTo<int>(in_len), CHIP_ERROR_INTERNAL);
     BN_bin2bn(Uint8::to_const_uchar(in), static_cast<int>(in_len), bn_fe);
-    error_openssl = BN_mod(bn_fe, bn_fe, (BIGNUM *) order, context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
+    const int error_openssl = BN_mod(bn_fe, bn_fe, (BIGNUM *) order, context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEWrite(const void * fe, uint8_t * out, size_t out_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    int bn_out_len;
-    VerifyOrExit(CanCastTo<int>(out_len), error = CHIP_ERROR_INTERNAL);
-    bn_out_len = BN_bn2binpad(static_cast<const BIGNUM *>(fe), Uint8::to_uchar(out), static_cast<int>(out_len));
+    VerifyOrReturnError(CanCastTo<int>(out_len), CHIP_ERROR_INTERNAL);
+    const int bn_out_len = BN_bn2binpad(static_cast<const BIGNUM *>(fe), Uint8::to_uchar(out), static_cast<int>(out_len));
+    VerifyOrReturnError(bn_out_len == static_cast<int>(out_len), CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(bn_out_len == static_cast<int>(out_len), error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const int error_openssl = BN_rand_range(static_cast<BIGNUM *>(fe), static_cast<BIGNUM *>(order));
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error_openssl = BN_rand_range(static_cast<BIGNUM *>(fe), static_cast<BIGNUM *>(order));
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEMul(void * fer, const void * fe1, const void * fe2)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    const int error_openssl = BN_mod_mul(static_cast<BIGNUM *>(fer), static_cast<const BIGNUM *>(fe1),
+                                         static_cast<const BIGNUM *>(fe2), static_cast<BIGNUM *>(order), context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error_openssl = BN_mod_mul(static_cast<BIGNUM *>(fer), static_cast<const BIGNUM *>(fe1), static_cast<const BIGNUM *>(fe2),
-                               static_cast<BIGNUM *>(order), context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const uint8_t * in, size_t in_len, void * R)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
-
-    error_openssl =
+    const int error_openssl =
         EC_POINT_oct2point(context->curve, static_cast<EC_POINT *>(R), Uint8::to_const_uchar(in), in_len, context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, uint8_t * out, size_t out_len)
 {
-    CHIP_ERROR error          = CHIP_ERROR_INTERNAL;
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    size_t ec_out_len = EC_POINT_point2oct(context->curve, static_cast<const EC_POINT *>(R), POINT_CONVERSION_UNCOMPRESSED,
-                                           Uint8::to_uchar(out), out_len, context->bn_ctx);
-    VerifyOrExit(ec_out_len == out_len, error = CHIP_ERROR_INTERNAL);
+    const size_t ec_out_len = EC_POINT_point2oct(context->curve, static_cast<const EC_POINT *>(R), POINT_CONVERSION_UNCOMPRESSED,
+                                                 Uint8::to_uchar(out), out_len, context->bn_ctx);
+    VerifyOrReturnError(ec_out_len == out_len, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, const void * fe1)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    const int error_openssl = EC_POINT_mul(context->curve, static_cast<EC_POINT *>(R), nullptr, static_cast<const EC_POINT *>(P1),
+                                           static_cast<const BIGNUM *>(fe1), context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_mul(context->curve, static_cast<EC_POINT *>(R), nullptr, static_cast<const EC_POINT *>(P1),
-                                 static_cast<const BIGNUM *>(fe1), context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1, const void * fe1, const void * P2,
@@ -1493,17 +1433,12 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    const int error_openssl = EC_POINT_invert(context->curve, static_cast<EC_POINT *>(R), context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_invert(context->curve, static_cast<EC_POINT *>(R), context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
@@ -1549,17 +1484,12 @@ exit:
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
-    CHIP_ERROR error  = CHIP_ERROR_INTERNAL;
-    int error_openssl = 0;
+    const Spake2p_Context * const context = to_inner_spake2p_context(&mSpake2pContext);
 
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    const int error_openssl = EC_POINT_is_on_curve(context->curve, static_cast<EC_POINT *>(R), context->bn_ctx);
+    VerifyOrReturnError(error_openssl == 1, CHIP_ERROR_INTERNAL);
 
-    error_openssl = EC_POINT_is_on_curve(context->curve, static_cast<EC_POINT *>(R), context->bn_ctx);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 static void security_free_cert_list(X509_LIST * certs)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -181,28 +181,22 @@ exit:
 
 CHIP_ERROR Hash_SHA256(const uint8_t * data, const size_t data_length, uint8_t * out_buffer)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
-
     // zero data length hash is supported.
 
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_sha256_ret(Uint8::to_const_uchar(data), data_length, Uint8::to_uchar(out_buffer), 0);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    const int result = mbedtls_sha256_ret(Uint8::to_const_uchar(data), data_length, Uint8::to_uchar(out_buffer), 0);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA1(const uint8_t * data, const size_t data_length, uint8_t * out_buffer)
 {
-    int result = 0;
-
     // zero data length hash is supported.
     VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    result = mbedtls_sha1_ret(Uint8::to_const_uchar(data), data_length, Uint8::to_uchar(out_buffer));
+    const int result = mbedtls_sha1_ret(Uint8::to_const_uchar(data), data_length, Uint8::to_uchar(out_buffer));
     VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -219,44 +213,32 @@ static inline mbedtls_sha256_context * to_inner_hash_sha256_context(HashSHA256Op
 
 CHIP_ERROR Hash_SHA256_stream::Begin(void)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    mbedtls_sha256_context * const context = to_inner_hash_sha256_context(&mContext);
 
-    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
+    const int result = mbedtls_sha256_starts_ret(context, 0);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_sha256_starts_ret(context, 0);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA256_stream::AddData(const uint8_t * data, const size_t data_length)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    mbedtls_sha256_context * const context = to_inner_hash_sha256_context(&mContext);
 
-    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
+    const int result = mbedtls_sha256_update_ret(context, Uint8::to_const_uchar(data), data_length);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_sha256_update_ret(context, Uint8::to_const_uchar(data), data_length);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Hash_SHA256_stream::Finish(uint8_t * out_buffer)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    mbedtls_sha256_context * const context = to_inner_hash_sha256_context(&mContext);
 
-    mbedtls_sha256_context * context = to_inner_hash_sha256_context(&mContext);
+    const int result = mbedtls_sha256_finish_ret(context, Uint8::to_uchar(out_buffer));
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_sha256_finish_ret(context, Uint8::to_uchar(out_buffer));
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 void Hash_SHA256_stream::Clear(void)
@@ -267,34 +249,29 @@ void Hash_SHA256_stream::Clear(void)
 CHIP_ERROR HKDF_sha::HKDF_SHA256(const uint8_t * secret, const size_t secret_length, const uint8_t * salt, const size_t salt_length,
                                  const uint8_t * info, const size_t info_length, uint8_t * out_buffer, size_t out_length)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 1;
-    const mbedtls_md_info_t * md;
-
-    VerifyOrExit(secret != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(secret_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(secret_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
 
     // Salt is optional
     if (salt_length > 0)
     {
-        VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(salt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(info_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    VerifyOrExit(md != nullptr, error = CHIP_ERROR_INTERNAL);
+    const mbedtls_md_info_t * const md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    VerifyOrReturnError(md != nullptr, CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_hkdf(md, Uint8::to_const_uchar(salt), salt_length, Uint8::to_const_uchar(secret), secret_length,
-                          Uint8::to_const_uchar(info), info_length, Uint8::to_uchar(out_buffer), out_length);
+    const int result = mbedtls_hkdf(md, Uint8::to_const_uchar(salt), salt_length, Uint8::to_const_uchar(secret), secret_length,
+                                    Uint8::to_const_uchar(info), info_length, Uint8::to_uchar(out_buffer), out_length);
     _log_mbedTLS_error(result);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR PBKDF2_sha256::pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * salt, size_t slen,
@@ -356,59 +333,50 @@ static EntropyContext * get_entropy_context()
 
 static mbedtls_ctr_drbg_context * get_drbg_context()
 {
-    EntropyContext * context = get_entropy_context();
+    EntropyContext * const context = get_entropy_context();
 
-    mbedtls_ctr_drbg_context * drbgCtxt = &context->mDRBGCtxt;
+    mbedtls_ctr_drbg_context * const drbgCtxt = &context->mDRBGCtxt;
 
     if (!context->mDRBGSeeded)
     {
-        int status = mbedtls_ctr_drbg_seed(drbgCtxt, mbedtls_entropy_func, &context->mEntropy, nullptr, 0);
-        VerifyOrExit(status == 0, _log_mbedTLS_error(status));
+        const int status = mbedtls_ctr_drbg_seed(drbgCtxt, mbedtls_entropy_func, &context->mEntropy, nullptr, 0);
+        if (status != 0)
+        {
+            _log_mbedTLS_error(status);
+            return nullptr;
+        }
 
         context->mDRBGSeeded = true;
     }
 
     return drbgCtxt;
-
-exit:
-    return nullptr;
 }
 
 CHIP_ERROR add_entropy_source(entropy_source fn_source, void * p_source, size_t threshold)
 {
-    CHIP_ERROR error              = CHIP_NO_ERROR;
-    int result                    = 0;
-    EntropyContext * entropy_ctxt = nullptr;
+    VerifyOrReturnError(fn_source != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(fn_source != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    EntropyContext * const entropy_ctxt = get_entropy_context();
+    VerifyOrReturnError(entropy_ctxt != nullptr, CHIP_ERROR_INTERNAL);
 
-    entropy_ctxt = get_entropy_context();
-    VerifyOrExit(entropy_ctxt != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_entropy_add_source(&entropy_ctxt->mEntropy, fn_source, p_source, threshold, MBEDTLS_ENTROPY_SOURCE_STRONG);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-exit:
-    return error;
+    const int result =
+        mbedtls_entropy_add_source(&entropy_ctxt->mEntropy, fn_source, p_source, threshold, MBEDTLS_ENTROPY_SOURCE_STRONG);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
 
-    mbedtls_ctr_drbg_context * drbg_ctxt = nullptr;
+    mbedtls_ctr_drbg_context * const drbg_ctxt = get_drbg_context();
+    VerifyOrReturnError(drbg_ctxt != nullptr, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
+    const int result = mbedtls_ctr_drbg_random(drbg_ctxt, Uint8::to_uchar(out_buffer), out_length);
+    VerifyOrReturnError(result == 0, CHIP_ERROR_INTERNAL);
 
-    drbg_ctxt = get_drbg_context();
-    VerifyOrExit(drbg_ctxt != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_ctr_drbg_random(drbg_ctxt, Uint8::to_uchar(out_buffer), out_length);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_HKDF.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_HKDF.cpp
@@ -40,11 +40,6 @@ CHIP_ERROR HKDF_shaHSM::HKDF_SHA256(const uint8_t * secret, const size_t secret_
                                     const size_t salt_length, const uint8_t * info, const size_t info_length, uint8_t * out_buffer,
                                     size_t out_length)
 {
-    CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
-    sss_status_t status    = kStatus_SSS_Success;
-    smStatus_t smstatus    = SM_NOT_OK;
-    sss_object_t keyObject = { 0 };
-
     if (salt_length > 64 || info_length > 80 || secret_length > 256 || out_length > 768)
     {
         /* Length not supported by se05x. Rollback to SW */
@@ -54,41 +49,40 @@ CHIP_ERROR HKDF_shaHSM::HKDF_SHA256(const uint8_t * secret, const size_t secret_
     // Salt is optional
     if (salt_length > 0)
     {
-        VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(salt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
-    VerifyOrExit(info_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(info != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_buffer != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(secret != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(info_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_buffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(keyid != kKeyId_NotInitialized, error = CHIP_ERROR_HSM);
+    VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);
 
     se05x_sessionOpen();
 
-    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    sss_object_t keyObject = { 0 };
+    sss_status_t status    = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, secret_length,
                                             kKeyObject_Mode_Transient);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, secret, secret_length, secret_length * 8, NULL, 0);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
-    smstatus = Se05x_API_HKDF_Extended(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyObject.keyId,
-                                       kSE05x_DigestMode_SHA256, kSE05x_HkdfMode_ExtractExpand, salt, salt_length, 0, info,
-                                       info_length, 0, (uint16_t) out_length, out_buffer, &out_length);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    const smStatus_t smstatus = Se05x_API_HKDF_Extended(
+        &((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyObject.keyId, kSE05x_DigestMode_SHA256,
+        kSE05x_HkdfMode_ExtractExpand, salt, salt_length, 0, info, info_length, 0, (uint16_t) out_length, out_buffer, &out_length);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Crypto

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_PBKDF.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_PBKDF.cpp
@@ -39,48 +39,42 @@ PBKDF2_sha256HSM::~PBKDF2_sha256HSM() {}
 CHIP_ERROR PBKDF2_sha256HSM::pbkdf2_sha256(const uint8_t * password, size_t plen, const uint8_t * salt, size_t slen,
                                            unsigned int iteration_count, uint32_t key_length, uint8_t * output)
 {
-    CHIP_ERROR error        = CHIP_ERROR_INTERNAL;
-    smStatus_t smStatus     = SM_NOT_OK;
-    sss_status_t status     = kStatus_SSS_Fail;
-    sss_object_t hmacKeyObj = {
-        0,
-    };
+    VerifyOrReturnError(password != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(plen > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(key_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(output != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(slen >= chip::Crypto::kMin_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(slen <= chip::Crypto::kMax_Salt_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(salt != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(password != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(plen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(key_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(output != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen >= chip::Crypto::kMin_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(slen <= chip::Crypto::kMax_Salt_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(salt != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    VerifyOrExit(keyid != kKeyId_NotInitialized, error = CHIP_ERROR_HSM);
+    VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);
 
     se05x_sessionOpen();
 
-    status = sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    sss_object_t hmacKeyObj = {
+        0,
+    };
+    sss_status_t status = sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&hmacKeyObj, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, sizeof(password),
                                             kKeyObject_Mode_Transient);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &hmacKeyObj, password, plen, plen * 8, NULL, 0);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
-    smStatus = Se05x_API_PBKDF2(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, kSE05x_Pbkdf2_HMAC_SHA256, salt,
-                                slen, (uint16_t) iteration_count, (uint16_t) key_length, output, (size_t *) &key_length);
-
-    VerifyOrExit(smStatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    const smStatus_t smStatus =
+        Se05x_API_PBKDF2(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, kSE05x_Pbkdf2_HMAC_SHA256, salt, slen,
+                         (uint16_t) iteration_count, (uint16_t) key_length, output, (size_t *) &key_length);
+    VerifyOrReturnError(smStatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &hmacKeyObj);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Crypto

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
@@ -91,23 +91,23 @@ CHIP_ERROR create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE role, hsm_pake
     se05x_delete_key(m_id);
     error = se05x_set_key(m_id, chip::Crypto::spake2p_M_p256, sizeof(chip::Crypto::spake2p_M_p256), kSSS_KeyPart_Public,
                           kSSS_CipherType_EC_NIST_P);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     se05x_delete_key(n_id);
     error = se05x_set_key(n_id, chip::Crypto::spake2p_N_p256, sizeof(chip::Crypto::spake2p_N_p256), kSSS_KeyPart_Public,
                           kSSS_CipherType_EC_NIST_P);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
     subtype.spakeAlgo = kSE05x_SpakeAlgo_P256_SHA256_HKDF_HMAC;
 
 #if ENABLE_REENTRANCY
-    VerifyOrExit(spake_objects_created < LIMIT_CRYPTO_OBJECTS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(spake_objects_created < LIMIT_CRYPTO_OBJECTS, CHIP_ERROR_INTERNAL);
 
     smstatus = Se05x_API_CreateCryptoObject(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
                                             kSE05x_CryptoContext_SPAKE, subtype);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     /* Increment number of crypto objects created */
     spake_objects_created++;
@@ -127,24 +127,19 @@ CHIP_ERROR create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE role, hsm_pake
     {
         smstatus = Se05x_API_CreateCryptoObject(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
                                                 kSE05x_CryptoContext_SPAKE, subtype);
-        VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
     }
 #endif
 
     smstatus = Se05x_API_PAKEInitProtocol(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId, m_id, n_id);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_ComputeRoundOne_HSM(hsm_pake_context_t * phsm_pake_context, chip::Crypto::CHIP_SPAKE2P_ROLE role,
                                        const uint8_t * pab, size_t pab_len, uint8_t * out, size_t * out_len)
 {
-    CHIP_ERROR error    = CHIP_ERROR_INTERNAL;
-    smStatus_t smstatus = SM_NOT_OK;
-
 #if SSS_HAVE_SE05X_VER_GTE_16_03
 #else
     uint8_t * prand     = NULL;
@@ -155,11 +150,11 @@ CHIP_ERROR Spake2p_ComputeRoundOne_HSM(hsm_pake_context_t * phsm_pake_context, c
 #endif
     SE05x_CryptoObjectID_t spakeObjectId = phsm_pake_context->spake_objId;
 
-    VerifyOrExit(out != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_len != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_len != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     if (pab_len > 0)
     {
-        VerifyOrExit(pab != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(pab != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER)
@@ -178,10 +173,10 @@ CHIP_ERROR Spake2p_ComputeRoundOne_HSM(hsm_pake_context_t * phsm_pake_context, c
     sss_rng_context_t rng_ctx;
 
     status = sss_rng_context_init(&rng_ctx, &gex_sss_chip_ctx.session);
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     status = sss_rng_get_random(&rng_ctx, tempBuf, sizeof(tempBuf));
-    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
 
     sss_rng_context_free(&rng_ctx);
 
@@ -190,71 +185,58 @@ CHIP_ERROR Spake2p_ComputeRoundOne_HSM(hsm_pake_context_t * phsm_pake_context, c
 
 #endif
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
 #if SSS_HAVE_SE05X_VER_GTE_16_03
-    smstatus = Se05x_API_PAKEComputeKeyShare(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
-                                             (uint8_t *) pab, pab_len, out, out_len);
+    const smStatus_t smstatus = Se05x_API_PAKEComputeKeyShare(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
+                                                              spakeObjectId, (uint8_t *) pab, pab_len, out, out_len);
 #else
-    smstatus  = Se05x_API_PAKEComputeKeyShare(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
-                                             (uint8_t *) pab, pab_len, out, out_len, prand, prand_len);
+    const smStatus_t smstatus =
+        Se05x_API_PAKEComputeKeyShare(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId, (uint8_t *) pab,
+                                      pab_len, out, out_len, prand, prand_len);
 #endif
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_ComputeRoundTwo_HSM(hsm_pake_context_t * phsm_pake_context, chip::Crypto::CHIP_SPAKE2P_ROLE role,
                                        const uint8_t * in, size_t in_len, uint8_t * out, size_t * out_len, uint8_t * pKeyKe,
                                        size_t * pkeyKeLen)
 {
-    CHIP_ERROR error                     = CHIP_ERROR_INTERNAL;
-    smStatus_t smstatus                  = SM_NOT_OK;
-    const uint8_t * pab                  = NULL;
-    size_t pab_len                       = 0;
-    SE05x_CryptoObjectID_t spakeObjectId = phsm_pake_context->spake_objId;
+    VerifyOrReturnError(in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_len != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(pKeyKe != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(pkeyKeLen != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(in != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(out_len != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pKeyKe != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pkeyKeLen != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    const uint8_t * const pab = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER) ? NULL : in;
+    const size_t pab_len      = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER) ? 0 : in_len;
 
-    pab     = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER) ? NULL : in;
-    pab_len = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER) ? 0 : in_len;
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+    const SE05x_CryptoObjectID_t spakeObjectId = phsm_pake_context->spake_objId;
+    const smStatus_t smstatus =
+        Se05x_API_PAKEComputeSessionKeys(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
+                                         (uint8_t *) pab, pab_len, pKeyKe, pkeyKeLen, out, out_len);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
-    smstatus = Se05x_API_PAKEComputeSessionKeys(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
-                                                (uint8_t *) pab, pab_len, pKeyKe, pkeyKeLen, out, out_len);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Spake2p_KeyConfirm_HSM(hsm_pake_context_t * phsm_pake_context, chip::Crypto::CHIP_SPAKE2P_ROLE role, const uint8_t * in,
                                   size_t in_len)
 {
-    CHIP_ERROR error                     = CHIP_ERROR_INTERNAL;
-    smStatus_t smstatus                  = SM_NOT_OK;
-    uint8_t presult                      = 0;
-    SE05x_CryptoObjectID_t spakeObjectId = phsm_pake_context->spake_objId;
+    VerifyOrReturnError(in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(in != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    uint8_t presult                            = 0;
+    const SE05x_CryptoObjectID_t spakeObjectId = phsm_pake_context->spake_objId;
+    const smStatus_t smstatus = Se05x_API_PAKEVerifySessionKeys(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
+                                                                spakeObjectId, (uint8_t *) in, in_len, &presult);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
-
-    smstatus = Se05x_API_PAKEVerifySessionKeys(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, spakeObjectId,
-                                               (uint8_t *) in, in_len, &presult);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
-
-    error = (presult == 1) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
-exit:
-    return error;
+    return (presult == 1) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
 }
 
 namespace chip {
@@ -262,8 +244,7 @@ namespace Crypto {
 
 CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::Init(const uint8_t * context, size_t context_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-    state            = CHIP_SPAKE2P_STATE::PREINIT;
+    state = CHIP_SPAKE2P_STATE::PREINIT;
 
 #if ENABLE_REENTRANCY
     static uint8_t alreadyInitialised = 0;
@@ -277,20 +258,19 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::Init(const uint8_t * context, size_
 
     if (context_len > 0)
     {
-        VerifyOrExit(context != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
-    VerifyOrExit(context_len <= sizeof(hsm_pake_context.spake_context), error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(context_len <= sizeof(hsm_pake_context.spake_context), CHIP_ERROR_INTERNAL);
     memset(hsm_pake_context.spake_context, 0, sizeof(hsm_pake_context.spake_context));
     memcpy(hsm_pake_context.spake_context, context, context_len);
     hsm_pake_context.spake_context_len = context_len;
 
-    error = Spake2p::Init(context, context_len);
+    const CHIP_ERROR error = Spake2p::Init(context, context_len);
     if (error == CHIP_NO_ERROR)
     {
         state = CHIP_SPAKE2P_STATE::INIT;
     }
 
-exit:
     return error;
 }
 
@@ -307,49 +287,49 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     size_t w0in_mod_len = 32;
     smStatus_t smstatus = SM_NOT_OK;
 
-    VerifyOrExit(w0in != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(Lin != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::INIT, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(w0in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(Lin != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::INIT, CHIP_ERROR_INTERNAL);
     if (my_identity_len > 0)
     {
-        VerifyOrExit(my_identity != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(my_identity != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
     if (peer_identity_len > 0)
     {
-        VerifyOrExit(peer_identity != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(peer_identity != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     error = FELoad(w0in, w0in_len, w0);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FEWrite(w0, w0in_mod, w0in_mod_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER, &hsm_pake_context);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) peer_identity, peer_identity_len, (uint8_t *) my_identity, my_identity_len);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 #endif
 
     error = se05x_set_key(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = se05x_set_key(Lin_id_v, Lin, Lin_len, kSSS_KeyPart_Public, kSSS_CipherType_EC_NIST_P);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEInitCredentials(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
@@ -358,14 +338,12 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_v, 0, Lin_id_v);
 #endif
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::VERIFIER;
-    error = CHIP_NO_ERROR;
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 #endif
 
@@ -386,56 +364,56 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     };
     size_t w1in_mod_len = 32;
 
-    VerifyOrExit(w0in != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(w1in != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w0in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w1in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     if (my_identity_len > 0)
     {
-        VerifyOrExit(my_identity != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(my_identity != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
     if (peer_identity_len > 0)
     {
-        VerifyOrExit(peer_identity != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(peer_identity != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::INIT, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::INIT, CHIP_ERROR_INTERNAL);
 
     error = FELoad(w0in, w0in_len, w0);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FEWrite(w0, w0in_mod, w0in_mod_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FELoad(w1in, w1in_len, w1);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = FEWrite(w1, w1in_mod, w1in_mod_len);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER, &hsm_pake_context);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) my_identity, my_identity_len, (uint8_t *) peer_identity, peer_identity_len);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 #endif
 
     error = se05x_set_key(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
     error = se05x_set_key(w1in_id_p, w1in_mod, w1in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEInitCredentials(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
@@ -444,120 +422,104 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_p, w1in_id_p, 0);
 #endif
-    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
 
-    error = CHIP_NO_ERROR;
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 #endif
 
 CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::ComputeRoundOne(const uint8_t * pab, size_t pab_len, uint8_t * out, size_t * out_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::STARTED, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(*out_len >= point_size, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::STARTED, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(*out_len >= point_size, CHIP_ERROR_INTERNAL);
 
 #if !ENABLE_HSM_SPAKE_VERIFIER
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_rollback_verifier = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER);
+#else
+    constexpr bool sw_rollback_verifier = false;
 #endif
 
 #if ((CHIP_CRYPTO_HSM) && (!ENABLE_HSM_SPAKE_PROVER))
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_roolback_prover = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER);
+#else
+    constexpr bool sw_rollback_prover   = false;
 #endif
 
-    error = Spake2p_ComputeRoundOne_HSM(&hsm_pake_context, role, pab, pab_len, out, out_len);
+    if (sw_rollback_verifier || sw_rollback_prover)
+    {
+        return Spake2p::ComputeRoundOne(pab, pab_len, out, out_len);
+    }
+
+    CHIP_ERROR error = Spake2p_ComputeRoundOne_HSM(&hsm_pake_context, role, pab, pab_len, out, out_len);
     if (CHIP_NO_ERROR == error)
     {
         state = CHIP_SPAKE2P_STATE::R1;
     }
-    goto exit;
-
-#if (!ENABLE_HSM_SPAKE_VERIFIER) || (!ENABLE_HSM_SPAKE_PROVER)
-sw_rollback:
-#endif
-
-    error = Spake2p::ComputeRoundOne(pab, pab_len, out, out_len);
-
-exit:
     return error;
 }
 
 CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::ComputeRoundTwo(const uint8_t * in, size_t in_len, uint8_t * out, size_t * out_len)
 {
-    CHIP_ERROR error   = CHIP_ERROR_INTERNAL;
-    uint8_t pKeyKe[16] = {
-        0,
-    };
-    size_t pkeyKeLen = sizeof(pKeyKe);
-
-    VerifyOrExit(*out_len >= hash_size, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(state == CHIP_SPAKE2P_STATE::R1, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(in_len == point_size, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(*out_len >= hash_size, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::R1, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(in_len == point_size, CHIP_ERROR_INTERNAL);
 
 #if !ENABLE_HSM_SPAKE_VERIFIER
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_rollback_verifier = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER);
+#else
+    constexpr bool sw_rollback_verifier = false;
 #endif
 
 #if !ENABLE_HSM_SPAKE_PROVER
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_roolback_prover = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER);
+#else
+    constexpr bool sw_rollback_prover   = false;
 #endif
 
-    error = Spake2p_ComputeRoundTwo_HSM(&hsm_pake_context, role, in, in_len, out, out_len, pKeyKe, &pkeyKeLen);
+    if (sw_rollback_verifier || sw_rollback_prover)
+    {
+        return Spake2p::ComputeRoundTwo(in, in_len, out, out_len);
+    }
+
+    uint8_t pKeyKe[16] = {
+        0,
+    };
+    constexpr size_t pkeyKeLen = sizeof(pKeyKe);
+
+    const CHIP_ERROR error = Spake2p_ComputeRoundTwo_HSM(&hsm_pake_context, role, in, in_len, out, out_len, pKeyKe, &pkeyKeLen);
     if (CHIP_NO_ERROR == error)
     {
         memcpy((Kae + 16), pKeyKe, pkeyKeLen);
         state = CHIP_SPAKE2P_STATE::R2;
     }
-
-    goto exit;
-
-#if ((!ENABLE_HSM_SPAKE_VERIFIER) || (!ENABLE_HSM_SPAKE_PROVER))
-sw_rollback:
-#endif
-
-    error = Spake2p::ComputeRoundTwo(in, in_len, out, out_len);
-
-exit:
     return error;
 }
 
 CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::KeyConfirm(const uint8_t * in, size_t in_len)
 {
-    CHIP_ERROR error = CHIP_ERROR_INTERNAL;
     VerifyOrExit(state == CHIP_SPAKE2P_STATE::R2, error = CHIP_ERROR_INTERNAL);
 
 #if !ENABLE_HSM_SPAKE_VERIFIER
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_rollback_verifier = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER);
+#else
+    constexpr bool sw_rollback_verifier = false;
 #endif
 
 #if !ENABLE_HSM_SPAKE_PROVER
-    if (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER)
-    {
-        goto sw_rollback;
-    }
+    const bool sw_roolback_prover = (role == chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER);
+#else
+    constexpr bool sw_rollback_prover   = false;
 #endif
 
-    error = Spake2p_KeyConfirm_HSM(&hsm_pake_context, role, in, in_len);
+    if (sw_rollback_verifier || sw_rollback_prover)
+    {
+        return Spake2p::KeyConfirm(in, in_len);
+    }
+
+    const CHIP_ERROR error = Spake2p_KeyConfirm_HSM(&hsm_pake_context, role, in, in_len);
     if (CHIP_NO_ERROR == error)
     {
         state = CHIP_SPAKE2P_STATE::KC;
@@ -565,15 +527,6 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::KeyConfirm(const uint8_t * in, size
 
     Spake2p_Finish_HSM(&hsm_pake_context);
 
-    goto exit;
-
-#if (!ENABLE_HSM_SPAKE_VERIFIER || !ENABLE_HSM_SPAKE_PROVER)
-sw_rollback:
-#endif
-
-    error = Spake2p::KeyConfirm(in, in_len);
-
-exit:
     return error;
 }
 

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -133,17 +133,11 @@ IPEndPointBasis::LeaveMulticastGroupHandler IPEndPointBasis::sLeaveMulticastGrou
 #if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 static INET_ERROR CheckMulticastGroupArgs(InterfaceId aInterfaceId, const IPAddress & aAddress)
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-    bool lIsPresent, lIsMulticast;
+    VerifyOrReturnError(IsInterfaceIdPresent(aInterfaceId), INET_ERROR_UNKNOWN_INTERFACE);
 
-    lIsPresent = IsInterfaceIdPresent(aInterfaceId);
-    VerifyOrExit(lIsPresent, lRetval = INET_ERROR_UNKNOWN_INTERFACE);
+    VerifyOrReturnError(aAddress.IsMulticast(), INET_ERROR_WRONG_ADDRESS_TYPE);
 
-    lIsMulticast = aAddress.IsMulticast();
-    VerifyOrExit(lIsMulticast, lRetval = INET_ERROR_WRONG_ADDRESS_TYPE);
-
-exit:
-    return (lRetval);
+    return INET_NO_ERROR;
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
@@ -153,32 +147,17 @@ exit:
 static INET_ERROR LwIPIPv4JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
                                                   err_t (*aMethod)(struct netif *, const LWIP_IPV4_ADDR_T *))
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-    err_t lStatus;
-    struct netif * lNetif;
-    LWIP_IPV4_ADDR_T lIPv4Address;
+    struct netif * const lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
+    VerifyOrReturnError(lNetif != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
 
-    lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
-    VerifyOrExit(lNetif != NULL, lRetval = INET_ERROR_UNKNOWN_INTERFACE);
+    const LWIP_IPV4_ADDR_T lIPv4Address = IPV4_TO_LWIPADDR(aAddress);
+    const err_t lStatus                 = aMethod(lNetif, &lIPv4Address);
 
-    lIPv4Address = IPV4_TO_LWIPADDR(aAddress);
-
-    lStatus = aMethod(lNetif, &lIPv4Address);
-
-    switch (lStatus)
+    if (lStatus == ERR_MEM)
     {
-
-    case ERR_MEM:
-        lRetval = INET_ERROR_NO_MEMORY;
-        break;
-
-    default:
-        lRetval = chip::System::MapErrorLwIP(lStatus);
-        break;
+        return INET_ERROR_NO_MEMORY;
     }
-
-exit:
-    return (lRetval);
+    return chip::System::MapErrorLwIP(lStatus);
 }
 #endif // LWIP_IPV4 && LWIP_IGMP
 #endif // INET_CONFIG_ENABLE_IPV4
@@ -197,32 +176,17 @@ exit:
 static INET_ERROR LwIPIPv6JoinLeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress,
                                                   err_t (*aMethod)(struct netif *, const LWIP_IPV6_ADDR_T *))
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-    err_t lStatus;
-    struct netif * lNetif;
-    LWIP_IPV6_ADDR_T lIPv6Address;
+    struct netif * const lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
+    VerifyOrReturnError(lNetif != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
 
-    lNetif = IPEndPointBasis::FindNetifFromInterfaceId(aInterfaceId);
-    VerifyOrExit(lNetif != NULL, lRetval = INET_ERROR_UNKNOWN_INTERFACE);
+    const LWIP_IPV6_ADDR_T lIPv6Address = IPV6_TO_LWIPADDR(aAddress);
+    const err_t lStatus                 = aMethod(lNetif, &lIPv6Address);
 
-    lIPv6Address = IPV6_TO_LWIPADDR(aAddress);
-
-    lStatus = aMethod(lNetif, &lIPv6Address);
-
-    switch (lStatus)
+    if (lStatus == ERR_MEM)
     {
-
-    case ERR_MEM:
-        lRetval = INET_ERROR_NO_MEMORY;
-        break;
-
-    default:
-        lRetval = chip::System::MapErrorLwIP(lStatus);
-        break;
+        return INET_ERROR_NO_MEMORY;
     }
-
-exit:
-    return (lRetval);
+    return chip::System::MapErrorLwIP(lStatus);
 }
 #endif // LWIP_IPV6_MLD && LWIP_IPV6_ND && LWIP_IPV6
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -231,15 +195,13 @@ exit:
 #if IP_MULTICAST_LOOP || IPV6_MULTICAST_LOOP
 static INET_ERROR SocketsSetMulticastLoopback(int aSocket, bool aLoopback, int aProtocol, int aOption)
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-    int lStatus;
-    unsigned int lValue = aLoopback;
+    const unsigned int lValue = aLoopback;
+    if (setsockopt(aSocket, aProtocol, aOption, &lValue, sizeof(lValue)) != 0)
+    {
+        return chip::System::MapErrorPOSIX(errno);
+    }
 
-    lStatus = setsockopt(aSocket, aProtocol, aOption, &lValue, sizeof(lValue));
-    VerifyOrExit(lStatus == 0, lRetval = chip::System::MapErrorPOSIX(errno));
-
-exit:
-    return (lRetval);
+    return INET_NO_ERROR;
 }
 #endif // IP_MULTICAST_LOOP || IPV6_MULTICAST_LOOP
 
@@ -276,10 +238,8 @@ static INET_ERROR SocketsSetMulticastLoopback(int aSocket, IPVersion aIPVersion,
 static INET_ERROR SocketsIPv4JoinLeaveMulticastGroup(int aSocket, InterfaceId aInterfaceId, const IPAddress & aAddress,
                                                      int aCommand)
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
     IPAddress lInterfaceAddress;
     bool lInterfaceAddressFound = false;
-    struct ip_mreq lMulticastRequest;
 
     for (InterfaceAddressIterator lAddressIterator; lAddressIterator.HasCurrent(); lAddressIterator.Next())
     {
@@ -296,17 +256,18 @@ static INET_ERROR SocketsIPv4JoinLeaveMulticastGroup(int aSocket, InterfaceId aI
         }
     }
 
-    VerifyOrExit(lInterfaceAddressFound, lRetval = INET_ERROR_ADDRESS_NOT_FOUND);
+    VerifyOrReturnError(lInterfaceAddressFound, INET_ERROR_ADDRESS_NOT_FOUND);
 
+    struct ip_mreq lMulticastRequest;
     memset(&lMulticastRequest, 0, sizeof(lMulticastRequest));
     lMulticastRequest.imr_interface = lInterfaceAddress.ToIPv4();
     lMulticastRequest.imr_multiaddr = aAddress.ToIPv4();
 
-    lRetval = setsockopt(aSocket, IPPROTO_IP, aCommand, &lMulticastRequest, sizeof(lMulticastRequest));
-    VerifyOrExit(lRetval == 0, lRetval = chip::System::MapErrorPOSIX(errno));
-
-exit:
-    return (lRetval);
+    if (setsockopt(aSocket, IPPROTO_IP, aCommand, &lMulticastRequest, sizeof(lMulticastRequest)) != 0)
+    {
+        return chip::System::MapErrorPOSIX(errno);
+    }
+    return INET_NO_ERROR;
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -314,26 +275,21 @@ exit:
 static INET_ERROR SocketsIPv6JoinLeaveMulticastGroup(int aSocket, InterfaceId aInterfaceId, const IPAddress & aAddress,
                                                      int aCommand)
 {
-    INET_ERROR lRetval          = INET_NO_ERROR;
+    VerifyOrReturnError(CanCastTo<unsigned int>(aInterfaceId), INET_ERROR_UNEXPECTED_EVENT);
     const unsigned int lIfIndex = static_cast<unsigned int>(aInterfaceId);
+
     struct ipv6_mreq lMulticastRequest;
-
-    // Check whether that cast we did was actually safe.  We can't VerifyOrExit
-    // before declaring variables, and can't reassign lIfIndex without making it
-    // non-const, so have to do things in this order.
-    VerifyOrExit(CanCastTo<unsigned int>(aInterfaceId), lRetval = INET_ERROR_UNEXPECTED_EVENT);
-
     memset(&lMulticastRequest, 0, sizeof(lMulticastRequest));
-    VerifyOrExit(CanCastTo<decltype(lMulticastRequest.ipv6mr_interface)>(lIfIndex), lRetval = INET_ERROR_UNEXPECTED_EVENT);
+    VerifyOrReturnError(CanCastTo<decltype(lMulticastRequest.ipv6mr_interface)>(lIfIndex), INET_ERROR_UNEXPECTED_EVENT);
 
     lMulticastRequest.ipv6mr_interface = static_cast<decltype(lMulticastRequest.ipv6mr_interface)>(lIfIndex);
     lMulticastRequest.ipv6mr_multiaddr = aAddress.ToIPv6();
 
-    lRetval = setsockopt(aSocket, IPPROTO_IPV6, aCommand, &lMulticastRequest, sizeof(lMulticastRequest));
-    VerifyOrExit(lRetval == 0, lRetval = chip::System::MapErrorPOSIX(errno));
-
-exit:
-    return (lRetval);
+    if (setsockopt(aSocket, IPPROTO_IPV6, aCommand, &lMulticastRequest, sizeof(lMulticastRequest)) != 0)
+    {
+        return chip::System::MapErrorPOSIX(errno);
+    }
+    return INET_NO_ERROR;
 }
 #endif // INET_IPV6_ADD_MEMBERSHIP || INET_IPV6_DROP_MEMBERSHIP
 
@@ -836,27 +792,23 @@ INET_ERROR IPEndPointBasis::BindInterface(IPAddressType aAddressType, InterfaceI
 
 INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags)
 {
-    INET_ERROR res = INET_NO_ERROR;
-    PeerSockAddr peerSockAddr;
-    struct iovec msgIOV;
-    uint8_t controlData[256];
-    struct msghdr msgHeader;
-    InterfaceId intfId = aPktInfo->Interface;
-
     // Ensure the destination address type is compatible with the endpoint address type.
-    VerifyOrExit(mAddrType == aPktInfo->DestAddress.Type(), res = INET_ERROR_BAD_ARGS);
+    VerifyOrReturnError(mAddrType == aPktInfo->DestAddress.Type(), INET_ERROR_BAD_ARGS);
 
     // For now the entire message must fit within a single buffer.
-    VerifyOrExit(!aBuffer->HasChainedBuffer(), res = INET_ERROR_MESSAGE_TOO_LONG);
+    VerifyOrReturnError(!aBuffer->HasChainedBuffer(), INET_ERROR_MESSAGE_TOO_LONG);
 
+    struct iovec msgIOV;
+    msgIOV.iov_base = aBuffer->Start();
+    msgIOV.iov_len  = aBuffer->DataLength();
+
+    struct msghdr msgHeader;
     memset(&msgHeader, 0, sizeof(msgHeader));
-
-    msgIOV.iov_base      = aBuffer->Start();
-    msgIOV.iov_len       = aBuffer->DataLength();
     msgHeader.msg_iov    = &msgIOV;
     msgHeader.msg_iovlen = 1;
 
     // Construct a sockaddr_in/sockaddr_in6 structure containing the destination information.
+    PeerSockAddr peerSockAddr;
     memset(&peerSockAddr, 0, sizeof(peerSockAddr));
     msgHeader.msg_name = &peerSockAddr;
     if (mAddrType == kIPAddressType_IPv6)
@@ -864,7 +816,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
         peerSockAddr.in6.sin6_family = AF_INET6;
         peerSockAddr.in6.sin6_port   = htons(aPktInfo->DestPort);
         peerSockAddr.in6.sin6_addr   = aPktInfo->DestAddress.ToIPv6();
-        VerifyOrExit(CanCastTo<decltype(peerSockAddr.in6.sin6_scope_id)>(aPktInfo->Interface), res = INET_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(CanCastTo<decltype(peerSockAddr.in6.sin6_scope_id)>(aPktInfo->Interface), INET_ERROR_INCORRECT_STATE);
         peerSockAddr.in6.sin6_scope_id = static_cast<decltype(peerSockAddr.in6.sin6_scope_id)>(aPktInfo->Interface);
         msgHeader.msg_namelen          = sizeof(sockaddr_in6);
     }
@@ -884,6 +836,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     // for messages to multicast addresses, which under Linux
     // don't seem to get sent out the correct interface, despite
     // the socket being bound.
+    InterfaceId intfId = aPktInfo->Interface;
     if (intfId == INET_NULL_INTERFACEID)
         intfId = mBoundIntfId;
 
@@ -894,6 +847,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     if (intfId != INET_NULL_INTERFACEID || aPktInfo->SrcAddress.Type() != kIPAddressType_Any)
     {
 #if defined(IP_PKTINFO) || defined(IPV6_PKTINFO)
+        uint8_t controlData[256];
         memset(controlData, 0, sizeof(controlData));
         msgHeader.msg_control    = controlData;
         msgHeader.msg_controllen = sizeof(controlData);
@@ -912,7 +866,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
             struct in_pktinfo * pktInfo = reinterpret_cast<struct in_pktinfo *> CMSG_DATA(controlHdr);
             if (!CanCastTo<decltype(pktInfo->ipi_ifindex)>(intfId))
             {
-                ExitNow(res = INET_ERROR_NOT_SUPPORTED);
+                return INET_ERROR_NOT_SUPPORTED;
             }
 
             pktInfo->ipi_ifindex  = static_cast<decltype(pktInfo->ipi_ifindex)>(intfId);
@@ -920,7 +874,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
 
             msgHeader.msg_controllen = CMSG_SPACE(sizeof(in_pktinfo));
 #else  // !defined(IP_PKTINFO)
-            ExitNow(res = INET_ERROR_NOT_SUPPORTED);
+            return INET_ERROR_NOT_SUPPORTED;
 #endif // !defined(IP_PKTINFO)
         }
 
@@ -936,34 +890,29 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
             struct in6_pktinfo * pktInfo = reinterpret_cast<struct in6_pktinfo *> CMSG_DATA(controlHdr);
             if (!CanCastTo<decltype(pktInfo->ipi6_ifindex)>(intfId))
             {
-                ExitNow(res = INET_ERROR_UNEXPECTED_EVENT);
+                return INET_ERROR_UNEXPECTED_EVENT;
             }
             pktInfo->ipi6_ifindex = static_cast<decltype(pktInfo->ipi6_ifindex)>(intfId);
             pktInfo->ipi6_addr    = aPktInfo->SrcAddress.ToIPv6();
 
             msgHeader.msg_controllen = CMSG_SPACE(sizeof(in6_pktinfo));
 #else  // !defined(IPV6_PKTINFO)
-            ExitNow(res = INET_ERROR_NOT_SUPPORTED);
+            return INET_ERROR_NOT_SUPPORTED;
 #endif // !defined(IPV6_PKTINFO)
         }
 
 #else  // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
-        IgnoreUnusedVariable(controlData);
-        ExitNow(res = INET_ERROR_NOT_SUPPORTED);
+        return INET_ERROR_NOT_SUPPORTED;
 #endif // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
     }
 
     // Send IP packet.
-    {
-        const ssize_t lenSent = sendmsg(mSocket.GetFD(), &msgHeader, 0);
-        if (lenSent == -1)
-            res = chip::System::MapErrorPOSIX(errno);
-        else if (lenSent != aBuffer->DataLength())
-            res = INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED;
-    }
-
-exit:
-    return (res);
+    const ssize_t lenSent = sendmsg(mSocket.GetFD(), &msgHeader, 0);
+    if (lenSent == -1)
+        return chip::System::MapErrorPOSIX(errno);
+    if (lenSent != aBuffer->DataLength())
+        return INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED;
+    return INET_NO_ERROR;
 }
 
 INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int aProtocol)
@@ -1236,51 +1185,46 @@ INET_ERROR IPEndPointBasis::ConfigureProtocol(IPAddressType aAddressType, const 
 INET_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort,
                                  const nw_parameters_t & aParameters)
 {
-    INET_ERROR res         = INET_NO_ERROR;
     nw_endpoint_t endpoint = nullptr;
 
-    VerifyOrExit(aParameters != NULL, res = INET_ERROR_BAD_ARGS);
+    VerifyOrReturnError(aParameters != NULL, INET_ERROR_BAD_ARGS);
 
-    res = ConfigureProtocol(aAddressType, aParameters);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(ConfigureProtocol(aAddressType, aParameters));
 
-    res = GetEndPoint(endpoint, aAddressType, aAddress, aPort);
+    INET_ERROR res = GetEndPoint(endpoint, aAddressType, aAddress, aPort);
     nw_parameters_set_local_endpoint(aParameters, endpoint);
     nw_release(endpoint);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(res);
 
     mDispatchQueue = dispatch_queue_create("inet_dispatch_global", DISPATCH_QUEUE_CONCURRENT);
-    VerifyOrExit(mDispatchQueue != NULL, res = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mDispatchQueue != NULL, INET_ERROR_NO_MEMORY);
     dispatch_retain(mDispatchQueue);
 
     mConnectionSemaphore = dispatch_semaphore_create(0);
-    VerifyOrExit(mConnectionSemaphore != NULL, res = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mConnectionSemaphore != NULL, INET_ERROR_NO_MEMORY);
     dispatch_retain(mConnectionSemaphore);
 
     mSendSemaphore = dispatch_semaphore_create(0);
-    VerifyOrExit(mSendSemaphore != NULL, res = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mSendSemaphore != NULL, INET_ERROR_NO_MEMORY);
     dispatch_retain(mSendSemaphore);
 
     mAddrType   = aAddressType;
     mConnection = NULL;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System::PacketBufferHandle && aBuffer, uint16_t aSendFlags)
 {
-    __block INET_ERROR res = INET_NO_ERROR;
     dispatch_data_t content;
 
     // Ensure the destination address type is compatible with the endpoint address type.
-    VerifyOrExit(mAddrType == aPktInfo->DestAddress.Type(), res = INET_ERROR_BAD_ARGS);
+    VerifyOrReturnError(mAddrType == aPktInfo->DestAddress.Type(), INET_ERROR_BAD_ARGS);
 
     // For now the entire message must fit within a single buffer.
-    VerifyOrExit(aBuffer->Next() == NULL, res = INET_ERROR_MESSAGE_TOO_LONG);
+    VerifyOrReturnError(aBuffer->Next() == NULL, INET_ERROR_MESSAGE_TOO_LONG);
 
-    res = GetConnection(aPktInfo);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(GetConnection(aPktInfo));
 
     // Send a message, and wait for it to be dispatched.
     content = dispatch_data_create(aBuffer->Start(), aBuffer->DataLength(), mDispatchQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
@@ -1291,7 +1235,7 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     // the semaphore. In this case the INET_ERROR will not update with the result of the completion handler.
     // To make sure caller knows that sending a message has failed the following code consider there is an error
     // _unless_ the completion handler says otherwise.
-    res = INET_ERROR_UNEXPECTED_EVENT;
+    __block INET_ERROR res = INET_ERROR_UNEXPECTED_EVENT;
     nw_connection_send(mConnection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
         if (error)
         {
@@ -1307,7 +1251,6 @@ INET_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
 
     dispatch_semaphore_wait(mSendSemaphore, DISPATCH_TIME_FOREVER);
 
-exit:
     return res;
 }
 
@@ -1376,7 +1319,6 @@ void IPEndPointBasis::GetPacketInfo(const nw_connection_t & aConnection, IPPacke
 INET_ERROR IPEndPointBasis::GetEndPoint(nw_endpoint_t & aEndPoint, const IPAddressType aAddressType, const IPAddress & aAddress,
                                         uint16_t aPort)
 {
-    INET_ERROR res = INET_NO_ERROR;
     char addrStr[INET6_ADDRSTRLEN];
     char portStr[INET_PORTSTRLEN];
 
@@ -1395,19 +1337,17 @@ INET_ERROR IPEndPointBasis::GetEndPoint(nw_endpoint_t & aEndPoint, const IPAddre
     snprintf(portStr, sizeof(portStr), "%u", aPort);
 
     aEndPoint = nw_endpoint_create_host(addrStr, portStr);
-    VerifyOrExit(aEndPoint != NULL, res = INET_ERROR_BAD_ARGS);
+    VerifyOrReturnError(aEndPoint != NULL, INET_ERROR_BAD_ARGS);
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 INET_ERROR IPEndPointBasis::GetConnection(const IPPacketInfo * aPktInfo)
 {
-    INET_ERROR res             = INET_NO_ERROR;
+    VerifyOrReturnError(mParameters != NULL, INET_ERROR_INCORRECT_STATE);
+
     nw_endpoint_t endpoint     = NULL;
     nw_connection_t connection = NULL;
-
-    VerifyOrExit(mParameters != NULL, res = INET_ERROR_INCORRECT_STATE);
 
     if (mConnection)
     {
@@ -1416,24 +1356,19 @@ INET_ERROR IPEndPointBasis::GetConnection(const IPPacketInfo * aPktInfo)
         const IPAddress remote_address = IPAddress::FromSockAddr(*nw_endpoint_get_address(remote_endpoint));
         const uint16_t remote_port     = nw_endpoint_get_port(remote_endpoint);
         const bool isDifferentEndPoint = aPktInfo->DestPort != remote_port || aPktInfo->DestAddress != remote_address;
-        VerifyOrExit(isDifferentEndPoint, res = INET_NO_ERROR);
+        VerifyOrReturnError(isDifferentEndPoint, INET_NO_ERROR);
 
-        res = ReleaseConnection();
+        ReturnErrorOnFailure(ReleaseConnection());
     }
-    SuccessOrExit(res);
 
-    res = GetEndPoint(endpoint, mAddrType, aPktInfo->DestAddress, aPktInfo->DestPort);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(GetEndPoint(endpoint, mAddrType, aPktInfo->DestAddress, aPktInfo->DestPort));
 
     connection = nw_connection_create(endpoint, mParameters);
     nw_release(endpoint);
 
-    VerifyOrExit(connection != NULL, res = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(connection != NULL, INET_ERROR_INCORRECT_STATE);
 
-    res = StartConnection(connection);
-
-exit:
-    return res;
+    return StartConnection(connection);
 }
 
 INET_ERROR IPEndPointBasis::StartListener()
@@ -1441,19 +1376,19 @@ INET_ERROR IPEndPointBasis::StartListener()
     __block INET_ERROR res = INET_NO_ERROR;
     nw_listener_t listener;
 
-    VerifyOrExit(mListener == NULL, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mListenerSemaphore == NULL, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mListenerQueue == NULL, res = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mListener == NULL, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mListenerSemaphore == NULL, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mListenerQueue == NULL, INET_ERROR_INCORRECT_STATE);
 
     listener = nw_listener_create(mParameters);
-    VerifyOrExit(listener != NULL, res = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(listener != NULL, INET_ERROR_INCORRECT_STATE);
 
     mListenerSemaphore = dispatch_semaphore_create(0);
-    VerifyOrExit(mListenerSemaphore != NULL, res = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mListenerSemaphore != NULL, INET_ERROR_NO_MEMORY);
     dispatch_retain(mListenerSemaphore);
 
     mListenerQueue = dispatch_queue_create("inet_dispatch_listener", DISPATCH_QUEUE_CONCURRENT);
-    VerifyOrExit(mListenerQueue != NULL, res = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mListenerQueue != NULL, INET_ERROR_NO_MEMORY);
     dispatch_retain(mListenerQueue);
 
     nw_listener_set_queue(listener, mListenerQueue);
@@ -1500,11 +1435,10 @@ INET_ERROR IPEndPointBasis::StartListener()
 
     nw_listener_start(listener);
     dispatch_semaphore_wait(mListenerSemaphore, DISPATCH_TIME_FOREVER);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(res);
 
     mListener = listener;
     nw_retain(mListener);
-exit:
     return res;
 }
 
@@ -1563,7 +1497,6 @@ INET_ERROR IPEndPointBasis::StartConnection(nw_connection_t & aConnection)
     nw_retain(mConnection);
     HandleDataReceived(mConnection);
 
-exit:
     return res;
 }
 
@@ -1617,35 +1550,30 @@ void IPEndPointBasis::ReleaseAll()
 
 INET_ERROR IPEndPointBasis::ReleaseListener()
 {
-    INET_ERROR res = INET_NO_ERROR;
-
-    VerifyOrExit(mListener, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mDispatchQueue, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mConnectionSemaphore, res = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mListener, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mDispatchQueue, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mConnectionSemaphore, INET_ERROR_INCORRECT_STATE);
 
     nw_listener_cancel(mListener);
     dispatch_semaphore_wait(mListenerSemaphore, DISPATCH_TIME_FOREVER);
     nw_release(mListener);
     mListener = NULL;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 INET_ERROR IPEndPointBasis::ReleaseConnection()
 {
-    INET_ERROR res = INET_NO_ERROR;
-    VerifyOrExit(mConnection, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mDispatchQueue, res = INET_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mConnectionSemaphore, res = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mConnection, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mDispatchQueue, INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mConnectionSemaphore, INET_ERROR_INCORRECT_STATE);
 
     nw_connection_cancel(mConnection);
     dispatch_semaphore_wait(mConnectionSemaphore, DISPATCH_TIME_FOREVER);
     nw_release(mConnection);
     mConnection = NULL;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -138,39 +138,31 @@ static void FillDataBufferPattern(uint8_t * aBuffer, uint16_t aLength, uint16_t 
 
 static bool CheckDataBufferPattern(const uint8_t * aBuffer, uint16_t aLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
 {
-    bool lStatus = true;
-
     for (uint16_t i = aPatternStartOffset; i < aLength; i++)
     {
         const uint8_t lValue = aBuffer[i];
 
-        // clang-format off
-        VerifyOrExit(lValue == static_cast<uint8_t>(aFirstValue),
-                     printf("Bad data value at offset %u (0x%04x): "
-                            "expected 0x%02x, found 0x%02x\n",
-                            i, i, aFirstValue, lValue);
-                     lStatus = false;
-                     DumpMemory(aBuffer + aPatternStartOffset,
-                                aLength - aPatternStartOffset,
-                                "0x",
-                                16));
-        // clang-format on
+        if (lValue != static_cast<uint8_t>(aFirstValue))
+        {
+            printf("Bad data value at offset %u (0x%04x): "
+                   "expected 0x%02x, found 0x%02x\n",
+                   i, i, aFirstValue, lValue);
+            DumpMemory(aBuffer + aPatternStartOffset, aLength - aPatternStartOffset, "0x", 16);
+            return false;
+        }
 
         aFirstValue++;
     }
 
-exit:
-    return (lStatus);
+    return true;
 }
 
 static PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset, uint8_t aFirstValue)
 {
-    PacketBufferHandle lBuffer;
+    VerifyOrReturnError(aPatternStartOffset <= aDesiredLength, PacketBufferHandle());
 
-    VerifyOrExit(aPatternStartOffset <= aDesiredLength, );
-
-    lBuffer = PacketBufferHandle::New(aDesiredLength);
-    VerifyOrExit(!lBuffer.IsNull(), );
+    PacketBufferHandle lBuffer = PacketBufferHandle::New(aDesiredLength);
+    VerifyOrReturnError(!lBuffer.IsNull(), lBuffer);
 
     aDesiredLength = min(lBuffer->MaxDataLength(), aDesiredLength);
 
@@ -178,18 +170,13 @@ static PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatt
 
     lBuffer->SetDataLength(aDesiredLength);
 
-exit:
     return lBuffer;
 }
 
 static PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength, uint16_t aPatternStartOffset)
 {
     constexpr uint8_t lFirstValue = 0;
-    PacketBufferHandle lBuffer    = MakeDataBuffer(aDesiredLength, aPatternStartOffset, lFirstValue);
-    VerifyOrExit(!lBuffer.IsNull(), );
-
-exit:
-    return (lBuffer);
+    return MakeDataBuffer(aDesiredLength, aPatternStartOffset, lFirstValue);
 }
 
 template <typename tType>
@@ -251,7 +238,6 @@ PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength)
 static bool HandleDataReceived(const PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer,
                                uint16_t aPatternStartOffset, uint8_t aFirstValue)
 {
-    bool lStatus              = true;
     uint16_t lTotalDataLength = 0;
 
     // Walk through each buffer in the packet chain, checking the
@@ -260,17 +246,15 @@ static bool HandleDataReceived(const PacketBufferHandle & aBuffer, TransferStats
     for (PacketBufferHandle lBuffer = aBuffer.Retain(); !lBuffer.IsNull(); lBuffer.Advance())
     {
         const uint16_t lDataLength = lBuffer->DataLength();
+        const uint8_t * const p    = lBuffer->Start();
 
-        if (aCheckBuffer)
+        if (aCheckBuffer && !CheckDataBufferPattern(p, lDataLength, aPatternStartOffset, aFirstValue))
         {
-            const uint8_t * p = lBuffer->Start();
-
-            lStatus = CheckDataBufferPattern(p, lDataLength, aPatternStartOffset, aFirstValue);
-            VerifyOrExit(lStatus == true, );
+            return false;
         }
 
-        lTotalDataLength = static_cast<uint16_t>(lTotalDataLength + lBuffer->DataLength());
-        aFirstValue      = static_cast<uint8_t>(aFirstValue + lBuffer->DataLength());
+        lTotalDataLength = static_cast<uint16_t>(lTotalDataLength + lDataLength);
+        aFirstValue      = static_cast<uint8_t>(aFirstValue + lDataLength);
     }
 
     // If we are accumulating stats by packet rather than by size,
@@ -278,8 +262,7 @@ static bool HandleDataReceived(const PacketBufferHandle & aBuffer, TransferStats
 
     aStats.mReceive.mActual += ((aStatsByPacket) ? 1 : lTotalDataLength);
 
-exit:
-    return (lStatus);
+    return true;
 }
 
 static bool HandleICMPDataReceived(PacketBufferHandle aBuffer, uint16_t aHeaderLength, TransferStats & aStats, bool aStatsByPacket,

--- a/src/inet/tests/TestInetLayerMulticast.cpp
+++ b/src/inet/tests/TestInetLayerMulticast.cpp
@@ -470,14 +470,11 @@ static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdent
 
 bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
 {
-    bool retval = true;
-
     if ((gOptFlags & (kOptFlagListen | kOptFlagNoLoopback)) == (kOptFlagListen | kOptFlagNoLoopback))
     {
         PrintArgError("%s: the listen option is exclusive with the loopback suppression option. Please select one or the other.\n",
                       aProgram);
-        retval = false;
-        goto exit;
+        return false;
     }
 
     // If there were any additional, non-parsed arguments, it's an error.
@@ -485,8 +482,7 @@ bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
     if (argc > 0)
     {
         PrintArgError("%s: unexpected argument: %s\n", aProgram, argv[0]);
-        retval = false;
-        goto exit;
+        return false;
     }
 
     // If no IP version or transport flags were specified, use the defaults.
@@ -496,8 +492,7 @@ bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
         gOptFlags |= kOptFlagsDefault;
     }
 
-exit:
-    return (retval);
+    return true;
 }
 
 // Create an IPv4 administratively-scoped multicast address
@@ -535,47 +530,40 @@ static void SetGroup(GroupAddress & aGroupAddress, uint32_t aGroupIdentifier, ui
 static bool ParseGroupOpt(const char * aProgram, const char * aValue, bool aIPv6, uint32_t & aOutLastGroupIndex)
 {
     uint32_t lGroupIdentifier;
-    bool lRetval = true;
 
     if (sGroupAddresses.mSize == sGroupAddresses.mCapacity)
     {
         PrintArgError("%s: the maximum number of allowed groups (%zu) have been specified\n", aProgram, sGroupAddresses.mCapacity);
-        lRetval = false;
-        goto exit;
+        return false;
     }
 
     if (!ParseInt(aValue, lGroupIdentifier))
     {
         PrintArgError("%s: unrecognized group %s\n", aProgram, aValue);
-        lRetval = false;
-        goto exit;
+        return false;
     }
 
     aOutLastGroupIndex = sGroupAddresses.mSize++;
 
     SetGroup(sGroupAddresses.mAddresses[aOutLastGroupIndex], lGroupIdentifier, lGroupIdentifier, lGroupIdentifier);
 
-exit:
-    return (lRetval);
+    return true;
 }
 
 static bool ParseAndUpdateExpectedGroupPackets(const char * aProgram, const char * aValue, uint32_t aGroup,
                                                const char * aDescription, uint32_t & aOutExpected)
 {
     uint32_t lExpectedGroupPackets;
-    bool lRetval = true;
 
     if (!ParseInt(aValue, lExpectedGroupPackets))
     {
         PrintArgError("%s: invalid value specified for expected group %u %s packets: %s\n", aProgram, aGroup, aDescription, aValue);
-        lRetval = false;
-        goto exit;
+        return false;
     }
 
     aOutExpected = lExpectedGroupPackets;
 
-exit:
-    return (lRetval);
+    return true;
 }
 
 static GroupAddress * FindGroupAddress(const IPAddress & aSourceAddress)
@@ -604,33 +592,25 @@ static void PrintReceivedStats(const GroupAddress & aGroupAddress)
 
 static bool HandleDataReceived(const PacketBufferHandle & aBuffer, GroupAddress & aGroupAddress, bool aCheckBuffer)
 {
-    const bool lStatsByPacket = true;
-    bool lStatus              = true;
-
-    lStatus = Common::HandleDataReceived(aBuffer, aGroupAddress.mStats, lStatsByPacket, aCheckBuffer);
-    VerifyOrExit(lStatus == true, );
+    constexpr bool lStatsByPacket = true;
+    if (!Common::HandleDataReceived(aBuffer, aGroupAddress.mStats, lStatsByPacket, aCheckBuffer))
+    {
+        return false;
+    }
 
     PrintReceivedStats(aGroupAddress);
 
-exit:
-    return (lStatus);
+    return true;
 }
 
 static bool HandleDataReceived(const PacketBufferHandle & aBuffer, const IPPacketInfo & aPacketInfo, bool aCheckBuffer)
 {
-    bool lStatus = true;
-    GroupAddress * lGroupAddress;
-
-    lGroupAddress = FindGroupAddress(aPacketInfo.DestAddress);
-
+    GroupAddress * const lGroupAddress = FindGroupAddress(aPacketInfo.DestAddress);
     if (lGroupAddress != nullptr)
     {
-        lStatus = HandleDataReceived(aBuffer, *lGroupAddress, aCheckBuffer);
-        VerifyOrExit(lStatus == true, );
+        return HandleDataReceived(aBuffer, *lGroupAddress, aCheckBuffer);
     }
-
-exit:
-    return (lStatus);
+    return true;
 }
 
 // Raw Endpoint Callbacks
@@ -747,7 +727,6 @@ static INET_ERROR PrepareTransportForSend()
 static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t aSize)
 {
     PacketBufferHandle lBuffer;
-    INET_ERROR lStatus = INET_NO_ERROR;
 
     if ((gOptFlags & (kOptFlagUseRawIP)) == (kOptFlagUseRawIP))
     {
@@ -759,48 +738,40 @@ static INET_ERROR DriveSendForDestination(const IPAddress & aAddress, uint16_t a
         if ((gOptFlags & kOptFlagUseIPv6) == (kOptFlagUseIPv6))
         {
             lBuffer = Common::MakeICMPv6DataBuffer(aSize);
-            VerifyOrExit(!lBuffer.IsNull(), lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrReturnError(!lBuffer.IsNull(), INET_ERROR_NO_MEMORY);
         }
 #if INET_CONFIG_ENABLE_IPV4
         else if ((gOptFlags & kOptFlagUseIPv4) == (kOptFlagUseIPv4))
         {
             lBuffer = Common::MakeICMPv4DataBuffer(aSize);
-            VerifyOrExit(!lBuffer.IsNull(), lStatus = INET_ERROR_NO_MEMORY);
+            VerifyOrReturnError(!lBuffer.IsNull(), INET_ERROR_NO_MEMORY);
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-        lStatus = sRawIPEndPoint->SendTo(aAddress, std::move(lBuffer));
-        SuccessOrExit(lStatus);
+        return sRawIPEndPoint->SendTo(aAddress, std::move(lBuffer));
     }
-    else
+
+    if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
     {
-        if ((gOptFlags & kOptFlagUseUDPIP) == kOptFlagUseUDPIP)
-        {
-            const uint8_t lFirstValue = 0;
+        const uint8_t lFirstValue = 0;
 
-            // For UDP, we'll send n aSize or smaller datagrams, each
-            // patterned from zero to aSize - 1.
+        // For UDP, we'll send n aSize or smaller datagrams, each
+        // patterned from zero to aSize - 1.
 
-            lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
-            VerifyOrExit(!lBuffer.IsNull(), lStatus = INET_ERROR_NO_MEMORY);
+        lBuffer = Common::MakeDataBuffer(aSize, lFirstValue);
+        VerifyOrReturnError(!lBuffer.IsNull(), INET_ERROR_NO_MEMORY);
 
-            lStatus = sUDPIPEndPoint->SendTo(aAddress, kUDPPort, std::move(lBuffer));
-            SuccessOrExit(lStatus);
-        }
+        return sUDPIPEndPoint->SendTo(aAddress, kUDPPort, std::move(lBuffer));
     }
 
-exit:
-    return (lStatus);
+    return INET_NO_ERROR;
 }
 
 static INET_ERROR DriveSendForGroup(GroupAddress & aGroupAddress)
 {
-    INET_ERROR lStatus = INET_NO_ERROR;
-
     if (aGroupAddress.mStats.mTransmit.mActual < aGroupAddress.mStats.mTransmit.mExpected)
     {
-        lStatus = DriveSendForDestination(aGroupAddress.mMulticastAddress, gSendSize);
-        SuccessOrExit(lStatus);
+        ReturnErrorOnFailure(DriveSendForDestination(aGroupAddress.mMulticastAddress, gSendSize));
 
         aGroupAddress.mStats.mTransmit.mActual++;
 
@@ -808,28 +779,20 @@ static INET_ERROR DriveSendForGroup(GroupAddress & aGroupAddress)
                aGroupAddress.mStats.mTransmit.mExpected, aGroupAddress.mGroup);
     }
 
-exit:
-    return (lStatus);
+    return INET_NO_ERROR;
 }
 
 template <size_t tCapacity>
 static INET_ERROR DriveSendForGroups(GroupAddresses<tCapacity> & aGroupAddresses)
 {
-    INET_ERROR lStatus = INET_NO_ERROR;
-
     // Iterate over each multicast group for which this node is a
     // member and send a packet.
-
     for (size_t i = 0; i < aGroupAddresses.mSize; i++)
     {
-        GroupAddress & lGroupAddress = aGroupAddresses.mAddresses[i];
-
-        lStatus = DriveSendForGroup(lGroupAddress);
-        SuccessOrExit(lStatus);
+        ReturnErrorOnFailure(DriveSendForGroup(aGroupAddresses.mAddresses[i]));
     }
 
-exit:
-    return (lStatus);
+    return INET_NO_ERROR;
 }
 
 void DriveSend()

--- a/src/inet/tests/TestSetupFaultInjectionPosix.cpp
+++ b/src/inet/tests/TestSetupFaultInjectionPosix.cpp
@@ -68,13 +68,13 @@ static void RebootCallbackFn()
     if (!lArgv.Alloc(static_cast<size_t>(sRestartCallbackCtx.mArgc + 2)))
     {
         printf("** failed to allocate memory **\n");
-        ExitNow();
+        return;
     }
 
     if (gSigusr1Received)
     {
         printf("** skipping restart case after SIGUSR1 **\n");
-        ExitNow();
+        return;
     }
 
     for (i = 0; sRestartCallbackCtx.mArgv[i] != nullptr; i++)
@@ -108,9 +108,6 @@ static void RebootCallbackFn()
     printf("********** Restarting *********\n");
     fflush(stdout);
     execvp(lArgv[0], lArgv.Get());
-
-exit:
-    return;
 }
 
 static void PostInjectionCallbackFn(nl::FaultInjection::Manager * aManager, nl::FaultInjection::Identifier aId,

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -335,16 +335,13 @@ ASN1_ERROR ASN1Writer::PutNull()
 
 ASN1_ERROR ASN1Writer::PutConstructedType(const uint8_t * val, uint16_t valLen)
 {
-    ASN1_ERROR err = ASN1_NO_ERROR;
-
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     memcpy(mWritePoint, val, valLen);
     mWritePoint += valLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::StartConstructedType(uint8_t cls, uint32_t tag)

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -3725,12 +3725,12 @@ static void TLVReaderFuzzTest(nlTestSuite * inSuite, void * inContext)
             {
                 printf("Unexpected success of fuzz test: offset %u, original value 0x%02X, mutated value 0x%02X\n",
                        static_cast<unsigned>(i), static_cast<unsigned>(origVal), static_cast<unsigned>(fuzzedData[i]));
-                ExitNow();
+                return;
             }
 
             time(&now);
             if (now >= endTime)
-                ExitNow();
+                return;
 
             fuzzedData[i] = origVal;
         }
@@ -3738,9 +3738,6 @@ static void TLVReaderFuzzTest(nlTestSuite * inSuite, void * inContext)
         if (m < sizeof(sFixedFuzzVals))
             m++;
     }
-
-exit:
-    return;
 }
 
 // Test Suite

--- a/src/lib/support/LifetimePersistedCounter.cpp
+++ b/src/lib/support/LifetimePersistedCounter.cpp
@@ -33,54 +33,38 @@ LifetimePersistedCounter::~LifetimePersistedCounter() {}
 CHIP_ERROR
 LifetimePersistedCounter::Init(const chip::Platform::PersistedStorage::Key aId)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     mId = aId;
     uint32_t startValue;
 
     // Read our previously-stored starting value.
-    SuccessOrExit(err = ReadStartValue(startValue));
+    ReturnErrorOnFailure(ReadStartValue(startValue));
 
     // This will set the starting value, after which we're ready.
-    SuccessOrExit(err = MonotonicallyIncreasingCounter::Init(startValue));
-
-exit:
-    return err;
+    return MonotonicallyIncreasingCounter::Init(startValue);
 }
 
 CHIP_ERROR
 LifetimePersistedCounter::Advance()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrReturnError(mId != chip::Platform::PersistedStorage::kEmptyKey, CHIP_ERROR_INCORRECT_STATE);
 
-    VerifyOrExit(mId != chip::Platform::PersistedStorage::kEmptyKey, err = CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(MonotonicallyIncreasingCounter::Advance());
 
-    SuccessOrExit(err = MonotonicallyIncreasingCounter::Advance());
-
-    SuccessOrExit(err = chip::Platform::PersistedStorage::Write(mId, GetValue()));
-exit:
-    return err;
+    return chip::Platform::PersistedStorage::Write(mId, GetValue());
 }
 
 CHIP_ERROR
 LifetimePersistedCounter::ReadStartValue(uint32_t & aStartValue)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     aStartValue = 0;
 
-    err = chip::Platform::PersistedStorage::Read(mId, aStartValue);
+    CHIP_ERROR err = chip::Platform::PersistedStorage::Read(mId, aStartValue);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // No previously-stored value, no worries, the counter is initialized to zero.
         // Suppress the error.
         err = CHIP_NO_ERROR;
     }
-    else
-    {
-        SuccessOrExit(err);
-    }
-exit:
     return err;
 }
 

--- a/src/lib/support/SerializableIntegerSet.cpp
+++ b/src/lib/support/SerializableIntegerSet.cpp
@@ -65,11 +65,9 @@ uint16_t SerializableU64SetBase::FindIndex(uint64_t value)
 
 CHIP_ERROR SerializableU64SetBase::Insert(uint64_t value)
 {
-    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
-    uint16_t index = 0;
-    VerifyOrExit(value != mEmptyValue, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(value != mEmptyValue, CHIP_ERROR_INVALID_ARGUMENT);
 
-    index = FirstAvailableForUniqueId(value);
+    const uint16_t index = FirstAvailableForUniqueId(value);
     if (index < mCapacity)
     {
         mData[index] = value;
@@ -77,18 +75,17 @@ CHIP_ERROR SerializableU64SetBase::Insert(uint64_t value)
         {
             mNextAvailable = static_cast<uint16_t>(index + 1);
         }
-        err = CHIP_NO_ERROR;
+        return CHIP_NO_ERROR;
     }
 
-exit:
-    return err;
+    return CHIP_ERROR_NO_MEMORY;
 }
 
 void SerializableU64SetBase::Remove(uint64_t value)
 {
     if (value != mEmptyValue)
     {
-        uint16_t index = FindIndex(value);
+        const uint16_t index = FindIndex(value);
         if (index < mCapacity)
         {
             mData[index] = mEmptyValue;

--- a/src/lib/support/TimeUtils.cpp
+++ b/src/lib/support/TimeUtils.cpp
@@ -545,18 +545,15 @@ void SecondsSinceEpochToCalendarTime(uint32_t secondsSinceEpoch, uint16_t & year
 bool CalendarToChipEpochTime(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute, uint8_t second,
                              uint32_t & chipEpochTime)
 {
-    bool res = true;
+    VerifyOrReturnError(year >= kChipEpochBaseYear && year <= kChipEpochMaxYear, false);
+
     uint32_t daysSinceUnixEpoch;
-
-    VerifyOrExit(year >= kChipEpochBaseYear && year <= kChipEpochMaxYear, res = false);
-
     CalendarDateToDaysSinceEpoch(year, month, dayOfMonth, daysSinceUnixEpoch);
 
     chipEpochTime = ((daysSinceUnixEpoch - kChipEpochDaysSinceUnixEpoch) * kSecondsPerDay) + (hour * kSecondsPerHour) +
         (minute * kSecondsPerMinute) + second;
 
-exit:
-    return res;
+    return true;
 }
 
 void ChipEpochToCalendarTime(uint32_t chipEpochTime, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour,
@@ -568,14 +565,11 @@ void ChipEpochToCalendarTime(uint32_t chipEpochTime, uint16_t & year, uint8_t & 
 
 bool UnixEpochToChipEpochTime(uint32_t unixEpochTime, uint32_t & chipEpochTime)
 {
-    bool res = true;
-
-    VerifyOrExit(unixEpochTime >= kChipEpochSecondsSinceUnixEpoch, res = false);
+    VerifyOrReturnError(unixEpochTime >= kChipEpochSecondsSinceUnixEpoch, false);
 
     chipEpochTime = unixEpochTime - kChipEpochSecondsSinceUnixEpoch;
 
-exit:
-    return res;
+    return true;
 }
 
 } // namespace chip

--- a/src/lib/support/tests/TestPersistedStorageImplementation.cpp
+++ b/src/lib/support/tests/TestPersistedStorageImplementation.cpp
@@ -61,7 +61,6 @@ static void RemoveEndOfLineSymbol(char * str)
 
 static CHIP_ERROR GetCounterValueFromFile(const char * aKey, uint32_t & aValue)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     char key[CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH];
     char value[CHIP_CONFIG_PERSISTED_STORAGE_MAX_VALUE_LENGTH];
 
@@ -75,24 +74,18 @@ static CHIP_ERROR GetCounterValueFromFile(const char * aKey, uint32_t & aValue)
         {
             if (fgets(value, sizeof(value), sPersistentStoreFile) == nullptr)
             {
-                err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+                return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
             }
-            else
-            {
-                RemoveEndOfLineSymbol(value);
+            RemoveEndOfLineSymbol(value);
 
-                if (!ParseInt(value, aValue, 0))
-                    err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-            }
+            if (!ParseInt(value, aValue, 0))
+                return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
 
-            ExitNow();
+            return CHIP_NO_ERROR;
         }
     }
 
-    err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-
-exit:
-    return err;
+    return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
 }
 
 static CHIP_ERROR SaveCounterValueToFile(const char * aKey, uint32_t aValue)
@@ -142,8 +135,8 @@ CHIP_ERROR Read(const char * aKey, uint32_t & aValue)
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::map<std::string, std::string>::iterator it;
 
-    VerifyOrExit(aKey != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrReturnError(aKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
 
     if (sPersistentStoreFile)
     {
@@ -152,14 +145,13 @@ CHIP_ERROR Read(const char * aKey, uint32_t & aValue)
     else
     {
         it = sPersistentStore.find(aKey);
-        VerifyOrExit(it != sPersistentStore.end(), err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+        VerifyOrReturnError(it != sPersistentStore.end(), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
         size_t aValueLength =
             Base64Decode(it->second.c_str(), static_cast<uint16_t>(it->second.length()), reinterpret_cast<uint8_t *>(&aValue));
-        VerifyOrExit(aValueLength == sizeof(uint32_t), err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+        VerifyOrReturnError(aValueLength == sizeof(uint32_t), CHIP_ERROR_PERSISTED_STORAGE_FAILED);
     }
 
-exit:
     return err;
 }
 
@@ -167,8 +159,8 @@ CHIP_ERROR Write(const char * aKey, uint32_t aValue)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(aKey != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, err = CHIP_ERROR_INVALID_STRING_LENGTH);
+    VerifyOrReturnError(aKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(strlen(aKey) <= CHIP_CONFIG_PERSISTED_STORAGE_MAX_KEY_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
 
     if (sPersistentStoreFile)
     {
@@ -184,7 +176,6 @@ CHIP_ERROR Write(const char * aKey, uint32_t aValue)
         sPersistentStore[aKey] = encodedValue;
     }
 
-exit:
     return err;
 }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -286,16 +286,13 @@ int CASE_TestSecurePairing_Setup(void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    CHIP_ERROR error;
     CertificateKeyId trustedRootId = { .mId = sTestCert_Root01_SubjectKeyId, .mLen = sTestCert_Root01_SubjectKeyId_Len };
 
-    error = chip::Platform::MemoryInit();
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(chip::Platform::MemoryInit());
 
     gTransportMgr.Init(&gLoopback);
 
-    error = ctx.Init(&sSuite, &gTransportMgr);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(ctx.Init(&sSuite, &gTransportMgr));
 
     ctx.SetSourceNodeId(kAnyNodeId);
     ctx.SetDestinationNodeId(kAnyNodeId);
@@ -305,71 +302,56 @@ int CASE_TestSecurePairing_Setup(void * inContext)
 
     gTransportMgr.SetSecureSessionMgr(&ctx.GetSecureSessionManager());
 
-    error = commissionerOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(
+        commissionerOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
     memcpy((uint8_t *) (commissionerOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
     memcpy((uint8_t *) (commissionerOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
            sTestCert_Node01_01_PrivateKey_Len);
 
-    error = commissionerOpKeys.Deserialize(commissionerOpKeysSerialized);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerOpKeys.Deserialize(commissionerOpKeysSerialized));
 
-    error = accessoryOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(
+        accessoryOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
     memcpy((uint8_t *) (accessoryOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
     memcpy((uint8_t *) (accessoryOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
            sTestCert_Node01_01_PrivateKey_Len);
 
-    error = accessoryOpKeys.Deserialize(accessoryOpKeysSerialized);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
 
-    error = commissionerCertificateSet.Init(kStandardCertsCount, kTestCertBufSize);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
 
-    error = accessoryCertificateSet.Init(kStandardCertsCount, kTestCertBufSize);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
 
     // Add the trusted root certificate to the certificate set.
-    error = commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
-                                                BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    error = accessoryCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
-                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    error = commissionerCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
-                                                BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    error = accessoryCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
-                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    error = commissionerDevOpCred.Init(&commissionerCertificateSet, 1);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerDevOpCred.Init(&commissionerCertificateSet, 1));
 
-    error = commissionerDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                               static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
+                                                            static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
 
-    error = commissionerDevOpCred.SetDevOpCredKeypair(trustedRootId, &commissionerOpKeys);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCredKeypair(trustedRootId, &commissionerOpKeys));
 
-    error = accessoryDevOpCred.Init(&accessoryCertificateSet, 1);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryDevOpCred.Init(&accessoryCertificateSet, 1));
 
-    error = accessoryDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                            static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len));
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
+                                                         static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
 
-    error = accessoryDevOpCred.SetDevOpCredKeypair(trustedRootId, &accessoryOpKeys);
-    SuccessOrExit(error);
+    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCredKeypair(trustedRootId, &accessoryOpKeys));
 
-exit:
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/setup_payload/AdditionalDataPayloadParser.cpp
+++ b/src/setup_payload/AdditionalDataPayloadParser.cpp
@@ -37,33 +37,26 @@ namespace chip {
 
 CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayloadData::AdditionalDataPayload & outPayload)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     TLV::TLVReader innerReader;
 
     reader.Init(mPayloadBufferData, mPayloadBufferLength);
-    err = reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag));
 
     // Open the container
-    err = reader.OpenContainer(innerReader);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.OpenContainer(innerReader));
 
-    err = innerReader.Next(TLV::kTLVType_UTF8String, TLV::ContextTag(SetupPayloadData::kRotatingDeviceIdTag));
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(innerReader.Next(TLV::kTLVType_UTF8String, TLV::ContextTag(SetupPayloadData::kRotatingDeviceIdTag)));
 
     // Get the value of the rotating device id
     char rotatingDeviceId[SetupPayloadData::kRotatingDeviceIdLength];
-    err = innerReader.GetString(rotatingDeviceId, sizeof(rotatingDeviceId));
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(innerReader.GetString(rotatingDeviceId, sizeof(rotatingDeviceId)));
     outPayload.rotatingDeviceId = std::string(rotatingDeviceId);
 
     // Verify the end of the container
-    err = reader.VerifyEndOfContainer();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -109,32 +109,22 @@ bool SetupPayload::isValidManualCode()
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, std::string data)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfo info;
     info.tag  = tag;
     info.type = optionalQRCodeInfoTypeString;
     info.data = std::move(data);
 
-    err = addOptionalVendorData(info);
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return addOptionalVendorData(info);
 }
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, int32_t data)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfo info;
     info.tag   = tag;
     info.type  = optionalQRCodeInfoTypeInt32;
     info.int32 = data;
 
-    err = addOptionalVendorData(info);
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return addOptionalVendorData(info);
 }
 
 std::vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData() const
@@ -149,51 +139,37 @@ std::vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData() const
 
 CHIP_ERROR SetupPayload::removeOptionalVendorData(uint8_t tag)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(optionalVendorData.find(tag) != optionalVendorData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    VerifyOrReturnError(optionalVendorData.find(tag) != optionalVendorData.end(), CHIP_ERROR_KEY_NOT_FOUND);
     optionalVendorData.erase(tag);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetupPayload::addSerialNumber(std::string serialNumber)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfoExtension info;
     info.tag  = kSerialNumberTag;
     info.type = optionalQRCodeInfoTypeString;
     info.data = std::move(serialNumber);
 
-    err = addOptionalExtensionData(info);
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return addOptionalExtensionData(info);
 }
 
 CHIP_ERROR SetupPayload::addSerialNumber(uint32_t serialNumber)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfoExtension info;
     info.tag    = kSerialNumberTag;
     info.type   = optionalQRCodeInfoTypeUInt32;
     info.uint32 = serialNumber;
 
-    err = addOptionalExtensionData(info);
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return addOptionalExtensionData(info);
 }
 
 CHIP_ERROR SetupPayload::getSerialNumber(std::string & outSerialNumber) const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfoExtension info;
-    err = getOptionalExtensionData(kSerialNumberTag, info);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(getOptionalExtensionData(kSerialNumberTag, info));
 
     switch (info.type)
     {
@@ -205,50 +181,42 @@ CHIP_ERROR SetupPayload::getSerialNumber(std::string & outSerialNumber) const
         break;
     default:
         err = CHIP_ERROR_INVALID_ARGUMENT;
+        break;
     }
 
-exit:
     return err;
 }
 
 CHIP_ERROR SetupPayload::removeSerialNumber()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(optionalExtensionData.find(kSerialNumberTag) != optionalExtensionData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    VerifyOrReturnError(optionalExtensionData.find(kSerialNumberTag) != optionalExtensionData.end(), CHIP_ERROR_KEY_NOT_FOUND);
     optionalExtensionData.erase(kSerialNumberTag);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(IsVendorTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsVendorTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
     optionalVendorData[info.tag] = info;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfoExtension & info)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(IsCHIPTag(info.tag), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsCHIPTag(info.tag), CHIP_ERROR_INVALID_ARGUMENT);
     optionalExtensionData[info.tag] = info;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetupPayload::getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(optionalVendorData.find(tag) != optionalVendorData.end(), err = CHIP_ERROR_KEY_NOT_FOUND);
+    VerifyOrReturnError(optionalVendorData.find(tag) != optionalVendorData.end(), CHIP_ERROR_KEY_NOT_FOUND);
     info = optionalVendorData[tag];
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetupPayload::getOptionalExtensionData(uint8_t tag, OptionalQRCodeInfoExtension & info) const
@@ -287,47 +255,45 @@ std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionDa
 
 bool SetupPayload::operator==(SetupPayload & input)
 {
-    bool isIdentical = true;
     std::vector<OptionalQRCodeInfo> inputOptionalVendorData;
     std::vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
 
-    VerifyOrExit(this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
-                     this->commissioningFlow == input.commissioningFlow &&
-                     this->rendezvousInformation == input.rendezvousInformation && this->discriminator == input.discriminator &&
-                     this->setUpPINCode == input.setUpPINCode,
-                 isIdentical = false);
+    VerifyOrReturnError(this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
+                            this->commissioningFlow == input.commissioningFlow &&
+                            this->rendezvousInformation == input.rendezvousInformation &&
+                            this->discriminator == input.discriminator && this->setUpPINCode == input.setUpPINCode,
+                        false);
 
     inputOptionalVendorData = input.getAllOptionalVendorData();
-    VerifyOrExit(optionalVendorData.size() == inputOptionalVendorData.size(), isIdentical = false);
+    VerifyOrReturnError(optionalVendorData.size() == inputOptionalVendorData.size(), false);
 
     for (const OptionalQRCodeInfo & inputInfo : inputOptionalVendorData)
     {
         OptionalQRCodeInfo info;
         CHIP_ERROR err = getOptionalVendorData(inputInfo.tag, info);
-        VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
-        VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
-        VerifyOrExit(inputInfo.data == info.data, isIdentical = false);
-        VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
+        VerifyOrReturnError(err == CHIP_NO_ERROR, false);
+        VerifyOrReturnError(inputInfo.type == info.type, false);
+        VerifyOrReturnError(inputInfo.data == info.data, false);
+        VerifyOrReturnError(inputInfo.int32 == info.int32, false);
     }
 
     inputOptionalExtensionData = input.getAllOptionalExtensionData();
-    VerifyOrExit(optionalExtensionData.size() == inputOptionalExtensionData.size(), isIdentical = false);
+    VerifyOrReturnError(optionalExtensionData.size() == inputOptionalExtensionData.size(), false);
 
     for (const OptionalQRCodeInfoExtension & inputInfo : inputOptionalExtensionData)
     {
         OptionalQRCodeInfoExtension info;
         CHIP_ERROR err = getOptionalExtensionData(inputInfo.tag, info);
-        VerifyOrExit(err == CHIP_NO_ERROR, isIdentical = false);
-        VerifyOrExit(inputInfo.type == info.type, isIdentical = false);
-        VerifyOrExit(inputInfo.data == info.data, isIdentical = false);
-        VerifyOrExit(inputInfo.int32 == info.int32, isIdentical = false);
-        VerifyOrExit(inputInfo.int64 == info.int64, isIdentical = false);
-        VerifyOrExit(inputInfo.uint32 == info.uint32, isIdentical = false);
-        VerifyOrExit(inputInfo.uint64 == info.uint64, isIdentical = false);
+        VerifyOrReturnError(err == CHIP_NO_ERROR, false);
+        VerifyOrReturnError(inputInfo.type == info.type, false);
+        VerifyOrReturnError(inputInfo.data == info.data, false);
+        VerifyOrReturnError(inputInfo.int32 == info.int32, false);
+        VerifyOrReturnError(inputInfo.int64 == info.int64, false);
+        VerifyOrReturnError(inputInfo.uint32 == info.uint32, false);
+        VerifyOrReturnError(inputInfo.uint64 == info.uint64, false);
     }
 
-exit:
-    return isIdentical;
+    return true;
 }
 
 } // namespace chip

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -143,9 +143,8 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, const SetupPayloadPa
 
 CHIP_ERROR loadPayloadFromFile(SetupPayload & setupPayload, const std::string & filePath)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     std::ifstream fileStream(filePath);
-    VerifyOrExit(!fileStream.fail(), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!fileStream.fail(), CHIP_ERROR_INVALID_ARGUMENT);
 
     while (fileStream)
     {
@@ -161,14 +160,11 @@ CHIP_ERROR loadPayloadFromFile(SetupPayload & setupPayload, const std::string & 
         {
             continue;
         }
-        err = resolveSetupPayloadParameter(parameter, key, value);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(resolveSetupPayloadParameter(parameter, key, value));
 
-        err = addParameter(setupPayload, parameter);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(addParameter(setupPayload, parameter));
     }
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR generateQRCodeFromFilePath(std::string filePath, std::string & outCode)

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -165,7 +165,6 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload)
 
 CHIP_ERROR ThrowUnrecognizedQRCodeException(JNIEnv * env, jstring qrCodeObj)
 {
-    CHIP_ERROR err                 = CHIP_NO_ERROR;
     jclass exceptionCls            = nullptr;
     jmethodID exceptionConstructor = nullptr;
     jthrowable exception           = nullptr;
@@ -173,20 +172,18 @@ CHIP_ERROR ThrowUnrecognizedQRCodeException(JNIEnv * env, jstring qrCodeObj)
     env->ExceptionClear();
 
     exceptionCls = env->FindClass("chip/setuppayload/SetupPayloadParser$UnrecognizedQrCodeException");
-    VerifyOrExit(exceptionCls != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_TYPE_NOT_FOUND);
+    VerifyOrReturnError(exceptionCls != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_TYPE_NOT_FOUND);
     exceptionConstructor = env->GetMethodID(exceptionCls, "<init>", "(Ljava/lang/String;)V");
-    VerifyOrExit(exceptionConstructor != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_METHOD_NOT_FOUND);
+    VerifyOrReturnError(exceptionConstructor != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_METHOD_NOT_FOUND);
     exception = (jthrowable) env->NewObject(exceptionCls, exceptionConstructor, qrCodeObj);
-    VerifyOrExit(exception != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_EXCEPTION_THROWN);
+    VerifyOrReturnError(exception != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_EXCEPTION_THROWN);
 
     env->Throw(exception);
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ThrowInvalidEntryCodeFormatException(JNIEnv * env, jstring entryCodeObj)
 {
-    CHIP_ERROR err                 = CHIP_NO_ERROR;
     jclass exceptionCls            = nullptr;
     jmethodID exceptionConstructor = nullptr;
     jthrowable exception           = nullptr;
@@ -194,13 +191,12 @@ CHIP_ERROR ThrowInvalidEntryCodeFormatException(JNIEnv * env, jstring entryCodeO
     env->ExceptionClear();
 
     exceptionCls = env->FindClass("chip/setuppayload/SetupPayloadParser$InvalidEntryCodeFormatException");
-    VerifyOrExit(exceptionCls != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_TYPE_NOT_FOUND);
+    VerifyOrReturnError(exceptionCls != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_TYPE_NOT_FOUND);
     exceptionConstructor = env->GetMethodID(exceptionCls, "<init>", "(Ljava/lang/String;)V");
-    VerifyOrExit(exceptionConstructor != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_METHOD_NOT_FOUND);
+    VerifyOrReturnError(exceptionConstructor != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_METHOD_NOT_FOUND);
     exception = (jthrowable) env->NewObject(exceptionCls, exceptionConstructor, entryCodeObj);
-    VerifyOrExit(exception != NULL, err = SETUP_PAYLOAD_PARSER_JNI_ERROR_EXCEPTION_THROWN);
+    VerifyOrReturnError(exception != NULL, SETUP_PAYLOAD_PARSER_JNI_ERROR_EXCEPTION_THROWN);
 
     env->Throw(exception);
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -61,11 +61,10 @@ void BLEBase::ClearState()
 
 CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
     BleLayer * bleLayer = param.GetBleLayer();
 
-    VerifyOrExit(mState == State::kNotReady, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(bleLayer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(bleLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mBleLayer                           = bleLayer;
     mBleLayer->mBleTransport            = this;
@@ -73,25 +72,19 @@ CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
 
     mState = State::kInitialized;
 
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEBase::SetEndPoint(Ble::BLEEndPoint * endPoint)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(endPoint->mState == BLEEndPoint::kState_Connected, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(endPoint->mState == BLEEndPoint::kState_Connected, CHIP_ERROR_INVALID_ARGUMENT);
 
     mBleEndPoint = endPoint;
 
     // Manually trigger the OnConnectComplete callback.
-    OnEndPointConnectComplete(endPoint, err);
+    OnEndPointConnectComplete(endPoint, CHIP_NO_ERROR);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)


### PR DESCRIPTION
#### Problem

The `Exit` group of error-handling macros inhibit scoping, and
are unnecessary when there is no cleanup at the `exit:` label.

Part of #7721 _goto exit pattern should be replaced with RAII in C++_

#### Change overview

Remove simple `exit: return` from

  * `src/app`
  * `src/controller`
  * `src/crypto`
  * `src/inet`
  * `src/lib`
  * `src/protocols`
  * `src/setup_payload`
  * `src/transport`
  * 
replacing `Exit` macros with corresponding `Return` macros.

Note that this does not change any `exit:` blocks with actual cleanup.

#### Testing

No change to functionality; existing tests should catch regressions.
