### PR TITLE
[ci] Lift "Run Build" time limit to 20 minutes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
               timeout-minutes: 20
               run: scripts/build/gn_build.sh
             - name: Run Tests
-              timeout-minutes: 2
+              timeout-minutes: 10
               run: scripts/tests/gn_tests.sh
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
 
                   scripts/build/gn_gen.sh --args="$GN_ARGS"
             - name: Run Build
-              timeout-minutes: 20
+              timeout-minutes: 10
               run: scripts/build/gn_build.sh
             - name: Run Tests
               timeout-minutes: 2
@@ -145,7 +145,7 @@ jobs:
               run: |
                   scripts/build/gn_gen.sh --args='is_clang=true target_os="all"'
             - name: Run Build
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: scripts/build/gn_build.sh
             - name: Run Tests
               timeout-minutes: 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
 
                   scripts/build/gn_gen.sh --args="$GN_ARGS"
             - name: Run Build
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: scripts/build/gn_build.sh
             - name: Run Tests
               timeout-minutes: 2


### PR DESCRIPTION
#### Problem

Current CI limit for "Run Build" step in "Builds" action is 10 minutes

Some runs in master branch reaches 9m53s https://github.com/project-chip/connectedhomeip/runs/2864147126

Thus some PR may met timeout if it runs a bit slower.

#### Change overview

Set timeout to 20 minutes

#### Testing

- CI timeout change