### PR TITLE
[python] Fix type cast of zclwrite

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -100,7 +100,6 @@ def DecodeHexIntOption(option, opt, value):
     except ValueError:
         raise OptionValueError("option %s: invalid value: %r" % (opt, value))
 
-
 def ParseEncodedString(value):
     if value.find(":") < 0:
         raise ParsingError(
@@ -113,6 +112,17 @@ def ParseEncodedString(value):
     raise ParsingError("only str and hex encoding is supported")
 
 
+def ParseValueWithType(value, type):
+    if type == 'int':
+        return int(value)
+    elif type == 'str':
+        return value
+    elif type == 'bytes':
+        return ParseEncodedString(value)
+    else:
+        raise ParsingError('cannot recognize type: {}'.format(type))
+
+
 def FormatZCLArguments(args, command):
     commandArgs = {}
     for kvPair in args:
@@ -120,12 +130,7 @@ def FormatZCLArguments(args, command):
             raise ParsingError("Argument should in key=value format")
         key, value = kvPair.split("=", 1)
         valueType = command.get(key, None)
-        if valueType == 'int':
-            commandArgs[key] = int(value)
-        elif valueType == 'str':
-            commandArgs[key] = value
-        elif valueType == 'bytes':
-            commandArgs[key] = ParseEncodedString(value)
+        commandArgs[key] = ParseValueWithType(int(value), valueType)
     return commandArgs
 
 
@@ -662,8 +667,10 @@ class DeviceMgrCmd(Cmd):
             elif len(args) == 6:
                 if args[0] not in all_attrs:
                     raise exceptions.UnknownCluster(args[0])
+                attribute_type = all_attrs.get(args[0], {}).get(
+                    args[1], {}).get("type", None)
                 self.devCtrl.ZCLWriteAttribute(args[0], args[1], int(
-                    args[2]), int(args[3]), int(args[4]), args[5])
+                    args[2]), int(args[3]), int(args[4]), ParseValueWithType(args[5], attribute_type))
             else:
                 self.do_help("zclwrite")
         except exceptions.ChipStackException as ex:


### PR DESCRIPTION
#### Problem
* chip-device-ctrl zclwrite fails for all data types except string
* Fixes #7775

#### Change overview
Add missing argument parsing code

Numberic values uses int for all types (boolean, enum, (u)int)
Bytes using `encoding:value` format
Strings can be passed as usual.

#### Testing

- Manually tested for script interface

```
chip-device-ctrl > zclwrite TestCluster Boolean 1 1 0 1
[1624262701.719187][3706687] CHIP:ZCL: Successfully encoded 11 bytes
[1624262701.719229][3706687] CHIP:IN: Connection from 'UDP:172.16.243.197:11097' expired
[1624262701.719243][3706687] CHIP:CTL: OnConnectionExpired was called for unknown device, ignoring it.
[1624262701.719259][3706687] CHIP:IN: New pairing for device 0x0000000000000001, key 0!!
[1624262701.719356][3706687] CHIP:IN: Secure message was encrypted: Msg ID 6
[1624262701.719369][3706687] CHIP:IN: Encrypted message 0x190cd10 from 0x000000000001B669 to 0x0000000000000001 of type 1 and protocolId 9 on exchange 39021.
[1624262701.719387][3706687] CHIP:IN: Sending msg 0x190cd10 to 0x0000000000000001 at utc time: 858663406 msec
[1624262701.719401][3706687] CHIP:IN: Sending secure msg on generic transport
[1624262701.719562][3706687] CHIP:IN: Secure msg send status No Error
[1624262701.719612][3706687] CHIP:CTL: SendMessage returned No Error
[1624262701.721499][3706695] CHIP:IN: Secure transport received message destined to fabric 0, node 0x000000000001B669. Key ID 0
[1624262701.721552][3706695] CHIP:EM: Received message of type 2 and protocolId 9 on exchange 39021
[1624262701.721573][3706695] CHIP:EM: Rxd Ack; Removing MsgId:00000006 from Retrans Table
[1624262701.721583][3706695] CHIP:EM: Removed CHIP MsgId:00000006 from RetransTable
[1624262701.721605][3706695] CHIP:ZCL: APS frame processing success!
[1624262701.721616][3706695] CHIP:ZCL: RX len 4, ep 1, clus 0x50f 
[1624262701.721625][3706695] CHIP:ZCL:  FC 8 seq 0 cmd 4 payload[
[1624262701.721639][3706695] CHIP:ZCL: 00 
[1624262701.721651][3706695] CHIP:ZCL: ]
[1624262701.721665][3706695] CHIP:ZCL: WriteAttributesResponse:
[1624262701.721673][3706695] CHIP:ZCL:   ClusterId: 0x050f
[1624262701.721684][3706695] CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
Secure Session to Device Established
[1624262701.721753][3706695] CHIP:ZCL: Data model processing success!
[1624262701.721764][3706695] CHIP:EM: Sending Standalone Ack for MsgId:00000004
[1624262701.721791][3706695] CHIP:IN: Secure message was encrypted: Msg ID 7
[1624262701.721802][3706695] CHIP:IN: Encrypted message 0x7f3e7dffa1e0 from 0x000000000001B669 to 0x0000000000000001 of type 16 and protocolId 0 on exchange 39021.
[1624262701.721815][3706695] CHIP:IN: Sending msg 0x7f3e7dffa1e0 to 0x0000000000000001 at utc time: 858663408 msec
[1624262701.721825][3706695] CHIP:IN: Sending secure msg on generic transport
[1624262701.721904][3706695] CHIP:IN: Secure msg send status No Error
[1624262701.721917][3706695] CHIP:EM: Flushed pending ack for MsgId:00000004
chip-device-ctrl > zclwrite TestCluster OctetString 1 1 0 str
An exception occurred during writing ZCL attribute:
Parsing Error: value should be encoded in encoding:encodedvalue format
chip-device-ctrl > zclwrite TestCluster OctetString 1 1 0 str:asdasdasd
[1624262742.502884][3706687] CHIP:ZCL: Successfully encoded 11 bytes
[1624262742.502961][3706687] CHIP:IN: Secure message was encrypted: Msg ID 8
[1624262742.502972][3706687] CHIP:IN: Encrypted message 0x190cd10 from 0x000000000001B669 to 0x0000000000000001 of type 1 and protocolId 9 on exchange 39022.
[1624262742.502986][3706687] CHIP:IN: Sending msg 0x190cd10 to 0x0000000000000001 at utc time: 858704189 msec
[1624262742.502994][3706687] CHIP:IN: Sending secure msg on generic transport
[1624262742.503080][3706687] CHIP:IN: Secure msg send status No Error
[1624262742.503126][3706687] CHIP:CTL: SendMessage returned No Error
[1624262742.505196][3706694] CHIP:IN: Secure transport received message destined to fabric 0, node 0x000000000001B669. Key ID 0
[1624262742.505252][3706694] CHIP:EM: Received message of type 2 and protocolId 9 on exchange 39022
[1624262742.505273][3706694] CHIP:EM: Rxd Ack; Removing MsgId:00000008 from Retrans Table
[1624262742.505282][3706694] CHIP:EM: Removed CHIP MsgId:00000008 from RetransTable
[1624262742.505304][3706694] CHIP:ZCL: APS frame processing success!
[1624262742.505315][3706694] CHIP:ZCL: RX len 4, ep 1, clus 0x50f 
[1624262742.505323][3706694] CHIP:ZCL:  FC 8 seq 1 cmd 4 payload[
[1624262742.505330][3706694] CHIP:ZCL: 00 
[1624262742.505336][3706694] CHIP:ZCL: ]
[1624262742.505346][3706694] CHIP:ZCL: WriteAttributesResponse:
[1624262742.505352][3706694] CHIP:ZCL:   ClusterId: 0x050f
[1624262742.505362][3706694] CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
Secure Session to Device Established
[1624262742.505446][3706694] CHIP:ZCL: Data model processing success!
[1624262742.505455][3706694] CHIP:EM: Sending Standalone Ack for MsgId:00000005
[1624262742.505478][3706694] CHIP:IN: Secure message was encrypted: Msg ID 9
[1624262742.505489][3706694] CHIP:IN: Encrypted message 0x7f3e7e7fb1e0 from 0x000000000001B669 to 0x0000000000000001 of type 16 and protocolId 0 on exchange 39022.
[1624262742.505501][3706694] CHIP:IN: Sending msg 0x7f3e7e7fb1e0 to 0x0000000000000001 at utc time: 858704192 msec
[1624262742.505510][3706694] CHIP:IN: Sending secure msg on generic transport
[1624262742.505581][3706694] CHIP:IN: Secure msg send status No Error
[1624262742.505592][3706694] CHIP:EM: Flushed pending ack for MsgId:00000005
chip-device-ctrl > zclwrite TestCluster OctetString 1 1 0 hex:01020304
[1624262760.302760][3706687] CHIP:ZCL: Successfully encoded 11 bytes
[1624262760.302841][3706687] CHIP:IN: Secure message was encrypted: Msg ID 10
[1624262760.302854][3706687] CHIP:IN: Encrypted message 0x190cd10 from 0x000000000001B669 to 0x0000000000000001 of type 1 and protocolId 9 on exchange 39023.
[1624262760.302870][3706687] CHIP:IN: Sending msg 0x190cd10 to 0x0000000000000001 at utc time: 858721989 msec
[1624262760.302879][3706687] CHIP:IN: Sending secure msg on generic transport
[1624262760.302970][3706687] CHIP:IN: Secure msg send status No Error
[1624262760.303009][3706687] CHIP:CTL: SendMessage returned No Error
[1624262760.305072][3706695] CHIP:IN: Secure transport received message destined to fabric 0, node 0x000000000001B669. Key ID 0
[1624262760.305129][3706695] CHIP:EM: Received message of type 2 and protocolId 9 on exchange 39023
[1624262760.305155][3706695] CHIP:EM: Rxd Ack; Removing MsgId:0000000A from Retrans Table
[1624262760.305165][3706695] CHIP:EM: Removed CHIP MsgId:0000000A from RetransTable
[1624262760.305189][3706695] CHIP:ZCL: APS frame processing success!
[1624262760.305199][3706695] CHIP:ZCL: RX len 4, ep 1, clus 0x50f 
[1624262760.305209][3706695] CHIP:ZCL:  FC 8 seq 2 cmd 4 payload[
[1624262760.305219][3706695] CHIP:ZCL: 00 
[1624262760.305228][3706695] CHIP:ZCL: ]
[1624262760.305239][3706695] CHIP:ZCL: WriteAttributesResponse:
[1624262760.305248][3706695] CHIP:ZCL:   ClusterId: 0x050f
[1624262760.305260][3706695] CHIP:ZCL:   status: EMBER_ZCL_STATUS_SUCCESS (0x00)
Secure Session to Device Established
[1624262760.305351][3706695] CHIP:ZCL: Data model processing success!
[1624262760.305362][3706695] CHIP:EM: Sending Standalone Ack for MsgId:00000006
[1624262760.305390][3706695] CHIP:IN: Secure message was encrypted: Msg ID 11
[1624262760.305401][3706695] CHIP:IN: Encrypted message 0x7f3e7dffa1e0 from 0x000000000001B669 to 0x0000000000000001 of type 16 and protocolId 0 on exchange 39023.
[1624262760.305414][3706695] CHIP:IN: Sending msg 0x7f3e7dffa1e0 to 0x0000000000000001 at utc time: 858721992 msec
[1624262760.305425][3706695] CHIP:IN: Sending secure msg on generic transport
[1624262760.305494][3706695] CHIP:IN: Secure msg send status No Error
[1624262760.305509][3706695] CHIP:EM: Flushed pending ack for MsgId:00000006
chip-device-ctrl > 
```