### PR TITLE
Fix data races in chip-tool on Darwin

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -31,7 +31,7 @@ static void OnDefaultSuccessResponse(void * context)
     ChipLogProgress(chipTool, "Default Success Response");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDefaultFailureResponse(void * context, uint8_t status)
@@ -39,7 +39,7 @@ static void OnDefaultFailureResponse(void * context, uint8_t status)
     ChipLogProgress(chipTool, "Default Failure Response: 0x%02x", status);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(false);
+    command->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
 static void OnBooleanAttributeResponse(void * context, bool value)
@@ -47,7 +47,7 @@ static void OnBooleanAttributeResponse(void * context, bool value)
     ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt8uAttributeResponse(void * context, uint8_t value)
@@ -55,7 +55,7 @@ static void OnInt8uAttributeResponse(void * context, uint8_t value)
     ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16uAttributeResponse(void * context, uint16_t value)
@@ -63,7 +63,7 @@ static void OnInt16uAttributeResponse(void * context, uint16_t value)
     ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt32uAttributeResponse(void * context, uint32_t value)
@@ -71,7 +71,7 @@ static void OnInt32uAttributeResponse(void * context, uint32_t value)
     ChipLogProgress(chipTool, "Int32u attribute Response: %" PRIu32, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64uAttributeResponse(void * context, uint64_t value)
@@ -79,7 +79,7 @@ static void OnInt64uAttributeResponse(void * context, uint64_t value)
     ChipLogProgress(chipTool, "Int64u attribute Response: %" PRIu64, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt8sAttributeResponse(void * context, int8_t value)
@@ -87,7 +87,7 @@ static void OnInt8sAttributeResponse(void * context, int8_t value)
     ChipLogProgress(chipTool, "Int8s attribute Response: %" PRId8, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16sAttributeResponse(void * context, int16_t value)
@@ -95,7 +95,7 @@ static void OnInt16sAttributeResponse(void * context, int16_t value)
     ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt32sAttributeResponse(void * context, int32_t value)
@@ -103,7 +103,7 @@ static void OnInt32sAttributeResponse(void * context, int32_t value)
     ChipLogProgress(chipTool, "Int32s attribute Response: %" PRId32, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64sAttributeResponse(void * context, int64_t value)
@@ -111,7 +111,7 @@ static void OnInt64sAttributeResponse(void * context, int64_t value)
     ChipLogProgress(chipTool, "Int64s attribute Response: %" PRId64, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnStringAttributeResponse(void * context, const chip::ByteSpan value)
@@ -119,7 +119,7 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
     ChipLogProgress(chipTool, "String attribute Response: %zu", value.size());
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnAccountLoginClusterGetSetupPINResponse(void * context, uint8_t * setupPIN)
@@ -127,7 +127,7 @@ static void OnAccountLoginClusterGetSetupPINResponse(void * context, uint8_t * s
     ChipLogProgress(chipTool, "AccountLoginClusterGetSetupPINResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_t * data)
@@ -135,7 +135,7 @@ static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_
     ChipLogProgress(chipTool, "ApplicationLauncherClusterLaunchAppResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnContentLauncherClusterLaunchContentResponse(void * context, uint8_t * data, uint8_t contentLaunchStatus)
@@ -143,7 +143,7 @@ static void OnContentLauncherClusterLaunchContentResponse(void * context, uint8_
     ChipLogProgress(chipTool, "ContentLauncherClusterLaunchContentResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnContentLauncherClusterLaunchURLResponse(void * context, uint8_t * data, uint8_t contentLaunchStatus)
@@ -151,7 +151,7 @@ static void OnContentLauncherClusterLaunchURLResponse(void * context, uint8_t * 
     ChipLogProgress(chipTool, "ContentLauncherClusterLaunchURLResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearAllPinsResponse(void * context)
@@ -159,7 +159,7 @@ static void OnDoorLockClusterClearAllPinsResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearAllPinsResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearAllRfidsResponse(void * context)
@@ -167,7 +167,7 @@ static void OnDoorLockClusterClearAllRfidsResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearAllRfidsResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearHolidayScheduleResponse(void * context)
@@ -175,7 +175,7 @@ static void OnDoorLockClusterClearHolidayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearHolidayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearPinResponse(void * context)
@@ -183,7 +183,7 @@ static void OnDoorLockClusterClearPinResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearPinResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearRfidResponse(void * context)
@@ -191,7 +191,7 @@ static void OnDoorLockClusterClearRfidResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearRfidResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearWeekdayScheduleResponse(void * context)
@@ -199,7 +199,7 @@ static void OnDoorLockClusterClearWeekdayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearWeekdayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterClearYeardayScheduleResponse(void * context)
@@ -207,7 +207,7 @@ static void OnDoorLockClusterClearYeardayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterClearYeardayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t scheduleId, uint32_t localStartTime,
@@ -216,7 +216,7 @@ static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t 
     ChipLogProgress(chipTool, "DoorLockClusterGetHolidayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType,
@@ -225,7 +225,7 @@ static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEn
     ChipLogProgress(chipTool, "DoorLockClusterGetLogRecordResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
@@ -233,7 +233,7 @@ static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uin
     ChipLogProgress(chipTool, "DoorLockClusterGetPinResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
@@ -241,7 +241,7 @@ static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, ui
     ChipLogProgress(chipTool, "DoorLockClusterGetRfidResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetUserTypeResponse(void * context, uint16_t userId, uint8_t userType)
@@ -249,7 +249,7 @@ static void OnDoorLockClusterGetUserTypeResponse(void * context, uint16_t userId
     ChipLogProgress(chipTool, "DoorLockClusterGetUserTypeResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetWeekdayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId, uint8_t daysMask,
@@ -258,7 +258,7 @@ static void OnDoorLockClusterGetWeekdayScheduleResponse(void * context, uint8_t 
     ChipLogProgress(chipTool, "DoorLockClusterGetWeekdayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterGetYeardayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId,
@@ -267,7 +267,7 @@ static void OnDoorLockClusterGetYeardayScheduleResponse(void * context, uint8_t 
     ChipLogProgress(chipTool, "DoorLockClusterGetYeardayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterLockDoorResponse(void * context)
@@ -275,7 +275,7 @@ static void OnDoorLockClusterLockDoorResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterLockDoorResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetHolidayScheduleResponse(void * context)
@@ -283,7 +283,7 @@ static void OnDoorLockClusterSetHolidayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetHolidayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetPinResponse(void * context)
@@ -291,7 +291,7 @@ static void OnDoorLockClusterSetPinResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetPinResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetRfidResponse(void * context)
@@ -299,7 +299,7 @@ static void OnDoorLockClusterSetRfidResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetRfidResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetUserTypeResponse(void * context)
@@ -307,7 +307,7 @@ static void OnDoorLockClusterSetUserTypeResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetUserTypeResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetWeekdayScheduleResponse(void * context)
@@ -315,7 +315,7 @@ static void OnDoorLockClusterSetWeekdayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetWeekdayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterSetYeardayScheduleResponse(void * context)
@@ -323,7 +323,7 @@ static void OnDoorLockClusterSetYeardayScheduleResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterSetYeardayScheduleResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterUnlockDoorResponse(void * context)
@@ -331,7 +331,7 @@ static void OnDoorLockClusterUnlockDoorResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterUnlockDoorResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDoorLockClusterUnlockWithTimeoutResponse(void * context)
@@ -339,7 +339,7 @@ static void OnDoorLockClusterUnlockWithTimeoutResponse(void * context)
     ChipLogProgress(chipTool, "DoorLockClusterUnlockWithTimeoutResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGeneralCommissioningClusterArmFailSafeResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -347,7 +347,7 @@ static void OnGeneralCommissioningClusterArmFailSafeResponse(void * context, uin
     ChipLogProgress(chipTool, "GeneralCommissioningClusterArmFailSafeResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGeneralCommissioningClusterCommissioningCompleteResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -355,7 +355,7 @@ static void OnGeneralCommissioningClusterCommissioningCompleteResponse(void * co
     ChipLogProgress(chipTool, "GeneralCommissioningClusterCommissioningCompleteResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGeneralCommissioningClusterSetRegulatoryConfigResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -363,7 +363,7 @@ static void OnGeneralCommissioningClusterSetRegulatoryConfigResponse(void * cont
     ChipLogProgress(chipTool, "GeneralCommissioningClusterSetRegulatoryConfigResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupsClusterAddGroupResponse(void * context, uint16_t groupId)
@@ -371,7 +371,7 @@ static void OnGroupsClusterAddGroupResponse(void * context, uint16_t groupId)
     ChipLogProgress(chipTool, "GroupsClusterAddGroupResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupsClusterGetGroupMembershipResponse(void * context, uint8_t capacity, uint8_t groupCount,
@@ -380,7 +380,7 @@ static void OnGroupsClusterGetGroupMembershipResponse(void * context, uint8_t ca
     ChipLogProgress(chipTool, "GroupsClusterGetGroupMembershipResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupsClusterRemoveGroupResponse(void * context, uint16_t groupId)
@@ -388,7 +388,7 @@ static void OnGroupsClusterRemoveGroupResponse(void * context, uint16_t groupId)
     ChipLogProgress(chipTool, "GroupsClusterRemoveGroupResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupsClusterViewGroupResponse(void * context, uint16_t groupId, uint8_t * groupName)
@@ -396,7 +396,7 @@ static void OnGroupsClusterViewGroupResponse(void * context, uint16_t groupId, u
     ChipLogProgress(chipTool, "GroupsClusterViewGroupResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnIdentifyClusterIdentifyQueryResponse(void * context, uint16_t timeout)
@@ -404,7 +404,7 @@ static void OnIdentifyClusterIdentifyQueryResponse(void * context, uint16_t time
     ChipLogProgress(chipTool, "IdentifyClusterIdentifyQueryResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnKeypadInputClusterSendKeyResponse(void * context)
@@ -412,7 +412,7 @@ static void OnKeypadInputClusterSendKeyResponse(void * context)
     ChipLogProgress(chipTool, "KeypadInputClusterSendKeyResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaFastForwardResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -420,7 +420,7 @@ static void OnMediaPlaybackClusterMediaFastForwardResponse(void * context, uint8
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaFastForwardResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaNextResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -428,7 +428,7 @@ static void OnMediaPlaybackClusterMediaNextResponse(void * context, uint8_t medi
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaNextResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaPauseResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -436,7 +436,7 @@ static void OnMediaPlaybackClusterMediaPauseResponse(void * context, uint8_t med
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaPauseResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaPlayResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -444,7 +444,7 @@ static void OnMediaPlaybackClusterMediaPlayResponse(void * context, uint8_t medi
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaPlayResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaPreviousResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -452,7 +452,7 @@ static void OnMediaPlaybackClusterMediaPreviousResponse(void * context, uint8_t 
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaPreviousResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaRewindResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -460,7 +460,7 @@ static void OnMediaPlaybackClusterMediaRewindResponse(void * context, uint8_t me
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaRewindResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaSkipBackwardResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -468,7 +468,7 @@ static void OnMediaPlaybackClusterMediaSkipBackwardResponse(void * context, uint
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaSkipBackwardResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaSkipForwardResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -476,7 +476,7 @@ static void OnMediaPlaybackClusterMediaSkipForwardResponse(void * context, uint8
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaSkipForwardResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaSkipSeekResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -484,7 +484,7 @@ static void OnMediaPlaybackClusterMediaSkipSeekResponse(void * context, uint8_t 
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaSkipSeekResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaStartOverResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -492,7 +492,7 @@ static void OnMediaPlaybackClusterMediaStartOverResponse(void * context, uint8_t
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaStartOverResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaPlaybackClusterMediaStopResponse(void * context, uint8_t mediaPlaybackStatus)
@@ -500,7 +500,7 @@ static void OnMediaPlaybackClusterMediaStopResponse(void * context, uint8_t medi
     ChipLogProgress(chipTool, "MediaPlaybackClusterMediaStopResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterAddThreadNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -508,7 +508,7 @@ static void OnNetworkCommissioningClusterAddThreadNetworkResponse(void * context
     ChipLogProgress(chipTool, "NetworkCommissioningClusterAddThreadNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterAddWiFiNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -516,7 +516,7 @@ static void OnNetworkCommissioningClusterAddWiFiNetworkResponse(void * context, 
     ChipLogProgress(chipTool, "NetworkCommissioningClusterAddWiFiNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterDisableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -524,7 +524,7 @@ static void OnNetworkCommissioningClusterDisableNetworkResponse(void * context, 
     ChipLogProgress(chipTool, "NetworkCommissioningClusterDisableNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -532,7 +532,7 @@ static void OnNetworkCommissioningClusterEnableNetworkResponse(void * context, u
     ChipLogProgress(chipTool, "NetworkCommissioningClusterEnableNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterRemoveNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -540,7 +540,7 @@ static void OnNetworkCommissioningClusterRemoveNetworkResponse(void * context, u
     ChipLogProgress(chipTool, "NetworkCommissioningClusterRemoveNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void
@@ -551,7 +551,7 @@ OnNetworkCommissioningClusterScanNetworksResponse(void * context, uint8_t errorC
     ChipLogProgress(chipTool, "NetworkCommissioningClusterScanNetworksResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterUpdateThreadNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -559,7 +559,7 @@ static void OnNetworkCommissioningClusterUpdateThreadNetworkResponse(void * cont
     ChipLogProgress(chipTool, "NetworkCommissioningClusterUpdateThreadNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnNetworkCommissioningClusterUpdateWiFiNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
@@ -567,7 +567,7 @@ static void OnNetworkCommissioningClusterUpdateWiFiNetworkResponse(void * contex
     ChipLogProgress(chipTool, "NetworkCommissioningClusterUpdateWiFiNetworkResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOtaSoftwareUpdateServerClusterApplyUpdateRequestResponse(void * context, uint8_t action, uint32_t delayedActionTime)
@@ -575,7 +575,7 @@ static void OnOtaSoftwareUpdateServerClusterApplyUpdateRequestResponse(void * co
     ChipLogProgress(chipTool, "OtaSoftwareUpdateServerClusterApplyUpdateRequestResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOtaSoftwareUpdateServerClusterQueryImageResponse(void * context, uint32_t delayedActionTime, uint8_t * imageURI,
@@ -585,7 +585,7 @@ static void OnOtaSoftwareUpdateServerClusterQueryImageResponse(void * context, u
     ChipLogProgress(chipTool, "OtaSoftwareUpdateServerClusterQueryImageResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOperationalCredentialsClusterOpCSRResponse(void * context, chip::ByteSpan CSR, chip::ByteSpan CSRNonce,
@@ -595,7 +595,7 @@ static void OnOperationalCredentialsClusterOpCSRResponse(void * context, chip::B
     ChipLogProgress(chipTool, "OperationalCredentialsClusterOpCSRResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOperationalCredentialsClusterOpCertResponse(void * context, uint8_t StatusCode, uint64_t FabricIndex,
@@ -604,7 +604,7 @@ static void OnOperationalCredentialsClusterOpCertResponse(void * context, uint8_
     ChipLogProgress(chipTool, "OperationalCredentialsClusterOpCertResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOperationalCredentialsClusterSetFabricResponse(void * context, chip::FabricId FabricId)
@@ -612,7 +612,7 @@ static void OnOperationalCredentialsClusterSetFabricResponse(void * context, chi
     ChipLogProgress(chipTool, "OperationalCredentialsClusterSetFabricResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterAddSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
@@ -620,7 +620,7 @@ static void OnScenesClusterAddSceneResponse(void * context, uint16_t groupId, ui
     ChipLogProgress(chipTool, "ScenesClusterAddSceneResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterGetSceneMembershipResponse(void * context, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
@@ -629,7 +629,7 @@ static void OnScenesClusterGetSceneMembershipResponse(void * context, uint8_t ca
     ChipLogProgress(chipTool, "ScenesClusterGetSceneMembershipResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterRemoveAllScenesResponse(void * context, uint16_t groupId)
@@ -637,7 +637,7 @@ static void OnScenesClusterRemoveAllScenesResponse(void * context, uint16_t grou
     ChipLogProgress(chipTool, "ScenesClusterRemoveAllScenesResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterRemoveSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
@@ -645,7 +645,7 @@ static void OnScenesClusterRemoveSceneResponse(void * context, uint16_t groupId,
     ChipLogProgress(chipTool, "ScenesClusterRemoveSceneResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterStoreSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
@@ -653,7 +653,7 @@ static void OnScenesClusterStoreSceneResponse(void * context, uint16_t groupId, 
     ChipLogProgress(chipTool, "ScenesClusterStoreSceneResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnScenesClusterViewSceneResponse(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
@@ -663,7 +663,7 @@ static void OnScenesClusterViewSceneResponse(void * context, uint16_t groupId, u
     ChipLogProgress(chipTool, "ScenesClusterViewSceneResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTvChannelClusterChangeChannelResponse(void * context,
@@ -673,7 +673,7 @@ static void OnTvChannelClusterChangeChannelResponse(void * context,
     ChipLogProgress(chipTool, "TvChannelClusterChangeChannelResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8_t * data)
@@ -681,7 +681,7 @@ static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8
     ChipLogProgress(chipTool, "TargetNavigatorClusterNavigateTargetResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTestClusterClusterTestSpecificResponse(void * context, uint8_t returnValue)
@@ -689,7 +689,7 @@ static void OnTestClusterClusterTestSpecificResponse(void * context, uint8_t ret
     ChipLogProgress(chipTool, "TestClusterClusterTestSpecificResponse");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnApplicationLauncherApplicationLauncherListListAttributeResponse(void * context, uint16_t count, uint16_t * entries)
@@ -702,7 +702,7 @@ static void OnApplicationLauncherApplicationLauncherListListAttributeResponse(vo
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnAudioOutputAudioOutputListListAttributeResponse(void * context, uint16_t count, _AudioOutputInfo * entries)
@@ -718,7 +718,7 @@ static void OnAudioOutputAudioOutputListListAttributeResponse(void * context, ui
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnContentLauncherAcceptsHeaderListListAttributeResponse(void * context, uint16_t count, chip::ByteSpan * entries)
@@ -731,7 +731,7 @@ static void OnContentLauncherAcceptsHeaderListListAttributeResponse(void * conte
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnContentLauncherSupportedStreamingTypesListAttributeResponse(void * context, uint16_t count, uint8_t * entries)
@@ -744,7 +744,7 @@ static void OnContentLauncherSupportedStreamingTypesListAttributeResponse(void *
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDescriptorDeviceListListAttributeResponse(void * context, uint16_t count, _DeviceType * entries)
@@ -759,7 +759,7 @@ static void OnDescriptorDeviceListListAttributeResponse(void * context, uint16_t
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDescriptorServerListListAttributeResponse(void * context, uint16_t count, chip::ClusterId * entries)
@@ -772,7 +772,7 @@ static void OnDescriptorServerListListAttributeResponse(void * context, uint16_t
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDescriptorClientListListAttributeResponse(void * context, uint16_t count, chip::ClusterId * entries)
@@ -785,7 +785,7 @@ static void OnDescriptorClientListListAttributeResponse(void * context, uint16_t
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDescriptorPartsListListAttributeResponse(void * context, uint16_t count, chip::EndpointId * entries)
@@ -798,7 +798,7 @@ static void OnDescriptorPartsListListAttributeResponse(void * context, uint16_t 
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnFixedLabelLabelListListAttributeResponse(void * context, uint16_t count, _LabelStruct * entries)
@@ -813,7 +813,7 @@ static void OnFixedLabelLabelListListAttributeResponse(void * context, uint16_t 
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(void * context, uint16_t count,
@@ -833,7 +833,7 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(void * co
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupKeyManagementGroupsListAttributeResponse(void * context, uint16_t count, _GroupState * entries)
@@ -849,7 +849,7 @@ static void OnGroupKeyManagementGroupsListAttributeResponse(void * context, uint
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnGroupKeyManagementGroupKeysListAttributeResponse(void * context, uint16_t count, _GroupKey * entries)
@@ -867,7 +867,7 @@ static void OnGroupKeyManagementGroupKeysListAttributeResponse(void * context, u
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnMediaInputMediaInputListListAttributeResponse(void * context, uint16_t count, _MediaInputInfo * entries)
@@ -884,7 +884,7 @@ static void OnMediaInputMediaInputListListAttributeResponse(void * context, uint
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnOperationalCredentialsFabricsListListAttributeResponse(void * context, uint16_t count, _FabricDescriptor * entries)
@@ -901,7 +901,7 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(void * cont
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTvChannelTvChannelListListAttributeResponse(void * context, uint16_t count, _TvChannelInfo * entries)
@@ -919,7 +919,7 @@ static void OnTvChannelTvChannelListListAttributeResponse(void * context, uint16
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(void * context, uint16_t count,
@@ -935,7 +935,7 @@ static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(void * con
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTestClusterListInt8uListAttributeResponse(void * context, uint16_t count, uint8_t * entries)
@@ -948,7 +948,7 @@ static void OnTestClusterListInt8uListAttributeResponse(void * context, uint16_t
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTestClusterListOctetStringListAttributeResponse(void * context, uint16_t count, chip::ByteSpan * entries)
@@ -961,7 +961,7 @@ static void OnTestClusterListOctetStringListAttributeResponse(void * context, ui
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnTestClusterListStructOctetStringListAttributeResponse(void * context, uint16_t count, _TestListStructOctet * entries)
@@ -976,7 +976,7 @@ static void OnTestClusterListStructOctetStringListAttributeResponse(void * conte
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(void * context, uint16_t count,
@@ -1004,7 +1004,7 @@ static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(voi
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(void * context, uint16_t count, _RouteTable * entries)
@@ -1027,7 +1027,7 @@ static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(void *
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse(void * context, uint16_t count, _SecurityPolicy * entries)
@@ -1042,7 +1042,7 @@ static void OnThreadNetworkDiagnosticsSecurityPolicyListAttributeResponse(void *
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeResponse(void * context, uint16_t count,
@@ -1069,7 +1069,7 @@ static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeR
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeResponse(void * context, uint16_t count,
@@ -1083,7 +1083,7 @@ static void OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeRespon
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 /*----------------------------------------------------------------------------*\

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -23,10 +23,6 @@
 
 using namespace ::chip;
 
-namespace {
-constexpr uint16_t kWaitDurationInSeconds = 10;
-} // namespace
-
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {
@@ -41,28 +37,12 @@ CHIP_ERROR ModelCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    //
-    // Set this to true first BEFORE we send commands to ensure we don't
-    // end up in a situation where the response comes back faster than we can
-    // set the variable to true, which will cause it to block indefinitely.
-    //
-    UpdateWaitForResponse(true);
+    auto * ctx = GetExecContext();
 
-    {
-        chip::DeviceLayer::StackLock lock;
-
-        auto * ctx = GetExecContext();
-
-        err =
-            ctx->commissioner->GetConnectedDevice(ctx->remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
-        VerifyOrExit(
-            err == CHIP_NO_ERROR,
-            ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %d", ctx->remoteId, err));
-    }
-
-    WaitForResponse(kWaitDurationInSeconds);
-
-    err = GetCommandExitStatus();
+    err = ctx->commissioner->GetConnectedDevice(ctx->remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    VerifyOrExit(
+        err == CHIP_NO_ERROR,
+        ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %d", ctx->remoteId, err));
 
 exit:
     return err;

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -37,7 +37,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         "Default DispatchSingleClusterCommand is called, this should be replaced by actual dispatched for cluster commands");
 }
 
-CHIP_ERROR ModelCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR ModelCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -51,10 +51,13 @@ CHIP_ERROR ModelCommand::Run(NodeId localId, NodeId remoteId)
     {
         chip::DeviceLayer::StackLock lock;
 
-        err = GetExecContext()->commissioner->GetConnectedDevice(remoteId, &mOnDeviceConnectedCallback,
-                                                                 &mOnDeviceConnectionFailureCallback);
-        VerifyOrExit(err == CHIP_NO_ERROR,
-                     ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %d", remoteId, err));
+        auto * ctx = GetExecContext();
+
+        err =
+            ctx->commissioner->GetConnectedDevice(ctx->remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+        VerifyOrExit(
+            err == CHIP_NO_ERROR,
+            ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %d", ctx->remoteId, err));
     }
 
     WaitForResponse(kWaitDurationInSeconds);

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR ModelCommand::Run()
 
     WaitForResponse(kWaitDurationInSeconds);
 
-    VerifyOrExit(GetCommandExitStatus(), err = CHIP_ERROR_INTERNAL);
+    err = GetCommandExitStatus();
 
 exit:
     return err;
@@ -81,5 +81,5 @@ void ModelCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     ChipLogError(chipTool, "Failed in connecting to the device %" PRIu64 ". Error %d", deviceId, error);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "ModelCommand context is null"));
-    command->SetCommandExitStatus(false);
+    command->SetCommandExitStatus(error);
 }

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -39,7 +39,7 @@ public:
     void AddArguments() { AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId); }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -40,6 +40,7 @@ public:
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 10; }
 
     virtual CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -164,7 +164,20 @@ public:
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64);
     }
 
+    // Will be called in a setting in which it's safe to touch the CHIP
+    // stack. The rules for Run() are as follows:
+    //
+    // 1) If error is returned, Run() must not call SetCommandExitStatus.
+    // 2) If success is returned Run() must either have called
+    //    SetCommandExitStatus() or scheduled async work that will do that.
     virtual CHIP_ERROR Run() = 0;
+
+    // Get the wait duration, in seconds, before the command times out.
+    virtual uint16_t GetWaitDurationInSeconds() const = 0;
+
+    // Shut down the command, in case any work needs to be done after the event
+    // loop has been stopped.
+    virtual void Shutdown() {}
 
     CHIP_ERROR GetCommandExitStatus() const { return mCommandExitStatus; }
     void SetCommandExitStatus(CHIP_ERROR status)

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -101,6 +101,8 @@ public:
         ChipDeviceCommissioner * commissioner;
         chip::Controller::ExampleOperationalCredentialsIssuer * opCredsIssuer;
         PersistentStorage * storage;
+        chip::NodeId localId;
+        chip::NodeId remoteId;
     };
 
     Command(const char * commandName) : mName(commandName) {}
@@ -162,7 +164,7 @@ public:
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64);
     }
 
-    virtual CHIP_ERROR Run(NodeId localId, NodeId remoteId) = 0;
+    virtual CHIP_ERROR Run() = 0;
 
     bool GetCommandExitStatus() const { return mCommandExitStatus; }
     void SetCommandExitStatus(bool status)

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -166,8 +166,8 @@ public:
 
     virtual CHIP_ERROR Run() = 0;
 
-    bool GetCommandExitStatus() const { return mCommandExitStatus; }
-    void SetCommandExitStatus(bool status)
+    CHIP_ERROR GetCommandExitStatus() const { return mCommandExitStatus; }
+    void SetCommandExitStatus(CHIP_ERROR status)
     {
         mCommandExitStatus = status;
         UpdateWaitForResponse(false);
@@ -185,8 +185,8 @@ private:
     size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type);
     size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out);
 
-    bool mCommandExitStatus = false;
-    const char * mName      = nullptr;
+    CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
+    const char * mName            = nullptr;
     std::vector<Argument> mArgs;
 
     std::condition_variable cvWaitingForResponse;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -158,10 +158,12 @@ CHIP_ERROR Commands::RunCommand(NodeId localId, NodeId remoteId, int argc, char 
         execContext.commissioner  = &mController;
         execContext.opCredsIssuer = &mOpCredsIssuer;
         execContext.storage       = &mStorage;
+        execContext.localId       = localId;
+        execContext.remoteId      = remoteId;
 
         command->SetExecutionContext(execContext);
 
-        err = command->Run(localId, remoteId);
+        err = command->Run();
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err));

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -42,6 +42,7 @@ int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Controller::CommissionerInitParams initParams;
+    Command * command = nullptr;
 
     err = chip::Platform::MemoryInit();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Memory failure: %s", chip::ErrorStr(err)));
@@ -72,13 +73,18 @@ int Commands::Run(NodeId localId, NodeId remoteId, int argc, char ** argv)
     err = mController.ServiceEvents();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Run Loop: %s", chip::ErrorStr(err)));
 
-    err = RunCommand(localId, remoteId, argc, argv);
+    err = RunCommand(localId, remoteId, argc, argv, &command);
     SuccessOrExit(err);
 
 exit:
 #if CONFIG_DEVICE_LAYER
     chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
 #endif
+
+    if (command)
+    {
+        command->Shutdown();
+    }
 
     //
     // We can call DeviceController::Shutdown() safely without grabbing the stack lock
@@ -90,7 +96,7 @@ exit:
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-CHIP_ERROR Commands::RunCommand(NodeId localId, NodeId remoteId, int argc, char ** argv)
+CHIP_ERROR Commands::RunCommand(NodeId localId, NodeId remoteId, int argc, char ** argv, Command ** ranCommand)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::map<std::string, CommandsVector>::iterator cluster;
@@ -162,8 +168,17 @@ CHIP_ERROR Commands::RunCommand(NodeId localId, NodeId remoteId, int argc, char 
         execContext.remoteId      = remoteId;
 
         command->SetExecutionContext(execContext);
+        *ranCommand = command;
 
-        err = command->Run();
+        //
+        // Set this to true first BEFORE we send commands to ensure we don't end
+        // up in a situation where the response comes back faster than we can
+        // set the variable to true, which will cause it to block indefinitely.
+        //
+        command->UpdateWaitForResponse(true);
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(RunQueuedCommand, reinterpret_cast<intptr_t>(command));
+        command->WaitForResponse(command->GetWaitDurationInSeconds());
+        err = command->GetCommandExitStatus();
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err));
@@ -173,6 +188,16 @@ CHIP_ERROR Commands::RunCommand(NodeId localId, NodeId remoteId, int argc, char 
 
 exit:
     return err;
+}
+
+void Commands::RunQueuedCommand(intptr_t commandArg)
+{
+    auto * command = reinterpret_cast<Command *>(commandArg);
+    CHIP_ERROR err = command->Run();
+    if (err != CHIP_NO_ERROR)
+    {
+        command->SetCommandExitStatus(err);
+    }
 }
 
 std::map<std::string, Commands::CommandsVector>::iterator Commands::GetCluster(std::string clusterName)

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -33,7 +33,11 @@ public:
     int Run(NodeId localId, NodeId remoteId, int argc, char ** argv);
 
 private:
-    CHIP_ERROR RunCommand(NodeId localId, NodeId remoteId, int argc, char ** argv);
+    // *ranCommand will be set to the command we ran if we get as far as running
+    // it.  If it's not null, we need to call Shutdown() on the command after we
+    // shut down the event loop.
+    CHIP_ERROR RunCommand(NodeId localId, NodeId remoteId, int argc, char ** argv, Command ** ranCommand);
+    static void RunQueuedCommand(intptr_t commandArg);
     std::map<std::string, CommandsVector>::iterator GetCluster(std::string clusterName);
     Command * GetCommand(CommandsVector & commands, std::string commandName);
     Command * GetGlobalCommand(CommandsVector & commands, std::string commandName, std::string attributeName);

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -47,13 +47,13 @@ public:
         nodeData.mAddress.ToString(addrBuffer);
         ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Address: %s, Port: %" PRIu16, nodeData.mPeerId.GetNodeId(),
                         addrBuffer, nodeData.mPort);
-        SetCommandExitStatus(true);
+        SetCommandExitStatus(CHIP_NO_ERROR);
     }
 
     void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override
     {
         ChipLogProgress(chipTool, "NodeId Resolution: failed!");
-        SetCommandExitStatus(false);
+        SetCommandExitStatus(CHIP_ERROR_INTERNAL);
     }
     void OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData) override {}
 };
@@ -82,7 +82,7 @@ public:
             ChipLogError(chipTool, "Failed to update the device address: %s", chip::ErrorStr(error));
         }
 
-        SetCommandExitStatus(CHIP_NO_ERROR == error);
+        SetCommandExitStatus(error);
     }
 };
 

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -47,6 +47,5 @@ exit:
         return err;
     }
 
-    VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
-    return CHIP_NO_ERROR;
+    return GetCommandExitStatus();
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -20,7 +20,7 @@
 
 constexpr uint16_t kWaitDurationInSeconds = 30;
 
-CHIP_ERROR DiscoverCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR DiscoverCommand::Run()
 {
     CHIP_ERROR err;
 

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -18,34 +18,8 @@
 
 #include "DiscoverCommand.h"
 
-constexpr uint16_t kWaitDurationInSeconds = 30;
-
 CHIP_ERROR DiscoverCommand::Run()
 {
-    CHIP_ERROR err;
-
-    //
-    // Set this to true first BEFORE we send commands to ensure we don't
-    // end up in a situation where the response comes back faster than we can
-    // set the variable to true, which will cause it to block indefinitely.
-    //
-    UpdateWaitForResponse(true);
-
-    {
-        chip::DeviceLayer::StackLock lock;
-
-        GetExecContext()->commissioner->RegisterDeviceAddressUpdateDelegate(this);
-        err = RunCommand(mNodeId, mFabricId);
-        SuccessOrExit(err);
-    }
-
-    WaitForResponse(kWaitDurationInSeconds);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        return err;
-    }
-
-    return GetCommandExitStatus();
+    GetExecContext()->commissioner->RegisterDeviceAddressUpdateDelegate(this);
+    return RunCommand(mNodeId, mFabricId);
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -35,7 +35,7 @@ public:
     void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override{};
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
     virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;
 

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -36,6 +36,7 @@ public:
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 30; }
 
     virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;
 

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -23,7 +23,7 @@ using namespace ::chip;
 
 constexpr uint16_t kWaitDurationInSeconds = 3;
 
-CHIP_ERROR DiscoverCommissionersCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR DiscoverCommissionersCommand::Run()
 {
     //
     // Set this to true first BEFORE we send commands to ensure we don't

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -21,25 +21,13 @@
 
 using namespace ::chip;
 
-constexpr uint16_t kWaitDurationInSeconds = 3;
-
 CHIP_ERROR DiscoverCommissionersCommand::Run()
 {
-    //
-    // Set this to true first BEFORE we send commands to ensure we don't
-    // end up in a situation where the response comes back faster than we can
-    // set the variable to true, which will cause it to block indefinitely.
-    //
-    UpdateWaitForResponse(true);
+    return mCommissionableNodeController.DiscoverCommissioners();
+}
 
-    {
-        chip::DeviceLayer::StackLock lock;
-
-        ReturnErrorOnFailure(mCommissionableNodeController.DiscoverCommissioners());
-    }
-
-    WaitForResponse(kWaitDurationInSeconds);
-
+void DiscoverCommissionersCommand::Shutdown()
+{
     int commissionerCount = 0;
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
     {
@@ -86,6 +74,5 @@ CHIP_ERROR DiscoverCommissionersCommand::Run()
         }
     }
 
-    printf("Total of %d commissioner(s) discovered in %d sec\n", commissionerCount, kWaitDurationInSeconds);
-    return CHIP_NO_ERROR;
+    printf("Total of %d commissioner(s) discovered in %" PRIu16 " sec\n", commissionerCount, GetWaitDurationInSeconds());
 }

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
@@ -26,6 +26,8 @@ class DiscoverCommissionersCommand : public Command
 public:
     DiscoverCommissionersCommand() : Command("discover-commissioners") {}
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 3; }
+    void Shutdown() override;
 
 private:
     chip::Controller::CommissionableNodeController mCommissionableNodeController;

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.h
@@ -25,7 +25,7 @@ class DiscoverCommissionersCommand : public Command
 {
 public:
     DiscoverCommissionersCommand() : Command("discover-commissioners") {}
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
 private:
     chip::Controller::CommissionableNodeController mCommissionableNodeController;

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -27,7 +27,7 @@ constexpr uint64_t kBreadcrumb                = 0;
 constexpr uint32_t kTimeoutMs                 = 6000;
 constexpr uint8_t kTemporaryThreadNetworkId[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
 
-CHIP_ERROR PairingCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR PairingCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -38,7 +38,7 @@ CHIP_ERROR PairingCommand::Run(NodeId localId, NodeId remoteId)
         GetExecContext()->commissioner->RegisterPairingDelegate(this);
     }
 
-    err = RunInternal(remoteId);
+    err = RunInternal(GetExecContext()->remoteId);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init Failure! PairDevice: %s", ErrorStr(err)));
 
 exit:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -98,6 +98,8 @@ public:
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 120; }
+    void Shutdown() override;
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
@@ -120,7 +122,6 @@ private:
     CHIP_ERROR Unpair(NodeId remoteId);
 
     void InitCallbacks();
-    void ReleaseCallbacks();
     CHIP_ERROR SetupNetwork();
     CHIP_ERROR AddNetwork(PairingNetworkType networkType);
     CHIP_ERROR AddThreadNetwork();
@@ -140,10 +141,10 @@ private:
     chip::ByteSpan mSSID;
     chip::ByteSpan mPassword;
 
-    chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> * mOnAddThreadNetworkCallback;
-    chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback;
-    chip::Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> * mOnEnableNetworkCallback;
-    chip::Callback::Callback<DefaultFailureCallback> * mOnFailureCallback;
+    chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> * mOnAddThreadNetworkCallback = nullptr;
+    chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback     = nullptr;
+    chip::Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> * mOnEnableNetworkCallback       = nullptr;
+    chip::Callback::Callback<DefaultFailureCallback> * mOnFailureCallback                                               = nullptr;
     ChipDevice * mDevice;
     chip::Controller::NetworkCommissioningCluster mCluster;
     chip::EndpointId mEndpointId = 0;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -97,7 +97,7 @@ public:
     }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
@@ -24,7 +24,7 @@
 using namespace ::chip;
 using namespace ::chip::SetupPayloadData;
 
-CHIP_ERROR AdditionalDataParseCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR AdditionalDataParseCommand::Run()
 {
     std::vector<uint8_t> payloadData;
     AdditionalDataPayload resultPayload;

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
@@ -47,5 +47,9 @@ CHIP_ERROR AdditionalDataParseCommand::Run()
     ChipLogProgress(chipTool, "AdditionalDataParseCommand, RotatingDeviceId=%s", resultPayload.rotatingDeviceId.c_str());
 
 exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommandExitStatus(CHIP_NO_ERROR);
+    }
     return err;
 }

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
@@ -24,7 +24,7 @@ class AdditionalDataParseCommand : public Command
 {
 public:
     AdditionalDataParseCommand() : Command("parse-additional-data-payload") { AddArgument("payload", &mPayload); }
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
 private:
     char * mPayload;

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.h
@@ -25,6 +25,7 @@ class AdditionalDataParseCommand : public Command
 public:
     AdditionalDataParseCommand() : Command("parse-additional-data-payload") { AddArgument("payload", &mPayload); }
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 5; }
 
 private:
     char * mPayload;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -23,7 +23,7 @@
 
 using namespace ::chip;
 
-CHIP_ERROR SetupPayloadParseCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR SetupPayloadParseCommand::Run()
 {
     std::string codeString(mCode);
     SetupPayload payload;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -35,6 +35,10 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
     err = Print(payload);
     SuccessOrExit(err);
 exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        SetCommandExitStatus(CHIP_NO_ERROR);
+    }
     return err;
 }
 

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
@@ -25,7 +25,7 @@ class SetupPayloadParseCommand : public Command
 {
 public:
     SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode); }
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
 private:
     char * mCode;

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
@@ -26,6 +26,7 @@ class SetupPayloadParseCommand : public Command
 public:
     SetupPayloadParseCommand() : Command("parse-setup-payload") { AddArgument("payload", &mCode); }
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 5; }
 
 private:
     char * mCode;

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -24,37 +24,20 @@
 
 using namespace ::chip;
 
-namespace {
-constexpr uint16_t kWaitDurationInSeconds = UINT16_MAX;
-} // namespace
-
 CHIP_ERROR ReportingCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Controller::BasicCluster cluster;
 
-    //
-    // Set this to true first BEFORE we send commands to ensure we don't
-    // end up in a situation where the response comes back faster than we can
-    // set the variable to true, which will cause it to block indefinitely.
-    //
-    UpdateWaitForResponse(true);
+    auto * ctx = GetExecContext();
+    err        = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, ctx->localId));
 
-    {
-        chip::DeviceLayer::StackLock lock;
+    AddReportCallbacks(mEndPointId);
+    cluster.Associate(mDevice, mEndPointId);
 
-        auto * ctx = GetExecContext();
-        err        = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
-        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, ctx->localId));
-
-        AddReportCallbacks(mEndPointId);
-        cluster.Associate(mDevice, mEndPointId);
-
-        err = cluster.MfgSpecificPing(nullptr, nullptr);
-        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
-    }
-
-    WaitForResponse(kWaitDurationInSeconds);
+    err = cluster.MfgSpecificPing(nullptr, nullptr);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
 
 exit:
     return err;

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -28,7 +28,7 @@ namespace {
 constexpr uint16_t kWaitDurationInSeconds = UINT16_MAX;
 } // namespace
 
-CHIP_ERROR ReportingCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR ReportingCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Controller::BasicCluster cluster;
@@ -43,8 +43,9 @@ CHIP_ERROR ReportingCommand::Run(NodeId localId, NodeId remoteId)
     {
         chip::DeviceLayer::StackLock lock;
 
-        err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
-        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, localId));
+        auto * ctx = GetExecContext();
+        err        = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, ctx->localId));
 
         AddReportCallbacks(mEndPointId);
         cluster.Associate(mDevice, mEndPointId);

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -36,7 +36,7 @@ public:
     }
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
     virtual void AddReportCallbacks(uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -37,6 +37,7 @@ public:
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return UINT16_MAX; }
 
     virtual void AddReportCallbacks(uint8_t endPointId) = 0;
 

--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -34,7 +34,7 @@ public:
         if (mTestCount == mTestIndex)
         {
             ChipLogProgress(chipTool, "TestCluster: Test complete");
-            SetCommandExitStatus(true);
+            SetCommandExitStatus(CHIP_NO_ERROR);
         }
 
         // Ensure we increment mTestIndex before we start running the relevant
@@ -351,7 +351,7 @@ public:
         if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "TestCluster: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(false);
+            SetCommandExitStatus(err);
         }
 
         return err;
@@ -408,7 +408,7 @@ private:
         if (runner->mIsFailureExpected_0 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -427,7 +427,7 @@ private:
         if (runner->mIsFailureExpected_0 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -477,7 +477,7 @@ private:
         if (runner->mIsFailureExpected_1 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -496,7 +496,7 @@ private:
         if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -546,7 +546,7 @@ private:
         if (runner->mIsFailureExpected_2 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -565,14 +565,14 @@ private:
         if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (returnValue != 7)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "7");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -622,7 +622,7 @@ private:
         if (runner->mIsFailureExpected_3 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -641,14 +641,14 @@ private:
         if (runner->mIsFailureExpected_3 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (boolean != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -699,7 +699,7 @@ private:
         if (runner->mIsFailureExpected_4 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -718,7 +718,7 @@ private:
         if (runner->mIsFailureExpected_4 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -768,7 +768,7 @@ private:
         if (runner->mIsFailureExpected_5 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -787,14 +787,14 @@ private:
         if (runner->mIsFailureExpected_5 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (boolean != 1)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -845,7 +845,7 @@ private:
         if (runner->mIsFailureExpected_6 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -864,7 +864,7 @@ private:
         if (runner->mIsFailureExpected_6 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -914,7 +914,7 @@ private:
         if (runner->mIsFailureExpected_7 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -933,14 +933,14 @@ private:
         if (runner->mIsFailureExpected_7 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (boolean != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -990,7 +990,7 @@ private:
         if (runner->mIsFailureExpected_8 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1009,14 +1009,14 @@ private:
         if (runner->mIsFailureExpected_8 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap8 != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1067,7 +1067,7 @@ private:
         if (runner->mIsFailureExpected_9 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1086,7 +1086,7 @@ private:
         if (runner->mIsFailureExpected_9 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1136,7 +1136,7 @@ private:
         if (runner->mIsFailureExpected_10 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1155,14 +1155,14 @@ private:
         if (runner->mIsFailureExpected_10 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap8 != 255)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "255");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1213,7 +1213,7 @@ private:
         if (runner->mIsFailureExpected_11 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1232,7 +1232,7 @@ private:
         if (runner->mIsFailureExpected_11 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1282,7 +1282,7 @@ private:
         if (runner->mIsFailureExpected_12 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1301,14 +1301,14 @@ private:
         if (runner->mIsFailureExpected_12 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap8 != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1358,7 +1358,7 @@ private:
         if (runner->mIsFailureExpected_13 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1377,14 +1377,14 @@ private:
         if (runner->mIsFailureExpected_13 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap16 != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1435,7 +1435,7 @@ private:
         if (runner->mIsFailureExpected_14 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1454,7 +1454,7 @@ private:
         if (runner->mIsFailureExpected_14 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1504,7 +1504,7 @@ private:
         if (runner->mIsFailureExpected_15 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1523,14 +1523,14 @@ private:
         if (runner->mIsFailureExpected_15 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap16 != 65535U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "65535");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1581,7 +1581,7 @@ private:
         if (runner->mIsFailureExpected_16 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1600,7 +1600,7 @@ private:
         if (runner->mIsFailureExpected_16 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1650,7 +1650,7 @@ private:
         if (runner->mIsFailureExpected_17 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1669,14 +1669,14 @@ private:
         if (runner->mIsFailureExpected_17 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap16 != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1726,7 +1726,7 @@ private:
         if (runner->mIsFailureExpected_18 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1745,14 +1745,14 @@ private:
         if (runner->mIsFailureExpected_18 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap32 != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1803,7 +1803,7 @@ private:
         if (runner->mIsFailureExpected_19 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1822,7 +1822,7 @@ private:
         if (runner->mIsFailureExpected_19 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1872,7 +1872,7 @@ private:
         if (runner->mIsFailureExpected_20 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1891,14 +1891,14 @@ private:
         if (runner->mIsFailureExpected_20 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap32 != 4294967295UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "4294967295");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1949,7 +1949,7 @@ private:
         if (runner->mIsFailureExpected_21 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -1968,7 +1968,7 @@ private:
         if (runner->mIsFailureExpected_21 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2018,7 +2018,7 @@ private:
         if (runner->mIsFailureExpected_22 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2037,14 +2037,14 @@ private:
         if (runner->mIsFailureExpected_22 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap32 != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2094,7 +2094,7 @@ private:
         if (runner->mIsFailureExpected_23 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2113,14 +2113,14 @@ private:
         if (runner->mIsFailureExpected_23 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap64 != 0ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2171,7 +2171,7 @@ private:
         if (runner->mIsFailureExpected_24 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2190,7 +2190,7 @@ private:
         if (runner->mIsFailureExpected_24 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2240,7 +2240,7 @@ private:
         if (runner->mIsFailureExpected_25 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2259,14 +2259,14 @@ private:
         if (runner->mIsFailureExpected_25 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap64 != 18446744073709551615ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "18446744073709551615");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2317,7 +2317,7 @@ private:
         if (runner->mIsFailureExpected_26 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2336,7 +2336,7 @@ private:
         if (runner->mIsFailureExpected_26 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2386,7 +2386,7 @@ private:
         if (runner->mIsFailureExpected_27 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2405,14 +2405,14 @@ private:
         if (runner->mIsFailureExpected_27 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (bitmap64 != 0ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2462,7 +2462,7 @@ private:
         if (runner->mIsFailureExpected_28 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2481,14 +2481,14 @@ private:
         if (runner->mIsFailureExpected_28 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8u != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2539,7 +2539,7 @@ private:
         if (runner->mIsFailureExpected_29 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2558,7 +2558,7 @@ private:
         if (runner->mIsFailureExpected_29 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2608,7 +2608,7 @@ private:
         if (runner->mIsFailureExpected_30 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2627,14 +2627,14 @@ private:
         if (runner->mIsFailureExpected_30 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8u != 255)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "255");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2685,7 +2685,7 @@ private:
         if (runner->mIsFailureExpected_31 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2704,7 +2704,7 @@ private:
         if (runner->mIsFailureExpected_31 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2754,7 +2754,7 @@ private:
         if (runner->mIsFailureExpected_32 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2773,14 +2773,14 @@ private:
         if (runner->mIsFailureExpected_32 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8u != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2830,7 +2830,7 @@ private:
         if (runner->mIsFailureExpected_33 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2849,14 +2849,14 @@ private:
         if (runner->mIsFailureExpected_33 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16u != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2907,7 +2907,7 @@ private:
         if (runner->mIsFailureExpected_34 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2926,7 +2926,7 @@ private:
         if (runner->mIsFailureExpected_34 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2976,7 +2976,7 @@ private:
         if (runner->mIsFailureExpected_35 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -2995,14 +2995,14 @@ private:
         if (runner->mIsFailureExpected_35 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16u != 65535U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "65535");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3053,7 +3053,7 @@ private:
         if (runner->mIsFailureExpected_36 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3072,7 +3072,7 @@ private:
         if (runner->mIsFailureExpected_36 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3122,7 +3122,7 @@ private:
         if (runner->mIsFailureExpected_37 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3141,14 +3141,14 @@ private:
         if (runner->mIsFailureExpected_37 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16u != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3198,7 +3198,7 @@ private:
         if (runner->mIsFailureExpected_38 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3217,14 +3217,14 @@ private:
         if (runner->mIsFailureExpected_38 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32u != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3275,7 +3275,7 @@ private:
         if (runner->mIsFailureExpected_39 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3294,7 +3294,7 @@ private:
         if (runner->mIsFailureExpected_39 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3344,7 +3344,7 @@ private:
         if (runner->mIsFailureExpected_40 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3363,14 +3363,14 @@ private:
         if (runner->mIsFailureExpected_40 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32u != 4294967295UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "4294967295");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3421,7 +3421,7 @@ private:
         if (runner->mIsFailureExpected_41 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3440,7 +3440,7 @@ private:
         if (runner->mIsFailureExpected_41 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3490,7 +3490,7 @@ private:
         if (runner->mIsFailureExpected_42 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3509,14 +3509,14 @@ private:
         if (runner->mIsFailureExpected_42 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32u != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3566,7 +3566,7 @@ private:
         if (runner->mIsFailureExpected_43 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3585,14 +3585,14 @@ private:
         if (runner->mIsFailureExpected_43 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64u != 0ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3643,7 +3643,7 @@ private:
         if (runner->mIsFailureExpected_44 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3662,7 +3662,7 @@ private:
         if (runner->mIsFailureExpected_44 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3712,7 +3712,7 @@ private:
         if (runner->mIsFailureExpected_45 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3731,14 +3731,14 @@ private:
         if (runner->mIsFailureExpected_45 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64u != 18446744073709551615ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "18446744073709551615");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3789,7 +3789,7 @@ private:
         if (runner->mIsFailureExpected_46 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3808,7 +3808,7 @@ private:
         if (runner->mIsFailureExpected_46 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3858,7 +3858,7 @@ private:
         if (runner->mIsFailureExpected_47 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3877,14 +3877,14 @@ private:
         if (runner->mIsFailureExpected_47 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64u != 0ULL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3934,7 +3934,7 @@ private:
         if (runner->mIsFailureExpected_48 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -3953,14 +3953,14 @@ private:
         if (runner->mIsFailureExpected_48 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8s != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4011,7 +4011,7 @@ private:
         if (runner->mIsFailureExpected_49 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4030,7 +4030,7 @@ private:
         if (runner->mIsFailureExpected_49 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4080,7 +4080,7 @@ private:
         if (runner->mIsFailureExpected_50 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4099,14 +4099,14 @@ private:
         if (runner->mIsFailureExpected_50 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8s != 127)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "127");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4157,7 +4157,7 @@ private:
         if (runner->mIsFailureExpected_51 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4176,7 +4176,7 @@ private:
         if (runner->mIsFailureExpected_51 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4226,7 +4226,7 @@ private:
         if (runner->mIsFailureExpected_52 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4245,14 +4245,14 @@ private:
         if (runner->mIsFailureExpected_52 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8s != -128)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "-128");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4303,7 +4303,7 @@ private:
         if (runner->mIsFailureExpected_53 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4322,7 +4322,7 @@ private:
         if (runner->mIsFailureExpected_53 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4372,7 +4372,7 @@ private:
         if (runner->mIsFailureExpected_54 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4391,14 +4391,14 @@ private:
         if (runner->mIsFailureExpected_54 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int8s != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4448,7 +4448,7 @@ private:
         if (runner->mIsFailureExpected_55 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4467,14 +4467,14 @@ private:
         if (runner->mIsFailureExpected_55 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16s != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4525,7 +4525,7 @@ private:
         if (runner->mIsFailureExpected_56 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4544,7 +4544,7 @@ private:
         if (runner->mIsFailureExpected_56 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4594,7 +4594,7 @@ private:
         if (runner->mIsFailureExpected_57 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4613,14 +4613,14 @@ private:
         if (runner->mIsFailureExpected_57 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16s != 32767)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "32767");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4671,7 +4671,7 @@ private:
         if (runner->mIsFailureExpected_58 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4690,7 +4690,7 @@ private:
         if (runner->mIsFailureExpected_58 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4740,7 +4740,7 @@ private:
         if (runner->mIsFailureExpected_59 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4759,14 +4759,14 @@ private:
         if (runner->mIsFailureExpected_59 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16s != -32768)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "-32768");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4817,7 +4817,7 @@ private:
         if (runner->mIsFailureExpected_60 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4836,7 +4836,7 @@ private:
         if (runner->mIsFailureExpected_60 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4886,7 +4886,7 @@ private:
         if (runner->mIsFailureExpected_61 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4905,14 +4905,14 @@ private:
         if (runner->mIsFailureExpected_61 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int16s != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4962,7 +4962,7 @@ private:
         if (runner->mIsFailureExpected_62 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -4981,14 +4981,14 @@ private:
         if (runner->mIsFailureExpected_62 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32s != 0L)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5039,7 +5039,7 @@ private:
         if (runner->mIsFailureExpected_63 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5058,7 +5058,7 @@ private:
         if (runner->mIsFailureExpected_63 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5108,7 +5108,7 @@ private:
         if (runner->mIsFailureExpected_64 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5127,14 +5127,14 @@ private:
         if (runner->mIsFailureExpected_64 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32s != 2147483647L)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2147483647");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5185,7 +5185,7 @@ private:
         if (runner->mIsFailureExpected_65 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5204,7 +5204,7 @@ private:
         if (runner->mIsFailureExpected_65 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5254,7 +5254,7 @@ private:
         if (runner->mIsFailureExpected_66 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5273,14 +5273,14 @@ private:
         if (runner->mIsFailureExpected_66 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32s != -2147483648L)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "-2147483648");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5331,7 +5331,7 @@ private:
         if (runner->mIsFailureExpected_67 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5350,7 +5350,7 @@ private:
         if (runner->mIsFailureExpected_67 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5400,7 +5400,7 @@ private:
         if (runner->mIsFailureExpected_68 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5419,14 +5419,14 @@ private:
         if (runner->mIsFailureExpected_68 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int32s != 0L)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5476,7 +5476,7 @@ private:
         if (runner->mIsFailureExpected_69 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5495,14 +5495,14 @@ private:
         if (runner->mIsFailureExpected_69 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64s != 0LL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5553,7 +5553,7 @@ private:
         if (runner->mIsFailureExpected_70 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5572,7 +5572,7 @@ private:
         if (runner->mIsFailureExpected_70 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5622,7 +5622,7 @@ private:
         if (runner->mIsFailureExpected_71 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5641,14 +5641,14 @@ private:
         if (runner->mIsFailureExpected_71 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64s != 9223372036854775807LL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "9223372036854775807");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5699,7 +5699,7 @@ private:
         if (runner->mIsFailureExpected_72 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5718,7 +5718,7 @@ private:
         if (runner->mIsFailureExpected_72 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5768,7 +5768,7 @@ private:
         if (runner->mIsFailureExpected_73 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5787,14 +5787,14 @@ private:
         if (runner->mIsFailureExpected_73 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64s != -9223372036854775807LL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "-9223372036854775807");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5845,7 +5845,7 @@ private:
         if (runner->mIsFailureExpected_74 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5864,7 +5864,7 @@ private:
         if (runner->mIsFailureExpected_74 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5914,7 +5914,7 @@ private:
         if (runner->mIsFailureExpected_75 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5933,14 +5933,14 @@ private:
         if (runner->mIsFailureExpected_75 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (int64s != 0LL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -5990,7 +5990,7 @@ private:
         if (runner->mIsFailureExpected_76 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6009,14 +6009,14 @@ private:
         if (runner->mIsFailureExpected_76 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum8 != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6067,7 +6067,7 @@ private:
         if (runner->mIsFailureExpected_77 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6086,7 +6086,7 @@ private:
         if (runner->mIsFailureExpected_77 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6136,7 +6136,7 @@ private:
         if (runner->mIsFailureExpected_78 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6155,14 +6155,14 @@ private:
         if (runner->mIsFailureExpected_78 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum8 != 255)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "255");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6213,7 +6213,7 @@ private:
         if (runner->mIsFailureExpected_79 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6232,7 +6232,7 @@ private:
         if (runner->mIsFailureExpected_79 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6282,7 +6282,7 @@ private:
         if (runner->mIsFailureExpected_80 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6301,14 +6301,14 @@ private:
         if (runner->mIsFailureExpected_80 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum8 != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6358,7 +6358,7 @@ private:
         if (runner->mIsFailureExpected_81 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6377,14 +6377,14 @@ private:
         if (runner->mIsFailureExpected_81 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum16 != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6435,7 +6435,7 @@ private:
         if (runner->mIsFailureExpected_82 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6454,7 +6454,7 @@ private:
         if (runner->mIsFailureExpected_82 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6504,7 +6504,7 @@ private:
         if (runner->mIsFailureExpected_83 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6523,14 +6523,14 @@ private:
         if (runner->mIsFailureExpected_83 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum16 != 65535U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "65535");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6581,7 +6581,7 @@ private:
         if (runner->mIsFailureExpected_84 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6600,7 +6600,7 @@ private:
         if (runner->mIsFailureExpected_84 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6650,7 +6650,7 @@ private:
         if (runner->mIsFailureExpected_85 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6669,14 +6669,14 @@ private:
         if (runner->mIsFailureExpected_85 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (enum16 != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6726,7 +6726,7 @@ private:
         if (runner->mIsFailureExpected_86 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6745,7 +6745,7 @@ private:
         if (runner->mIsFailureExpected_86 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6753,7 +6753,7 @@ private:
         if (!octetString.data_equal(octetStringArgument))
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6805,7 +6805,7 @@ private:
         if (runner->mIsFailureExpected_87 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6824,7 +6824,7 @@ private:
         if (runner->mIsFailureExpected_87 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6874,7 +6874,7 @@ private:
         if (runner->mIsFailureExpected_88 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6893,7 +6893,7 @@ private:
         if (runner->mIsFailureExpected_88 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6901,7 +6901,7 @@ private:
         if (!octetString.data_equal(octetStringArgument))
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "TestValue");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6954,7 +6954,7 @@ private:
         if (runner->mIsFailureExpected_89 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -6973,7 +6973,7 @@ private:
         if (runner->mIsFailureExpected_89 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7023,7 +7023,7 @@ private:
         if (runner->mIsFailureExpected_90 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7042,7 +7042,7 @@ private:
         if (runner->mIsFailureExpected_90 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7050,7 +7050,7 @@ private:
         if (!octetString.data_equal(octetStringArgument))
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "TestValue");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7102,7 +7102,7 @@ private:
         if (runner->mIsFailureExpected_91 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7121,7 +7121,7 @@ private:
         if (runner->mIsFailureExpected_91 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7171,7 +7171,7 @@ private:
         if (runner->mIsFailureExpected_92 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7190,7 +7190,7 @@ private:
         if (runner->mIsFailureExpected_92 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7198,7 +7198,7 @@ private:
         if (!longOctetString.data_equal(longOctetStringArgument))
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7257,7 +7257,7 @@ private:
         if (runner->mIsFailureExpected_93 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7276,7 +7276,7 @@ private:
         if (runner->mIsFailureExpected_93 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7326,7 +7326,7 @@ private:
         if (runner->mIsFailureExpected_94 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7345,7 +7345,7 @@ private:
         if (runner->mIsFailureExpected_94 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7363,7 +7363,7 @@ private:
                          "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                          "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
                          "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7415,7 +7415,7 @@ private:
         if (runner->mIsFailureExpected_95 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7434,7 +7434,7 @@ private:
         if (runner->mIsFailureExpected_95 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7484,7 +7484,7 @@ private:
         if (runner->mIsFailureExpected_96 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7504,14 +7504,14 @@ private:
         if (runner->mIsFailureExpected_96 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (count != 4)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1,2,3,4");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7561,7 +7561,7 @@ private:
         if (runner->mIsFailureExpected_97 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7581,14 +7581,14 @@ private:
         if (runner->mIsFailureExpected_97 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (count != 4)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "Test0,Test1,Test2,Test3");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7638,7 +7638,7 @@ private:
         if (runner->mIsFailureExpected_98 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7658,7 +7658,7 @@ private:
         if (runner->mIsFailureExpected_98 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7666,7 +7666,7 @@ private:
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'",
                          "[object Object],[object Object],[object Object],[object Object]");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7716,7 +7716,7 @@ private:
         if (runner->mIsFailureExpected_99 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7735,14 +7735,14 @@ private:
         if (runner->mIsFailureExpected_99 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (unsupported != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7794,7 +7794,7 @@ private:
         if (runner->mIsFailureExpected_100 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7813,7 +7813,7 @@ private:
         if (runner->mIsFailureExpected_100 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7834,7 +7834,7 @@ public:
         if (mTestCount == mTestIndex)
         {
             ChipLogProgress(chipTool, "Test_3_1_1: Test complete");
-            SetCommandExitStatus(true);
+            SetCommandExitStatus(CHIP_NO_ERROR);
         }
 
         // Ensure we increment mTestIndex before we start running the relevant
@@ -7860,7 +7860,7 @@ public:
         if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "Test_3_1_1: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(false);
+            SetCommandExitStatus(err);
         }
 
         return err;
@@ -7917,7 +7917,7 @@ private:
         if (runner->mIsFailureExpected_0 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7936,14 +7936,14 @@ private:
         if (runner->mIsFailureExpected_0 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (clusterRevision != 2U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -7993,7 +7993,7 @@ private:
         if (runner->mIsFailureExpected_1 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8012,14 +8012,14 @@ private:
         if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (clusterRevision != 2U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8069,7 +8069,7 @@ private:
         if (runner->mIsFailureExpected_2 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8088,14 +8088,14 @@ private:
         if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (featureMap != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8145,7 +8145,7 @@ private:
         if (runner->mIsFailureExpected_3 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8164,14 +8164,14 @@ private:
         if (runner->mIsFailureExpected_3 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (featureMap != 0UL)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8192,7 +8192,7 @@ public:
         if (mTestCount == mTestIndex)
         {
             ChipLogProgress(chipTool, "Test_3_2_1: Test complete");
-            SetCommandExitStatus(true);
+            SetCommandExitStatus(CHIP_NO_ERROR);
         }
 
         // Ensure we increment mTestIndex before we start running the relevant
@@ -8242,7 +8242,7 @@ public:
         if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "Test_3_2_1: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(false);
+            SetCommandExitStatus(err);
         }
 
         return err;
@@ -8299,7 +8299,7 @@ private:
         if (runner->mIsFailureExpected_0 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8318,14 +8318,14 @@ private:
         if (runner->mIsFailureExpected_0 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8375,7 +8375,7 @@ private:
         if (runner->mIsFailureExpected_1 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8394,14 +8394,14 @@ private:
         if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8451,7 +8451,7 @@ private:
         if (runner->mIsFailureExpected_2 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8470,14 +8470,14 @@ private:
         if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (globalSceneControl != 1)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8527,7 +8527,7 @@ private:
         if (runner->mIsFailureExpected_3 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8546,14 +8546,14 @@ private:
         if (runner->mIsFailureExpected_3 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onTime != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8603,7 +8603,7 @@ private:
         if (runner->mIsFailureExpected_4 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8622,14 +8622,14 @@ private:
         if (runner->mIsFailureExpected_4 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (offWaitTime != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8679,7 +8679,7 @@ private:
         if (runner->mIsFailureExpected_5 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8698,14 +8698,14 @@ private:
         if (runner->mIsFailureExpected_5 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (startUpOnOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8756,7 +8756,7 @@ private:
         if (runner->mIsFailureExpected_6 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8775,7 +8775,7 @@ private:
         if (runner->mIsFailureExpected_6 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8827,7 +8827,7 @@ private:
         if (runner->mIsFailureExpected_7 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8846,7 +8846,7 @@ private:
         if (runner->mIsFailureExpected_7 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8898,7 +8898,7 @@ private:
         if (runner->mIsFailureExpected_8 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8917,7 +8917,7 @@ private:
         if (runner->mIsFailureExpected_8 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8967,7 +8967,7 @@ private:
         if (runner->mIsFailureExpected_9 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -8986,14 +8986,14 @@ private:
         if (runner->mIsFailureExpected_9 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onTime != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9043,7 +9043,7 @@ private:
         if (runner->mIsFailureExpected_10 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9062,14 +9062,14 @@ private:
         if (runner->mIsFailureExpected_10 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (offWaitTime != 0U)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9119,7 +9119,7 @@ private:
         if (runner->mIsFailureExpected_11 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9138,14 +9138,14 @@ private:
         if (runner->mIsFailureExpected_11 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (startUpOnOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9166,7 +9166,7 @@ public:
         if (mTestCount == mTestIndex)
         {
             ChipLogProgress(chipTool, "Test_3_2_2: Test complete");
-            SetCommandExitStatus(true);
+            SetCommandExitStatus(CHIP_NO_ERROR);
         }
 
         // Ensure we increment mTestIndex before we start running the relevant
@@ -9222,7 +9222,7 @@ public:
         if (CHIP_NO_ERROR != err)
         {
             ChipLogProgress(chipTool, "Test_3_2_2: %s", chip::ErrorStr(err));
-            SetCommandExitStatus(false);
+            SetCommandExitStatus(err);
         }
 
         return err;
@@ -9279,7 +9279,7 @@ private:
         if (runner->mIsFailureExpected_0 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9298,7 +9298,7 @@ private:
         if (runner->mIsFailureExpected_0 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9348,7 +9348,7 @@ private:
         if (runner->mIsFailureExpected_1 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9367,14 +9367,14 @@ private:
         if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9424,7 +9424,7 @@ private:
         if (runner->mIsFailureExpected_2 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9443,7 +9443,7 @@ private:
         if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9493,7 +9493,7 @@ private:
         if (runner->mIsFailureExpected_3 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9512,14 +9512,14 @@ private:
         if (runner->mIsFailureExpected_3 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 1)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9569,7 +9569,7 @@ private:
         if (runner->mIsFailureExpected_4 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9588,7 +9588,7 @@ private:
         if (runner->mIsFailureExpected_4 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9638,7 +9638,7 @@ private:
         if (runner->mIsFailureExpected_5 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9657,14 +9657,14 @@ private:
         if (runner->mIsFailureExpected_5 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9714,7 +9714,7 @@ private:
         if (runner->mIsFailureExpected_6 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9733,7 +9733,7 @@ private:
         if (runner->mIsFailureExpected_6 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9783,7 +9783,7 @@ private:
         if (runner->mIsFailureExpected_7 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9802,14 +9802,14 @@ private:
         if (runner->mIsFailureExpected_7 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 1)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9859,7 +9859,7 @@ private:
         if (runner->mIsFailureExpected_8 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9878,7 +9878,7 @@ private:
         if (runner->mIsFailureExpected_8 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9928,7 +9928,7 @@ private:
         if (runner->mIsFailureExpected_9 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -9947,14 +9947,14 @@ private:
         if (runner->mIsFailureExpected_9 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10004,7 +10004,7 @@ private:
         if (runner->mIsFailureExpected_10 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10023,7 +10023,7 @@ private:
         if (runner->mIsFailureExpected_10 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10073,7 +10073,7 @@ private:
         if (runner->mIsFailureExpected_11 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10092,14 +10092,14 @@ private:
         if (runner->mIsFailureExpected_11 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 1)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "1");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10149,7 +10149,7 @@ private:
         if (runner->mIsFailureExpected_12 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10168,7 +10168,7 @@ private:
         if (runner->mIsFailureExpected_12 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10218,7 +10218,7 @@ private:
         if (runner->mIsFailureExpected_13 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -10237,14 +10237,14 @@ private:
         if (runner->mIsFailureExpected_13 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
         if (onOff != 0)
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "0");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 

--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -27,7 +27,7 @@ public:
     TestCluster() : TestCommand("TestCluster"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
-    CHIP_ERROR NextTest() override
+    void NextTest() override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -353,8 +353,6 @@ public:
             ChipLogProgress(chipTool, "TestCluster: %s", chip::ErrorStr(err));
             SetCommandExitStatus(err);
         }
-
-        return err;
     }
 
 private:
@@ -7827,7 +7825,7 @@ public:
     Test_3_1_1() : TestCommand("Test_3_1_1"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
-    CHIP_ERROR NextTest() override
+    void NextTest() override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -7862,8 +7860,6 @@ public:
             ChipLogProgress(chipTool, "Test_3_1_1: %s", chip::ErrorStr(err));
             SetCommandExitStatus(err);
         }
-
-        return err;
     }
 
 private:
@@ -8185,7 +8181,7 @@ public:
     Test_3_2_1() : TestCommand("Test_3_2_1"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
-    CHIP_ERROR NextTest() override
+    void NextTest() override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -8244,8 +8240,6 @@ public:
             ChipLogProgress(chipTool, "Test_3_2_1: %s", chip::ErrorStr(err));
             SetCommandExitStatus(err);
         }
-
-        return err;
     }
 
 private:
@@ -9159,7 +9153,7 @@ public:
     Test_3_2_2() : TestCommand("Test_3_2_2"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
-    CHIP_ERROR NextTest() override
+    void NextTest() override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -9224,8 +9218,6 @@ public:
             ChipLogProgress(chipTool, "Test_3_2_2: %s", chip::ErrorStr(err));
             SetCommandExitStatus(err);
         }
-
-        return err;
     }
 
 private:

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -20,7 +20,7 @@
 
 constexpr uint16_t kWaitDurationInSeconds = 30;
 
-CHIP_ERROR TestCommand::Run(NodeId localId, NodeId remoteId)
+CHIP_ERROR TestCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -34,7 +34,9 @@ CHIP_ERROR TestCommand::Run(NodeId localId, NodeId remoteId)
     {
         chip::DeviceLayer::StackLock lock;
 
-        err = GetExecContext()->commissioner->GetDevice(remoteId, &mDevice);
+        auto * ctx = GetExecContext();
+
+        err = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
         ReturnErrorOnFailure(err);
 
         err = NextTest();

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -18,32 +18,15 @@
 
 #include "TestCommand.h"
 
-constexpr uint16_t kWaitDurationInSeconds = 30;
-
 CHIP_ERROR TestCommand::Run()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    //
-    // Set this to true first BEFORE we send commands to ensure we don't
-    // end up in a situation where the response comes back faster than we can
-    // set the variable to true, which will cause it to block indefinitely.
-    //
-    UpdateWaitForResponse(true);
+    auto * ctx = GetExecContext();
 
-    {
-        chip::DeviceLayer::StackLock lock;
+    err = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
+    ReturnErrorOnFailure(err);
 
-        auto * ctx = GetExecContext();
-
-        err = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
-        ReturnErrorOnFailure(err);
-
-        err = NextTest();
-        ReturnErrorOnFailure(err);
-    }
-
-    WaitForResponse(kWaitDurationInSeconds);
-
-    return GetCommandExitStatus();
+    NextTest();
+    return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -45,6 +45,5 @@ CHIP_ERROR TestCommand::Run()
 
     WaitForResponse(kWaitDurationInSeconds);
 
-    VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
-    return CHIP_NO_ERROR;
+    return GetCommandExitStatus();
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -27,7 +27,7 @@ public:
     TestCommand(const char * commandName) : Command(commandName) {}
 
     /////////// Command Interface /////////
-    CHIP_ERROR Run(NodeId localId, NodeId remoteId) override;
+    CHIP_ERROR Run() override;
 
     virtual CHIP_ERROR NextTest() = 0;
 

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -28,8 +28,9 @@ public:
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 30; }
 
-    virtual CHIP_ERROR NextTest() = 0;
+    virtual void NextTest() = 0;
 
 protected:
     ChipDevice * mDevice;

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -14,7 +14,7 @@ static void OnDefaultSuccessResponse(void * context)
     ChipLogProgress(chipTool, "Default Success Response");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnDefaultFailureResponse(void * context, uint8_t status)
@@ -22,7 +22,7 @@ static void OnDefaultFailureResponse(void * context, uint8_t status)
     ChipLogProgress(chipTool, "Default Failure Response: 0x%02x", status);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(false);
+    command->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
 static void OnBooleanAttributeResponse(void * context, bool value)
@@ -30,7 +30,7 @@ static void OnBooleanAttributeResponse(void * context, bool value)
     ChipLogProgress(chipTool, "Boolean attribute Response: %d", value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt8uAttributeResponse(void * context, uint8_t value)
@@ -38,7 +38,7 @@ static void OnInt8uAttributeResponse(void * context, uint8_t value)
     ChipLogProgress(chipTool, "Int8u attribute Response: %" PRIu8, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16uAttributeResponse(void * context, uint16_t value)
@@ -46,7 +46,7 @@ static void OnInt16uAttributeResponse(void * context, uint16_t value)
     ChipLogProgress(chipTool, "Int16u attribute Response: %" PRIu16, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt32uAttributeResponse(void * context, uint32_t value)
@@ -54,7 +54,7 @@ static void OnInt32uAttributeResponse(void * context, uint32_t value)
     ChipLogProgress(chipTool, "Int32u attribute Response: %" PRIu32, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64uAttributeResponse(void * context, uint64_t value)
@@ -62,7 +62,7 @@ static void OnInt64uAttributeResponse(void * context, uint64_t value)
     ChipLogProgress(chipTool, "Int64u attribute Response: %" PRIu64, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt8sAttributeResponse(void * context, int8_t value)
@@ -70,7 +70,7 @@ static void OnInt8sAttributeResponse(void * context, int8_t value)
     ChipLogProgress(chipTool, "Int8s attribute Response: %" PRId8, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt16sAttributeResponse(void * context, int16_t value)
@@ -78,7 +78,7 @@ static void OnInt16sAttributeResponse(void * context, int16_t value)
     ChipLogProgress(chipTool, "Int16s attribute Response: %" PRId16, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt32sAttributeResponse(void * context, int32_t value)
@@ -86,7 +86,7 @@ static void OnInt32sAttributeResponse(void * context, int32_t value)
     ChipLogProgress(chipTool, "Int32s attribute Response: %" PRId32, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnInt64sAttributeResponse(void * context, int64_t value)
@@ -94,7 +94,7 @@ static void OnInt64sAttributeResponse(void * context, int64_t value)
     ChipLogProgress(chipTool, "Int64s attribute Response: %" PRId64, value);
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 static void OnStringAttributeResponse(void * context, const chip::ByteSpan value)
@@ -102,7 +102,7 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
     ChipLogProgress(chipTool, "String attribute Response: %zu", value.size());
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 {{#chip_client_clusters}}
@@ -116,7 +116,7 @@ static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 {{/if}}
@@ -159,7 +159,7 @@ static void On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListA
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
-    command->SetCommandExitStatus(true);
+    command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
 {{/if}}

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -5,7 +5,7 @@ class {{filename}}: public TestCommand
     {{filename}}(): TestCommand("{{filename}}"), mTestIndex(0) {}
 
     /////////// TestCommand Interface /////////
-    CHIP_ERROR NextTest() override
+    void NextTest() override
     {
       CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -33,8 +33,6 @@ class {{filename}}: public TestCommand
           ChipLogProgress(chipTool, "{{filename}}: %s", chip::ErrorStr(err));
           SetCommandExitStatus(err);
       }
-
-      return err;
     }
 
 

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -12,7 +12,7 @@ class {{filename}}: public TestCommand
       if (mTestCount == mTestIndex)
       {
           ChipLogProgress(chipTool, "{{filename}}: Test complete");
-          SetCommandExitStatus(true);
+          SetCommandExitStatus(CHIP_NO_ERROR);
       }
 
       // Ensure we increment mTestIndex before we start running the relevant
@@ -31,7 +31,7 @@ class {{filename}}: public TestCommand
       if (CHIP_NO_ERROR != err)
       {
           ChipLogProgress(chipTool, "{{filename}}: %s", chip::ErrorStr(err));
-          SetCommandExitStatus(false);
+          SetCommandExitStatus(err);
       }
 
       return err;
@@ -109,7 +109,7 @@ class {{filename}}: public TestCommand
 
         if (runner->mIsFailureExpected_{{index}} == false) {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -128,7 +128,7 @@ class {{filename}}: public TestCommand
         if (runner->mIsFailureExpected_{{index}} == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
 
@@ -138,7 +138,7 @@ class {{filename}}: public TestCommand
         if (count != {{expectedValue.length}})
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
         {{else}}
@@ -150,7 +150,7 @@ class {{filename}}: public TestCommand
         {{/if}}
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
-            runner->SetCommandExitStatus(false);
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
         {{/if}}


### PR DESCRIPTION
#### Problem
We have some remaining data races in chip-tool on Darwin.

#### Change overview
Queue the initial command `Run` method over to the CHIP thread so that all the work apart from initial setup and final teardown of the CHIP stack happens on that thread, avoiding races.

#### Testing
Ran #7797 without this change (fails every time) and with this change (passes every time on Darwin).

Note that this change makes #7797 fail on Linux until #7828 is fixed.

Reviewer note: There are 4 changesets here; reviewing them separately is probably a lot easier than reviewing the whole thing all at once.