### PR TITLE
Enable CHIPOBLE_SINGLE_CONNECTION in ESP32

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -554,7 +554,7 @@ menu "CHIP Device Layer"
 
         config CHIPOBLE_SINGLE_CONNECTION
             bool "Single Connection Mode"
-            default n
+            default y
             depends on ENABLE_CHIPOBLE
             help
                 Limit support for CHIP-over-BLE (WoBLE) to a single inbound connection.


### PR DESCRIPTION
It ensures that only one BLE connection at a time. When the BLE connection is active, advertising is stopped.
This prevents advertising when mac address is changed when RPA is turned on.
