### PR TITLE
Remove casts now that our enums are the right size.

### DIFF
--- a/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
+++ b/examples/tv-app/linux/include/keypad-input/KeypadInputManager.cpp
@@ -53,11 +53,9 @@ EmberAfKeypadInputStatus KeypadInputManager::proxyKeypadInputRequest(EmberAfKeyp
 
 static void sendResponse(const char * responseName, EmberAfKeypadInputStatus keypadInputStatus)
 {
-    // TODO: Once our enums are sized properly, or once we stop depending on the
-    // value being a certain type, we can remove the static_cast.  For now the
-    // cast is safe because all EmberAfKeypadInputStatus values fit in uint32_t.
+    static_assert(std::is_same<std::underlying_type_t<EmberAfKeypadInputStatus>, uint8_t>::value, "Wrong enum size");
     emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_KEYPAD_INPUT_CLUSTER_ID,
-                              ZCL_SEND_KEY_RESPONSE_COMMAND_ID, "u", static_cast<uint8_t>(keypadInputStatus));
+                              ZCL_SEND_KEY_RESPONSE_COMMAND_ID, "u", keypadInputStatus);
 
     EmberStatus status = emberAfSendResponse();
     if (status != EMBER_SUCCESS)

--- a/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/linux/include/media-playback/MediaPlaybackManager.cpp
@@ -83,11 +83,9 @@ void MediaPlaybackManager::storeNewPlaybackState(chip::EndpointId endpoint, uint
 
 static void sendResponse(const char * responseName, chip::CommandId commandId, EmberAfMediaPlaybackStatus mediaPlaybackStatus)
 {
-    // TODO: Once our enums are sized properly, or once we stop depending on the
-    // value being a certain type, we can remove the static_cast.  For now the
-    // cast is safe because all EmberAfKeypadInputStatus values fit in uint32_t.
+    static_assert(std::is_same<std::underlying_type_t<EmberAfMediaPlaybackStatus>, uint8_t>::value, "Wrong enum size");
     emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_MEDIA_PLAYBACK_CLUSTER_ID,
-                              commandId, "u", static_cast<uint8_t>(mediaPlaybackStatus));
+                              commandId, "u", mediaPlaybackStatus);
 
     EmberStatus status = emberAfSendResponse();
     if (status != EMBER_SUCCESS)


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/7746 made the
enums be sized correctly.

Fixes https://github.com/project-chip/connectedhomeip/issues/7622

#### Problem
We have `static_cast`s we no longer need.

#### Change overview
Remove the casts, replace with `static_assert`s.

#### Testing
Tested compilation on Mac.