### PR TITLE
Clean up lwIP build file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -95,7 +95,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
 
     if (chip_with_lwip) {
-      deps += [ "${chip_root}/src/lwip:all" ]
+      deps += [ "${chip_root}/src/lwip" ]
     }
 
     if (chip_build_tools) {

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -125,7 +125,4 @@ if (current_os == "zephyr") {
       "${chip_root}/src:includes",
     ]
   }
-  group("all") {
-    deps = [ ":lwip_all" ]
-  }
 }

--- a/src/platform/EFR32/args.gni
+++ b/src/platform/EFR32/args.gni
@@ -29,9 +29,6 @@ chip_device_platform = "efr32"
 chip_mdns = "platform"
 
 lwip_platform = "efr32"
-lwip_ipv6 = true
-lwip_ipv4 = false
-lwip_api = true
 
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false

--- a/src/platform/K32W/args.gni
+++ b/src/platform/K32W/args.gni
@@ -19,9 +19,6 @@ import("//build_overrides/openthread.gni")
 chip_device_platform = "k32w"
 
 lwip_platform = "k32w"
-lwip_ipv6 = true
-lwip_ipv4 = false
-lwip_api = true
 
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false

--- a/src/platform/cc13x2_26x2/args.gni
+++ b/src/platform/cc13x2_26x2/args.gni
@@ -27,9 +27,6 @@ openthread_external_platform =
     "${ti_simplelink_sdk_build_root}:ti_simplelink_sdk"
 
 lwip_platform = "cc13x2_26x2"
-lwip_ipv6 = true
-lwip_ipv4 = false
-lwip_api = true
 
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false

--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -24,9 +24,6 @@ chip_device_platform = "qpg6100"
 chip_mdns = "platform"
 
 lwip_platform = "qpg6100"
-lwip_ipv6 = true
-lwip_ipv4 = false
-lwip_api = true
 
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false

--- a/third_party/lwip/lwip.gni
+++ b/third_party/lwip/lwip.gni
@@ -14,65 +14,6 @@
 
 import("//build_overrides/lwip.gni")
 
-declare_args() {
-  # Default enablement for lwIP library components.
-  # This has no effect on its own; it only changes between opt-out and opt-in.
-  lwip_default = current_os != "freertos"
-}
-
-declare_args() {
-  # Build IPv4 support in lwIP.
-  lwip_ipv4 = lwip_default
-
-  # Enable IPv6 support in lwIP.
-  lwip_ipv6 = lwip_default
-
-  # Enable sequential & socket API support in lwIP.
-  lwip_api = lwip_default
-
-  # Enable ethernet support in lwIP.
-  lwip_ethernet = lwip_default
-
-  # Enable SLIP interface support in lwIP.
-  lwip_slip = false
-
-  # Enable 6LoWPAN support in lwIP.
-  lwip_6lowpan = lwip_default
-
-  # Enable PPP support in lwIP.
-  lwip_ppp = lwip_default
-
-  # Default enablement for lwIP application components.
-  # This has no effect on its own; it only changes between opt-out and opt-in.
-  lwip_apps_default = false
-}
-
-declare_args() {
-  # Enable SNMPv2c agent application.
-  lwip_snmp = lwip_apps_default
-
-  # Enable HTTP server.
-  lwip_httpd = lwip_apps_default
-
-  # Enable IPERF server.
-  lwip_iperf = lwip_apps_default
-
-  # Enable SNTP client.
-  lwip_sntp = lwip_apps_default
-
-  # Enable MDNS responder.
-  lwip_mdns = lwip_apps_default
-
-  # Enable NetBIOS name server.
-  lwip_netbiosns = lwip_apps_default
-
-  # Enable TFTP server.
-  lwip_tftp = lwip_apps_default
-
-  # Enable MQTT client.
-  lwip_mqtt = lwip_apps_default
-}
-
 # Defines a lwIP build target.
 #
 # lwIP depends on external header files to compile. This template defines
@@ -81,6 +22,36 @@ template("lwip_target") {
   _lwip_root = "${lwip_root}/repo/lwip"
 
   lwip_target_name = target_name
+
+  # Apply overrides for lwIP features.
+  forward_variables_from(invoker,
+                         [
+                           "lwip_ipv4",
+                           "lwip_ipv6",
+                           "lwip_api",
+                           "lwip_ethernet",
+                           "lwip_slip",
+                           "lwip_6lowpan",
+                         ])
+
+  if (!defined(lwip_ipv4)) {
+    lwip_ipv4 = true
+  }
+  if (!defined(lwip_ipv6)) {
+    lwip_ipv6 = true
+  }
+  if (!defined(lwip_api)) {
+    lwip_api = true
+  }
+  if (!defined(lwip_ethernet)) {
+    lwip_ethernet = true
+  }
+  if (!defined(lwip_slip)) {
+    lwip_slip = false
+  }
+  if (!defined(lwip_6lowpan)) {
+    lwip_6lowpan = false
+  }
 
   config("${lwip_target_name}_warnings") {
     cflags = [
@@ -94,54 +65,6 @@ template("lwip_target") {
 
   config("${lwip_target_name}_base_config") {
     include_dirs = [ "${lwip_root}/repo/lwip/src/include" ]
-
-    # These options may have overlap with lwipopts.h, however this is harmless
-    # as long the options are the same and if they are not the same it's a
-    # compile error.
-    if (lwip_ipv4) {
-      enable_ipv4 = 1
-    } else {
-      enable_ipv4 = 0
-    }
-    if (lwip_ipv6) {
-      enable_ipv6 = 1
-    } else {
-      enable_ipv6 = 0
-    }
-    if (lwip_api) {
-      enable_api = 1
-    } else {
-      enable_api = 0
-    }
-    if (lwip_ethernet) {
-      enable_ethernet = 1
-    } else {
-      enable_ethernet = 0
-    }
-    if (lwip_slip) {
-      enable_slip = 1
-    } else {
-      enable_slip = 0
-    }
-    if (lwip_6lowpan) {
-      enable_6lowpan = 1
-    } else {
-      enable_6lowpan = 0
-    }
-    if (lwip_ppp) {
-      enable_ppp = 1
-    } else {
-      enable_ppp = 0
-    }
-    defines = [
-      "LWIP_IPV4=${enable_ipv4}",
-      "LWIP_IPV6=${enable_ipv6}",
-      "LWIP_API=${enable_api}",
-      "LWIP_ETHERNET=${enable_ethernet}",
-      "LWIP_SLIP=${enable_slip}",
-      "LWIP_6LOWPAN=${enable_6lowpan}",
-      "LWIP_PPP=${enable_ppp}",
-    ]
   }
 
   source_set(lwip_target_name) {
@@ -292,120 +215,5 @@ template("lwip_target") {
     configs += [ ":${lwip_target_name}_warnings" ]
 
     public_configs += [ ":${lwip_target_name}_base_config" ]
-  }
-
-  lwip_apps = []
-
-  template("lwip_app") {
-    app_name = target_name
-
-    static_library("${lwip_target_name}_${app_name}") {
-      forward_variables_from(invoker, [ "sources" ])
-
-      deps = [ ":lwip" ]
-
-      # Relax warnings for third_party code.
-      configs += [ ":${lwip_target_name}_warnings" ]
-    }
-  }
-
-  if (lwip_snmp) {
-    lwip_app("snmp") {
-      sources = [
-        "${_lwip_root}/src/apps/snmp/snmp_asn1.c",
-        "${_lwip_root}/src/apps/snmp/snmp_core.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_icmp.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_interfaces.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_ip.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_snmp.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_system.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_tcp.c",
-        "${_lwip_root}/src/apps/snmp/snmp_mib2_udp.c",
-        "${_lwip_root}/src/apps/snmp/snmp_msg.c",
-        "${_lwip_root}/src/apps/snmp/snmp_netconn.c",
-        "${_lwip_root}/src/apps/snmp/snmp_pbuf_stream.c",
-        "${_lwip_root}/src/apps/snmp/snmp_raw.c",
-        "${_lwip_root}/src/apps/snmp/snmp_scalar.c",
-        "${_lwip_root}/src/apps/snmp/snmp_table.c",
-        "${_lwip_root}/src/apps/snmp/snmp_threadsync.c",
-        "${_lwip_root}/src/apps/snmp/snmp_traps.c",
-        "${_lwip_root}/src/apps/snmp/snmpv3.c",
-        "${_lwip_root}/src/apps/snmp/snmpv3_dummy.c",
-        "${_lwip_root}/src/apps/snmp/snmpv3_mbedtls.c",
-      ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_snmp" ]
-  }
-
-  if (lwip_httpd) {
-    lwip_app("httpd") {
-      sources = [
-        "${_lwip_root}/src/apps/httpd/fs.c",
-        "${_lwip_root}/src/apps/httpd/httpd.c",
-      ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_httpd" ]
-  }
-
-  if (lwip_iperf) {
-    lwip_app("lwiperf") {
-      sources = [ "${_lwip_root}/src/apps/lwiperf/lwiperf.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_lwiperf" ]
-  }
-
-  if (lwip_sntp) {
-    lwip_app("sntp") {
-      sources = [ "${_lwip_root}/src/apps/sntp/sntp.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_sntp" ]
-  }
-
-  if (lwip_mdns) {
-    lwip_app("mdns") {
-      sources = [ "${_lwip_root}/src/apps/mdns/mdns.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_mdns" ]
-  }
-
-  if (lwip_netbiosns) {
-    lwip_app("netbiosns") {
-      sources = [ "${_lwip_root}/src/apps/netbiosns/netbiosns.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_netbiosns" ]
-  }
-
-  if (lwip_tftp) {
-    lwip_app("tftp") {
-      sources = [ "${_lwip_root}/src/apps/tftp/tftp_server.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_tftp" ]
-  }
-
-  if (lwip_mqtt) {
-    lwip_app("mqtt") {
-      sources = [ "${_lwip_root}/src/apps/mqtt/mqtt.c" ]
-    }
-
-    lwip_apps += [ ":${lwip_target_name}_mqtt" ]
-  }
-
-  group("${lwip_target_name}_apps") {
-    deps = lwip_apps
-  }
-
-  group("${lwip_target_name}_all") {
-    deps = [
-      ":${lwip_target_name}",
-      ":${lwip_target_name}_apps",
-    ]
   }
 }


### PR DESCRIPTION
#### Problem

The lwIP build file is specifying some configuration options on the
compiler command line. This seemed like a decent way to validate the list
of source files compiled matched the preprocessor configuration, however
this isn't actually necessary - turning off most options like IPV4 just
empties out all of the IPV4 specific files.

#### Change overview

- Use lwipopts.h exclusively for #defines
- Match the defaults to those from lwip/opt.h
- Remove examples as they are not needed

#### Testing

- Check defines via `gn gen --root-target=//examples/lighting-app/efr32 --args='import("//examples/lighting-app/efr32/args.gni") target_os="freertos" target_cpu="arm" efr32_board="BRD4161A"' out/efr32_lighting_app && gn desc out/efr32_lighting_app //src/lib defines`