### PR TITLE
PoC: Python binding using C-api

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -63,6 +63,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   # This is a real toolchain. Build CHIP.
   group("default") {
     deps = [
+      "${chip_root}/bindings/python:chip",
       "${chip_root}/src/app",
       "${chip_root}/src/ble",
       "${chip_root}/src/channel",

--- a/bindings/python/BUILD.gn
+++ b/bindings/python/BUILD.gn
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+shared_library("chip") {
+  output_name = "chip"
+  output_dir = "${target_out_dir}"
+  include_dirs = [
+    ".",
+    # TODO: from `python3-config --includes`
+    "/usr/include/python3.9",
+  ]
+  ldflags = [
+    # TODO: from `python3-config --ldflags`
+    "-L/usr/lib/python3.9/config-3.9-x86_64-linux-gnu",
+  ]
+  libs = [
+    "python3.9",
+  ]
+
+  sources = [
+    "CommissionerInitParams.cpp",
+    "CommissionerInitParams.h",
+    "Converter.cpp",
+    "Converter.h",
+    "DeviceCommissioner.cpp",
+    "DeviceCommissioner.h",
+    "Module.cpp",
+    "PersistentStorage.cpp",
+    "PersistentStorage.h",
+    "PythonGil.h",
+    "PythonType.h",
+    "RendezvousParameters.cpp",
+    "RendezvousParameters.h",
+    "TransportType.cpp",
+    "TransportType.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/controller",
+    "${chip_root}/src/controller/data_model",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/mdns",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/src/transport",
+    #"${chip_root}/third_party/pybind11",
+  ]
+}

--- a/bindings/python/CommissionerInitParams.cpp
+++ b/bindings/python/CommissionerInitParams.cpp
@@ -1,0 +1,117 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
+#include <CommissionerInitParams.h>
+
+#include <controller/CHIPDeviceController.h>
+#include <support/ErrorStr.h>
+
+#include <PersistentStorage.h>
+
+static PyObject * PythonCommissionerInitParamsNew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PythonCommissionerInitParams *pyo = reinterpret_cast<PythonCommissionerInitParams *>(type->tp_alloc(type, 0));
+    new (&pyo->mOpCredsIssuer) chip::Controller::ExampleOperationalCredentialsIssuer();
+    new (&pyo->mPrarms) chip::Controller::CommissionerInitParams();
+    return (PyObject *)pyo;
+}
+
+static void PythonCommissionerInitParamsDealloc(PyObject *self)
+{
+    PythonCommissionerInitParams *pyo = reinterpret_cast<PythonCommissionerInitParams*>(self);
+    pyo->mPrarms.~CommissionerInitParams();
+    pyo->mOpCredsIssuer.~ExampleOperationalCredentialsIssuer();
+
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free(self);
+}
+
+
+PyDoc_STRVAR(SetPersistentStorageDocument, "SetPersistentStorage()");
+static PyObject * PythonCommissionerInitParamsSetPersistentStorage(PyObject *self, PyObject *args)
+{
+    PythonCommissionerInitParams *pyo = reinterpret_cast<PythonCommissionerInitParams*>(self);
+    PyObject * pyStorage;
+
+    // 1nd arg (O!: PyObject *): storage
+    if (!PyArg_ParseTuple(args, "O!", &PythonPersistentStorageType, &pyStorage)) {
+        return nullptr;
+    }
+
+
+    chip::PersistentStorageDelegate * storage = &reinterpret_cast<PythonPersistentStorage*>(pyStorage)->mDelegate;
+
+    // TODO: wrap a real OpCredsIssuer in python.
+    CHIP_ERROR err = pyo->mOpCredsIssuer.Initialize(*storage);
+    if (err != CHIP_NO_ERROR) {
+        PyErr_Format(PyExc_RuntimeError, "OpCredsIssuer.Initialize failed: %s.", chip::ErrorStr(err));
+        return nullptr;
+    }
+    pyo->mPrarms.operationalCredentialsDelegate = &pyo->mOpCredsIssuer;
+
+    pyo->mPrarms.storageDelegate = storage;
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef PythonCommissionerInitParamsMethods[] = {
+    {"SetPersistentStorage", PythonCommissionerInitParamsSetPersistentStorage, METH_VARARGS, SetPersistentStorageDocument},
+    {NULL, NULL, 0, NULL}
+};
+
+PyTypeObject PythonCommissionerInitParamsType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "chip.CommissionerInitParams",        /* tp_name */
+    sizeof(PythonCommissionerInitParams), /* tp_basicsize */
+    0,                                /* tp_itemsize */
+    PythonCommissionerInitParamsDealloc,  /* tp_dealloc */
+    0,                                /* tp_vectorcall_offset */
+    0,                                /* tp_getattr */
+    0,                                /* tp_setattr */
+    0,                                /* tp_as_async */
+    0,                                /* tp_repr */
+    0,                                /* tp_as_number */
+    0,                                /* tp_as_sequence */
+    0,                                /* tp_as_mapping */
+    0,                                /* tp_hash */
+    0,                                /* tp_call */
+    0,                                /* tp_str */
+    0,                                /* tp_getattro */
+    0,                                /* tp_setattro */
+    0,                                /* tp_as_buffer */
+    0,                                /* tp_flags */
+    0,                                /* tp_doc */
+    0,                                /* tp_traverse */
+    0,                                /* tp_clear */
+    0,                                /* tp_richcompare */
+    0,                                /* tp_weaklistoffset */
+    0,                                /* tp_iter */
+    0,                                /* tp_iternext */
+    PythonCommissionerInitParamsMethods,  /* tp_methods */
+    0,                                /* tp_members */
+    0,                                /* tp_getset */
+    0,                                /* tp_base */
+    0,                                /* tp_dict */
+    0,                                /* tp_descr_get */
+    0,                                /* tp_descr_set */
+    0,                                /* tp_dictoffset */
+    0,                                /* tp_init */
+    0,                                /* tp_alloc */
+    PythonCommissionerInitParamsNew,      /* tp_new */
+};

--- a/bindings/python/CommissionerInitParams.h
+++ b/bindings/python/CommissionerInitParams.h
@@ -1,0 +1,33 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <controller/CHIPDeviceController.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+
+struct PythonCommissionerInitParams {
+    PyObject_HEAD
+    chip::Controller::CommissionerInitParams mPrarms;
+
+    // TODO: wrap a real OpCredsIssuer in python.
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+};
+
+extern PyTypeObject PythonCommissionerInitParamsType;

--- a/bindings/python/Converter.cpp
+++ b/bindings/python/Converter.cpp
@@ -1,0 +1,91 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Converter.h>
+
+#include <netinet/in.h>
+
+int PyObjectToAddress(PyObject * pyo, chip::Inet::IPAddress * address)
+{
+    PyObject * pyVersion = PyObject_GetAttrString(pyo, "version");
+    if (pyVersion == nullptr) {
+        return false;
+    }
+
+    long version = PyLong_AsLong(pyVersion);
+    Py_DECREF(pyVersion);
+    if (PyErr_Occurred()) {
+        return false;
+    }
+
+    switch(version) {
+        case 4:
+            {
+                PyObject * pyAddressBytes = PyObject_GetAttrString(pyo, "packed");
+                if (pyAddressBytes == nullptr) {
+                    return false;
+                }
+
+                if (!PyBytes_Check(pyAddressBytes)) {
+                    Py_DECREF(pyAddressBytes);
+                    return false;
+                }
+
+                in_addr addr;
+                Py_ssize_t size = PyBytes_Size(pyAddressBytes);
+                if (size != sizeof(addr)) {
+                    Py_DECREF(pyAddressBytes);
+                    return false;
+                }
+
+                memcpy(&addr.s_addr, PyBytes_AsString(pyAddressBytes), sizeof(addr));
+                Py_DECREF(pyAddressBytes);
+                *address = chip::Inet::IPAddress::FromIPv4(addr);
+
+                return true;
+            }
+            break;
+        case 6:
+            {
+                PyObject * pyAddressBytes = PyObject_GetAttrString(pyo, "packed");
+                if (pyAddressBytes == nullptr) {
+                    return false;
+                }
+
+                if (!PyBytes_Check(pyAddressBytes)) {
+                    Py_DECREF(pyAddressBytes);
+                    return false;
+                }
+
+                in6_addr addr;
+                Py_ssize_t size = PyBytes_Size(pyAddressBytes);
+                if (size != sizeof(addr)) {
+                    Py_DECREF(pyAddressBytes);
+                    return false;
+                }
+
+                memcpy(addr.s6_addr, PyBytes_AsString(pyAddressBytes), sizeof(addr));
+                Py_DECREF(pyAddressBytes);
+                *address = chip::Inet::IPAddress::FromIPv6(addr);
+
+                return true;
+            }
+            break;
+        default:
+            return false;
+    }
+}

--- a/bindings/python/Converter.h
+++ b/bindings/python/Converter.h
@@ -1,0 +1,24 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <inet/IPAddress.h>
+
+int PyObjectToAddress(PyObject * pyo, chip::Inet::IPAddress * address);

--- a/bindings/python/DeviceCommissioner.cpp
+++ b/bindings/python/DeviceCommissioner.cpp
@@ -1,0 +1,134 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
+#include <DeviceCommissioner.h>
+
+#include <controller/CHIPDeviceController.h>
+#include <support/ErrorStr.h>
+
+#include <CommissionerInitParams.h>
+#include <RendezvousParameters.h>
+
+static PyObject * PythonDeviceCommissionerNew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    uint64_t nodeId;
+    PyObject * initParameters;
+
+    // 1st arg (K: uint64_t): node id
+    // 2nd arg (O!: PyObject *): init parameters
+    if (!PyArg_ParseTuple(args, "KO!", &nodeId, &PythonCommissionerInitParamsType, &initParameters)) {
+        return nullptr;
+    }
+
+    PythonDeviceCommissioner *pyo = reinterpret_cast<PythonDeviceCommissioner*>(type->tp_alloc(type, 0));
+
+    new (&pyo->mCommissioner) chip::Controller::DeviceCommissioner();
+    CHIP_ERROR err = pyo->mCommissioner.Init(nodeId, reinterpret_cast<PythonCommissionerInitParams*>(initParameters)->mPrarms);
+    if (err != CHIP_NO_ERROR) {
+        pyo->~PythonDeviceCommissioner();
+        PyErr_Format(PyExc_RuntimeError, "DeviceCommissioner Init failed: %s.", chip::ErrorStr(err));
+        type->tp_free(pyo);
+        return nullptr;
+    }
+    return (PyObject *)pyo;
+}
+
+static void PythonDeviceCommissionerDealloc(PyObject *self)
+{
+    PythonDeviceCommissioner *pyo = reinterpret_cast<PythonDeviceCommissioner*>(self);
+    pyo->mCommissioner.Shutdown();
+    pyo->mCommissioner.~DeviceCommissioner();
+
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free(self);
+}
+
+PyDoc_STRVAR(ServiceEventsDocument, "ServiceEvents()");
+static PyObject * PythonDeviceCommissionerServiceEvents(PyObject *self, PyObject *args)
+{
+    PythonDeviceCommissioner *pyo = reinterpret_cast<PythonDeviceCommissioner*>(self);
+    pyo->mCommissioner.ServiceEvents();
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(PairDeviceDocument, "PairDevice(remoteDeviceId: long long, parameters: RendezvousParameters)");
+static PyObject * PythonDeviceCommissionerPairDevice(PyObject *self, PyObject *args)
+{
+    PythonDeviceCommissioner *pyo = reinterpret_cast<PythonDeviceCommissioner*>(self);
+
+    unsigned long long remoteDeviceId;
+    PyObject * pyRendezvousParameters;
+
+    // K (int) [unsigned long long]
+    // O! (object) [typeobject, PyObject *]
+    if (!PyArg_ParseTuple(args, "KO!", &remoteDeviceId, &PythonRendezvousParametersType, &pyRendezvousParameters)) {
+        return nullptr;
+    }
+
+    pyo->mCommissioner.PairDevice(remoteDeviceId, reinterpret_cast<PythonRendezvousParameters*>(pyRendezvousParameters)->mParameters);
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef PythonDeviceCommissionerMethods[] = {
+    {"ServiceEvents", PythonDeviceCommissionerServiceEvents, METH_NOARGS, ServiceEventsDocument},
+    {"PairDevice", PythonDeviceCommissionerPairDevice, METH_VARARGS, PairDeviceDocument},
+    {NULL, NULL, 0, NULL}
+};
+
+PyTypeObject PythonDeviceCommissionerType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "chip.DeviceCommissioner",        /* tp_name */
+    sizeof(PythonDeviceCommissioner), /* tp_basicsize */
+    0,                                /* tp_itemsize */
+    PythonDeviceCommissionerDealloc,  /* tp_dealloc */
+    0,                                /* tp_vectorcall_offset */
+    0,                                /* tp_getattr */
+    0,                                /* tp_setattr */
+    0,                                /* tp_as_async */
+    0,                                /* tp_repr */
+    0,                                /* tp_as_number */
+    0,                                /* tp_as_sequence */
+    0,                                /* tp_as_mapping */
+    0,                                /* tp_hash */
+    0,                                /* tp_call */
+    0,                                /* tp_str */
+    0,                                /* tp_getattro */
+    0,                                /* tp_setattro */
+    0,                                /* tp_as_buffer */
+    0,                                /* tp_flags */
+    0,                                /* tp_doc */
+    0,                                /* tp_traverse */
+    0,                                /* tp_clear */
+    0,                                /* tp_richcompare */
+    0,                                /* tp_weaklistoffset */
+    0,                                /* tp_iter */
+    0,                                /* tp_iternext */
+    PythonDeviceCommissionerMethods,  /* tp_methods */
+    0,                                /* tp_members */
+    0,                                /* tp_getset */
+    0,                                /* tp_base */
+    0,                                /* tp_dict */
+    0,                                /* tp_descr_get */
+    0,                                /* tp_descr_set */
+    0,                                /* tp_dictoffset */
+    0,                                /* tp_init */
+    0,                                /* tp_alloc */
+    PythonDeviceCommissionerNew,      /* tp_new */
+};

--- a/bindings/python/DeviceCommissioner.h
+++ b/bindings/python/DeviceCommissioner.h
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <controller/CHIPDeviceController.h>
+
+struct PythonDeviceCommissioner {
+    PyObject_HEAD
+    chip::Controller::DeviceCommissioner mCommissioner;
+};
+
+extern PyTypeObject PythonDeviceCommissionerType;

--- a/bindings/python/Module.cpp
+++ b/bindings/python/Module.cpp
@@ -1,0 +1,113 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
+#include <core/CHIPError.h>
+#include <support/CHIPMem.h>
+#include <support/ErrorStr.h>
+
+#include <CommissionerInitParams.h>
+#include <DeviceCommissioner.h>
+#include <PersistentStorage.h>
+#include <RendezvousParameters.h>
+#include <TransportType.h>
+
+PyDoc_STRVAR(ChipInitDocument, "");
+static PyObject * ChipInit(PyObject *self, PyObject *args)
+{
+    CHIP_ERROR err = chip::Platform::MemoryInit();
+    if (err != CHIP_NO_ERROR) {
+        PyErr_Format(PyExc_RuntimeError, "Init Memory failure: %s", chip::ErrorStr(err));
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef ChipMethods[] = {
+    {"Init", ChipInit, METH_NOARGS, ChipInitDocument},
+    {NULL, NULL, 0, NULL}
+};
+
+PyDoc_STRVAR(ChipDocument, "");
+static struct PyModuleDef PythonChipModule = {
+    PyModuleDef_HEAD_INIT,
+    "ChipBindings",         /* m_name */
+    ChipDocument,           /* m_doc */
+    -1,                     /* m_size */
+    ChipMethods,            /* m_methods */
+    NULL,                   /* m_reload */
+    NULL,                   /* m_traverse */
+    NULL,                   /* m_clear */
+    NULL                    /* m_free */
+};
+
+PyMODINIT_FUNC
+PyInit_chip(void)
+{
+    PyObject *module = PyModule_Create(&PythonChipModule);
+    if (!module) {
+        return NULL;
+    }
+
+    // CommissionerInitParams
+    if (PyType_Ready(&PythonCommissionerInitParamsType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&PythonCommissionerInitParamsType);
+    PyModule_AddObject(module, "CommissionerInitParams", (PyObject *)&PythonCommissionerInitParamsType);
+
+    // DeviceCommissioner
+    if (PyType_Ready(&PythonDeviceCommissionerType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&PythonDeviceCommissionerType);
+    PyModule_AddObject(module, "DeviceCommissioner", (PyObject *)&PythonDeviceCommissionerType);
+
+    // PersistentStorage
+    if (PyType_Ready(&PythonPersistentStorageType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&PythonPersistentStorageType);
+    PyModule_AddObject(module, "PersistentStorageInterface", (PyObject *)&PythonPersistentStorageType);
+
+    // TransportType
+    if (PyType_Ready(&PythonTransportTypeType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&PythonTransportTypeType);
+    PyObject * pyPythonTransportTypeType = reinterpret_cast<PyObject*>(&PythonTransportTypeType);
+    PyModule_AddObject(module, "TransportType", pyPythonTransportTypeType);
+
+    // TransportType enums
+    PythonTransportType * udp = PyObject_New(PythonTransportType, &PythonTransportTypeType);
+    udp->mType = chip::Transport::Type::kUdp;
+    PythonTransportType * tcp = PyObject_New(PythonTransportType, &PythonTransportTypeType);
+    tcp->mType = chip::Transport::Type::kTcp;
+    PyObject * transport = Py_BuildValue("{s:N,s:N}", "UDP", udp, "TCP", tcp);
+    PyModule_AddObject(module, "Transport", transport);
+
+    // RendezvousParameters
+    if (PyType_Ready(&PythonRendezvousParametersType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&PythonRendezvousParametersType);
+    PyModule_AddObject(module, "RendezvousParameters", (PyObject *)&PythonRendezvousParametersType);
+
+    return module;
+}

--- a/bindings/python/PersistentStorage.cpp
+++ b/bindings/python/PersistentStorage.cpp
@@ -1,0 +1,156 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <PersistentStorage.h>
+
+#include <new>
+
+#include <support/ErrorStr.h>
+
+#include <PythonGil.h>
+
+static PyObject * PythonPersistentStorageNew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PythonPersistentStorage *pyo = reinterpret_cast<PythonPersistentStorage*>(type->tp_alloc(type, 0));
+    new (&pyo->mDelegate) PythonPersistentStorageDelegate(pyo);
+    return (PyObject *)pyo;
+}
+
+static void PythonPersistentStorageDealloc(PyObject *self)
+{
+    PythonPersistentStorage *pyo = reinterpret_cast<PythonPersistentStorage*>(self);
+    pyo->mDelegate.~PythonPersistentStorageDelegate();
+
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free(self);
+}
+
+CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, void * buffer, uint16_t & size)
+{
+    PythonGil lock;
+
+    // s (str or None) [const char *]
+    PyObject *result = PyObject_CallMethod(&mOwner->ob_base, "SyncGetKeyValue", "(s)", key);
+    if (result == nullptr) {
+        PyErr_Print();
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if (result == Py_None) {
+        Py_DECREF(result);
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    if (!PyBytes_Check(result)) {
+        fprintf(stderr, "PythonPersistentStorage::SyncGetKeyValue returns wrong type, expect bytes");
+        Py_DECREF(result);
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    Py_ssize_t outSize = PyBytes_Size(result);
+    if (outSize > size) {
+        fprintf(stderr, "PythonPersistentStorage::SyncGetKeyValue not enough space");
+        size = outSize;
+        Py_DECREF(result);
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    memcpy(buffer, PyBytes_AsString(result), outSize);
+    size = outSize;
+
+    Py_DECREF(result);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PythonPersistentStorageDelegate::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
+{
+    PythonGil lock;
+
+    // s (str or None) [const char *]
+    // y# (bytes) [const char *, int or Py_ssize_t]
+    PyObject *result = PyObject_CallMethod(&mOwner->ob_base, "SyncSetKeyValue", "(sy#)", key, value, size);
+    if (result == nullptr) {
+        PyErr_Print();
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    Py_DECREF(result);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PythonPersistentStorageDelegate::SyncDeleteKeyValue(const char * key)
+{
+    PythonGil lock;
+
+    // s (str or None) [const char *]
+    PyObject *result = PyObject_CallMethod(&mOwner->ob_base, "SyncDeleteKeyValue", "(s)", key);
+    if (result == nullptr) {
+        PyErr_Print();
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    Py_DECREF(result);
+    return CHIP_NO_ERROR;
+}
+
+static PyMethodDef PythonPersistentStorageMethods[] = {
+    {NULL, NULL, 0, NULL}
+};
+
+PyTypeObject PythonPersistentStorageType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "chip.PersistentStorageInterface",        /* tp_name */
+    sizeof(PythonPersistentStorage), /* tp_basicsize */
+    0,                                /* tp_itemsize */
+    PythonPersistentStorageDealloc,  /* tp_dealloc */
+    0,                                /* tp_vectorcall_offset */
+    0,                                /* tp_getattr */
+    0,                                /* tp_setattr */
+    0,                                /* tp_as_async */
+    0,                                /* tp_repr */
+    0,                                /* tp_as_number */
+    0,                                /* tp_as_sequence */
+    0,                                /* tp_as_mapping */
+    0,                                /* tp_hash */
+    0,                                /* tp_call */
+    0,                                /* tp_str */
+    0,                                /* tp_getattro */
+    0,                                /* tp_setattro */
+    0,                                /* tp_as_buffer */
+    Py_TPFLAGS_BASETYPE,              /* tp_flags */
+    0,                                /* tp_doc */
+    0,                                /* tp_traverse */
+    0,                                /* tp_clear */
+    0,                                /* tp_richcompare */
+    0,                                /* tp_weaklistoffset */
+    0,                                /* tp_iter */
+    0,                                /* tp_iternext */
+    PythonPersistentStorageMethods,  /* tp_methods */
+    0,                                /* tp_members */
+    0,                                /* tp_getset */
+    0,                                /* tp_base */
+    0,                                /* tp_dict */
+    0,                                /* tp_descr_get */
+    0,                                /* tp_descr_set */
+    0,                                /* tp_dictoffset */
+    0,                                /* tp_init */
+    0,                                /* tp_alloc */
+    PythonPersistentStorageNew,      /* tp_new */
+};

--- a/bindings/python/PersistentStorage.h
+++ b/bindings/python/PersistentStorage.h
@@ -1,0 +1,44 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <core/CHIPPersistentStorageDelegate.h>
+
+struct PythonPersistentStorage;
+
+class PythonPersistentStorageDelegate : public chip::PersistentStorageDelegate
+{
+public:
+    PythonPersistentStorageDelegate(PythonPersistentStorage * owner) : mOwner(owner) {}
+
+    /////////// PersistentStorageDelegate Interface /////////
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+private:
+    PythonPersistentStorage * mOwner;
+};
+
+struct PythonPersistentStorage {
+    PyObject_HEAD
+    PythonPersistentStorageDelegate mDelegate;
+};
+
+extern PyTypeObject PythonPersistentStorageType;

--- a/bindings/python/PythonGil.h
+++ b/bindings/python/PythonGil.h
@@ -1,0 +1,34 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+class PythonGil
+{
+public:
+    PythonGil() : mState(PyGILState_Ensure()) {}
+
+    ~PythonGil()
+    {
+        PyGILState_Release(mState);
+    }
+
+private:
+    PyGILState_STATE mState;
+};

--- a/bindings/python/RendezvousParameters.cpp
+++ b/bindings/python/RendezvousParameters.cpp
@@ -1,0 +1,129 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
+#include <RendezvousParameters.h>
+
+#include <support/ErrorStr.h>
+
+#include <Converter.h>
+#include <TransportType.h>
+
+static PyObject * PythonRendezvousParametersNew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PythonRendezvousParameters *pyo = reinterpret_cast<PythonRendezvousParameters*>(type->tp_alloc(type, 0));
+    new (&pyo->mParameters) chip::RendezvousParameters();
+    return (PyObject *)pyo;
+}
+
+static void PythonRendezvousParametersDealloc(PyObject *self)
+{
+    PythonRendezvousParameters *pyo = reinterpret_cast<PythonRendezvousParameters*>(self);
+    pyo->mParameters.~RendezvousParameters();
+
+    PyTypeObject *tp = Py_TYPE(self);
+    tp->tp_free(self);
+}
+
+PyDoc_STRVAR(SetSetupPINCodeDocument, "SetSetupPINCode(pin: unsigned long long)");
+static PyObject * PythonRendezvousParametersSetSetupPINCode(PyObject *self, PyObject *args)
+{
+    PythonRendezvousParameters *pyo = reinterpret_cast<PythonRendezvousParameters*>(self);
+
+    unsigned long long pin;
+
+    // 1nd arg (I: (int) [unsigned int])
+    if (!PyArg_ParseTuple(args, "K", &pin)) {
+        return nullptr;
+    }
+
+    pyo->mParameters.SetSetupPINCode(pin);
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(SetPeerAddressDocument, "SetPeerAddress(type: int, address: IPv4Address or IPv6Address, port: unsigned short)");
+static PyObject * PythonRendezvousParametersSetPeerAddress(PyObject *self, PyObject *args)
+{
+    PythonRendezvousParameters *pyo = reinterpret_cast<PythonRendezvousParameters*>(self);
+
+    chip::Transport::Type type;
+    chip::Inet::IPAddress address;
+    unsigned short port;
+
+    // O& (object) [converter, anything]
+    // H (int) [unsigned short int]
+    if (!PyArg_ParseTuple(args, "O&O&H", &PyObjectToTransportType, &type, &PyObjectToAddress, &address, &port)) {
+        return nullptr;
+    }
+
+    chip::Transport::PeerAddress peer;
+    peer.SetTransportType(type);
+    peer.SetIPAddress(address);
+    peer.SetPort(port);
+    pyo->mParameters.SetPeerAddress(peer);
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef PythonRendezvousParametersMethods[] = {
+    {"SetSetupPINCode", PythonRendezvousParametersSetSetupPINCode, METH_VARARGS, SetSetupPINCodeDocument},
+    {"SetPeerAddress", PythonRendezvousParametersSetPeerAddress, METH_VARARGS, SetPeerAddressDocument},
+    {NULL, NULL, 0, NULL}
+};
+
+PyTypeObject PythonRendezvousParametersType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "chip.RendezvousParameters",        /* tp_name */
+    sizeof(PythonRendezvousParameters), /* tp_basicsize */
+    0,                                /* tp_itemsize */
+    PythonRendezvousParametersDealloc,  /* tp_dealloc */
+    0,                                /* tp_vectorcall_offset */
+    0,                                /* tp_getattr */
+    0,                                /* tp_setattr */
+    0,                                /* tp_as_async */
+    0,                                /* tp_repr */
+    0,                                /* tp_as_number */
+    0,                                /* tp_as_sequence */
+    0,                                /* tp_as_mapping */
+    0,                                /* tp_hash */
+    0,                                /* tp_call */
+    0,                                /* tp_str */
+    0,                                /* tp_getattro */
+    0,                                /* tp_setattro */
+    0,                                /* tp_as_buffer */
+    0,                                /* tp_flags */
+    0,                                /* tp_doc */
+    0,                                /* tp_traverse */
+    0,                                /* tp_clear */
+    0,                                /* tp_richcompare */
+    0,                                /* tp_weaklistoffset */
+    0,                                /* tp_iter */
+    0,                                /* tp_iternext */
+    PythonRendezvousParametersMethods,  /* tp_methods */
+    0,                                /* tp_members */
+    0,                                /* tp_getset */
+    0,                                /* tp_base */
+    0,                                /* tp_dict */
+    0,                                /* tp_descr_get */
+    0,                                /* tp_descr_set */
+    0,                                /* tp_dictoffset */
+    0,                                /* tp_init */
+    0,                                /* tp_alloc */
+    PythonRendezvousParametersNew,      /* tp_new */
+};

--- a/bindings/python/RendezvousParameters.h
+++ b/bindings/python/RendezvousParameters.h
@@ -1,0 +1,30 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <protocols/secure_channel/RendezvousParameters.h>
+#include <support/ErrorStr.h>
+
+struct PythonRendezvousParameters {
+    PyObject_HEAD
+    chip::RendezvousParameters mParameters;
+};
+
+extern PyTypeObject PythonRendezvousParametersType;

--- a/bindings/python/TransportType.cpp
+++ b/bindings/python/TransportType.cpp
@@ -1,0 +1,71 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Python.h>
+
+#include <TransportType.h>
+
+PyTypeObject PythonTransportTypeType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "chip.TransportType",        /* tp_name */
+    sizeof(PythonTransportType), /* tp_basicsize */
+    0,                           /* tp_itemsize */
+    0,                           /* tp_dealloc */
+    0,                           /* tp_vectorcall_offset */
+    0,                           /* tp_getattr */
+    0,                           /* tp_setattr */
+    0,                           /* tp_as_async */
+    0,                           /* tp_repr */
+    0,                           /* tp_as_number */
+    0,                           /* tp_as_sequence */
+    0,                           /* tp_as_mapping */
+    0,                           /* tp_hash */
+    0,                           /* tp_call */
+    0,                           /* tp_str */
+    0,                           /* tp_getattro */
+    0,                           /* tp_setattro */
+    0,                           /* tp_as_buffer */
+    0,                           /* tp_flags */
+    0,                           /* tp_doc */
+    0,                           /* tp_traverse */
+    0,                           /* tp_clear */
+    0,                           /* tp_richcompare */
+    0,                           /* tp_weaklistoffset */
+    0,                           /* tp_iter */
+    0,                           /* tp_iternext */
+    0,                           /* tp_methods */
+    0,                           /* tp_members */
+    0,                           /* tp_getset */
+    0,                           /* tp_base */
+    0,                           /* tp_dict */
+    0,                           /* tp_descr_get */
+    0,                           /* tp_descr_set */
+    0,                           /* tp_dictoffset */
+    0,                           /* tp_init */
+    0,                           /* tp_alloc */
+    0,                           /* tp_new */
+};
+
+int PyObjectToTransportType(PyObject * pyo, chip::Transport::Type * type)
+{
+    if (!PyObject_TypeCheck(pyo, &PythonTransportTypeType)) {
+        return false;
+    }
+
+    *type = reinterpret_cast<PythonTransportType*>(pyo)->mType;
+    return true;
+}

--- a/bindings/python/TransportType.h
+++ b/bindings/python/TransportType.h
@@ -1,0 +1,31 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <Python.h>
+
+#include <transport/raw/PeerAddress.h>
+
+struct PythonTransportType {
+    PyObject_HEAD
+    chip::Transport::Type mType;
+};
+
+extern PyTypeObject PythonTransportTypeType;
+
+int PyObjectToTransportType(PyObject * pyo, chip::Transport::Type * type);


### PR DESCRIPTION
#### Problem
As we have already discussed, it is going to deprecate CType binding

#### Change overview
Implement Python binding using C-api

#### Testing
Pairing works.

After ninja build, it will output `chip.so` inside `out/debug/linux_x64_gcc/obj/bindings/python/chip.so`

use `PYTHONPATH` to allow python locate the `chip.so` module

```
export PYTHONPATH=`pwd`/out/debug/linux_x64_gcc/obj/bindings/python
```

Then following python scripts can be used to establish a PASE connection:

```
import time
import ipaddress

import chip

class Storage(chip.PersistentStorageInterface):
    def __init__(self):
        self.data = {}

    def SyncGetKeyValue(self, key):
        return self.data.get(key, None)

    def SyncSetKeyValue(self, key, value):
        self.data[key] = value

    def SyncDeleteKeyValue(self, key):
        del self.data[key]

chip.Init()

storage = Storage()
param = chip.CommissionerInitParams()
param.SetPersistentStorage(storage)

deviceCommissioner = chip.DeviceCommissioner(112233, param)
deviceCommissioner.ServiceEvents()

rendezvousParameters = chip.RendezvousParameters()
rendezvousParameters.SetSetupPINCode(20202021)
rendezvousParameters.SetPeerAddress(chip.Transport["UDP"], ipaddress.IPv4Address('192.168.69.6'), 11097)

deviceCommissioner.PairDevice(12344321, rendezvousParameters)

time.sleep(10)
```