### PR TITLE
Enable Java CHIP classes to be loaded from any thread

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -25,7 +25,7 @@
 #include <platform/KeyValueStoreManager.h>
 #include <support/ThreadOperationalDataset.h>
 
-using chip::Controller::DeviceCommissioner;
+using namespace chip::Controller;
 
 extern chip::Ble::BleLayer * GetJNIBleLayer();
 
@@ -33,7 +33,7 @@ AndroidDeviceControllerWrapper::~AndroidDeviceControllerWrapper()
 {
     if ((mJavaVM != nullptr) && (mJavaObjectRef != nullptr))
     {
-        JniReferences::GetEnvForCurrentThread()->DeleteGlobalRef(mJavaObjectRef);
+        JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mJavaObjectRef);
     }
     mController->Shutdown();
 }
@@ -41,12 +41,13 @@ AndroidDeviceControllerWrapper::~AndroidDeviceControllerWrapper()
 void AndroidDeviceControllerWrapper::SetJavaObjectRef(JavaVM * vm, jobject obj)
 {
     mJavaVM        = vm;
-    mJavaObjectRef = JniReferences::GetEnvForCurrentThread()->NewGlobalRef(obj);
+    mJavaObjectRef = JniReferences::GetInstance().GetEnvForCurrentThread()->NewGlobalRef(obj);
 }
 
 void AndroidDeviceControllerWrapper::CallJavaMethod(const char * methodName, jint argument)
 {
-    CallVoidInt(JniReferences::GetEnvForCurrentThread(), mJavaObjectRef, methodName, argument);
+    JniReferences::GetInstance().CallVoidInt(JniReferences::GetInstance().GetEnvForCurrentThread(), mJavaObjectRef, methodName,
+                                             argument);
 }
 
 AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(JavaVM * vm, jobject deviceControllerObj,

--- a/src/controller/java/AndroidKeyValueStoreManagerImpl.cpp
+++ b/src/controller/java/AndroidKeyValueStoreManagerImpl.cpp
@@ -28,6 +28,8 @@
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+using namespace chip::Controller;
+
 namespace chip {
 namespace DeviceLayer {
 namespace PersistedStorage {
@@ -47,7 +49,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     ReturnErrorCodeIf(mGetMethod == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(offset != 0, CHIP_ERROR_INVALID_ARGUMENT);
 
-    JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     ReturnErrorCodeIf(env == nullptr, CHIP_ERROR_INTERNAL);
 
     UtfString javaKey(env, key);
@@ -100,7 +102,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
     ReturnErrorCodeIf(mKeyValueStoreManagerClass == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(mDeleteMethod == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     ReturnErrorCodeIf(env == nullptr, CHIP_ERROR_INTERNAL);
 
     UtfString javaKey(env, key);
@@ -124,7 +126,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     ReturnErrorCodeIf(mSetMethod == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(value_size > kMaxKvsValueBytes, CHIP_ERROR_INVALID_ARGUMENT);
 
-    JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     ReturnErrorCodeIf(env == nullptr, CHIP_ERROR_INTERNAL);
 
     std::unique_ptr<char[]> buffer(new char[BASE64_ENCODED_LEN(value_size) + 1]);
@@ -152,7 +154,8 @@ void KeyValueStoreManagerImpl::InitializeMethodForward(JavaVM * vm, JNIEnv * env
 {
     mJvm = vm;
 
-    CHIP_ERROR err = GetClassRef(env, "chip/devicecontroller/KeyValueStoreManager", mKeyValueStoreManagerClass);
+    CHIP_ERROR err =
+        JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/KeyValueStoreManager", mKeyValueStoreManagerClass);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to get reference to KeyValueStoreManager");

--- a/src/controller/java/JniReferences.cpp
+++ b/src/controller/java/JniReferences.cpp
@@ -21,37 +21,41 @@
 
 #include <support/CodeUtils.h>
 
-pthread_mutex_t JniReferences::sStackLock  = PTHREAD_MUTEX_INITIALIZER;
-JavaVM * JniReferences::sJvm               = nullptr;
-jclass JniReferences::sClusterExceptionCls = nullptr;
+namespace chip {
+namespace Controller {
+
+pthread_mutex_t * JniReferences::GetStackLock()
+{
+    return &mStackLock;
+}
 
 void JniReferences::SetJavaVm(JavaVM * jvm)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    sJvm           = jvm;
+    mJvm           = jvm;
     JNIEnv * env   = GetEnvForCurrentThread();
 
     VerifyOrReturn(env != NULL, ChipLogError(Controller, "Could not get JNI env for current thread"));
-    err = GetClassRef(env, "chip/devicecontroller/ChipClusterException", sClusterExceptionCls);
+    err = GetClassRef(env, "chip/devicecontroller/ChipClusterException", mClusterExceptionCls);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find ChipClusterException class"));
 }
 
 JNIEnv * JniReferences::GetEnvForCurrentThread()
 {
     JNIEnv * env;
-    if (sJvm == NULL)
+    if (mJvm == NULL)
     {
         ChipLogError(Controller, "Missing Java VM");
         return nullptr;
     }
-    sJvm->GetEnv((void **) &env, JNI_VERSION_1_6);
+    mJvm->GetEnv((void **) &env, JNI_VERSION_1_6);
     if (env == NULL)
     {
         jint error;
 #ifdef __ANDROID__
-        error = sJvm->AttachCurrentThreadAsDaemon(&env, NULL);
+        error = mJvm->AttachCurrentThreadAsDaemon(&env, NULL);
 #else
-        error = sJvm->AttachCurrentThreadAsDaemon((void **) &env, NULL);
+        error = mJvm->AttachCurrentThreadAsDaemon((void **) &env, NULL);
 #endif
         if (error != JNI_OK)
         {
@@ -62,7 +66,7 @@ JNIEnv * JniReferences::GetEnvForCurrentThread()
     return env;
 }
 
-CHIP_ERROR GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls)
+CHIP_ERROR JniReferences::GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jclass cls     = NULL;
@@ -78,7 +82,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature, jmethodID * methodId)
+CHIP_ERROR JniReferences::FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
+                                     jmethodID * methodId)
 {
     CHIP_ERROR err   = CHIP_NO_ERROR;
     jclass javaClass = NULL;
@@ -94,12 +99,12 @@ exit:
     return err;
 }
 
-void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument)
+void JniReferences::CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID method;
 
-    err = FindMethod(env, object, methodName, "(I)V", &method);
+    err = JniReferences::FindMethod(env, object, methodName, "(I)V", &method);
     SuccessOrExit(err);
 
     env->ExceptionClear();
@@ -111,3 +116,11 @@ exit:
         ChipLogError(Controller, "Error calling Java method: %d", err);
     }
 }
+
+jclass JniReferences::GetClusterExceptionCls()
+{
+    return mClusterExceptionCls;
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/java/JniReferences.h
+++ b/src/controller/java/JniReferences.h
@@ -22,24 +22,64 @@
 #include <pthread.h>
 #include <support/CodeUtils.h>
 
+namespace chip {
+namespace Controller {
 class JniReferences
 {
 public:
-    static pthread_mutex_t * GetStackLock() { return &sStackLock; }
+    // No copy, move or assignment.
+    JniReferences(const JniReferences &)  = delete;
+    JniReferences(const JniReferences &&) = delete;
+    JniReferences & operator=(const JniReferences &) = delete;
 
-    static void SetJavaVm(JavaVM * jvm);
+    static JniReferences & GetInstance()
+    {
+        static JniReferences jniReferences;
+        return jniReferences;
+    }
 
-    static JNIEnv * GetEnvForCurrentThread();
+    /**
+     * Returns a stack lock to be shared by all controller JNI code.
+     */
+    pthread_mutex_t * GetStackLock();
 
-    static jclass GetClusterExceptionCls() { return sClusterExceptionCls; }
+    /**
+     * Set the JavaVM.
+     *
+     * This must be called before GetEnvForCurrentThread() or GetClassRef().
+     */
+    void SetJavaVm(JavaVM * jvm);
+
+    /**
+     * Returns a JNIEnv for the current thread.
+     *
+     * This must be called after SetJavaVm(). If the current thread is not attached to the JVM, this method will attach the thread
+     * first, then retrieve the JNIEnv.
+     */
+    JNIEnv * GetEnvForCurrentThread();
+
+    /**
+     * @brief
+     *   Gets a jclass reference to the given class type.
+     *
+     *   This must be called after SetJavaVm().
+     *
+     * @param[in] env The JNIEnv for finding a Java class and creating a new Java reference.
+     * @param[in] clsType The fully-qualified Java class name to find, e.g. java/lang/IllegalStateException.
+     * @param[out] outCls A Java reference to the class matching clsType.
+     */
+    CHIP_ERROR GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls);
+    CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
+                          jmethodID * methodId);
+    void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);
+    jclass GetClusterExceptionCls();
 
 private:
-    static pthread_mutex_t sStackLock;
-    static JavaVM * sJvm;
-    static jclass sClusterExceptionCls;
+    JniReferences() {}
+    pthread_mutex_t mStackLock  = PTHREAD_MUTEX_INITIALIZER;
+    JavaVM * mJvm               = nullptr;
+    jclass mClusterExceptionCls = nullptr;
 };
 
-jclass GetClusterExceptionCls();
-CHIP_ERROR GetClassRef(JNIEnv * env, const char * clsType, jclass & outCls);
-CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature, jmethodID * methodId);
-void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);
+} // namespace Controller
+} // namespace chip

--- a/src/controller/java/JniReferences.h
+++ b/src/controller/java/JniReferences.h
@@ -60,7 +60,7 @@ public:
 
     /**
      * @brief
-     *   Gets a jclass reference to the given class type.
+     *   Creates a jclass reference to the given class type.
      *
      *   This must be called after SetJavaVm().
      *
@@ -72,13 +72,14 @@ public:
     CHIP_ERROR FindMethod(JNIEnv * env, jobject object, const char * methodName, const char * methodSignature,
                           jmethodID * methodId);
     void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);
-    jclass GetClusterExceptionCls();
 
 private:
     JniReferences() {}
-    pthread_mutex_t mStackLock  = PTHREAD_MUTEX_INITIALIZER;
-    JavaVM * mJvm               = nullptr;
-    jclass mClusterExceptionCls = nullptr;
+
+    pthread_mutex_t mStackLock = PTHREAD_MUTEX_INITIALIZER;
+    JavaVM * mJvm              = nullptr;
+    jobject mClassLoader       = nullptr;
+    jmethodID mFindClassMethod = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[], jint 
     jclass exceptionClass;
     jstring errStr;
 
-    err = GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
+    err = JniReferences::GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
     SuccessOrExit(err);
 
     exceptionConstructor = env->GetMethodID(exceptionClass, "<init>", "(Ljava/lang/String;)V");
@@ -124,7 +124,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->ExceptionClear();
@@ -194,7 +194,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
         SuccessOrExit(err);
 
         err = CreateChipClusterException(env, status, exception);
@@ -269,7 +269,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, setupPINStr.jniValue());
@@ -340,7 +340,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
@@ -411,7 +411,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
@@ -482,7 +482,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
@@ -550,7 +550,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -618,7 +618,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -687,7 +687,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -755,7 +755,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -823,7 +823,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -892,7 +892,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -961,7 +961,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1031,7 +1031,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IJJI)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJJI)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jlong>(localStartTime),
@@ -1103,7 +1103,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(logEntryId), static_cast<jlong>(timestamp),
@@ -1175,7 +1175,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
@@ -1246,7 +1246,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
@@ -1315,7 +1315,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userType));
@@ -1385,7 +1385,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIII)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIII)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
@@ -1456,7 +1456,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJ)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJ)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
@@ -1525,7 +1525,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1594,7 +1594,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1662,7 +1662,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1730,7 +1730,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1798,7 +1798,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1867,7 +1867,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1936,7 +1936,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2004,7 +2004,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2073,7 +2073,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2144,7 +2144,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2215,7 +2215,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2286,7 +2286,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2354,7 +2354,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -2424,7 +2424,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(capacity), static_cast<jint>(groupCount)
@@ -2495,7 +2495,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -2565,7 +2565,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), groupNameStr.jniValue());
@@ -2633,7 +2633,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(timeout));
@@ -2701,7 +2701,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2770,7 +2770,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2838,7 +2838,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2906,7 +2906,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2974,7 +2974,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3043,7 +3043,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3112,7 +3112,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3181,7 +3181,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3250,7 +3250,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3319,7 +3319,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3388,7 +3388,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3456,7 +3456,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3527,7 +3527,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3598,7 +3598,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3669,7 +3669,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3740,7 +3740,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3811,7 +3811,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3884,7 +3884,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue()
@@ -3960,7 +3960,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -4031,7 +4031,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -4100,7 +4100,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IJ)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJ)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(action), static_cast<jlong>(delayedActionTime));
@@ -4174,7 +4174,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BI[B)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BI[B)V", &javaMethod);
         SuccessOrExit(err);
 
         updateTokenArr = env->NewByteArray(updateToken.size());
@@ -4267,7 +4267,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "([B[B[B[B[B[B)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "([B[B[B[B[B[B)V", &javaMethod);
         SuccessOrExit(err);
 
         CSRArr = env->NewByteArray(CSR.size());
@@ -4380,7 +4380,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IJLjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJLjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(StatusCode), static_cast<jlong>(FabricIndex),
@@ -4450,7 +4450,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(J)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(J)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jlong>(FabricId));
@@ -4518,7 +4518,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4588,7 +4588,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(capacity), static_cast<jint>(groupId),
@@ -4660,7 +4660,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -4728,7 +4728,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4796,7 +4796,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4867,7 +4867,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId),
@@ -4939,7 +4939,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef,
@@ -5015,7 +5015,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
@@ -5083,7 +5083,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(returnValue));
@@ -5156,7 +5156,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5206,7 +5206,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5260,7 +5260,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5319,7 +5319,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5376,7 +5376,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5421,7 +5421,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5476,7 +5476,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5521,7 +5521,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5575,7 +5575,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5639,7 +5639,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5685,7 +5685,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5749,7 +5749,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5797,7 +5797,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5843,7 +5843,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5889,7 +5889,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5937,7 +5937,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5985,7 +5985,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6033,7 +6033,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6081,7 +6081,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6129,7 +6129,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6177,7 +6177,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6225,7 +6225,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6273,7 +6273,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6321,7 +6321,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6367,7 +6367,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6424,7 +6424,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6474,7 +6474,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6537,7 +6537,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6582,7 +6582,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6628,7 +6628,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6673,7 +6673,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6718,7 +6718,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6764,7 +6764,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6810,7 +6810,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6856,7 +6856,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6901,7 +6901,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6946,7 +6946,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6991,7 +6991,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7036,7 +7036,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7082,7 +7082,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7128,7 +7128,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7175,7 +7175,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7223,7 +7223,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7271,7 +7271,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7319,7 +7319,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7365,7 +7365,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7413,7 +7413,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7461,7 +7461,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7508,7 +7508,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7556,7 +7556,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7610,7 +7610,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7674,7 +7674,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7719,7 +7719,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7769,7 +7769,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7844,7 +7844,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7892,7 +7892,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7938,7 +7938,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7983,7 +7983,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8028,7 +8028,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8073,7 +8073,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8127,7 +8127,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8172,7 +8172,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8226,7 +8226,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8281,7 +8281,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8328,7 +8328,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8374,7 +8374,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8420,7 +8420,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8468,7 +8468,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8514,7 +8514,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8560,7 +8560,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8605,7 +8605,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8659,7 +8659,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8713,7 +8713,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8761,7 +8761,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8806,7 +8806,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8851,7 +8851,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8905,7 +8905,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8950,7 +8950,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8995,7 +8995,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9040,7 +9040,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9085,7 +9085,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9130,7 +9130,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9176,7 +9176,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9222,7 +9222,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9268,7 +9268,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9313,7 +9313,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9358,7 +9358,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9416,7 +9416,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9467,7 +9467,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9516,7 +9516,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9565,7 +9565,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9611,7 +9611,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9660,7 +9660,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9708,7 +9708,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9757,7 +9757,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9808,7 +9808,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9866,7 +9866,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9915,7 +9915,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9968,7 +9968,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10022,7 +10022,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10067,7 +10067,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10112,7 +10112,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10173,7 +10173,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10222,7 +10222,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10270,7 +10270,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10315,7 +10315,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10361,7 +10361,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10410,7 +10410,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10456,7 +10456,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10504,7 +10504,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10580,7 +10580,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10625,7 +10625,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10671,7 +10671,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10716,7 +10716,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10762,7 +10762,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10808,7 +10808,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10854,7 +10854,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10908,7 +10908,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10973,7 +10973,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11019,7 +11019,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11064,7 +11064,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11121,7 +11121,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11184,7 +11184,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11229,7 +11229,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11274,7 +11274,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11319,7 +11319,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11373,7 +11373,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11418,7 +11418,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11464,7 +11464,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11512,7 +11512,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11558,7 +11558,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11612,7 +11612,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11675,7 +11675,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11721,7 +11721,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11767,7 +11767,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11813,7 +11813,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11859,7 +11859,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11904,7 +11904,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11949,7 +11949,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -42,14 +42,17 @@ CHIP_ERROR CreateChipClusterException(JNIEnv * env, jint errorCode, jthrowable &
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID exceptionConstructor;
+    jclass clusterExceptionCls;
 
-    exceptionConstructor = env->GetMethodID(JniReferences::GetClusterExceptionCls(), "<init>", "(I)V");
-    VerifyOrExit(exceptionConstructor != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipClusterException", clusterExceptionCls);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-    outEx = (jthrowable) env->NewObject(JniReferences::GetClusterExceptionCls(), exceptionConstructor, errorCode);
-    VerifyOrExit(outEx != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    exceptionConstructor = env->GetMethodID(clusterExceptionCls, "<init>", "(I)V");
+    VerifyOrReturnError(exceptionConstructor != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-exit:
+    outEx = (jthrowable) env->NewObject(clusterExceptionCls, exceptionConstructor, errorCode);
+    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+
     return err;
 }
 
@@ -60,7 +63,7 @@ CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[], jint 
     jclass exceptionClass;
     jstring errStr;
 
-    err = JniReferences::GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
+    err = JniReferences::GetInstance().GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
     SuccessOrExit(err);
 
     exceptionConstructor = env->GetMethodID(exceptionClass, "<init>", "(Ljava/lang/String;)V");
@@ -82,7 +85,7 @@ class CHIPDefaultSuccessCallback : public Callback::Callback<DefaultSuccessCallb
 public:
     CHIPDefaultSuccessCallback(jobject javaCallback) : Callback::Callback<DefaultSuccessCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -97,7 +100,7 @@ public:
 
     ~CHIPDefaultSuccessCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -108,10 +111,10 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
         jmethodID javaMethod;
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         CHIPDefaultSuccessCallback * cppCallback = nullptr;
 
@@ -124,7 +127,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->ExceptionClear();
@@ -151,7 +154,7 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
 public:
     CHIPDefaultFailureCallback(jobject javaCallback) : Callback::Callback<DefaultFailureCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -166,7 +169,7 @@ public:
 
     ~CHIPDefaultFailureCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -177,10 +180,10 @@ public:
 
     static void CallbackFn(void * context, uint8_t status)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
         jmethodID javaMethod;
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jthrowable exception;
         CHIPDefaultFailureCallback * cppCallback = nullptr;
@@ -194,7 +197,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
         SuccessOrExit(err);
 
         err = CreateChipClusterException(env, status, exception);
@@ -226,7 +229,7 @@ public:
     CHIPAccountLoginClusterGetSetupPINResponseCallback(jobject javaCallback) :
         Callback::Callback<AccountLoginClusterGetSetupPINResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -241,7 +244,7 @@ public:
     }
     ~CHIPAccountLoginClusterGetSetupPINResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -252,9 +255,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t * setupPIN)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPAccountLoginClusterGetSetupPINResponseCallback * cppCallback = nullptr;
@@ -269,7 +272,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, setupPINStr.jniValue());
@@ -297,7 +300,7 @@ public:
     CHIPApplicationLauncherClusterLaunchAppResponseCallback(jobject javaCallback) :
         Callback::Callback<ApplicationLauncherClusterLaunchAppResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -312,7 +315,7 @@ public:
     }
     ~CHIPApplicationLauncherClusterLaunchAppResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -323,9 +326,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t * data)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPApplicationLauncherClusterLaunchAppResponseCallback * cppCallback = nullptr;
@@ -340,7 +343,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
@@ -368,7 +371,7 @@ public:
     CHIPContentLauncherClusterLaunchContentResponseCallback(jobject javaCallback) :
         Callback::Callback<ContentLauncherClusterLaunchContentResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -383,7 +386,7 @@ public:
     }
     ~CHIPContentLauncherClusterLaunchContentResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -394,9 +397,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchContentResponseCallback * cppCallback = nullptr;
@@ -411,7 +414,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
@@ -439,7 +442,7 @@ public:
     CHIPContentLauncherClusterLaunchURLResponseCallback(jobject javaCallback) :
         Callback::Callback<ContentLauncherClusterLaunchURLResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -454,7 +457,7 @@ public:
     }
     ~CHIPContentLauncherClusterLaunchURLResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -465,9 +468,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchURLResponseCallback * cppCallback = nullptr;
@@ -482,7 +485,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
@@ -509,7 +512,7 @@ public:
     CHIPDoorLockClusterClearAllPinsResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearAllPinsResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -524,7 +527,7 @@ public:
     }
     ~CHIPDoorLockClusterClearAllPinsResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -535,9 +538,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearAllPinsResponseCallback * cppCallback = nullptr;
@@ -550,7 +553,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -577,7 +580,7 @@ public:
     CHIPDoorLockClusterClearAllRfidsResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearAllRfidsResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -592,7 +595,7 @@ public:
     }
     ~CHIPDoorLockClusterClearAllRfidsResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -603,9 +606,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearAllRfidsResponseCallback * cppCallback = nullptr;
@@ -618,7 +621,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -646,7 +649,7 @@ public:
     CHIPDoorLockClusterClearHolidayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearHolidayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -661,7 +664,7 @@ public:
     }
     ~CHIPDoorLockClusterClearHolidayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -672,9 +675,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearHolidayScheduleResponseCallback * cppCallback = nullptr;
@@ -687,7 +690,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -714,7 +717,7 @@ public:
     CHIPDoorLockClusterClearPinResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearPinResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -729,7 +732,7 @@ public:
     }
     ~CHIPDoorLockClusterClearPinResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -740,9 +743,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearPinResponseCallback * cppCallback = nullptr;
@@ -755,7 +758,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -782,7 +785,7 @@ public:
     CHIPDoorLockClusterClearRfidResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearRfidResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -797,7 +800,7 @@ public:
     }
     ~CHIPDoorLockClusterClearRfidResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -808,9 +811,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearRfidResponseCallback * cppCallback = nullptr;
@@ -823,7 +826,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -851,7 +854,7 @@ public:
     CHIPDoorLockClusterClearWeekdayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearWeekdayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -866,7 +869,7 @@ public:
     }
     ~CHIPDoorLockClusterClearWeekdayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -877,9 +880,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearWeekdayScheduleResponseCallback * cppCallback = nullptr;
@@ -892,7 +895,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -920,7 +923,7 @@ public:
     CHIPDoorLockClusterClearYeardayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterClearYeardayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -935,7 +938,7 @@ public:
     }
     ~CHIPDoorLockClusterClearYeardayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -946,9 +949,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterClearYeardayScheduleResponseCallback * cppCallback = nullptr;
@@ -961,7 +964,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -989,7 +992,7 @@ public:
     CHIPDoorLockClusterGetHolidayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetHolidayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1004,7 +1007,7 @@ public:
     }
     ~CHIPDoorLockClusterGetHolidayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1016,9 +1019,9 @@ public:
     static void CallbackFn(void * context, uint8_t scheduleId, uint32_t localStartTime, uint32_t localEndTime,
                            uint8_t operatingModeDuringHoliday)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetHolidayScheduleResponseCallback * cppCallback = nullptr;
@@ -1031,7 +1034,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJJI)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJJI)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jlong>(localStartTime),
@@ -1059,7 +1062,7 @@ public:
     CHIPDoorLockClusterGetLogRecordResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetLogRecordResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1074,7 +1077,7 @@ public:
     }
     ~CHIPDoorLockClusterGetLogRecordResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1086,9 +1089,9 @@ public:
     static void CallbackFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
                            uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetLogRecordResponseCallback * cppCallback = nullptr;
@@ -1103,7 +1106,8 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
+        err =
+            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(logEntryId), static_cast<jlong>(timestamp),
@@ -1132,7 +1136,7 @@ public:
     CHIPDoorLockClusterGetPinResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetPinResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1147,7 +1151,7 @@ public:
     }
     ~CHIPDoorLockClusterGetPinResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1158,9 +1162,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetPinResponseCallback * cppCallback = nullptr;
@@ -1175,7 +1179,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
@@ -1203,7 +1207,7 @@ public:
     CHIPDoorLockClusterGetRfidResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetRfidResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1218,7 +1222,7 @@ public:
     }
     ~CHIPDoorLockClusterGetRfidResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1229,9 +1233,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetRfidResponseCallback * cppCallback = nullptr;
@@ -1246,7 +1250,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
@@ -1274,7 +1278,7 @@ public:
     CHIPDoorLockClusterGetUserTypeResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetUserTypeResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1289,7 +1293,7 @@ public:
     }
     ~CHIPDoorLockClusterGetUserTypeResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1300,9 +1304,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t userId, uint8_t userType)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetUserTypeResponseCallback * cppCallback = nullptr;
@@ -1315,7 +1319,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userType));
@@ -1343,7 +1347,7 @@ public:
     CHIPDoorLockClusterGetWeekdayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetWeekdayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1358,7 +1362,7 @@ public:
     }
     ~CHIPDoorLockClusterGetWeekdayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1370,9 +1374,9 @@ public:
     static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t daysMask, uint8_t startHour,
                            uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetWeekdayScheduleResponseCallback * cppCallback = nullptr;
@@ -1385,7 +1389,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIII)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIII)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
@@ -1415,7 +1419,7 @@ public:
     CHIPDoorLockClusterGetYeardayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterGetYeardayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1430,7 +1434,7 @@ public:
     }
     ~CHIPDoorLockClusterGetYeardayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1441,9 +1445,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint32_t localStartTime, uint32_t localEndTime)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetYeardayScheduleResponseCallback * cppCallback = nullptr;
@@ -1456,7 +1460,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJ)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJ)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
@@ -1484,7 +1488,7 @@ public:
     CHIPDoorLockClusterLockDoorResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterLockDoorResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1499,7 +1503,7 @@ public:
     }
     ~CHIPDoorLockClusterLockDoorResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1510,9 +1514,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterLockDoorResponseCallback * cppCallback = nullptr;
@@ -1525,7 +1529,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1553,7 +1557,7 @@ public:
     CHIPDoorLockClusterSetHolidayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetHolidayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1568,7 +1572,7 @@ public:
     }
     ~CHIPDoorLockClusterSetHolidayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1579,9 +1583,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetHolidayScheduleResponseCallback * cppCallback = nullptr;
@@ -1594,7 +1598,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1621,7 +1625,7 @@ public:
     CHIPDoorLockClusterSetPinResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetPinResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1636,7 +1640,7 @@ public:
     }
     ~CHIPDoorLockClusterSetPinResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1647,9 +1651,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetPinResponseCallback * cppCallback = nullptr;
@@ -1662,7 +1666,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1689,7 +1693,7 @@ public:
     CHIPDoorLockClusterSetRfidResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetRfidResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1704,7 +1708,7 @@ public:
     }
     ~CHIPDoorLockClusterSetRfidResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1715,9 +1719,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetRfidResponseCallback * cppCallback = nullptr;
@@ -1730,7 +1734,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1757,7 +1761,7 @@ public:
     CHIPDoorLockClusterSetUserTypeResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetUserTypeResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1772,7 +1776,7 @@ public:
     }
     ~CHIPDoorLockClusterSetUserTypeResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1783,9 +1787,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetUserTypeResponseCallback * cppCallback = nullptr;
@@ -1798,7 +1802,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1826,7 +1830,7 @@ public:
     CHIPDoorLockClusterSetWeekdayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetWeekdayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1841,7 +1845,7 @@ public:
     }
     ~CHIPDoorLockClusterSetWeekdayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1852,9 +1856,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetWeekdayScheduleResponseCallback * cppCallback = nullptr;
@@ -1867,7 +1871,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1895,7 +1899,7 @@ public:
     CHIPDoorLockClusterSetYeardayScheduleResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterSetYeardayScheduleResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1910,7 +1914,7 @@ public:
     }
     ~CHIPDoorLockClusterSetYeardayScheduleResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1921,9 +1925,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterSetYeardayScheduleResponseCallback * cppCallback = nullptr;
@@ -1936,7 +1940,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -1963,7 +1967,7 @@ public:
     CHIPDoorLockClusterUnlockDoorResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterUnlockDoorResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1978,7 +1982,7 @@ public:
     }
     ~CHIPDoorLockClusterUnlockDoorResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -1989,9 +1993,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterUnlockDoorResponseCallback * cppCallback = nullptr;
@@ -2004,7 +2008,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2032,7 +2036,7 @@ public:
     CHIPDoorLockClusterUnlockWithTimeoutResponseCallback(jobject javaCallback) :
         Callback::Callback<DoorLockClusterUnlockWithTimeoutResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2047,7 +2051,7 @@ public:
     }
     ~CHIPDoorLockClusterUnlockWithTimeoutResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2058,9 +2062,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterUnlockWithTimeoutResponseCallback * cppCallback = nullptr;
@@ -2073,7 +2077,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2101,7 +2105,7 @@ public:
     CHIPGeneralCommissioningClusterArmFailSafeResponseCallback(jobject javaCallback) :
         Callback::Callback<GeneralCommissioningClusterArmFailSafeResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2116,7 +2120,7 @@ public:
     }
     ~CHIPGeneralCommissioningClusterArmFailSafeResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2127,9 +2131,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterArmFailSafeResponseCallback * cppCallback = nullptr;
@@ -2144,7 +2148,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2172,7 +2176,7 @@ public:
     CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallback(jobject javaCallback) :
         Callback::Callback<GeneralCommissioningClusterCommissioningCompleteResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2187,7 +2191,7 @@ public:
     }
     ~CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2198,9 +2202,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallback * cppCallback = nullptr;
@@ -2215,7 +2219,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2243,7 +2247,7 @@ public:
     CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(jobject javaCallback) :
         Callback::Callback<GeneralCommissioningClusterSetRegulatoryConfigResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2258,7 +2262,7 @@ public:
     }
     ~CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2269,9 +2273,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallback * cppCallback = nullptr;
@@ -2286,7 +2290,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -2313,7 +2317,7 @@ public:
     CHIPGroupsClusterAddGroupResponseCallback(jobject javaCallback) :
         Callback::Callback<GroupsClusterAddGroupResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2328,7 +2332,7 @@ public:
     }
     ~CHIPGroupsClusterAddGroupResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2339,9 +2343,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterAddGroupResponseCallback * cppCallback = nullptr;
@@ -2354,7 +2358,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -2382,7 +2386,7 @@ public:
     CHIPGroupsClusterGetGroupMembershipResponseCallback(jobject javaCallback) :
         Callback::Callback<GroupsClusterGetGroupMembershipResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2397,7 +2401,7 @@ public:
     }
     ~CHIPGroupsClusterGetGroupMembershipResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2409,9 +2413,9 @@ public:
     static void CallbackFn(void * context, uint8_t capacity, uint8_t groupCount,
                            /* TYPE WARNING: array array defaults to */ uint8_t * groupList)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterGetGroupMembershipResponseCallback * cppCallback = nullptr;
@@ -2424,7 +2428,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(capacity), static_cast<jint>(groupCount)
@@ -2454,7 +2458,7 @@ public:
     CHIPGroupsClusterRemoveGroupResponseCallback(jobject javaCallback) :
         Callback::Callback<GroupsClusterRemoveGroupResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2469,7 +2473,7 @@ public:
     }
     ~CHIPGroupsClusterRemoveGroupResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2480,9 +2484,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterRemoveGroupResponseCallback * cppCallback = nullptr;
@@ -2495,7 +2499,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -2522,7 +2526,7 @@ public:
     CHIPGroupsClusterViewGroupResponseCallback(jobject javaCallback) :
         Callback::Callback<GroupsClusterViewGroupResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2537,7 +2541,7 @@ public:
     }
     ~CHIPGroupsClusterViewGroupResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2548,9 +2552,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId, uint8_t * groupName)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterViewGroupResponseCallback * cppCallback = nullptr;
@@ -2565,7 +2569,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), groupNameStr.jniValue());
@@ -2592,7 +2596,7 @@ public:
     CHIPIdentifyClusterIdentifyQueryResponseCallback(jobject javaCallback) :
         Callback::Callback<IdentifyClusterIdentifyQueryResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2607,7 +2611,7 @@ public:
     }
     ~CHIPIdentifyClusterIdentifyQueryResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2618,9 +2622,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t timeout)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPIdentifyClusterIdentifyQueryResponseCallback * cppCallback = nullptr;
@@ -2633,7 +2637,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(timeout));
@@ -2660,7 +2664,7 @@ public:
     CHIPKeypadInputClusterSendKeyResponseCallback(jobject javaCallback) :
         Callback::Callback<KeypadInputClusterSendKeyResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2675,7 +2679,7 @@ public:
     }
     ~CHIPKeypadInputClusterSendKeyResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2686,9 +2690,9 @@ public:
 
     static void CallbackFn(void * context)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPKeypadInputClusterSendKeyResponseCallback * cppCallback = nullptr;
@@ -2701,7 +2705,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod);
@@ -2729,7 +2733,7 @@ public:
     CHIPMediaPlaybackClusterMediaFastForwardResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaFastForwardResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2744,7 +2748,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaFastForwardResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2755,9 +2759,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaFastForwardResponseCallback * cppCallback = nullptr;
@@ -2770,7 +2774,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2797,7 +2801,7 @@ public:
     CHIPMediaPlaybackClusterMediaNextResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaNextResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2812,7 +2816,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaNextResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2823,9 +2827,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaNextResponseCallback * cppCallback = nullptr;
@@ -2838,7 +2842,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2865,7 +2869,7 @@ public:
     CHIPMediaPlaybackClusterMediaPauseResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaPauseResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2880,7 +2884,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaPauseResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2891,9 +2895,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaPauseResponseCallback * cppCallback = nullptr;
@@ -2906,7 +2910,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -2933,7 +2937,7 @@ public:
     CHIPMediaPlaybackClusterMediaPlayResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaPlayResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2948,7 +2952,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaPlayResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -2959,9 +2963,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaPlayResponseCallback * cppCallback = nullptr;
@@ -2974,7 +2978,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3002,7 +3006,7 @@ public:
     CHIPMediaPlaybackClusterMediaPreviousResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaPreviousResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3017,7 +3021,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaPreviousResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3028,9 +3032,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaPreviousResponseCallback * cppCallback = nullptr;
@@ -3043,7 +3047,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3071,7 +3075,7 @@ public:
     CHIPMediaPlaybackClusterMediaRewindResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaRewindResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3086,7 +3090,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaRewindResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3097,9 +3101,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaRewindResponseCallback * cppCallback = nullptr;
@@ -3112,7 +3116,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3140,7 +3144,7 @@ public:
     CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaSkipBackwardResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3155,7 +3159,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3166,9 +3170,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaSkipBackwardResponseCallback * cppCallback = nullptr;
@@ -3181,7 +3185,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3209,7 +3213,7 @@ public:
     CHIPMediaPlaybackClusterMediaSkipForwardResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaSkipForwardResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3224,7 +3228,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaSkipForwardResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3235,9 +3239,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaSkipForwardResponseCallback * cppCallback = nullptr;
@@ -3250,7 +3254,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3278,7 +3282,7 @@ public:
     CHIPMediaPlaybackClusterMediaSkipSeekResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaSkipSeekResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3293,7 +3297,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaSkipSeekResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3304,9 +3308,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaSkipSeekResponseCallback * cppCallback = nullptr;
@@ -3319,7 +3323,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3347,7 +3351,7 @@ public:
     CHIPMediaPlaybackClusterMediaStartOverResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaStartOverResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3362,7 +3366,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaStartOverResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3373,9 +3377,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaStartOverResponseCallback * cppCallback = nullptr;
@@ -3388,7 +3392,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3415,7 +3419,7 @@ public:
     CHIPMediaPlaybackClusterMediaStopResponseCallback(jobject javaCallback) :
         Callback::Callback<MediaPlaybackClusterMediaStopResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3430,7 +3434,7 @@ public:
     }
     ~CHIPMediaPlaybackClusterMediaStopResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3441,9 +3445,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t mediaPlaybackStatus)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPMediaPlaybackClusterMediaStopResponseCallback * cppCallback = nullptr;
@@ -3456,7 +3460,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(mediaPlaybackStatus));
@@ -3484,7 +3488,7 @@ public:
     CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3499,7 +3503,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3510,9 +3514,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallback * cppCallback = nullptr;
@@ -3527,7 +3531,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3555,7 +3559,7 @@ public:
     CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3570,7 +3574,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3581,9 +3585,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallback * cppCallback = nullptr;
@@ -3598,7 +3602,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3626,7 +3630,7 @@ public:
     CHIPNetworkCommissioningClusterDisableNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterDisableNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3641,7 +3645,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterDisableNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3652,9 +3656,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterDisableNetworkResponseCallback * cppCallback = nullptr;
@@ -3669,7 +3673,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3697,7 +3701,7 @@ public:
     CHIPNetworkCommissioningClusterEnableNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3712,7 +3716,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterEnableNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3723,9 +3727,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterEnableNetworkResponseCallback * cppCallback = nullptr;
@@ -3740,7 +3744,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3768,7 +3772,7 @@ public:
     CHIPNetworkCommissioningClusterRemoveNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterRemoveNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3783,7 +3787,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterRemoveNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3794,9 +3798,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterRemoveNetworkResponseCallback * cppCallback = nullptr;
@@ -3811,7 +3815,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3839,7 +3843,7 @@ public:
     CHIPNetworkCommissioningClusterScanNetworksResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterScanNetworksResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3854,7 +3858,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterScanNetworksResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3867,9 +3871,9 @@ public:
                            /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
                            /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterScanNetworksResponseCallback * cppCallback = nullptr;
@@ -3884,7 +3888,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue()
@@ -3917,7 +3921,7 @@ public:
     CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterUpdateThreadNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3932,7 +3936,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -3943,9 +3947,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallback * cppCallback = nullptr;
@@ -3960,7 +3964,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -3988,7 +3992,7 @@ public:
     CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(jobject javaCallback) :
         Callback::Callback<NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4003,7 +4007,7 @@ public:
     }
     ~CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4014,9 +4018,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback * cppCallback = nullptr;
@@ -4031,7 +4035,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
@@ -4059,7 +4063,7 @@ public:
     CHIPOtaSoftwareUpdateServerClusterApplyUpdateRequestResponseCallback(jobject javaCallback) :
         Callback::Callback<OtaSoftwareUpdateServerClusterApplyUpdateRequestResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4074,7 +4078,7 @@ public:
     }
     ~CHIPOtaSoftwareUpdateServerClusterApplyUpdateRequestResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4085,9 +4089,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t action, uint32_t delayedActionTime)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOtaSoftwareUpdateServerClusterApplyUpdateRequestResponseCallback * cppCallback = nullptr;
@@ -4100,7 +4104,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJ)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJ)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(action), static_cast<jlong>(delayedActionTime));
@@ -4128,7 +4132,7 @@ public:
     CHIPOtaSoftwareUpdateServerClusterQueryImageResponseCallback(jobject javaCallback) :
         Callback::Callback<OtaSoftwareUpdateServerClusterQueryImageResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4143,7 +4147,7 @@ public:
     }
     ~CHIPOtaSoftwareUpdateServerClusterQueryImageResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4155,9 +4159,9 @@ public:
     static void CallbackFn(void * context, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
                            chip::ByteSpan updateToken, uint8_t userConsentNeeded, chip::ByteSpan metadataForClient)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOtaSoftwareUpdateServerClusterQueryImageResponseCallback * cppCallback = nullptr;
@@ -4174,7 +4178,8 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BI[B)V", &javaMethod);
+        err =
+            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BI[B)V", &javaMethod);
         SuccessOrExit(err);
 
         updateTokenArr = env->NewByteArray(updateToken.size());
@@ -4219,7 +4224,7 @@ public:
     CHIPOperationalCredentialsClusterOpCSRResponseCallback(jobject javaCallback) :
         Callback::Callback<OperationalCredentialsClusterOpCSRResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4234,7 +4239,7 @@ public:
     }
     ~CHIPOperationalCredentialsClusterOpCSRResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4246,9 +4251,9 @@ public:
     static void CallbackFn(void * context, chip::ByteSpan CSR, chip::ByteSpan CSRNonce, chip::ByteSpan VendorReserved1,
                            chip::ByteSpan VendorReserved2, chip::ByteSpan VendorReserved3, chip::ByteSpan Signature)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOperationalCredentialsClusterOpCSRResponseCallback * cppCallback = nullptr;
@@ -4267,7 +4272,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "([B[B[B[B[B[B)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "([B[B[B[B[B[B)V", &javaMethod);
         SuccessOrExit(err);
 
         CSRArr = env->NewByteArray(CSR.size());
@@ -4337,7 +4342,7 @@ public:
     CHIPOperationalCredentialsClusterOpCertResponseCallback(jobject javaCallback) :
         Callback::Callback<OperationalCredentialsClusterOpCertResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4352,7 +4357,7 @@ public:
     }
     ~CHIPOperationalCredentialsClusterOpCertResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4363,9 +4368,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t StatusCode, uint64_t FabricIndex, uint8_t * DebugText)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOperationalCredentialsClusterOpCertResponseCallback * cppCallback = nullptr;
@@ -4380,7 +4385,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IJLjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJLjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(StatusCode), static_cast<jlong>(FabricIndex),
@@ -4409,7 +4414,7 @@ public:
     CHIPOperationalCredentialsClusterSetFabricResponseCallback(jobject javaCallback) :
         Callback::Callback<OperationalCredentialsClusterSetFabricResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4424,7 +4429,7 @@ public:
     }
     ~CHIPOperationalCredentialsClusterSetFabricResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4435,9 +4440,9 @@ public:
 
     static void CallbackFn(void * context, chip::FabricId FabricId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOperationalCredentialsClusterSetFabricResponseCallback * cppCallback = nullptr;
@@ -4450,7 +4455,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(J)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(J)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jlong>(FabricId));
@@ -4477,7 +4482,7 @@ public:
     CHIPScenesClusterAddSceneResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterAddSceneResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4492,7 +4497,7 @@ public:
     }
     ~CHIPScenesClusterAddSceneResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4503,9 +4508,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterAddSceneResponseCallback * cppCallback = nullptr;
@@ -4518,7 +4523,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4546,7 +4551,7 @@ public:
     CHIPScenesClusterGetSceneMembershipResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterGetSceneMembershipResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4561,7 +4566,7 @@ public:
     }
     ~CHIPScenesClusterGetSceneMembershipResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4573,9 +4578,9 @@ public:
     static void CallbackFn(void * context, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
                            /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterGetSceneMembershipResponseCallback * cppCallback = nullptr;
@@ -4588,7 +4593,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(capacity), static_cast<jint>(groupId),
@@ -4619,7 +4624,7 @@ public:
     CHIPScenesClusterRemoveAllScenesResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterRemoveAllScenesResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4634,7 +4639,7 @@ public:
     }
     ~CHIPScenesClusterRemoveAllScenesResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4645,9 +4650,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterRemoveAllScenesResponseCallback * cppCallback = nullptr;
@@ -4660,7 +4665,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
@@ -4687,7 +4692,7 @@ public:
     CHIPScenesClusterRemoveSceneResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterRemoveSceneResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4702,7 +4707,7 @@ public:
     }
     ~CHIPScenesClusterRemoveSceneResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4713,9 +4718,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterRemoveSceneResponseCallback * cppCallback = nullptr;
@@ -4728,7 +4733,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4755,7 +4760,7 @@ public:
     CHIPScenesClusterStoreSceneResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterStoreSceneResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4770,7 +4775,7 @@ public:
     }
     ~CHIPScenesClusterStoreSceneResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4781,9 +4786,9 @@ public:
 
     static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterStoreSceneResponseCallback * cppCallback = nullptr;
@@ -4796,7 +4801,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
@@ -4823,7 +4828,7 @@ public:
     CHIPScenesClusterViewSceneResponseCallback(jobject javaCallback) :
         Callback::Callback<ScenesClusterViewSceneResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4838,7 +4843,7 @@ public:
     }
     ~CHIPScenesClusterViewSceneResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4850,9 +4855,9 @@ public:
     static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                            /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterViewSceneResponseCallback * cppCallback = nullptr;
@@ -4867,7 +4872,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId),
@@ -4898,7 +4903,7 @@ public:
     CHIPTvChannelClusterChangeChannelResponseCallback(jobject javaCallback) :
         Callback::Callback<TvChannelClusterChangeChannelResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4913,7 +4918,7 @@ public:
     }
     ~CHIPTvChannelClusterChangeChannelResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4924,9 +4929,9 @@ public:
 
     static void CallbackFn(void * context, /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch, uint8_t ErrorType)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPTvChannelClusterChangeChannelResponseCallback * cppCallback = nullptr;
@@ -4939,7 +4944,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef,
@@ -4972,7 +4977,7 @@ public:
     CHIPTargetNavigatorClusterNavigateTargetResponseCallback(jobject javaCallback) :
         Callback::Callback<TargetNavigatorClusterNavigateTargetResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4987,7 +4992,7 @@ public:
     }
     ~CHIPTargetNavigatorClusterNavigateTargetResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -4998,9 +5003,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t * data)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPTargetNavigatorClusterNavigateTargetResponseCallback * cppCallback = nullptr;
@@ -5015,7 +5020,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
@@ -5042,7 +5047,7 @@ public:
     CHIPTestClusterClusterTestSpecificResponseCallback(jobject javaCallback) :
         Callback::Callback<TestClusterClusterTestSpecificResponseCallback>(CallbackFn, this)
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -5057,7 +5062,7 @@ public:
     }
     ~CHIPTestClusterClusterTestSpecificResponseCallback()
     {
-        JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         if (env == nullptr)
         {
             ChipLogError(Zcl, "Could not create global reference for Java callback");
@@ -5068,9 +5073,9 @@ public:
 
     static void CallbackFn(void * context, uint8_t returnValue)
     {
-        StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+        StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
-        JNIEnv * env   = JniReferences::GetEnvForCurrentThread();
+        JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPTestClusterClusterTestSpecificResponseCallback * cppCallback = nullptr;
@@ -5083,7 +5088,7 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(returnValue));
@@ -5106,7 +5111,7 @@ private:
 
 JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlong clusterPtr)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ClusterBase * cluster = reinterpret_cast<ClusterBase *>(clusterPtr);
     if (cluster != nullptr)
     {
@@ -5116,7 +5121,7 @@ JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlo
 
 JNI_METHOD(jlong, AccountLoginCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     AccountLoginCluster * cppCluster = new AccountLoginCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5126,7 +5131,7 @@ JNI_METHOD(jlong, AccountLoginCluster, initWithDevice)(JNIEnv * env, jobject sel
 JNI_METHOD(void, AccountLoginCluster, getSetupPIN)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     AccountLoginCluster * cppCluster;
 
@@ -5156,7 +5161,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5175,7 +5180,7 @@ exit:
 JNI_METHOD(void, AccountLoginCluster, login)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring tempAccountIdentifier, jstring setupPIN)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     AccountLoginCluster * cppCluster;
 
@@ -5206,7 +5211,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5224,7 +5229,7 @@ exit:
 }
 JNI_METHOD(jlong, ApplicationBasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ApplicationBasicCluster * cppCluster = new ApplicationBasicCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5233,7 +5238,7 @@ JNI_METHOD(jlong, ApplicationBasicCluster, initWithDevice)(JNIEnv * env, jobject
 
 JNI_METHOD(void, ApplicationBasicCluster, changeStatus)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint status)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ApplicationBasicCluster * cppCluster;
 
@@ -5260,7 +5265,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5278,7 +5283,7 @@ exit:
 }
 JNI_METHOD(jlong, ApplicationLauncherCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ApplicationLauncherCluster * cppCluster = new ApplicationLauncherCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5288,7 +5293,7 @@ JNI_METHOD(jlong, ApplicationLauncherCluster, initWithDevice)(JNIEnv * env, jobj
 JNI_METHOD(void, ApplicationLauncherCluster, launchApp)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring data, jint catalogVendorId, jstring applicationId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ApplicationLauncherCluster * cppCluster;
 
@@ -5319,7 +5324,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5337,7 +5342,7 @@ exit:
 }
 JNI_METHOD(jlong, AudioOutputCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     AudioOutputCluster * cppCluster = new AudioOutputCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5347,7 +5352,7 @@ JNI_METHOD(jlong, AudioOutputCluster, initWithDevice)(JNIEnv * env, jobject self
 JNI_METHOD(void, AudioOutputCluster, renameOutput)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint index, jstring name)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     AudioOutputCluster * cppCluster;
 
@@ -5376,7 +5381,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5394,7 +5399,7 @@ exit:
 }
 JNI_METHOD(void, AudioOutputCluster, selectOutput)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint index)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     AudioOutputCluster * cppCluster;
 
@@ -5421,7 +5426,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5439,7 +5444,7 @@ exit:
 }
 JNI_METHOD(jlong, BarrierControlCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     BarrierControlCluster * cppCluster = new BarrierControlCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5449,7 +5454,7 @@ JNI_METHOD(jlong, BarrierControlCluster, initWithDevice)(JNIEnv * env, jobject s
 JNI_METHOD(void, BarrierControlCluster, barrierControlGoToPercent)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint percentOpen)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     BarrierControlCluster * cppCluster;
 
@@ -5476,7 +5481,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5494,7 +5499,7 @@ exit:
 }
 JNI_METHOD(void, BarrierControlCluster, barrierControlStop)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     BarrierControlCluster * cppCluster;
 
@@ -5521,7 +5526,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5539,7 +5544,7 @@ exit:
 }
 JNI_METHOD(jlong, BasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     BasicCluster * cppCluster = new BasicCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5548,7 +5553,7 @@ JNI_METHOD(jlong, BasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
 
 JNI_METHOD(void, BasicCluster, mfgSpecificPing)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     BasicCluster * cppCluster;
 
@@ -5575,7 +5580,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5593,7 +5598,7 @@ exit:
 }
 JNI_METHOD(jlong, BinaryInputBasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     BinaryInputBasicCluster * cppCluster = new BinaryInputBasicCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5602,7 +5607,7 @@ JNI_METHOD(jlong, BinaryInputBasicCluster, initWithDevice)(JNIEnv * env, jobject
 
 JNI_METHOD(jlong, BindingCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     BindingCluster * cppCluster = new BindingCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5612,7 +5617,7 @@ JNI_METHOD(jlong, BindingCluster, initWithDevice)(JNIEnv * env, jobject self, jl
 JNI_METHOD(void, BindingCluster, bind)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong nodeId, jint groupId, jint endpointId, jint clusterId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     BindingCluster * cppCluster;
 
@@ -5639,7 +5644,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5658,7 +5663,7 @@ exit:
 JNI_METHOD(void, BindingCluster, unbind)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong nodeId, jint groupId, jint endpointId, jint clusterId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     BindingCluster * cppCluster;
 
@@ -5685,7 +5690,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5703,7 +5708,7 @@ exit:
 }
 JNI_METHOD(jlong, BridgedDeviceBasicCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     BridgedDeviceBasicCluster * cppCluster = new BridgedDeviceBasicCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5712,7 +5717,7 @@ JNI_METHOD(jlong, BridgedDeviceBasicCluster, initWithDevice)(JNIEnv * env, jobje
 
 JNI_METHOD(jlong, ColorControlCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ColorControlCluster * cppCluster = new ColorControlCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -5722,7 +5727,7 @@ JNI_METHOD(jlong, ColorControlCluster, initWithDevice)(JNIEnv * env, jobject sel
 JNI_METHOD(void, ColorControlCluster, moveColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint rateX, jint rateY, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5749,7 +5754,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5769,7 +5774,7 @@ JNI_METHOD(void, ColorControlCluster, moveColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint moveMode, jint rate, jint colorTemperatureMinimum,
  jint colorTemperatureMaximum, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5797,7 +5802,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5816,7 +5821,7 @@ exit:
 JNI_METHOD(void, ColorControlCluster, moveHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint moveMode, jint rate, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5843,7 +5848,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5862,7 +5867,7 @@ exit:
 JNI_METHOD(void, ColorControlCluster, moveSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint moveMode, jint rate, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5889,7 +5894,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5909,7 +5914,7 @@ JNI_METHOD(void, ColorControlCluster, moveToColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint colorX, jint colorY, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5937,7 +5942,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -5957,7 +5962,7 @@ JNI_METHOD(void, ColorControlCluster, moveToColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint colorTemperature, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -5985,7 +5990,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6005,7 +6010,7 @@ JNI_METHOD(void, ColorControlCluster, moveToHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint hue, jint direction, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6033,7 +6038,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6053,7 +6058,7 @@ JNI_METHOD(void, ColorControlCluster, moveToHueAndSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint hue, jint saturation, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6081,7 +6086,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6101,7 +6106,7 @@ JNI_METHOD(void, ColorControlCluster, moveToSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint saturation, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6129,7 +6134,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6149,7 +6154,7 @@ JNI_METHOD(void, ColorControlCluster, stepColor)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepX, jint stepY, jint transitionTime, jint optionsMask,
  jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6177,7 +6182,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6197,7 +6202,7 @@ JNI_METHOD(void, ColorControlCluster, stepColorTemperature)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepMode, jint stepSize, jint transitionTime,
  jint colorTemperatureMinimum, jint colorTemperatureMaximum, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6225,7 +6230,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6245,7 +6250,7 @@ JNI_METHOD(void, ColorControlCluster, stepHue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepMode, jint stepSize, jint transitionTime,
  jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6273,7 +6278,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6293,7 +6298,7 @@ JNI_METHOD(void, ColorControlCluster, stepSaturation)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepMode, jint stepSize, jint transitionTime,
  jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6321,7 +6326,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6340,7 +6345,7 @@ exit:
 JNI_METHOD(void, ColorControlCluster, stopMoveStep)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint optionsMask, jint optionsOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ColorControlCluster * cppCluster;
 
@@ -6367,7 +6372,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6385,7 +6390,7 @@ exit:
 }
 JNI_METHOD(jlong, ContentLauncherCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ContentLauncherCluster * cppCluster = new ContentLauncherCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -6395,7 +6400,7 @@ JNI_METHOD(jlong, ContentLauncherCluster, initWithDevice)(JNIEnv * env, jobject 
 JNI_METHOD(void, ContentLauncherCluster, launchContent)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint autoPlay, jstring data)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ContentLauncherCluster * cppCluster;
 
@@ -6424,7 +6429,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6443,7 +6448,7 @@ exit:
 JNI_METHOD(void, ContentLauncherCluster, launchURL)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring contentURL, jstring displayString)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ContentLauncherCluster * cppCluster;
 
@@ -6474,7 +6479,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6492,7 +6497,7 @@ exit:
 }
 JNI_METHOD(jlong, DescriptorCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     DescriptorCluster * cppCluster = new DescriptorCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -6501,7 +6506,7 @@ JNI_METHOD(jlong, DescriptorCluster, initWithDevice)(JNIEnv * env, jobject self,
 
 JNI_METHOD(jlong, DoorLockCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     DoorLockCluster * cppCluster = new DoorLockCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -6510,7 +6515,7 @@ JNI_METHOD(jlong, DoorLockCluster, initWithDevice)(JNIEnv * env, jobject self, j
 
 JNI_METHOD(void, DoorLockCluster, clearAllPins)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6537,7 +6542,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6555,7 +6560,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, clearAllRfids)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6582,7 +6587,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6601,7 +6606,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, clearHolidaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6628,7 +6633,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6646,7 +6651,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, clearPin)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6673,7 +6678,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6691,7 +6696,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, clearRfid)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6718,7 +6723,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6737,7 +6742,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, clearWeekdaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6764,7 +6769,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6783,7 +6788,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, clearYeardaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6810,7 +6815,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6829,7 +6834,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, getHolidaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6856,7 +6861,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6874,7 +6879,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, getLogRecord)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint logIndex)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6901,7 +6906,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6919,7 +6924,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, getPin)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6946,7 +6951,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -6964,7 +6969,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, getRfid)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -6991,7 +6996,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7009,7 +7014,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, getUserType)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7036,7 +7041,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7055,7 +7060,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, getWeekdaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7082,7 +7087,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7101,7 +7106,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, getYeardaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7128,7 +7133,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7146,7 +7151,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, lockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring pin)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7175,7 +7180,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7195,7 +7200,7 @@ JNI_METHOD(void, DoorLockCluster, setHolidaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jlong localStartTime, jlong localEndTime,
  jint operatingModeDuringHoliday)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7223,7 +7228,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7242,7 +7247,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, setPin)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jstring pin)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7271,7 +7276,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7290,7 +7295,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, setRfid)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userStatus, jint userType, jstring id)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7319,7 +7324,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7338,7 +7343,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, setUserType)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint userId, jint userType)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7365,7 +7370,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7385,7 +7390,7 @@ JNI_METHOD(void, DoorLockCluster, setWeekdaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId, jint daysMask, jint startHour,
  jint startMinute, jint endHour, jint endMinute)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7413,7 +7418,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7433,7 +7438,7 @@ JNI_METHOD(void, DoorLockCluster, setYeardaySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint scheduleId, jint userId, jlong localStartTime,
  jlong localEndTime)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7461,7 +7466,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7479,7 +7484,7 @@ exit:
 }
 JNI_METHOD(void, DoorLockCluster, unlockDoor)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring pin)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7508,7 +7513,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7527,7 +7532,7 @@ exit:
 JNI_METHOD(void, DoorLockCluster, unlockWithTimeout)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint timeoutInSeconds, jstring pin)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     DoorLockCluster * cppCluster;
 
@@ -7556,7 +7561,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7574,7 +7579,7 @@ exit:
 }
 JNI_METHOD(jlong, EthernetNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     EthernetNetworkDiagnosticsCluster * cppCluster = new EthernetNetworkDiagnosticsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7583,7 +7588,7 @@ JNI_METHOD(jlong, EthernetNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * en
 
 JNI_METHOD(void, EthernetNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     EthernetNetworkDiagnosticsCluster * cppCluster;
 
@@ -7610,7 +7615,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7628,7 +7633,7 @@ exit:
 }
 JNI_METHOD(jlong, FixedLabelCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     FixedLabelCluster * cppCluster = new FixedLabelCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7637,7 +7642,7 @@ JNI_METHOD(jlong, FixedLabelCluster, initWithDevice)(JNIEnv * env, jobject self,
 
 JNI_METHOD(jlong, GeneralCommissioningCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     GeneralCommissioningCluster * cppCluster = new GeneralCommissioningCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7647,7 +7652,7 @@ JNI_METHOD(jlong, GeneralCommissioningCluster, initWithDevice)(JNIEnv * env, job
 JNI_METHOD(void, GeneralCommissioningCluster, armFailSafe)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint expiryLengthSeconds, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GeneralCommissioningCluster * cppCluster;
 
@@ -7674,7 +7679,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7692,7 +7697,7 @@ exit:
 }
 JNI_METHOD(void, GeneralCommissioningCluster, commissioningComplete)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GeneralCommissioningCluster * cppCluster;
 
@@ -7719,7 +7724,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7739,7 +7744,7 @@ JNI_METHOD(void, GeneralCommissioningCluster, setRegulatoryConfig)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint location, jstring countryCode, jlong breadcrumb,
  jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GeneralCommissioningCluster * cppCluster;
 
@@ -7769,7 +7774,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7787,7 +7792,7 @@ exit:
 }
 JNI_METHOD(jlong, GeneralDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     GeneralDiagnosticsCluster * cppCluster = new GeneralDiagnosticsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7796,7 +7801,7 @@ JNI_METHOD(jlong, GeneralDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobje
 
 JNI_METHOD(jlong, GroupKeyManagementCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     GroupKeyManagementCluster * cppCluster = new GroupKeyManagementCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7805,7 +7810,7 @@ JNI_METHOD(jlong, GroupKeyManagementCluster, initWithDevice)(JNIEnv * env, jobje
 
 JNI_METHOD(jlong, GroupsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     GroupsCluster * cppCluster = new GroupsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -7815,7 +7820,7 @@ JNI_METHOD(jlong, GroupsCluster, initWithDevice)(JNIEnv * env, jobject self, jlo
 JNI_METHOD(void, GroupsCluster, addGroup)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jstring groupName)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -7844,7 +7849,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7863,7 +7868,7 @@ exit:
 JNI_METHOD(void, GroupsCluster, addGroupIfIdentifying)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jstring groupName)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -7892,7 +7897,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7911,7 +7916,7 @@ exit:
 JNI_METHOD(void, GroupsCluster, getGroupMembership)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupCount, jint groupList)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -7938,7 +7943,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -7956,7 +7961,7 @@ exit:
 }
 JNI_METHOD(void, GroupsCluster, removeAllGroups)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -7983,7 +7988,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8001,7 +8006,7 @@ exit:
 }
 JNI_METHOD(void, GroupsCluster, removeGroup)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -8028,7 +8033,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8046,7 +8051,7 @@ exit:
 }
 JNI_METHOD(void, GroupsCluster, viewGroup)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     GroupsCluster * cppCluster;
 
@@ -8073,7 +8078,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8091,7 +8096,7 @@ exit:
 }
 JNI_METHOD(jlong, IdentifyCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     IdentifyCluster * cppCluster = new IdentifyCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8100,7 +8105,7 @@ JNI_METHOD(jlong, IdentifyCluster, initWithDevice)(JNIEnv * env, jobject self, j
 
 JNI_METHOD(void, IdentifyCluster, identify)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint identifyTime)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     IdentifyCluster * cppCluster;
 
@@ -8127,7 +8132,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8145,7 +8150,7 @@ exit:
 }
 JNI_METHOD(void, IdentifyCluster, identifyQuery)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     IdentifyCluster * cppCluster;
 
@@ -8172,7 +8177,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8190,7 +8195,7 @@ exit:
 }
 JNI_METHOD(jlong, KeypadInputCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     KeypadInputCluster * cppCluster = new KeypadInputCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8199,7 +8204,7 @@ JNI_METHOD(jlong, KeypadInputCluster, initWithDevice)(JNIEnv * env, jobject self
 
 JNI_METHOD(void, KeypadInputCluster, sendKey)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint keyCode)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     KeypadInputCluster * cppCluster;
 
@@ -8226,7 +8231,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8244,7 +8249,7 @@ exit:
 }
 JNI_METHOD(jlong, LevelControlCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     LevelControlCluster * cppCluster = new LevelControlCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8254,7 +8259,7 @@ JNI_METHOD(jlong, LevelControlCluster, initWithDevice)(JNIEnv * env, jobject sel
 JNI_METHOD(void, LevelControlCluster, move)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint moveMode, jint rate, jint optionMask, jint optionOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8281,7 +8286,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8301,7 +8306,7 @@ JNI_METHOD(void, LevelControlCluster, moveToLevel)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint level, jint transitionTime, jint optionMask,
  jint optionOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8328,7 +8333,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8347,7 +8352,7 @@ exit:
 JNI_METHOD(void, LevelControlCluster, moveToLevelWithOnOff)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint level, jint transitionTime)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8374,7 +8379,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8393,7 +8398,7 @@ exit:
 JNI_METHOD(void, LevelControlCluster, moveWithOnOff)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint moveMode, jint rate)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8420,7 +8425,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8440,7 +8445,7 @@ JNI_METHOD(void, LevelControlCluster, step)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepMode, jint stepSize, jint transitionTime, jint optionMask,
  jint optionOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8468,7 +8473,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8487,7 +8492,7 @@ exit:
 JNI_METHOD(void, LevelControlCluster, stepWithOnOff)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint stepMode, jint stepSize, jint transitionTime)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8514,7 +8519,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8533,7 +8538,7 @@ exit:
 JNI_METHOD(void, LevelControlCluster, stop)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint optionMask, jint optionOverride)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8560,7 +8565,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8578,7 +8583,7 @@ exit:
 }
 JNI_METHOD(void, LevelControlCluster, stopWithOnOff)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LevelControlCluster * cppCluster;
 
@@ -8605,7 +8610,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8623,7 +8628,7 @@ exit:
 }
 JNI_METHOD(jlong, LowPowerCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     LowPowerCluster * cppCluster = new LowPowerCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8632,7 +8637,7 @@ JNI_METHOD(jlong, LowPowerCluster, initWithDevice)(JNIEnv * env, jobject self, j
 
 JNI_METHOD(void, LowPowerCluster, sleep)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     LowPowerCluster * cppCluster;
 
@@ -8659,7 +8664,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8677,7 +8682,7 @@ exit:
 }
 JNI_METHOD(jlong, MediaInputCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     MediaInputCluster * cppCluster = new MediaInputCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8686,7 +8691,7 @@ JNI_METHOD(jlong, MediaInputCluster, initWithDevice)(JNIEnv * env, jobject self,
 
 JNI_METHOD(void, MediaInputCluster, hideInputStatus)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaInputCluster * cppCluster;
 
@@ -8713,7 +8718,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8732,7 +8737,7 @@ exit:
 JNI_METHOD(void, MediaInputCluster, renameInput)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint index, jstring name)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaInputCluster * cppCluster;
 
@@ -8761,7 +8766,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8779,7 +8784,7 @@ exit:
 }
 JNI_METHOD(void, MediaInputCluster, selectInput)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint index)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaInputCluster * cppCluster;
 
@@ -8806,7 +8811,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8824,7 +8829,7 @@ exit:
 }
 JNI_METHOD(void, MediaInputCluster, showInputStatus)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaInputCluster * cppCluster;
 
@@ -8851,7 +8856,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8869,7 +8874,7 @@ exit:
 }
 JNI_METHOD(jlong, MediaPlaybackCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     MediaPlaybackCluster * cppCluster = new MediaPlaybackCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -8878,7 +8883,7 @@ JNI_METHOD(jlong, MediaPlaybackCluster, initWithDevice)(JNIEnv * env, jobject se
 
 JNI_METHOD(void, MediaPlaybackCluster, mediaFastForward)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -8905,7 +8910,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8923,7 +8928,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaNext)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -8950,7 +8955,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -8968,7 +8973,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaPause)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -8995,7 +9000,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9013,7 +9018,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaPlay)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9040,7 +9045,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9058,7 +9063,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaPrevious)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9085,7 +9090,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9103,7 +9108,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaRewind)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9130,7 +9135,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9149,7 +9154,7 @@ exit:
 JNI_METHOD(void, MediaPlaybackCluster, mediaSkipBackward)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong deltaPositionMilliseconds)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9176,7 +9181,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9195,7 +9200,7 @@ exit:
 JNI_METHOD(void, MediaPlaybackCluster, mediaSkipForward)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong deltaPositionMilliseconds)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9222,7 +9227,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9241,7 +9246,7 @@ exit:
 JNI_METHOD(void, MediaPlaybackCluster, mediaSkipSeek)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong position)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9268,7 +9273,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9286,7 +9291,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaStartOver)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9313,7 +9318,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9331,7 +9336,7 @@ exit:
 }
 JNI_METHOD(void, MediaPlaybackCluster, mediaStop)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     MediaPlaybackCluster * cppCluster;
 
@@ -9358,7 +9363,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9376,7 +9381,7 @@ exit:
 }
 JNI_METHOD(jlong, NetworkCommissioningCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     NetworkCommissioningCluster * cppCluster = new NetworkCommissioningCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -9386,7 +9391,7 @@ JNI_METHOD(jlong, NetworkCommissioningCluster, initWithDevice)(JNIEnv * env, job
 JNI_METHOD(void, NetworkCommissioningCluster, addThreadNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray operationalDataset, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9416,7 +9421,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9436,7 +9441,7 @@ JNI_METHOD(void, NetworkCommissioningCluster, addWiFiNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jbyteArray credentials, jlong breadcrumb,
  jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9467,7 +9472,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9486,7 +9491,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, disableNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9516,7 +9521,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9535,7 +9540,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, enableNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9565,7 +9570,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9584,7 +9589,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, getLastNetworkCommissioningResult)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9611,7 +9616,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9630,7 +9635,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, removeNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray networkID, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9660,7 +9665,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9679,7 +9684,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, scanNetworks)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9708,7 +9713,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9727,7 +9732,7 @@ exit:
 JNI_METHOD(void, NetworkCommissioningCluster, updateThreadNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray operationalDataset, jlong breadcrumb, jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9757,7 +9762,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9777,7 +9782,7 @@ JNI_METHOD(void, NetworkCommissioningCluster, updateWiFiNetwork)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray ssid, jbyteArray credentials, jlong breadcrumb,
  jlong timeoutMs)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     NetworkCommissioningCluster * cppCluster;
 
@@ -9808,7 +9813,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9826,7 +9831,7 @@ exit:
 }
 JNI_METHOD(jlong, OtaSoftwareUpdateServerCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     OtaSoftwareUpdateServerCluster * cppCluster = new OtaSoftwareUpdateServerCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -9836,7 +9841,7 @@ JNI_METHOD(jlong, OtaSoftwareUpdateServerCluster, initWithDevice)(JNIEnv * env, 
 JNI_METHOD(void, OtaSoftwareUpdateServerCluster, applyUpdateRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jlong newVersion)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OtaSoftwareUpdateServerCluster * cppCluster;
 
@@ -9866,7 +9871,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9885,7 +9890,7 @@ exit:
 JNI_METHOD(void, OtaSoftwareUpdateServerCluster, notifyUpdateApplied)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray updateToken, jlong currentVersion)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OtaSoftwareUpdateServerCluster * cppCluster;
 
@@ -9915,7 +9920,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9936,7 +9941,7 @@ JNI_METHOD(void, OtaSoftwareUpdateServerCluster, queryImage)
  jint hardwareVersion, jlong currentVersion, jint protocolsSupported, jstring location, jint clientCanConsent,
  jbyteArray metadataForServer)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OtaSoftwareUpdateServerCluster * cppCluster;
 
@@ -9968,7 +9973,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -9986,7 +9991,7 @@ exit:
 }
 JNI_METHOD(jlong, OnOffCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     OnOffCluster * cppCluster = new OnOffCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -9995,7 +10000,7 @@ JNI_METHOD(jlong, OnOffCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
 
 JNI_METHOD(void, OnOffCluster, off)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OnOffCluster * cppCluster;
 
@@ -10022,7 +10027,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10040,7 +10045,7 @@ exit:
 }
 JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OnOffCluster * cppCluster;
 
@@ -10067,7 +10072,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10085,7 +10090,7 @@ exit:
 }
 JNI_METHOD(void, OnOffCluster, toggle)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OnOffCluster * cppCluster;
 
@@ -10112,7 +10117,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10130,7 +10135,7 @@ exit:
 }
 JNI_METHOD(jlong, OperationalCredentialsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     OperationalCredentialsCluster * cppCluster = new OperationalCredentialsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10141,7 +10146,7 @@ JNI_METHOD(void, OperationalCredentialsCluster, addOpCert)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray operationalCert, jbyteArray iPKValue,
  jlong caseAdminNode, jint adminVendorId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10173,7 +10178,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10192,7 +10197,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, addTrustedRootCertificate)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray rootCertificate)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10222,7 +10227,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10241,7 +10246,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, opCSRRequest)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray cSRNonce)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10270,7 +10275,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10288,7 +10293,7 @@ exit:
 }
 JNI_METHOD(void, OperationalCredentialsCluster, removeAllFabrics)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10315,7 +10320,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10334,7 +10339,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, removeFabric)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jlong fabricId, jlong nodeId, jint vendorId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10361,7 +10366,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10380,7 +10385,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, removeTrustedRootCertificate)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jbyteArray trustedRootIdentifier)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10410,7 +10415,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10429,7 +10434,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, setFabric)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint vendorId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10456,7 +10461,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10475,7 +10480,7 @@ exit:
 JNI_METHOD(void, OperationalCredentialsCluster, updateFabricLabel)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring label)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     OperationalCredentialsCluster * cppCluster;
 
@@ -10504,7 +10509,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10522,7 +10527,7 @@ exit:
 }
 JNI_METHOD(jlong, PumpConfigurationAndControlCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     PumpConfigurationAndControlCluster * cppCluster = new PumpConfigurationAndControlCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10531,7 +10536,7 @@ JNI_METHOD(jlong, PumpConfigurationAndControlCluster, initWithDevice)(JNIEnv * e
 
 JNI_METHOD(jlong, RelativeHumidityMeasurementCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     RelativeHumidityMeasurementCluster * cppCluster = new RelativeHumidityMeasurementCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10540,7 +10545,7 @@ JNI_METHOD(jlong, RelativeHumidityMeasurementCluster, initWithDevice)(JNIEnv * e
 
 JNI_METHOD(jlong, ScenesCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ScenesCluster * cppCluster = new ScenesCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10551,7 +10556,7 @@ JNI_METHOD(void, ScenesCluster, addScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jint sceneId, jint transitionTime, jstring sceneName,
  jint clusterId, jint length, jint value)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10580,7 +10585,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10598,7 +10603,7 @@ exit:
 }
 JNI_METHOD(void, ScenesCluster, getSceneMembership)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10625,7 +10630,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10644,7 +10649,7 @@ exit:
 JNI_METHOD(void, ScenesCluster, recallScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jint sceneId, jint transitionTime)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10671,7 +10676,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10689,7 +10694,7 @@ exit:
 }
 JNI_METHOD(void, ScenesCluster, removeAllScenes)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10716,7 +10721,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10735,7 +10740,7 @@ exit:
 JNI_METHOD(void, ScenesCluster, removeScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jint sceneId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10762,7 +10767,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10781,7 +10786,7 @@ exit:
 JNI_METHOD(void, ScenesCluster, storeScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jint sceneId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10808,7 +10813,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10827,7 +10832,7 @@ exit:
 JNI_METHOD(void, ScenesCluster, viewScene)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint groupId, jint sceneId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ScenesCluster * cppCluster;
 
@@ -10854,7 +10859,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10872,7 +10877,7 @@ exit:
 }
 JNI_METHOD(jlong, SoftwareDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     SoftwareDiagnosticsCluster * cppCluster = new SoftwareDiagnosticsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10881,7 +10886,7 @@ JNI_METHOD(jlong, SoftwareDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobj
 
 JNI_METHOD(void, SoftwareDiagnosticsCluster, resetWatermarks)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     SoftwareDiagnosticsCluster * cppCluster;
 
@@ -10908,7 +10913,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10926,7 +10931,7 @@ exit:
 }
 JNI_METHOD(jlong, SwitchCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     SwitchCluster * cppCluster = new SwitchCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10935,7 +10940,7 @@ JNI_METHOD(jlong, SwitchCluster, initWithDevice)(JNIEnv * env, jobject self, jlo
 
 JNI_METHOD(jlong, TvChannelCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     TvChannelCluster * cppCluster = new TvChannelCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -10944,7 +10949,7 @@ JNI_METHOD(jlong, TvChannelCluster, initWithDevice)(JNIEnv * env, jobject self, 
 
 JNI_METHOD(void, TvChannelCluster, changeChannel)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jstring match)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TvChannelCluster * cppCluster;
 
@@ -10973,7 +10978,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -10992,7 +10997,7 @@ exit:
 JNI_METHOD(void, TvChannelCluster, changeChannelByNumber)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint majorNumber, jint minorNumber)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TvChannelCluster * cppCluster;
 
@@ -11019,7 +11024,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11037,7 +11042,7 @@ exit:
 }
 JNI_METHOD(void, TvChannelCluster, skipChannel)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint count)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TvChannelCluster * cppCluster;
 
@@ -11064,7 +11069,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11082,7 +11087,7 @@ exit:
 }
 JNI_METHOD(jlong, TargetNavigatorCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     TargetNavigatorCluster * cppCluster = new TargetNavigatorCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11092,7 +11097,7 @@ JNI_METHOD(jlong, TargetNavigatorCluster, initWithDevice)(JNIEnv * env, jobject 
 JNI_METHOD(void, TargetNavigatorCluster, navigateTarget)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint target, jstring data)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TargetNavigatorCluster * cppCluster;
 
@@ -11121,7 +11126,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11139,7 +11144,7 @@ exit:
 }
 JNI_METHOD(jlong, TemperatureMeasurementCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     TemperatureMeasurementCluster * cppCluster = new TemperatureMeasurementCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11148,7 +11153,7 @@ JNI_METHOD(jlong, TemperatureMeasurementCluster, initWithDevice)(JNIEnv * env, j
 
 JNI_METHOD(jlong, TestClusterCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     TestClusterCluster * cppCluster = new TestClusterCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11157,7 +11162,7 @@ JNI_METHOD(jlong, TestClusterCluster, initWithDevice)(JNIEnv * env, jobject self
 
 JNI_METHOD(void, TestClusterCluster, test)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestClusterCluster * cppCluster;
 
@@ -11184,7 +11189,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11202,7 +11207,7 @@ exit:
 }
 JNI_METHOD(void, TestClusterCluster, testNotHandled)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestClusterCluster * cppCluster;
 
@@ -11229,7 +11234,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11247,7 +11252,7 @@ exit:
 }
 JNI_METHOD(void, TestClusterCluster, testSpecific)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestClusterCluster * cppCluster;
 
@@ -11274,7 +11279,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11292,7 +11297,7 @@ exit:
 }
 JNI_METHOD(void, TestClusterCluster, testUnknownCommand)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestClusterCluster * cppCluster;
 
@@ -11319,7 +11324,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11337,7 +11342,7 @@ exit:
 }
 JNI_METHOD(jlong, ThermostatCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ThermostatCluster * cppCluster = new ThermostatCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11346,7 +11351,7 @@ JNI_METHOD(jlong, ThermostatCluster, initWithDevice)(JNIEnv * env, jobject self,
 
 JNI_METHOD(void, ThermostatCluster, clearWeeklySchedule)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThermostatCluster * cppCluster;
 
@@ -11373,7 +11378,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11391,7 +11396,7 @@ exit:
 }
 JNI_METHOD(void, ThermostatCluster, getRelayStatusLog)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThermostatCluster * cppCluster;
 
@@ -11418,7 +11423,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11437,7 +11442,7 @@ exit:
 JNI_METHOD(void, ThermostatCluster, getWeeklySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint daysToReturn, jint modeToReturn)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThermostatCluster * cppCluster;
 
@@ -11464,7 +11469,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11484,7 +11489,7 @@ JNI_METHOD(void, ThermostatCluster, setWeeklySchedule)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint numberOfTransitionsForSequence, jint dayOfWeekForSequence,
  jint modeForSequence, jint payload)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThermostatCluster * cppCluster;
 
@@ -11512,7 +11517,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11531,7 +11536,7 @@ exit:
 JNI_METHOD(void, ThermostatCluster, setpointRaiseLower)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint mode, jint amount)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThermostatCluster * cppCluster;
 
@@ -11558,7 +11563,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11576,7 +11581,7 @@ exit:
 }
 JNI_METHOD(jlong, ThreadNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ThreadNetworkDiagnosticsCluster * cppCluster = new ThreadNetworkDiagnosticsCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11585,7 +11590,7 @@ JNI_METHOD(jlong, ThreadNetworkDiagnosticsCluster, initWithDevice)(JNIEnv * env,
 
 JNI_METHOD(void, ThreadNetworkDiagnosticsCluster, resetCounts)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     ThreadNetworkDiagnosticsCluster * cppCluster;
 
@@ -11612,7 +11617,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11630,7 +11635,7 @@ exit:
 }
 JNI_METHOD(jlong, WakeOnLanCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     WakeOnLanCluster * cppCluster = new WakeOnLanCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11639,7 +11644,7 @@ JNI_METHOD(jlong, WakeOnLanCluster, initWithDevice)(JNIEnv * env, jobject self, 
 
 JNI_METHOD(jlong, WindowCoveringCluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     WindowCoveringCluster * cppCluster = new WindowCoveringCluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -11648,7 +11653,7 @@ JNI_METHOD(jlong, WindowCoveringCluster, initWithDevice)(JNIEnv * env, jobject s
 
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringDownClose)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11675,7 +11680,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11694,7 +11699,7 @@ exit:
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringGoToLiftPercentage)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint percentageLiftValue)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11721,7 +11726,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11740,7 +11745,7 @@ exit:
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringGoToLiftValue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint liftValue)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11767,7 +11772,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11786,7 +11791,7 @@ exit:
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringGoToTiltPercentage)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint percentageTiltValue)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11813,7 +11818,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11832,7 +11837,7 @@ exit:
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringGoToTiltValue)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint tiltValue)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11859,7 +11864,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11877,7 +11882,7 @@ exit:
 }
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringStop)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11904,7 +11909,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
@@ -11922,7 +11927,7 @@ exit:
 }
 JNI_METHOD(void, WindowCoveringCluster, windowCoveringUpOpen)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     WindowCoveringCluster * cppCluster;
 
@@ -11949,7 +11954,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = JniReferences::FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -26,10 +26,10 @@ CHIP_ERROR CreateChipClusterException(JNIEnv * env, jint errorCode, jthrowable &
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID exceptionConstructor;
     
-    exceptionConstructor = env->GetMethodID(JniReferences::GetClusterExceptionCls(), "<init>", "(I)V");
+    exceptionConstructor = env->GetMethodID(JniReferences::GetInstance().GetClusterExceptionCls(), "<init>", "(I)V");
     VerifyOrExit(exceptionConstructor != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
     
-    outEx = (jthrowable) env->NewObject(JniReferences::GetClusterExceptionCls(), exceptionConstructor, errorCode);
+    outEx = (jthrowable) env->NewObject(JniReferences::GetInstance().GetClusterExceptionCls(), exceptionConstructor, errorCode);
     VerifyOrExit(outEx != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
 exit:
@@ -42,7 +42,7 @@ CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[], jint 
     jclass exceptionClass;
     jstring errStr;
 
-    err = GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
+    err = JniReferences::GetInstance().GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
     SuccessOrExit(err);
     
     exceptionConstructor = env->GetMethodID(exceptionClass, "<init>", "(Ljava/lang/String;)V");
@@ -63,7 +63,7 @@ class CHIPDefaultSuccessCallback : public Callback::Callback<DefaultSuccessCallb
     public:
         CHIPDefaultSuccessCallback(jobject javaCallback): Callback::Callback<DefaultSuccessCallback>(CallbackFn, this)
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -76,7 +76,7 @@ class CHIPDefaultSuccessCallback : public Callback::Callback<DefaultSuccessCallb
 
         ~CHIPDefaultSuccessCallback()
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -86,10 +86,10 @@ class CHIPDefaultSuccessCallback : public Callback::Callback<DefaultSuccessCallb
 
         static void CallbackFn(void * context)
         {
-            StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+            StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
             jmethodID javaMethod;
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             jobject javaCallbackRef;
             CHIPDefaultSuccessCallback * cppCallback = nullptr;
 
@@ -102,7 +102,7 @@ class CHIPDefaultSuccessCallback : public Callback::Callback<DefaultSuccessCallb
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
             SuccessOrExit(err);
         
             env->ExceptionClear();
@@ -126,7 +126,7 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
     public:
         CHIPDefaultFailureCallback(jobject javaCallback): Callback::Callback<DefaultFailureCallback>(CallbackFn, this)
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -139,7 +139,7 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
 
         ~CHIPDefaultFailureCallback()
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -149,10 +149,10 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
 
         static void CallbackFn(void * context, uint8_t status)
         {
-            StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+            StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
             jmethodID javaMethod;
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             jobject javaCallbackRef;
             jthrowable exception;
             CHIPDefaultFailureCallback * cppCallback = nullptr;
@@ -166,7 +166,7 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onError", "(Ljava/lang/Exception;)V", &javaMethod);
             SuccessOrExit(err);
 
             err = CreateChipClusterException(env, status, exception);
@@ -201,7 +201,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
     public:
         CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(jobject javaCallback): Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>(CallbackFn, this)
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -214,7 +214,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
         }
         ~CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback()
         {
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
                 return;
@@ -224,9 +224,9 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
 
         static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
         {
-            StackUnlockGuard unlockGuard(JniReferences::GetStackLock());
+            StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
-            JNIEnv * env = JniReferences::GetEnvForCurrentThread();
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             jobject javaCallbackRef;
             jmethodID javaMethod;
             CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback * cppCallback = nullptr;
@@ -249,7 +249,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = FindMethod(env, javaCallbackRef, "onSuccess", "({{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature label type}}{{/if}}{{/unless}}{{/zcl_command_arguments}})V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature label type}}{{/if}}{{/unless}}{{/zcl_command_arguments}})V", &javaMethod);
             SuccessOrExit(err);
 
             {{#zcl_command_arguments}}
@@ -311,7 +311,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
 {{/all_user_clusters}}
 JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlong clusterPtr)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     ClusterBase * cluster = reinterpret_cast<ClusterBase *>(clusterPtr);
     if (cluster != nullptr) {
         delete cluster;
@@ -321,7 +321,7 @@ JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlo
 {{#chip_client_clusters}}
 JNI_METHOD(jlong, {{asCamelCased name false}}Cluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     {{asCamelCased name false}}Cluster * cppCluster = new {{asCamelCased name false}}Cluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
@@ -335,7 +335,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(J
 JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {{/if}}
 {
-    StackLockGuard lock(JniReferences::GetStackLock());
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
     {{asCamelCased ../name false}}Cluster * cppCluster;
     
@@ -376,7 +376,7 @@ exit:
         jthrowable exception;
         jmethodID method;
 
-        err = FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
         if (err != CHIP_NO_ERROR) {
             ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
             return;

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -25,14 +25,17 @@ static CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[]
 CHIP_ERROR CreateChipClusterException(JNIEnv * env, jint errorCode, jthrowable & outEx) {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID exceptionConstructor;
-    
-    exceptionConstructor = env->GetMethodID(JniReferences::GetInstance().GetClusterExceptionCls(), "<init>", "(I)V");
-    VerifyOrExit(exceptionConstructor != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    
-    outEx = (jthrowable) env->NewObject(JniReferences::GetInstance().GetClusterExceptionCls(), exceptionConstructor, errorCode);
-    VerifyOrExit(outEx != nullptr, err = CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    jclass clusterExceptionCls;
 
-exit:
+    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipClusterException", clusterExceptionCls);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    
+    exceptionConstructor = env->GetMethodID(clusterExceptionCls, "<init>", "(I)V");
+    VerifyOrReturnError(exceptionConstructor != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+    
+    outEx = (jthrowable) env->NewObject(clusterExceptionCls, exceptionConstructor, errorCode);
+    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
+
     return err;
 }
 


### PR DESCRIPTION
#### Problem
* `JNIEnv->FindClass` can default to the system class loader if called from a different thread. If this is the case, our custom Chip classes can't be found. Currently, our workaround is to load classes in `JNI_OnLoad()` and cache them, but this solution does not scale.
  * https://developer.android.com/training/articles/perf-jni#faq_FindClass
  * https://stackoverflow.com/questions/13263340/findclass-from-any-thread-in-android-jni 

#### Change overview
* While I'm here, clean up `JniReferences`
  * Convert to namespace, since it's all static methods (fixes #7802)
  * Replace `goto: exit` with return
  * `NULL` -> `nullptr`
* Cache desired class loader in `SetJavaVM`, and use it in `GetClassRef`.
  * Use this to replace `GetClusterExceptionCls()` 

#### Testing
* Ran through commissioning and control flow in Android CHIPTool
