### PR TITLE
Mdns: _chip* -> _matter*, remove 0's on subtypes

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -176,7 +176,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     }
 
     EFR32_LOG("App Task started");
-    SetDeviceName("EFR32LightingDemo._chip._udp.local.");
+    SetDeviceName("EFR32LightingDemo._matter._udp.local.");
 
     while (true)
     {

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -172,7 +172,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     }
 
     EFR32_LOG("App Task started");
-    SetDeviceName("EFR32LockDemo._chip._udp.local.");
+    SetDeviceName("EFR32LockDemo._matter._udp.local.");
 
     while (true)
     {

--- a/examples/minimal-mdns/README.md
+++ b/examples/minimal-mdns/README.md
@@ -39,7 +39,7 @@ which is likely to list a lot of answers.
 You can customize the queries run:
 
 ```sh
-/out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._chip._tcp.local
+/out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._matter._tcp.local
 ```
 
 see
@@ -88,43 +88,43 @@ discovery.
 #### Simulated uncommisioned node
 
 ```sh
-dns-sd -R DD200C20D25AE5F7 _chipc._udp,S052,L0840,V123 . 11111 D=0840 VP=123+456
+dns-sd -R DD200C20D25AE5F7 _matterc._udp,S52,L840,V123 . 11111 D=840 VP=123+456
 ```
 
 Will create the following records
 
 ```
-_chipc._udp.local.                   PTR   DD200C20D25AE5F7._chipc._udp.local.
-S052._sub._chipc._udp.local.         PTR   DD200C20D25AE5F7._chipc._udp.local.
-L0840._sub._chipc._udp.local.        PTR   DD200C20D25AE5F7._chipc._udp.local.
-V123._sub._chipc._udp.local.         PTR   DD200C20D25AE5F7._chipc._udp.local.
-DD200C20D25AE5F7._chipc._udp.local.  TXT   "D=0840" "VP=123+456"
-DD200C20D25AE5F7._chipc._udp.local.  SRV   0 0 11111 B75AFB458ECD.local.
+_matterc._udp.local.                   PTR   DD200C20D25AE5F7._matterc._udp.local.
+S52._sub._matterc._udp.local.          PTR   DD200C20D25AE5F7._matterc._udp.local.
+L840._sub._matterc._udp.local.         PTR   DD200C20D25AE5F7._matterc._udp.local.
+V123._sub._matterc._udp.local.         PTR   DD200C20D25AE5F7._matterc._udp.local.
+DD200C20D25AE5F7._matterc._udp.local.  TXT   "D=840" "VP=123+456"
+DD200C20D25AE5F7._mattterc._udp.local.  SRV   0 0 11111 B75AFB458ECD.local.
 B75AFB458ECD.local.                  AAAA  ba2a:b311:742e:b44c:f515:576f:9783:3f30
 ```
 
 #### Simulated commisioning node
 
 ```sh
-dns-sd -R DD200C20D25AE5F7 _chipd._udp,S052,L0840,V123 . 11111 D=0840 VP=123+456 PH=3
+dns-sd -R DD200C20D25AE5F7 _matterd._udp,S52,L840,V123 . 11111 D=840 VP=123+456 PH=3
 ```
 
 Will create the following records:
 
 ```
-_chipd._udp.local.              PTR   DD200C20D25AE5F7._chipd._udp.local.
-S052._sub._chipd._udp.local.    PTR   DD200C20D25AE5F7._chipd._udp.local.
-V123._sub._chipd._udp.local.    PTR   DD200C20D25AE5F7._chipd._udp.local.
-D0840._sub._chipd._udp.local.   PTR   DD200C20D25AE5F7._chipd._udp.local.
-DD200C20D25AE5F7._chipd._udp.local.  TXT   "D=0840" "VP=123+456" "PH=3"
-DD200C20D25AE5F7._chipd._udp.local.  SRV   0 0 11111 B75AFB458ECD.local.
-B75AFB458ECD.local.             AAAA  ba2a:b311:742e:b44c:f515:576f:9783:3f30
+_matterd._udp.local.                   PTR   DD200C20D25AE5F7._matterd._udp.local.
+S52._sub._matterd._udp.local.          PTR   DD200C20D25AE5F7._matterd._udp.local.
+V123._sub._matterd._udp.local.         PTR   DD200C20D25AE5F7._matterd._udp.local.
+D840._sub._matterd._udp.local.         PTR   DD200C20D25AE5F7._matterd._udp.local.
+DD200C20D25AE5F7._matterd._udp.local.  TXT   "D=840" "VP=123+456" "PH=3"
+DD200C20D25AE5F7._matterd._udp.local.  SRV   0 0 11111 B75AFB458ECD.local.
+B75AFB458ECD.local.                    AAAA  ba2a:b311:742e:b44c:f515:576f:9783:3f30
 ```
 
 #### Simulated commisioned node
 
 ```sh
-dns-sd -R 2906C908D115D362-8FC7772401CD0696 _chip._tcp . 22222
+dns-sd -R 2906C908D115D362-8FC7772401CD0696 _matter._tcp . 22222
 ```
 
 ### Discovery commands
@@ -132,20 +132,20 @@ dns-sd -R 2906C908D115D362-8FC7772401CD0696 _chip._tcp . 22222
 Nodes:
 
 ```sh
-dns-sd -B _chipc._udp          # Nodes awaiting commisioning
-dns-sd -B _chipc._udp,S052     # Nodes awaiting commisioning with short discriminator 052
-dns-sd -B _chipc._udp,L0840    # Nodes awaiting commisioning with long discriminator 0840
-dns-sd -B _chipc._udp,V123     # Nodes awaiting commisioning with vendor id 123
+dns-sd -B _matterc._udp         # Nodes awaiting commisioning
+dns-sd -B _matterc._udp,S52     # Nodes awaiting commisioning with short discriminator 52
+dns-sd -B _matterc._udp,L840    # Nodes awaiting commisioning with long discriminator 840
+dns-sd -B _matterc._udp,V123    # Nodes awaiting commisioning with vendor id 123
 
-dns-sd -B _chipd._udp          # Commisionable nodes
-dns-sd -B _chipd._udp,S052     # Commisionable nodes with short discriminator 052
-dns-sd -B _chipd._udp,L0840    # Commisionable nodes with long discriminator 0840
-dns-sd -B _chipd._udp,V123     # Commisionable nodes with vendor id 123
+dns-sd -B _matterd._udp         # Commisionable nodes
+dns-sd -B _matterd._udp,S52     # Commisionable nodes with short discriminator 52
+dns-sd -B _matterd._udp,L840    # Commisionable nodes with long discriminator 840
+dns-sd -B _matterd._udp,V123    # Commisionable nodes with vendor id 123
 ```
 
 IP Address:
 
 ```sh
-dns-sd -L 2906C908D115D362-8FC7772401CD0696 _chip._tcp  # find server address
-dns-sd -Gv6 B75AFB458ECD.local                          # get IPv6 address
+dns-sd -L 2906C908D115D362-8FC7772401CD0696 _matter._tcp  # find server address
+dns-sd -Gv6 B75AFB458ECD.local                            # get IPv6 address
 ```

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -22,6 +22,7 @@
 
 #include <inet/InetInterface.h>
 #include <inet/UDPEndPoint.h>
+#include <mdns/ServiceNaming.h>
 #include <mdns/minimal/QueryBuilder.h>
 #include <mdns/minimal/ResponseSender.h>
 #include <mdns/minimal/Server.h>
@@ -187,17 +188,22 @@ int main(int argc, char ** args)
     mdns::Minimal::Server<10 /* endpoints */> mdnsServer;
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
-    mdns::Minimal::QNamePart tcpServiceName[]       = { "_chip", "_tcp", "local" };
-    mdns::Minimal::QNamePart tcpServerServiceName[] = { gOptions.instanceName, "_chip", "_tcp", "local" };
-    mdns::Minimal::QNamePart udpServiceName[]       = { "_chip", "_udp", "local" };
-    mdns::Minimal::QNamePart udpServerServiceName[] = { gOptions.instanceName, "_chip", "_udp", "local" };
+    mdns::Minimal::QNamePart tcpServiceName[]       = { kOperationalServiceName, kOperationalProtocol, kLocalDomain };
+    mdns::Minimal::QNamePart tcpServerServiceName[] = { gOptions.instanceName, kOperationalServiceName, kOperationalProtocol,
+                                                        kLocalDomain };
+    mdns::Minimal::QNamePart udpServiceName[]       = { kCommissionableServiceName, kCommissionProtocol, kLocalDomain };
+    mdns::Minimal::QNamePart udpServerServiceName[] = { gOptions.instanceName, kCommissionableServiceName, kCommissionProtocol,
+                                                        kLocalDomain };
 
     // several UDP versions for discriminators
-    mdns::Minimal::QNamePart udpDiscriminator1[] = { "S052", "_sub", "_chip", "_udp", "local" };
-    mdns::Minimal::QNamePart udpDiscriminator2[] = { "V123", "_sub", "_chip", "_udp", "local" };
-    mdns::Minimal::QNamePart udpDiscriminator3[] = { "L0840", "_sub", "_chip", "_udp", "local" };
+    mdns::Minimal::QNamePart udpDiscriminator1[] = { "S52", kSubtypeServiceNamePart, kCommissionableServiceName,
+                                                     kCommissionProtocol, kLocalDomain };
+    mdns::Minimal::QNamePart udpDiscriminator2[] = { "V123", kSubtypeServiceNamePart, kCommissionableServiceName,
+                                                     kCommissionProtocol, kLocalDomain };
+    mdns::Minimal::QNamePart udpDiscriminator3[] = { "L840", kSubtypeServiceNamePart, kCommissionableServiceName,
+                                                     kCommissionProtocol, kLocalDomain };
 
-    mdns::Minimal::QNamePart serverName[] = { gOptions.instanceName, "local" };
+    mdns::Minimal::QNamePart serverName[] = { gOptions.instanceName, kLocalDomain };
 
     mdns::Minimal::IPv4Responder ipv4Responder(serverName);
     mdns::Minimal::IPv6Responder ipv6Responder(serverName);

--- a/examples/window-app/efr32/src/AppTask.cpp
+++ b/examples/window-app/efr32/src/AppTask.cpp
@@ -109,7 +109,7 @@ void AppTask::Main(void * pvParameter)
     }
 
     EFR32_LOG("App Task started");
-    SetDeviceName("EFR32WindowCoverDemo._chip._udp.local.");
+    SetDeviceName("EFR32WindowCoverDemo._matter._udp.local.");
 
     while (true)
     {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -100,7 +100,7 @@ class OnOffClientFragment : Fragment() {
         fabricIdEd.text.toString().toLong(),
         deviceIdEd.text.toString().toLong()
       )
-      serviceType = "_chip._tcp"
+      serviceType = "_matter._tcp"
     }
 
     // TODO: implement the common CHIP mDNS interface for Android and make CHIP stack call the resolver

--- a/src/darwin/CHIPTool/CHIPTool/Info.plist
+++ b/src/darwin/CHIPTool/CHIPTool/Info.plist
@@ -26,7 +26,7 @@
 	<string>Used to connect to the peripheral</string>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_chip._tcp</string>
+		<string>_matter._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Used to scan QR code</string>

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -207,11 +207,13 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
     /// need to set server name
     ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), params.GetPeerId()));
 
-    FullQName operationalServiceName = mQueryResponderAllocator.AllocateQName("_chip", "_tcp", "local");
-    FullQName operationalServerName  = mQueryResponderAllocator.AllocateQName(nameBuffer, "_chip", "_tcp", "local");
+    FullQName operationalServiceName =
+        mQueryResponderAllocator.AllocateQName(kOperationalServiceName, kOperationalProtocol, kLocalDomain);
+    FullQName operationalServerName =
+        mQueryResponderAllocator.AllocateQName(nameBuffer, kOperationalServiceName, kOperationalProtocol, kLocalDomain);
 
     ReturnErrorOnFailure(MakeHostName(nameBuffer, sizeof(nameBuffer), params.GetMac()));
-    FullQName serverName = mQueryResponderAllocator.AllocateQName(nameBuffer, "local");
+    FullQName serverName = mQueryResponderAllocator.AllocateQName(nameBuffer, kLocalDomain);
 
     if ((operationalServiceName.nameCount == 0) || (operationalServerName.nameCount == 0) || (serverName.nameCount == 0))
     {

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -115,7 +115,7 @@ CHIP_ERROR MakeHostName(char * buffer, size_t bufferLen, const chip::ByteSpan & 
     size_t idx = 0;
     for (size_t i = 0; i < macOrEui64.size(); ++i)
     {
-        idx += snprintf(buffer + idx, 3, "%X", macOrEui64.data()[i]);
+        idx += snprintf(buffer + idx, 3, "%02X", macOrEui64.data()[i]);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -115,7 +115,7 @@ CHIP_ERROR MakeHostName(char * buffer, size_t bufferLen, const chip::ByteSpan & 
     size_t idx = 0;
     for (size_t i = 0; i < macOrEui64.size(); ++i)
     {
-        idx += snprintf(buffer + idx, 3, "%02X", macOrEui64.data()[i]);
+        idx += snprintf(buffer + idx, 3, "%X", macOrEui64.data()[i]);
     }
     return CHIP_NO_ERROR;
 }
@@ -131,7 +131,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_S%03u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_S%u", subtype.code);
         break;
     case DiscoveryFilterType::kLong:
         // 12-bit number
@@ -139,16 +139,16 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_L%04u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_L%u", subtype.code);
         break;
     case DiscoveryFilterType::kVendor:
         // Vendor ID is 16-bit, so if it fits in the code, it's good.
         // NOTE: size here is wrong, will be changed in upcming PR to remove leading zeros.
-        requiredSize = snprintf(buffer, bufferLen, "_V%03u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_V%u", subtype.code);
         break;
     case DiscoveryFilterType::kDeviceType:
         // TODO: Not totally clear the size required here: see spec issue #3226
-        requiredSize = snprintf(buffer, bufferLen, "_T%03u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_T%u", subtype.code);
         break;
     case DiscoveryFilterType::kCommissioningMode:
         if (subtype.code > 1)
@@ -187,11 +187,11 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
     {
         if (type == DiscoveryType::kCommissionableNode)
         {
-            requiredSize = snprintf(buffer, bufferLen, "_chipc");
+            requiredSize = snprintf(buffer, bufferLen, kCommissionableServiceName);
         }
         else if (type == DiscoveryType::kCommissionerNode)
         {
-            requiredSize = snprintf(buffer, bufferLen, "_chipd");
+            requiredSize = snprintf(buffer, bufferLen, kCommissionerServiceName);
         }
         else
         {

--- a/src/lib/mdns/ServiceNaming.h
+++ b/src/lib/mdns/ServiceNaming.h
@@ -29,9 +29,9 @@ namespace chip {
 namespace Mdns {
 constexpr size_t kMaxSubtypeDescSize        = 8; // max 5 decimal digits + _X prefix. + null character
 constexpr char kSubtypeServiceNamePart[]    = "_sub";
-constexpr char kCommissionableServiceName[] = "_chipc";
-constexpr char kOperationalServiceName[]    = "_chip";
-constexpr char kCommissionerServiceName[]   = "_chipd";
+constexpr char kCommissionableServiceName[] = "_matterc";
+constexpr char kOperationalServiceName[]    = "_matter";
+constexpr char kCommissionerServiceName[]   = "_matterd";
 constexpr char kOperationalProtocol[]       = "_tcp";
 constexpr char kCommissionProtocol[]        = "_udp";
 constexpr char kLocalDomain[]               = "local";

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -25,20 +25,24 @@
 
 #pragma once
 
+#include <algorithm>
 #include <stdint.h>
 
 #include "core/CHIPError.h"
 #include "inet/IPAddress.h"
 #include "inet/InetInterface.h"
 #include "lib/core/Optional.h"
+#include "lib/mdns/ServiceNaming.h"
 
 namespace chip {
 namespace Mdns {
 
-static constexpr uint8_t kMdnsInstanceNameMaxSize    = 33; // [Node]-[Fabric] ID in hex - 16+1+16
-static constexpr uint8_t kMdnsHostNameMaxSize        = 16; // 64-bits in hex.
-static constexpr uint8_t kMdnsProtocolTextMaxSize    = 4;  // "_tcp" or "_udp"
-static constexpr uint8_t kMdnsTypeMaxSize            = 6;  // "_chip", "_chipc" or "_chipd"
+// None of these sizes include an nullptr at the end.
+static constexpr uint8_t kMdnsInstanceNameMaxSize = 33; // [Node]-[Fabric] ID in hex - 16+1+16
+static constexpr uint8_t kMdnsHostNameMaxSize     = 16; // 64-bits in hex.
+static constexpr size_t kMdnsProtocolTextMaxSize  = std::max(sizeof(kOperationalProtocol), sizeof(kCommissionProtocol)) - 1;
+static constexpr size_t kMdnsTypeMaxSize =
+    std::max({ sizeof(kCommissionableServiceName), sizeof(kOperationalServiceName), sizeof(kCommissionerServiceName) }) - 1;
 static constexpr uint8_t kMdnsTypeAndProtocolMaxSize = kMdnsTypeMaxSize + kMdnsProtocolTextMaxSize + 1; // <type>.<protocol>
 static constexpr uint16_t kMdnsTextMaxSize           = 64;
 

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -37,7 +37,7 @@
 namespace chip {
 namespace Mdns {
 
-// None of these sizes include an nullptr at the end.
+// None of these sizes include an null character at the end.
 static constexpr uint8_t kMdnsInstanceNameMaxSize = 33; // [Node]-[Fabric] ID in hex - 16+1+16
 static constexpr uint8_t kMdnsHostNameMaxSize     = 16; // 64-bits in hex.
 static constexpr size_t kMdnsProtocolTextMaxSize  = std::max(sizeof(kOperationalProtocol), sizeof(kCommissionProtocol)) - 1;

--- a/src/lib/mdns/tests/TestServiceNaming.cpp
+++ b/src/lib/mdns/tests/TestServiceNaming.cpp
@@ -83,7 +83,6 @@ void TestExtractIdFromInstanceName(nlTestSuite * inSuite, void * inContext)
 
 void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
 {
-    // TODO(cecille): These need to be changed to remove leading zeros
     constexpr size_t kSize = 16;
     char buffer[kSize];
     DiscoveryFilter filter;
@@ -92,7 +91,7 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     filter.type = DiscoveryFilterType::kLong;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L0003") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L3") == 0);
 
     filter.code = (1 << 12) - 1;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
@@ -105,7 +104,7 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     filter.type = DiscoveryFilterType::kShort;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S003") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S3") == 0);
 
     filter.code = (1 << 8) - 1;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
@@ -118,15 +117,17 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     filter.type = DiscoveryFilterType::kVendor;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V003") == 0);
-    // TODO:add tests for longer vendor codes once the leading zero issue is fixed.
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V3") == 0);
+    filter.code = 0xFFFF;
+    NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V65535") == 0);
 
     // Device Type tests
     filter.type = DiscoveryFilterType::kDeviceType;
     filter.code = 3;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_T003") == 0);
-    // TODO: Add tests for longer device types once the leadng zero issue is fixed.
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_T3") == 0);
+    // TODO: Add tests for longer device types once spec issue #3226 is closed.
 
     // Commisioning mode tests
     filter.type = DiscoveryFilterType::kCommissioningMode;
@@ -165,12 +166,12 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L0003._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L3._sub._matterc") == 0);
 
     filter.code = (1 << 12) - 1;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L4095._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_L4095._sub._matterc") == 0);
 
     filter.code = 1 << 12;
     NL_TEST_ASSERT(inSuite,
@@ -182,12 +183,12 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
     printf("buffer: %s\n", buffer);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S003._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S3._sub._matterc") == 0);
 
     filter.code = (1 << 8) - 1;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S255._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S255._sub._matterc") == 0);
 
     filter.code = 1 << 8;
     NL_TEST_ASSERT(inSuite,
@@ -198,7 +199,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V003._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_V3._sub._matterc") == 0);
     // TODO:add tests for longer vendor codes once the leading zero issue is fixed.
 
     // Device Type tests
@@ -206,7 +207,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_T003._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_T3._sub._matterc") == 0);
     // TODO: Add tests for longer device types once the leadng zero issue is fixed.
 
     // Commisioning mode tests
@@ -214,11 +215,11 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 0;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C0._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C0._sub._matterc") == 0);
     filter.code = 1;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C1._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C1._sub._matterc") == 0);
     filter.code = 2; // only or or 1 allwoed
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) != CHIP_NO_ERROR);
@@ -228,7 +229,7 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 1;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_A1._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_A1._sub._matterc") == 0);
     filter.code = 0; // 1 is only value allowed
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) != CHIP_NO_ERROR);
@@ -237,26 +238,26 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.type = DiscoveryFilterType::kNone;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterc") == 0);
 
     filter.type = DiscoveryFilterType::kNone;
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionerNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_chipd") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterd") == 0);
 
     // Test buffer exactly the right size - "_chipc" = 6 + nullptr = 7
     filter.type = DiscoveryFilterType::kNone;
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 6, filter, DiscoveryType::kCommissionableNode) == CHIP_ERROR_NO_MEMORY);
 
-    // Test buffer exactly the right size - "_chipc" = 6 + nullptr = 7
+    // Test buffer exactly the right size - "_matterc" = 8 + nullptr = 9
     filter.type = DiscoveryFilterType::kNone;
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 7, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterc") == 0);
 
-    // Test buffer exactly the right size for subtype - "_C1._sub._chipc" = 15 + nullptr = 16
+    // Test buffer exactly the right size for subtype - "_C1._sub._matter" = 17 + nullptr = 18
     filter.type = DiscoveryFilterType::kCommissioningMode;
     filter.code = 1;
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 16, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C1._sub._chipc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C1._sub._matterc") == 0);
 }
 
 const nlTest sTests[] = {

--- a/src/lib/mdns/tests/TestServiceNaming.cpp
+++ b/src/lib/mdns/tests/TestServiceNaming.cpp
@@ -244,19 +244,19 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionerNode) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterd") == 0);
 
-    // Test buffer exactly the right size - "_chipc" = 6 + nullptr = 7
+    // Test buffer exactly the right size - "_matterc" = 8 + nullchar = 9
     filter.type = DiscoveryFilterType::kNone;
-    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 6, filter, DiscoveryType::kCommissionableNode) == CHIP_ERROR_NO_MEMORY);
+    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 9, filter, DiscoveryType::kCommissionableNode) == CHIP_ERROR_NO_MEMORY);
 
-    // Test buffer exactly the right size - "_matterc" = 8 + nullptr = 9
+    // Test buffer exactly the right size - "_matterc" = 8 + nullchar = 9
     filter.type = DiscoveryFilterType::kNone;
-    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 7, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 9, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterc") == 0);
 
-    // Test buffer exactly the right size for subtype - "_C1._sub._matter" = 17 + nullptr = 18
+    // Test buffer exactly the right size for subtype - "_C1._sub._matterc" = 17 + nullchar = 18
     filter.type = DiscoveryFilterType::kCommissioningMode;
     filter.code = 1;
-    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 16, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 18, filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_C1._sub._matterc") == 0);
 }
 

--- a/src/lib/mdns/tests/TestServiceNaming.cpp
+++ b/src/lib/mdns/tests/TestServiceNaming.cpp
@@ -244,9 +244,9 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionerNode) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_matterd") == 0);
 
-    // Test buffer exactly the right size - "_matterc" = 8 + nullchar = 9
+    // Test buffer just under the right size - "_matterc" = 8 + nullchar = 9
     filter.type = DiscoveryFilterType::kNone;
-    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 9, filter, DiscoveryType::kCommissionableNode) == CHIP_ERROR_NO_MEMORY);
+    NL_TEST_ASSERT(inSuite, MakeServiceTypeName(buffer, 8, filter, DiscoveryType::kCommissionableNode) == CHIP_ERROR_NO_MEMORY);
 
     // Test buffer exactly the right size - "_matterc" = 8 + nullchar = 9
     filter.type = DiscoveryFilterType::kNone;

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -33,7 +33,7 @@ using namespace chip::Mdns;
 
 namespace {
 
-constexpr const char * kLocalDomain = "local.";
+constexpr const char * kLocalDot    = "local.";
 constexpr const char * kProtocolTcp = "._tcp";
 constexpr const char * kProtocolUdp = "._udp";
 constexpr uint8_t kMdnsKeyMaxSize   = 32;
@@ -292,7 +292,7 @@ CHIP_ERROR Register(uint32_t interfaceId, const char * type, const char * name, 
     }
 
     sdCtx = chip::Platform::New<RegisterContext>(type, nullptr);
-    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, ::kLocalDomain, NULL, ntohs(port), recordLen,
+    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDot, NULL, ntohs(port), recordLen,
                              recordBytesPtr, OnRegister, sdCtx);
     TXTRecordDeallocate(recordRef);
 
@@ -309,7 +309,7 @@ void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, 
     ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %d", __func__, name, type, domain,
                   interfaceId);
 
-    VerifyOrReturn(strcmp(::kLocalDomain, domain) == 0);
+    VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
 
     char * tokens  = strdup(type);
     char * regtype = strtok(tokens, ".");
@@ -333,7 +333,7 @@ void OnBrowseRemove(BrowseContext * context, const char * name, const char * typ
     ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %d", __func__, name, type, domain,
                   interfaceId);
 
-    VerifyOrReturn(strcmp(::kLocalDomain, domain) == 0);
+    VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
 
     std::remove_if(context->services.begin(), context->services.end(), [name, type, interfaceId](const MdnsService & service) {
         return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol) &&
@@ -365,7 +365,7 @@ CHIP_ERROR Browse(void * context, MdnsBrowseCallback callback, uint32_t interfac
     BrowseContext * sdCtx;
 
     sdCtx = chip::Platform::New<BrowseContext>(context, callback, protocol);
-    err   = DNSServiceBrowse(&sdRef, 0 /* flags */, interfaceId, type, ::kLocalDomain, OnBrowse, sdCtx);
+    err   = DNSServiceBrowse(&sdRef, 0 /* flags */, interfaceId, type, kLocalDot, OnBrowse, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
     err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
@@ -467,7 +467,7 @@ static CHIP_ERROR Resolve(void * context, MdnsResolveCallback callback, uint32_t
     ResolveContext * sdCtx;
 
     sdCtx = chip::Platform::New<ResolveContext>(context, callback, name, addressType);
-    err   = DNSServiceResolve(&sdRef, 0 /* flags */, interfaceId, name, type, ::kLocalDomain, OnResolve, sdCtx);
+    err   = DNSServiceResolve(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDot, OnResolve, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
     err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -292,7 +292,7 @@ CHIP_ERROR Register(uint32_t interfaceId, const char * type, const char * name, 
     }
 
     sdCtx = chip::Platform::New<RegisterContext>(type, nullptr);
-    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDomain, NULL, ntohs(port), recordLen,
+    err   = DNSServiceRegister(&sdRef, 0 /* flags */, interfaceId, name, type, ::kLocalDomain, NULL, ntohs(port), recordLen,
                              recordBytesPtr, OnRegister, sdCtx);
     TXTRecordDeallocate(recordRef);
 
@@ -309,7 +309,7 @@ void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, 
     ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %d", __func__, name, type, domain,
                   interfaceId);
 
-    VerifyOrReturn(strcmp(kLocalDomain, domain) == 0);
+    VerifyOrReturn(strcmp(::kLocalDomain, domain) == 0);
 
     char * tokens  = strdup(type);
     char * regtype = strtok(tokens, ".");
@@ -333,7 +333,7 @@ void OnBrowseRemove(BrowseContext * context, const char * name, const char * typ
     ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %d", __func__, name, type, domain,
                   interfaceId);
 
-    VerifyOrReturn(strcmp(kLocalDomain, domain) == 0);
+    VerifyOrReturn(strcmp(::kLocalDomain, domain) == 0);
 
     std::remove_if(context->services.begin(), context->services.end(), [name, type, interfaceId](const MdnsService & service) {
         return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol) &&
@@ -365,7 +365,7 @@ CHIP_ERROR Browse(void * context, MdnsBrowseCallback callback, uint32_t interfac
     BrowseContext * sdCtx;
 
     sdCtx = chip::Platform::New<BrowseContext>(context, callback, protocol);
-    err   = DNSServiceBrowse(&sdRef, 0 /* flags */, interfaceId, type, kLocalDomain, OnBrowse, sdCtx);
+    err   = DNSServiceBrowse(&sdRef, 0 /* flags */, interfaceId, type, ::kLocalDomain, OnBrowse, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
     err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
@@ -467,7 +467,7 @@ static CHIP_ERROR Resolve(void * context, MdnsResolveCallback callback, uint32_t
     ResolveContext * sdCtx;
 
     sdCtx = chip::Platform::New<ResolveContext>(context, callback, name, addressType);
-    err   = DNSServiceResolve(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDomain, OnResolve, sdCtx);
+    err   = DNSServiceResolve(&sdRef, 0 /* flags */, interfaceId, name, type, ::kLocalDomain, OnResolve, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
     err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());


### PR DESCRIPTION
#### Problem
The second ballot changed the format of the subtypes as well as
fixed the service name prefix from _chip* to _matter*.

NOTE FOR DEVs: Updating past this change will require updating the
devices and controllers as otherwise they will be unable to find
each other.

Fixes #6518

#### Change overview
Changes _chip* to _matter* for mdns, removes leading zeros on subtypes in code and documentation.

#### Testing
unit tests cover name changes (updated). Tested in the wild using M5, chip-device-tool with https://github.com/project-chip/connectedhomeip/pull/7659
