### PR TITLE
Move src/app configuration to generated header

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -14,6 +14,8 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/nlio.gni")
+
+import("${chip_root}/build/chip/buildconfig_header.gni")
 import("common_flags.gni")
 
 declare_args() {
@@ -22,12 +24,11 @@ declare_args() {
       is_debug && (current_os == "linux" || current_os == "mac")
 }
 
-config("app_config") {
-  if (chip_enable_schema_check) {
-    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=1" ]
-  } else {
-    defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=0" ]
-  }
+buildconfig_header("app_buildconfig") {
+  header = "AppBuildConfig.h"
+  header_dir = "app"
+
+  defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=${chip_enable_schema_check}" ]
 }
 
 static_library("app") {
@@ -108,6 +109,7 @@ static_library("app") {
   }
 
   public_deps = [
+    ":app_buildconfig",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/system",
@@ -116,8 +118,5 @@ static_library("app") {
 
   cflags = [ "-Wconversion" ]
 
-  public_configs = [
-    ":app_config",
-    "${chip_root}/src:includes",
-  ]
+  public_configs = [ "${chip_root}/src:includes" ]
 }

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -26,6 +26,8 @@
 #include "CommandHandler.h"
 #include "CommandSender.h"
 #include "InteractionModelEngine.h"
+
+#include <app/AppBuildConfig.h>
 #include <core/CHIPTLVDebug.hpp>
 
 namespace chip {

--- a/src/app/MessageDef/AttributeDataElement.cpp
+++ b/src/app/MessageDef/AttributeDataElement.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributeDataElement.h
+++ b/src/app/MessageDef/AttributeDataElement.h
@@ -26,6 +26,8 @@
 #include "AttributePath.h"
 #include "Builder.h"
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributeDataList.cpp
+++ b/src/app/MessageDef/AttributeDataList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributeDataList.h
+++ b/src/app/MessageDef/AttributeDataList.h
@@ -26,6 +26,8 @@
 #include "AttributeDataElement.h"
 #include "ListBuilder.h"
 #include "ListParser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributeDataVersionList.cpp
+++ b/src/app/MessageDef/AttributeDataVersionList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributeDataVersionList.h
+++ b/src/app/MessageDef/AttributeDataVersionList.h
@@ -27,6 +27,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributePath.h
+++ b/src/app/MessageDef/AttributePath.h
@@ -25,6 +25,8 @@
 
 #include "Builder.h"
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributePathList.cpp
+++ b/src/app/MessageDef/AttributePathList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributePathList.h
+++ b/src/app/MessageDef/AttributePathList.h
@@ -27,6 +27,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributeStatusElement.cpp
+++ b/src/app/MessageDef/AttributeStatusElement.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributeStatusElement.h
+++ b/src/app/MessageDef/AttributeStatusElement.h
@@ -27,6 +27,8 @@
 #include "Builder.h"
 #include "Parser.h"
 #include "StatusElement.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/AttributeStatusList.cpp
+++ b/src/app/MessageDef/AttributeStatusList.cpp
@@ -30,6 +30,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/AttributeStatusList.h
+++ b/src/app/MessageDef/AttributeStatusList.h
@@ -27,6 +27,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/CommandDataElement.cpp
+++ b/src/app/MessageDef/CommandDataElement.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/CommandDataElement.h
+++ b/src/app/MessageDef/CommandDataElement.h
@@ -28,6 +28,8 @@
 
 #include "Parser.h"
 #include "StatusElement.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/CommandList.cpp
+++ b/src/app/MessageDef/CommandList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/CommandList.h
+++ b/src/app/MessageDef/CommandList.h
@@ -27,6 +27,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/CommandPath.h
+++ b/src/app/MessageDef/CommandPath.h
@@ -25,6 +25,8 @@
 
 #include "Builder.h"
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/EventDataElement.cpp
+++ b/src/app/MessageDef/EventDataElement.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/EventDataElement.h
+++ b/src/app/MessageDef/EventDataElement.h
@@ -27,6 +27,8 @@
 #include "EventPath.h"
 
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/EventList.cpp
+++ b/src/app/MessageDef/EventList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/EventList.h
+++ b/src/app/MessageDef/EventList.h
@@ -27,6 +27,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/EventPath.h
+++ b/src/app/MessageDef/EventPath.h
@@ -25,6 +25,8 @@
 
 #include "Builder.h"
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/EventPathList.cpp
+++ b/src/app/MessageDef/EventPathList.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/EventPathList.h
+++ b/src/app/MessageDef/EventPathList.h
@@ -28,6 +28,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/InvokeCommand.cpp
+++ b/src/app/MessageDef/InvokeCommand.cpp
@@ -28,6 +28,8 @@
 #include "InvokeCommand.h"
 #include "MessageDefHelper.h"
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/InvokeCommand.h
+++ b/src/app/MessageDef/InvokeCommand.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -26,6 +26,8 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
+
+#include <app/AppBuildConfig.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 namespace chip {
 namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING

--- a/src/app/MessageDef/ReadRequest.cpp
+++ b/src/app/MessageDef/ReadRequest.cpp
@@ -26,6 +26,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/ReadRequest.h
+++ b/src/app/MessageDef/ReadRequest.h
@@ -29,6 +29,8 @@
 #include "EventPathList.h"
 
 #include "Parser.h"
+
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/ReportData.cpp
+++ b/src/app/MessageDef/ReportData.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/ReportData.h
+++ b/src/app/MessageDef/ReportData.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/StatusElement.cpp
+++ b/src/app/MessageDef/StatusElement.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/StatusElement.h
+++ b/src/app/MessageDef/StatusElement.h
@@ -26,6 +26,7 @@
 #include "ListBuilder.h"
 #include "ListParser.h"
 
+#include <app/AppBuildConfig.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/MessageDef/WriteRequest.cpp
+++ b/src/app/MessageDef/WriteRequest.cpp
@@ -26,6 +26,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/MessageDef/WriteResponse.cpp
+++ b/src/app/MessageDef/WriteResponse.cpp
@@ -26,6 +26,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include <app/AppBuildConfig.h>
+
 using namespace chip;
 using namespace chip::TLV;
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPath.h>
 #include <app/ReadHandler.h>

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/WriteClient.h>
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPath.h>
 #include <app/WriteHandler.h>

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/Engine.h>
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -24,6 +24,7 @@
 
 #include <cinttypes>
 
+#include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/AppBuildConfig.h>
 #include <app/MessageDef/CommandDataElement.h>
 #include <app/MessageDef/CommandList.h>
 #include <app/MessageDef/InvokeCommand.h>


### PR DESCRIPTION
#### Problem
We generate headers containing build time configuration choices for good
reason: some builds use multiple build systems and writing out a header
is how we ensure consistent choices are made between them (thus avoiding
ODR violations that can cause catastrophic breakage).

#### Change overview
Move the command line #defines for src/app to a new generated header.
This makes it safe to enable schema checking in hybrid builds if this is
desired.

#### Testing

`gn gen out/host && gn desc out/host //src/lib defines`

`ninja -C out/host src/app && cat out/host/gen/include/app/AppBuildConfig.h`
