### PR TITLE
Fix Ble endpoint pool FULL on macOS controller

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -48,6 +48,7 @@ constexpr uint64_t kScanningTimeoutInSeconds = 60;
 @property (strong, nonatomic) CBPeripheral * peripheral;
 @property (strong, nonatomic) CBUUID * shortServiceUUID;
 @property (nonatomic, readonly, nullable) dispatch_source_t timer;
+@property (unsafe_unretained, nonatomic) bool found;
 @property (unsafe_unretained, nonatomic) uint16_t deviceDiscriminator;
 @property (unsafe_unretained, nonatomic) void * appState;
 @property (unsafe_unretained, nonatomic) BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete;
@@ -103,6 +104,7 @@ namespace DeviceLayer {
         _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
         _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _workQueue);
         _centralManager = [CBCentralManager alloc];
+        _found = false;
 
         dispatch_source_set_event_handler(_timer, ^{
             [self stop];
@@ -206,17 +208,15 @@ namespace DeviceLayer {
         ChipLogError(Ble, "BLE:Error finding Chip Service in the device: [%s]", [error.localizedDescription UTF8String]);
     }
 
-    bool found;
-
     for (CBService * service in peripheral.services) {
-        if ([service.UUID.data isEqualToData:_shortServiceUUID.data]) {
-            found = true;
+        if ([service.UUID.data isEqualToData:_shortServiceUUID.data] && !self.found) {
             [peripheral discoverCharacteristics:nil forService:service];
+            self.found = true;
             break;
         }
     }
 
-    if (!found || error != nil) {
+    if (!self.found || error != nil) {
         ChipLogError(Ble, "Service not found on the device.");
         _onConnectionError(_appState, BLE_ERROR_INCORRECT_STATE);
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #6863 chip-tool on Mac throws Ble endpoint pool FULL

#### Change overview
- Updated the found variable from local to global.
- Prevents multiple calls to the same service.

#### Testing
How was this tested? (at least one bullet point required)
* Tested pairing BLE accessory with chip-device-ctrl 
* BLE accessory that was tested was RasPi (Linux)
* Controller platform was macOS
* macOS is the only platform accepted 