### PR TITLE
Use libshell under examples/platform/linux/AppMain.cpp only if chip_b…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -25,11 +25,14 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <core/CHIPError.h>
-#include <lib/shell/Engine.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/CHIPMem.h>
 #include <support/RandUtils.h>
+
+#if defined(ENABLE_CHIP_SHELL)
+#include <lib/shell/Engine.h>
+#endif
 
 #if defined(PW_RPC_ENABLED)
 #include <CommonRpc.h>
@@ -41,7 +44,10 @@ using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
+
+#if defined(ENABLE_CHIP_SHELL)
 using chip::Shell::Engine;
+#endif
 
 namespace {
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
@@ -116,11 +122,15 @@ exit:
 
 void ChipLinuxAppMainLoop()
 {
+#if defined(ENABLE_CHIP_SHELL)
     std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
+#endif
 
     // Init ZCL Data Model and CHIP App Server
     InitServer();
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+#if defined(ENABLE_CHIP_SHELL)
     shellThread.join();
+#endif
 }

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/common_flags.gni")
+import("${chip_root}/src/lib/lib.gni")
 
 config("app-main-config") {
   include_dirs = [ "." ]
@@ -38,6 +39,9 @@ source_set("app-main") {
     # BLE and on-network. Code defaults to BLE if this is not set.
     defines += [ "CONFIG_RENDEZVOUS_MODE=6" ]
   }
+  if (chip_build_libshell) {
+    defines += [ "ENABLE_CHIP_SHELL" ]
+  }
 
   public_deps = [
     "${chip_root}/src/app/server",
@@ -45,9 +49,6 @@ source_set("app-main") {
     "${chip_root}/src/lib/shell",
     "${chip_root}/src/lib/shell:shell_core",
   ]
-
-    public_deps += [ 
-    ]
 
   public_configs = [ ":app-main-config" ]
 }

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -73,6 +73,7 @@ for j in "${iter_array[@]}"; do
         # Clear out our temp files so we don't accidentally do a stale
         # read from them before we write to them.
         rm -rf /tmp/all-clusters-log
+        touch /tmp/all-clusters-log
         rm -rf /tmp/pid
         (
             stdbuf -o0 out/debug/standalone/chip-all-clusters-app &

--- a/src/lib/BUILD.gn
+++ b/src/lib/BUILD.gn
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-
-declare_args() {
-  chip_build_libshell = false
-}
+import("lib.gni")
 
 config("includes") {
   include_dirs = [ "." ]

--- a/src/lib/lib.gni
+++ b/src/lib/lib.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Enable libshell support.
+  chip_build_libshell = false
+}


### PR DESCRIPTION
…uild_libshell is true

#### Problem
`./scripts/tests/test_suites.sh` can not be runned under darwin because of the usage of libshell.

#### Change overview
 * Enable libshell for `examples/platform/linux/AppMain.cpp ` only if `chip_build_libshell=true` 
 * Add `touch /tmp/all-clusters-log` to `scripts/tests/test_suites.sh` to avoid an error message `grep: /tmp/all-clusters-log: No such file or directory`

#### Testing
 This was tested running  `scripts/tests/test_suites.sh` on the command line. It was not working previously.