### PR TITLE
[ESP32]fix get wrong MAC on SoftAP mode

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -102,7 +102,28 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    return esp_wifi_get_mac(WIFI_IF_STA, buf);
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if ((mode == WIFI_MODE_AP) || (mode == WIFI_MODE_APSTA))
+        return MapConfigError(esp_wifi_get_mac(WIFI_IF_AP, buf));
+    else
+        return MapConfigError(esp_wifi_get_mac(WIFI_IF_STA, buf));
+}
+
+CHIP_ERROR ConfigurationManagerImpl::MapConfigError(esp_err_t error)
+{
+    switch (error)
+    {
+    case ESP_OK:
+        return CHIP_NO_ERROR;
+    case ESP_ERR_WIFI_NOT_INIT:
+        return CHIP_ERROR_WELL_UNINITIALIZED;
+    case ESP_ERR_INVALID_ARG:
+    case ESP_ERR_WIFI_IF:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    default:
+        return CHIP_ERROR_INTERNAL;
+    }
 }
 
 bool ConfigurationManagerImpl::_CanFactoryReset()

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -67,6 +67,7 @@ private:
     CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
     bool _CanFactoryReset(void);
     void _InitiateFactoryReset(void);
+    CHIP_ERROR MapConfigError(esp_err_t error);
     CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value);
 


### PR DESCRIPTION
#### Problem
The hostname is wrong when the Rendezvous Mode is SoftAP because `GetPrimaryWiFiMACAddress` gets wrong MAC.

#### Change overview
Fix above problem

#### Testing
Tested manually with avahi-browse after connecting the SoftAP.