### PR TITLE
Followups from #6561 Generalize socket-based event loop

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -30,9 +30,6 @@
 
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
 // from which the GenericPlatformManagerImpl_POSIX<> template inherits.
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-#include "lib/mdns/platform/Mdns.h"
-#endif
 #include <platform/internal/GenericPlatformManagerImpl.cpp>
 
 #include <system/SystemError.h>

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -424,7 +424,7 @@ INET_ERROR RawEndPoint::Listen(IPEndPointBasis::OnMessageReceivedFunct onMessage
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Wait for ability to read on this endpoint.
-    mSocket.SetCallback(HandlePendingIO, this);
+    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
     mSocket.RequestCallbackOnPendingRead();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
@@ -1026,7 +1026,7 @@ INET_ERROR RawEndPoint::GetSocket(IPAddressType aAddressType)
 // static
 void RawEndPoint::HandlePendingIO(System::WatchableSocket & socket)
 {
-    static_cast<RawEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
+    reinterpret_cast<RawEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
 }
 
 void RawEndPoint::HandlePendingIO()

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -303,7 +303,7 @@ INET_ERROR TCPEndPoint::Listen(uint16_t backlog)
         res = chip::System::MapErrorPOSIX(errno);
 
     // Wait for ability to read on this endpoint.
-    mSocket.SetCallback(HandlePendingIO, this);
+    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
     mSocket.RequestCallbackOnPendingRead();
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -507,7 +507,7 @@ INET_ERROR TCPEndPoint::Connect(const IPAddress & addr, uint16_t port, Interface
         return res;
     }
 
-    mSocket.SetCallback(HandlePendingIO, this);
+    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
 
     // Once Connecting or Connected, bump the reference count.  The corresponding Release()
     // [or on LwIP, DeferredRelease()] will happen in DoClose().
@@ -2440,7 +2440,7 @@ INET_ERROR TCPEndPoint::GetSocket(IPAddressType addrType)
 // static
 void TCPEndPoint::HandlePendingIO(System::WatchableSocket & socket)
 {
-    static_cast<TCPEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
+    reinterpret_cast<TCPEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
 }
 
 void TCPEndPoint::HandlePendingIO()
@@ -2693,7 +2693,7 @@ void TCPEndPoint::HandleIncomingConnection()
         conEP->Retain();
 
         // Wait for ability to read on this endpoint.
-        conEP->mSocket.SetCallback(HandlePendingIO, conEP);
+        conEP->mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(conEP));
         conEP->mSocket.RequestCallbackOnPendingRead();
 
         // Call the app's callback function.

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -350,7 +350,7 @@ INET_ERROR UDPEndPoint::Listen(OnMessageReceivedFunct onMessageReceived, OnRecei
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Wait for ability to read on this endpoint.
-    mSocket.SetCallback(HandlePendingIO, this);
+    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
     mSocket.RequestCallbackOnPendingRead();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
@@ -909,7 +909,7 @@ INET_ERROR UDPEndPoint::GetSocket(IPAddressType aAddressType)
 // static
 void UDPEndPoint::HandlePendingIO(System::WatchableSocket & socket)
 {
-    static_cast<UDPEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
+    reinterpret_cast<UDPEndPoint *>(socket.GetCallbackData())->HandlePendingIO();
 }
 
 void UDPEndPoint::HandlePendingIO()

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -544,9 +544,9 @@ CHIP_ERROR ChipMdnsResolve(MdnsService * service, chip::Inet::InterfaceId interf
     return Resolve(context, callback, interfaceId, service->mAddressType, regtype.c_str(), service->mName);
 }
 
-void UpdateMdnsDataset(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout) {}
+void GetMdnsTimeout(timeval & timeout) {}
 
-void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet) {}
+void HandleMdnsTimeout() {}
 
 } // namespace Mdns
 } // namespace chip

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -25,6 +25,7 @@
 
 #include <netinet/in.h>
 
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <support/CHIPMem.h>
 #include <support/CHIPMemString.h>
 #include <support/CodeUtils.h>
@@ -32,6 +33,7 @@
 using chip::Mdns::kMdnsTypeMaxSize;
 using chip::Mdns::MdnsServiceProtocol;
 using chip::Mdns::TextEntry;
+using chip::System::SocketEvents;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::seconds;
@@ -77,6 +79,29 @@ chip::Inet::IPAddressType ToAddressType(AvahiProtocol protocol)
     }
 
     return type;
+}
+
+#if 0
+SocketEvents ToSocketEvents(AvahiWatchEvent events)
+{
+    return SocketEvents()
+        .Set(chip::System::SocketEventFlags::kRead, events & AVAHI_WATCH_IN)
+        .Set(chip::System::SocketEventFlags::kWrite, events & AVAHI_WATCH_OUT)
+        .Set(chip::System::SocketEventFlags::kError, events & AVAHI_WATCH_ERR);
+}
+#endif
+
+AvahiWatchEvent ToAvahiWatchEvent(SocketEvents events)
+{
+    return static_cast<AvahiWatchEvent>((events.Has(chip::System::SocketEventFlags::kRead) ? AVAHI_WATCH_IN : 0) |
+                                        (events.Has(chip::System::SocketEventFlags::kWrite) ? AVAHI_WATCH_OUT : 0) |
+                                        (events.Has(chip::System::SocketEventFlags::kError) ? AVAHI_WATCH_ERR : 0));
+}
+
+void AvahiWatchCallbackTrampoline(chip::System::WatchableSocket & socket)
+{
+    AvahiWatch * const watch = reinterpret_cast<AvahiWatch *>(socket.GetCallbackData());
+    watch->mCallback(watch, socket.GetFD(), ToAvahiWatchEvent(socket.GetPendingEvents()), watch->mContext);
 }
 
 CHIP_ERROR MakeAvahiStringListFromTextEntries(TextEntry * entries, size_t size, AvahiStringList ** strListOut)
@@ -133,6 +158,8 @@ Poller::Poller()
     mAvahiPoller.timeout_new    = TimeoutNew;
     mAvahiPoller.timeout_update = TimeoutUpdate;
     mAvahiPoller.timeout_free   = TimeoutFree;
+
+    mWatchableEvents = &DeviceLayer::SystemLayer.WatchableEvents();
 }
 
 AvahiWatch * Poller::WatchNew(const struct AvahiPoll * poller, int fd, AvahiWatchEvent event, AvahiWatchCallback callback,
@@ -145,19 +172,43 @@ AvahiWatch * Poller::WatchNew(int fd, AvahiWatchEvent event, AvahiWatchCallback 
 {
     VerifyOrDie(callback != nullptr && fd >= 0);
 
-    mWatches.emplace_back(new AvahiWatch{ fd, event, 0, callback, context, this });
+    AvahiWatch * const watch = new AvahiWatch;
+    watch->mSocket.Init(*mWatchableEvents)
+        .Attach(fd)
+        .SetCallback(AvahiWatchCallbackTrampoline, reinterpret_cast<intptr_t>(watch))
+        .RequestCallbackOnPendingRead(event & AVAHI_WATCH_IN)
+        .RequestCallbackOnPendingWrite(event & AVAHI_WATCH_OUT);
+    watch->mCallback = callback;
+    watch->mContext  = context;
+    watch->mPoller   = this;
+    mWatches.emplace_back(watch);
 
-    return mWatches.back().get();
+    return watch;
 }
 
 void Poller::WatchUpdate(AvahiWatch * watch, AvahiWatchEvent event)
 {
-    watch->mWatchEvents = event;
+    if (event & AVAHI_WATCH_IN)
+    {
+        watch->mSocket.RequestCallbackOnPendingRead();
+    }
+    else
+    {
+        watch->mSocket.ClearCallbackOnPendingRead();
+    }
+    if (event & AVAHI_WATCH_OUT)
+    {
+        watch->mSocket.RequestCallbackOnPendingWrite();
+    }
+    else
+    {
+        watch->mSocket.ClearCallbackOnPendingWrite();
+    }
 }
 
 AvahiWatchEvent Poller::WatchGetEvents(AvahiWatch * watch)
 {
-    return static_cast<AvahiWatchEvent>(watch->mHappenedEvents);
+    return ToAvahiWatchEvent(watch->mSocket.GetPendingEvents());
 }
 
 void Poller::WatchFree(AvahiWatch * watch)
@@ -167,6 +218,7 @@ void Poller::WatchFree(AvahiWatch * watch)
 
 void Poller::WatchFree(AvahiWatch & watch)
 {
+    (void) watch.mSocket.ReleaseFD();
     mWatches.erase(std::remove_if(mWatches.begin(), mWatches.end(),
                                   [&watch](const std::unique_ptr<AvahiWatch> & aValue) { return aValue.get() == &watch; }),
                    mWatches.end());
@@ -226,37 +278,9 @@ void Poller::TimeoutFree(AvahiTimeout & timer)
                   mTimers.end());
 }
 
-void Poller::UpdateFdSet(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & aMaxFd, timeval & timeout)
+void Poller::GetTimeout(timeval & timeout)
 {
     microseconds timeoutVal = seconds(timeout.tv_sec) + microseconds(timeout.tv_usec);
-
-    for (auto && watch : mWatches)
-    {
-        int fd                 = watch->mFd;
-        AvahiWatchEvent events = watch->mWatchEvents;
-
-        if (AVAHI_WATCH_IN & events)
-        {
-            FD_SET(fd, &readFdSet);
-        }
-
-        if (AVAHI_WATCH_OUT & events)
-        {
-            FD_SET(fd, &writeFdSet);
-        }
-
-        if (AVAHI_WATCH_ERR & events)
-        {
-            FD_SET(fd, &errorFdSet);
-        }
-
-        if (aMaxFd < fd)
-        {
-            aMaxFd = fd;
-        }
-
-        watch->mHappenedEvents = 0;
-    }
 
     for (auto && timer : mTimers)
     {
@@ -282,37 +306,9 @@ void Poller::UpdateFdSet(fd_set & readFdSet, fd_set & writeFdSet, fd_set & error
     timeout.tv_usec = static_cast<uint64_t>(timeoutVal.count()) % kUsPerSec;
 }
 
-void Poller::Process(const fd_set & readFdSet, const fd_set & writeFdSet, const fd_set & errorFdSet)
+void Poller::HandleTimeout()
 {
     steady_clock::time_point now = steady_clock::now();
-
-    for (auto && watch : mWatches)
-    {
-        int fd                 = watch->mFd;
-        AvahiWatchEvent events = watch->mWatchEvents;
-
-        watch->mHappenedEvents = 0;
-
-        if ((AVAHI_WATCH_IN & events) && FD_ISSET(fd, &readFdSet))
-        {
-            watch->mHappenedEvents |= AVAHI_WATCH_IN;
-        }
-
-        if ((AVAHI_WATCH_OUT & events) && FD_ISSET(fd, &writeFdSet))
-        {
-            watch->mHappenedEvents |= AVAHI_WATCH_OUT;
-        }
-
-        if ((AVAHI_WATCH_ERR & events) && FD_ISSET(fd, &errorFdSet))
-        {
-            watch->mHappenedEvents |= AVAHI_WATCH_ERR;
-        }
-
-        if (watch->mHappenedEvents)
-        {
-            watch->mCallback(watch.get(), watch->mFd, static_cast<AvahiWatchEvent>(watch->mHappenedEvents), watch->mContext);
-        }
-    }
 
     for (auto && timer : mTimers)
     {
@@ -753,14 +749,14 @@ MdnsAvahi::~MdnsAvahi()
     }
 }
 
-void UpdateMdnsDataset(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout)
+void GetMdnsTimeout(timeval & timeout)
 {
-    MdnsAvahi::GetInstance().GetPoller().UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
+    MdnsAvahi::GetInstance().GetPoller().GetTimeout(timeout);
 }
 
-void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet)
+void HandleMdnsTimeout()
 {
-    MdnsAvahi::GetInstance().GetPoller().Process(readFdSet, writeFdSet, errorFdSet);
+    MdnsAvahi::GetInstance().GetPoller().HandleTimeout();
 }
 
 CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -81,16 +81,6 @@ chip::Inet::IPAddressType ToAddressType(AvahiProtocol protocol)
     return type;
 }
 
-#if 0
-SocketEvents ToSocketEvents(AvahiWatchEvent events)
-{
-    return SocketEvents()
-        .Set(chip::System::SocketEventFlags::kRead, events & AVAHI_WATCH_IN)
-        .Set(chip::System::SocketEventFlags::kWrite, events & AVAHI_WATCH_OUT)
-        .Set(chip::System::SocketEventFlags::kError, events & AVAHI_WATCH_ERR);
-}
-#endif
-
 AvahiWatchEvent ToAvahiWatchEvent(SocketEvents events)
 {
     return static_cast<AvahiWatchEvent>((events.Has(chip::System::SocketEventFlags::kRead) ? AVAHI_WATCH_IN : 0) |

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -34,12 +34,17 @@
 #include <avahi-common/watch.h>
 
 #include "lib/mdns/platform/Mdns.h"
+#include "system/SystemSockets.h"
 
 struct AvahiWatch
 {
+#if 1
+    chip::System::WatchableSocket mSocket;
+#else
     int mFd;                      ///< The file descriptor to watch.
     AvahiWatchEvent mWatchEvents; ///< The interested events.
     int mHappenedEvents;          ///< The events happened.
+#endif
     AvahiWatchCallback mCallback; ///< The function to be called when interested events happened on mFd.
     void * mContext;              ///< A pointer to application-specific context.
     void * mPoller;               ///< The poller created this watch.
@@ -62,9 +67,8 @@ class Poller
 public:
     Poller(void);
 
-    void UpdateFdSet(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout);
-
-    void Process(const fd_set & readFdSet, const fd_set & writeFdSet, const fd_set & errorFdSet);
+    void GetTimeout(timeval & timeout);
+    void HandleTimeout();
 
     const AvahiPoll * GetAvahiPoll(void) const { return &mAvahiPoller; }
 
@@ -92,6 +96,7 @@ private:
     std::vector<std::unique_ptr<AvahiWatch>> mWatches;
     std::vector<std::unique_ptr<AvahiTimeout>> mTimers;
     AvahiPoll mAvahiPoller;
+    System::WatchableEventManager * mWatchableEvents;
 };
 
 class MdnsAvahi

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -38,13 +38,7 @@
 
 struct AvahiWatch
 {
-#if 1
     chip::System::WatchableSocket mSocket;
-#else
-    int mFd;                      ///< The file descriptor to watch.
-    AvahiWatchEvent mWatchEvents; ///< The interested events.
-    int mHappenedEvents;          ///< The events happened.
-#endif
     AvahiWatchCallback mCallback; ///< The function to be called when interested events happened on mFd.
     void * mContext;              ///< A pointer to application-specific context.
     void * mPoller;               ///< The poller created this watch.

--- a/src/system/SystemSockets.cpp
+++ b/src/system/SystemSockets.cpp
@@ -70,7 +70,7 @@ Error WakeEvent::Open(WatchableEventManager & watchState)
 
     mFD.Init(watchState);
     mFD.Attach(fds[FD_READ]);
-    mFD.SetCallback(Confirm, this);
+    mFD.SetCallback(Confirm, reinterpret_cast<intptr_t>(this));
     mFD.RequestCallbackOnPendingRead();
 
     mWriteFD = fds[FD_WRITE];
@@ -135,7 +135,7 @@ Error WakeEvent::Open(WatchableEventManager & watchState)
     }
 
     mFD.Attach(fd);
-    mFD.SetCallback(Confirm, this);
+    mFD.SetCallback(Confirm, reinterpret_cast<intptr_t>(this));
     mFD.RequestCallbackOnPendingRead();
 
     return CHIP_SYSTEM_NO_ERROR;

--- a/src/system/WatchableSocketLibevent.cpp
+++ b/src/system/WatchableSocketLibevent.cpp
@@ -29,7 +29,6 @@
 
 namespace chip {
 namespace Mdns {
-// TODO(#5556): Convert MDNS to WatchableSocket.
 void GetMdnsTimeout(timeval & timeout);
 void HandleMdnsTimeout();
 } // namespace Mdns

--- a/src/system/WatchableSocketLibevent.cpp
+++ b/src/system/WatchableSocketLibevent.cpp
@@ -20,14 +20,22 @@
  *      This file implements WatchableEvents using libevent.
  */
 
+#include <platform/CHIPDeviceBuildConfig.h>
 #include <support/CodeUtils.h>
 #include <system/SystemLayer.h>
 #include <system/SystemSockets.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
+
+namespace chip {
+namespace Mdns {
 // TODO(#5556): Convert MDNS to WatchableSocket.
-#error "POSIX platform with MDNS currently must use select()"
-#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+void GetMdnsTimeout(timeval & timeout);
+void HandleMdnsTimeout();
+} // namespace Mdns
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
 
 #ifndef CHIP_CONFIG_LIBEVENT_DEBUG_CHECKS
 #define CHIP_CONFIG_LIBEVENT_DEBUG_CHECKS 1 // TODO(#5556): default to off
@@ -96,6 +104,10 @@ void WatchableEventManager::WaitForEvents()
 void WatchableEventManager::HandleEvents()
 {
     mSystemLayer->HandleTimeout();
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
+    chip::Mdns::HandleMdnsTimeout();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
 
     while (mActiveSockets != nullptr)
     {

--- a/src/system/WatchableSocketSelect.cpp
+++ b/src/system/WatchableSocketSelect.cpp
@@ -34,7 +34,6 @@
 
 namespace chip {
 namespace Mdns {
-// TODO(#5556): Convert MDNS to WatchableSocket.
 void GetMdnsTimeout(timeval & timeout);
 void HandleMdnsTimeout();
 } // namespace Mdns
@@ -164,7 +163,6 @@ void WatchableEventManager::PrepareEventsWithTimeout(struct timeval & nextTimeou
     mSystemLayer->GetTimeout(nextTimeout);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
-    // TODO(#5556): Convert MDNS to WatchableSocket.
     chip::Mdns::GetMdnsTimeout(nextTimeout);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
 
@@ -203,7 +201,6 @@ void WatchableEventManager::HandleEvents()
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
-    // TODO(#5556): Convert MDNS to WatchableSocket.
     chip::Mdns::HandleMdnsTimeout();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
 }

--- a/src/system/WatchableSocketSelect.cpp
+++ b/src/system/WatchableSocketSelect.cpp
@@ -35,8 +35,8 @@
 namespace chip {
 namespace Mdns {
 // TODO(#5556): Convert MDNS to WatchableSocket.
-void UpdateMdnsDataset(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout);
-void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet);
+void GetMdnsTimeout(timeval & timeout);
+void HandleMdnsTimeout();
 } // namespace Mdns
 } // namespace chip
 
@@ -163,12 +163,12 @@ void WatchableEventManager::PrepareEventsWithTimeout(struct timeval & nextTimeou
     // TODO(#5556): Integrate timer platform details with WatchableEventManager.
     mSystemLayer->GetTimeout(nextTimeout);
 
-    mSelected = mRequest;
-
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
     // TODO(#5556): Convert MDNS to WatchableSocket.
-    chip::Mdns::UpdateMdnsDataset(mSelected.mReadSet, mSelected.mWriteSet, mSelected.mErrorSet, mMaxFd, nextTimeout);
+    chip::Mdns::GetMdnsTimeout(nextTimeout);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
+
+    mSelected = mRequest;
 }
 
 void WatchableEventManager::WaitForEvents()
@@ -204,7 +204,7 @@ void WatchableEventManager::HandleEvents()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
     // TODO(#5556): Convert MDNS to WatchableSocket.
-    chip::Mdns::ProcessMdns(mSelected.mReadSet, mSelected.mWriteSet, mSelected.mErrorSet);
+    chip::Mdns::HandleMdnsTimeout();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS && !__ZEPHYR__
 }
 


### PR DESCRIPTION
#### Problem

Followups from #6561 Generalize socket-based event loop

#### Change overview

* mDNS: Convert `platform/Linux/MdnsImpl`; remove Darwin stubs.
* Change `mCallbackData` type to `intptr_t` (review feedback).
* Comment for `System::WakeEvent` (this is minimal since it's
  likely to change soon for issue #7725).

Fixes #7758 _Convert MDNS to WatchableSocket._

#### Testing

Manual sanity check of mDNS using chip-device-ctrl on Linux.
Otherwise, no change to functionality is intended.