### PR TITLE
Make System::Layer::mHandleSelectThread atomic.

### DIFF
--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -41,6 +41,7 @@
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
+#include <atomic>
 #include <pthread.h>
 #endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
 
@@ -204,7 +205,7 @@ private:
     WatchableEventManager mWatchableEvents;
     WakeEvent mWakeEvent;
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-    pthread_t mHandleSelectThread;
+    std::atomic<pthread_t> mHandleSelectThread;
 #endif // CHIP_SYSTEM_CONFIG_POSIX_LOCKING
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 


### PR DESCRIPTION
mHandleSelectThread is used for an optimization: when it's set to the
current thread id, WakeIOThread knows that:

1) We're in the middle of running Layer::HandleTimeout
2) We're doing that on the same thread where WakeIOThread was called

and hence WakeIOThread doesn't need to do anything, because we're
already on the IO thread and it's already awake.

The read of this member in WakeIOThread is not synchronized in any
way, but as long as we guarantee that it correctly reads a value that
was actually assigned to the member (which std::atomic does), things
will work correctly.  Either the value we read will be equal to the
current thread id, in which case we know we're on the one thread that
called Layer::HandleTimeout and are inside that function, or it will
not be equal to our thread id and then we need to do the actual wakeup
work, whatever that value is (including if it's null).

Fixes https://github.com/project-chip/connectedhomeip/issues/7818

#### Problem
TSan shows that we have a data race on Linux if `PlatformManager::PostEvent` is called while `Layer::HandleTimeout` is running on another thread.

#### Change overview
Use `std::atomic` to guarantee that we don't have a data race.  With that fixed, the overall logic does not seem to have races that lead to incorrect behavior.

#### Testing
Manually tested this with #7797 and changes to make CHIP-tool use `PostEvent` which failed CI without this change and pass with it.