### PR TITLE
Remove lwIP from src/inet deps in socket builds

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -103,7 +103,7 @@ static_library("inet") {
     "${nlio_root}:nlio",
   ]
 
-  if (chip_with_lwip) {
+  if (chip_system_config_use_lwip) {
     public_deps += [ "${chip_root}/src/lwip" ]
   }
 

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -43,9 +43,9 @@
 #include <lwip/raw.h>
 #include <lwip/tcpip.h>
 #if CHIP_HAVE_CONFIG_H
-#include <lwip/lwip_buildconfig.h>
-#endif // CHIP_HAVE_CONFIG_H
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/lwip_buildconfig.h> // nogncheck
+#endif                             // CHIP_HAVE_CONFIG_H
+#endif                             // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #include <system/SystemSockets.h>

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -42,9 +42,9 @@
 #include <lwip/tcpip.h>
 #include <lwip/udp.h>
 #if CHIP_HAVE_CONFIG_H
-#include <lwip/lwip_buildconfig.h>
-#endif // CHIP_HAVE_CONFIG_H
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/lwip_buildconfig.h> // nogncheck
+#endif                             // CHIP_HAVE_CONFIG_H
+#endif                             // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #if HAVE_SYS_SOCKET_H


### PR DESCRIPTION
#### Problem
We're getting a bunch of lwIP #defines in Linux builds, even though
these builds don't use lwIP. 
#### Change overview
Fix the src/inet dependency to check `chip_system_config_use_lwip`,
which controls whether CHIP uses lwIP in its networking abstractions.

This requires annotating some conditional #includes with `// nogncheck`
to avoid false positives, because the checker doesn't preprocess the file.

#### Testing

Check defines via `gn gen out/host && gn desc out/host //src/lib defines`

Run build via `./gn_build.sh`