### PR TITLE
[ZAP] Add isAnalog instead of isDiscreteType to account …

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -344,11 +344,9 @@ public:
         AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        {{#unless (isDiscreteType)}}
-        {{#unless (isString type)}}
+        {{#if isAnalog}}
         AddArgument("change", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &mChange);
-        {{/unless}}
-        {{/unless}}
+        {{/if}}
         ModelCommand::AddArguments();
     }
 
@@ -372,7 +370,7 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval, mMaxInterval{{#unless (isDiscreteType)}}, mChange{{/unless}});
+        return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval, mMaxInterval{{#if isAnalog}}, mChange{{/if}});
     }
 
 private:
@@ -381,11 +379,9 @@ private:
     chip::Callback::Callback<{{asCallbackAttributeType atomicTypeId}}AttributeCallback> * onReportCallback = new chip::Callback::Callback<{{asCallbackAttributeType atomicTypeId}}AttributeCallback>(On{{asCallbackAttributeType atomicTypeId}}AttributeResponse, this);
     uint16_t mMinInterval;
     uint16_t mMaxInterval;
-    {{#unless (isDiscreteType)}}
-    {{#unless (isString type)}}
+    {{#if isAnalog}}
     {{chipType}} mChange;
-    {{/unless}}
-    {{/unless}}
+    {{/if}}
 };
 
 {{/if}}

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -262,7 +262,7 @@ function handleBasic(item, [ atomics, enums, bitmaps, structs ])
     item.name                = item.name || item.label;
     item.isStruct            = false;
     item.atomicTypeId        = atomic.atomicId;
-    item.discrete            = atomic.isDiscrete;
+    item.isAnalog            = atomic.isDiscrete == false && atomic.isString == false;
     item.size                = atomic.size;
     item.chipType            = atomic.chipType;
     item.chipTypePutLength   = asPutLength(atomic.chipType);

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -99,10 +99,10 @@ CHIP_ERROR {{asCamelCased parent.name false}}Cluster::WriteAttribute{{asCamelCas
 
 {{/if}}
 {{#if (isReportableAttribute)}}
-CHIP_ERROR {{asCamelCased parent.name false}}Cluster::ConfigureAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
+CHIP_ERROR {{asCamelCased parent.name false}}Cluster::ConfigureAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle encodedCommand = encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(seqNum, mEndpoint, minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(seqNum, mEndpoint, minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
     return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -41,7 +41,7 @@ public:
     {{/chip_server_cluster_attributes}}
     {{#chip_server_cluster_attributes}}
     {{#if (isReportableAttribute)}}
-    CHIP_ERROR ConfigureAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}});
+    CHIP_ERROR ConfigureAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}});
     CHIP_ERROR ReportAttribute{{asCamelCased name false}}(Callback::Cancelable * onReportCallback);
     {{/if}}
     {{/chip_server_cluster_attributes}}

--- a/src/app/zap-templates/templates/app/chip-zcl-zpro-codec-api.zapt
+++ b/src/app/zap-templates/templates/app/chip-zcl-zpro-codec-api.zapt
@@ -40,7 +40,7 @@ chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}Cluster
  * @brief
  *    Encode a {{parent.name}} server configure report command for the {{name}} attribute into buffer including the APS frame
  */
-chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(uint8_t seqNum, chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}});
+chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(uint8_t seqNum, chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}});
 
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/app/zap-templates/templates/app/encoder-src.zapt
+++ b/src/app/zap-templates/templates/app/encoder-src.zapt
@@ -122,7 +122,7 @@ PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterWrite{{asCamel
 
 {{/if}}
 {{#if (isReportableAttribute)}}
-PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(uint8_t seqNum, EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
+PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(uint8_t seqNum, EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     COMMAND_HEADER("Report{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID);
     buf.Put8(kFrameControlGlobalCommand)
@@ -133,9 +133,9 @@ PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterConfigure{{asC
        .Put8({{atomicTypeId}})
        .Put16(minInterval)
        .Put16(maxInterval);
-    {{#unless (isDiscreteType)}}
+    {{#if isAnalog}}
     buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>(change));
-    {{/unless}}
+    {{/if}}
     COMMAND_FOOTER();
 }
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -215,42 +215,6 @@ function chip_client_has_list_attributes(options)
 }
 
 /**
- * Returns if a given command argument chip type is signed.
- *
- * This function is meant to be used inside a {{#chip_*}} block.
- * It will throws otherwise.
- *
- * @param {*} options
- */
-function isSignedType()
-{
-  const type = checkIsChipType(this, 'isSignedType');
-  switch (type) {
-  case 'int8_t':
-  case 'int16_t':
-  case 'int32_t':
-  case 'int64_t':
-    return true;
-  default:
-    return false;
-  }
-}
-
-/**
- * Returns if a given command argument chip type is discrete.
- *
- * This function is meant to be used inside a {{#chip_*}} block.
- * It will throws otherwise.
- *
- * @param {*} options
- */
-function isDiscreteType()
-{
-  checkIsChipType(this, 'isSignedType');
-  return this.discrete;
-}
-
-/**
  * Creates block iterator over the server side cluster attributes
  * for a given cluster.
  *
@@ -403,8 +367,6 @@ exports.chip_server_cluster_commands          = chip_server_cluster_commands;
 exports.chip_server_cluster_command_arguments = chip_server_cluster_command_arguments
 exports.chip_attribute_list_entryTypes        = chip_attribute_list_entryTypes;
 exports.asBasicType                           = ChipTypesHelper.asBasicType;
-exports.isSignedType                          = isSignedType;
-exports.isDiscreteType                        = isDiscreteType;
 exports.chip_server_cluster_attributes        = chip_server_cluster_attributes;
 exports.chip_has_list_attributes              = chip_has_list_attributes;
 exports.chip_server_has_list_attributes       = chip_server_has_list_attributes;

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -138,16 +138,16 @@ CHIP_ERROR chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCa
 }
 
 {{#if (isReportableAttribute)}}
-CHIP_ERROR chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
+CHIP_ERROR chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
 {{#if isList}}
     chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>(On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse, nullptr);
-    return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+    return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
 {{else}}
-    return cluster.ConfigureAttribute{{asCamelCased name false}}(g{{asCallbackAttributeType atomicTypeId}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+    return cluster.ConfigureAttribute{{asCamelCased name false}}(g{{asCallbackAttributeType atomicTypeId}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
 {{/if}}
 }
 {{/if}}

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -142,7 +142,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
 {{#if (isReportableAttribute)}}
         # Cluster {{asCamelCased parent.name false}} ConfigureAttribute {{asCamelCased name false}}
-        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#unless (isDiscreteType)}}, ctypes.{{asPythonCType chipType}}{{/unless}}]
+        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#if isAnalog}}, ctypes.{{asPythonCType chipType}}{{/if}}]
         self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
 {{/if}}
 {{#if (isWritableAttribute)}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -696,7 +696,7 @@ private:
 
 {{/if}}
 {{#if (isReportableAttribute)}}
-- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#unless (isDiscreteType)}} change:({{chipType}})change{{/unless}} responseHandler:(ResponseHandler)responseHandler
+- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -714,7 +714,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+        err = self.cppCluster.ConfigureAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
     });
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttribute{{asCamelCased name false}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{#if (isReportableAttribute)}}
-- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#unless (isDiscreteType)}} change:({{chipType}})change{{/unless}} responseHandler:(ResponseHandler)responseHandler;
+- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler;
 - (void) reportAttribute{{asCamelCased name false}}WithResponseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{/chip_server_cluster_attributes}}


### PR DESCRIPTION
…for string types

#### Problem
 When generating the method signatures for configuring reporting of all attributes, it fails to build because the generation process wrongly emit a variable for a change delta for strings.

#### Change overview
 * Add `hasConfigurableChange` helper instead of `isDiscreteType` for emitting or not the `change` variable
 * Use it over the templates
 
#### Testing
 This is purely code generation. It has been tested by updating the templates and then running `./scripts/tools/zap_regen_all.py` and ensuring nothing has changed.
Nothing should have changed, since this error is only visible if one tries to enable the generation for all attributes of user-enabled clusters. The issues arise into the `language` attribute of the door lock cluster, and this attribute is not enabled yet.

