### PR TITLE
[nrfconnect] Fix Pigweed RPC server

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -146,7 +146,6 @@ target_sources(app PRIVATE
 )
 
 target_include_directories(app PRIVATE
-  ${ZEPHYR_BASE}/subsys // required to get access to `log_output_std.h`
   ${PIGWEED_ROOT}/pw_sys_io/public
   ${CHIP_ROOT}/src/lib/support
   ${CHIP_ROOT}/src/system
@@ -162,5 +161,7 @@ target_link_libraries(app PRIVATE
   pw_log
   pw_rpc.server
 )
+
+target_link_libraries(pw_build INTERFACE zephyr_interface)
 
 endif(CONFIG_CHIP_PW_RPC)

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -48,7 +48,6 @@ add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 
 target_include_directories(app PRIVATE main/include
-                           ${ZEPHYR_BASE}/subsys // required to get access to `log_output_std.h`
                            ${NRFCONNECT_COMMON}/util/include
                            ${CHIP_ROOT}/src/lib/support
                            ${PIGWEED_ROOT}/pw_sys_io/public
@@ -78,3 +77,5 @@ target_link_libraries(app PUBLIC
   pw_rpc.nanopb.echo_service
   pw_rpc.server
 )
+
+target_link_libraries(pw_build INTERFACE zephyr_interface)

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -325,7 +325,7 @@ to read more about flashing on the nRF52840 Dongle.
 Run the following command to start an interactive Python shell, where the Echo
 RPC commands can be invoked:
 
-        python -m pw_hdlc.rpc_console --device /dev/ttyACM0 -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/pw_rpc_protos/echo.proto -o /tmp/pw_rpc.out
+        python -m pw_hdlc.rpc_console --device /dev/ttyACM0 -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/echo.proto -o /tmp/pw_rpc.out
 
 To send an Echo RPC message, type the following command, where the actual
 message is the text in quotation marks after the `msg=` phrase:

--- a/examples/pigweed-app/nrfconnect/main/main.cpp
+++ b/examples/pigweed-app/nrfconnect/main/main.cpp
@@ -30,25 +30,13 @@
 
 LOG_MODULE_REGISTER(app);
 
-static LEDWidget sStatusLED;
-
 namespace {
-#define RPC_STACK_SIZE (8 * 1024)
-#define RPC_PRIORITY 7
-
-K_THREAD_STACK_DEFINE(rpc_stack_area, RPC_STACK_SIZE);
-struct k_thread rpc_thread_data;
-
-pw::rpc::EchoService echo_service;
+LEDWidget sStatusLED;
+pw::rpc::EchoService sEchoService;
 
 void RegisterServices(pw::rpc::Server & server)
 {
-    server.RegisterService(echo_service);
-}
-
-void RunRpcService(void *, void *, void *)
-{
-    Start(RegisterServices, &::chip::rpc::logger_mutex);
+    server.RegisterService(sEchoService);
 }
 
 } // namespace
@@ -72,8 +60,6 @@ int main()
     sStatusLED.Init(SYSTEM_STATE_LED);
     sStatusLED.Set(true);
 
-    k_thread_create(&rpc_thread_data, rpc_stack_area, K_THREAD_STACK_SIZEOF(rpc_stack_area), RunRpcService, NULL, NULL, NULL,
-                    RPC_PRIORITY, 0, K_NO_WAIT);
-    k_thread_join(&rpc_thread_data, K_FOREVER);
+    Start(RegisterServices, &::chip::rpc::logger_mutex);
     return 0;
 }

--- a/examples/platform/nrfconnect/pw_sys_io/CMakeLists.txt
+++ b/examples/platform/nrfconnect/pw_sys_io/CMakeLists.txt
@@ -10,7 +10,6 @@ pw_add_module_library(pw_sys_io.nrfconnect
     SOURCES
       sys_io_nrfconnect.cc
     PRIVATE_DEPS
-      zephyr_interface
       pw_sys_io
       suppress_zephyr_warnings
 )


### PR DESCRIPTION
#### Problem
It turns out that for some time, the Pigweed libraries have been built without "-mthumb" flag (contrary to Zephyr) causing crashes due to different ARM instruction sets used in a single binary.

#### Change overview
Make sure `pw_build` target, which all Pigweed targets inherit from, inherits from `zephyr_interface` which encapsulates all
compiler options used by Zephyr and the application. Also, do minor cleanup in the Pigweed app.

#### Testing
Programmed the pigweed-app onto a nRF52840 DK and checked with `python -m pw_hdlc.rpc_console` that both Pigweed Echo Service and logging work correctly.
