### PR TITLE
Fix CHIPDeviceCallbacksMgr callback info storage

### DIFF
--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite("tests") {
   output_name = "libAppTests"
 
   test_sources = [
+    "TestCHIPDeviceCallbacksMgr.cpp",
     "TestClusterInfo.cpp",
     "TestCommandInteraction.cpp",
     "TestCommandPathParams.cpp",
@@ -38,6 +39,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app",
+    "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/protocols",
     "${nlunit_test_root}:nlunit-test",

--- a/src/app/tests/TestCHIPDeviceCallbacksMgr.cpp
+++ b/src/app/tests/TestCHIPDeviceCallbacksMgr.cpp
@@ -1,0 +1,444 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/util/CHIPDeviceCallbacksMgr.h>
+#include <nlunit-test.h>
+#include <support/UnitTestRegistration.h>
+
+namespace chip {
+namespace app {
+namespace {
+
+using SuccessCallback = void (*)(void * context, uint64_t value);
+using FailureCallback = void (*)(void * context, CHIP_ERROR error);
+
+void ShouldGetSingleResponseCallback(nlTestSuite * testSuite, void * apContext)
+{
+    auto & callbacks = CHIPDeviceCallbacksMgr::GetInstance();
+
+    static constexpr NodeId kTestNodeId     = 0x9b3780f93739918d;
+    static constexpr uint8_t kTestSequence  = 0x8b;
+    static constexpr uint64_t kTestArgument = 0x973f2e7071e0c12a;
+    static constexpr CHIP_ERROR kTestError  = CHIP_ERROR_INVALID_ARGUMENT;
+
+    struct CallbackContext
+    {
+        nlTestSuite * const testSuite;
+    } callbackContext = { testSuite };
+
+    const auto onSuccess = [](void * opaqueContext, uint64_t value) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        NL_TEST_ASSERT(context.testSuite, value == kTestArgument);
+    };
+
+    const auto onFailure = [](void * opaqueContext, CHIP_ERROR error) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        NL_TEST_ASSERT(context.testSuite, error == kTestError);
+    };
+
+    Callback::Callback<SuccessCallback> successCallback{ onSuccess, &callbackContext };
+    Callback::Callback<FailureCallback> failureCallback{ onFailure, &callbackContext };
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId, kTestSequence, successCallback.Cancel(), failureCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outSuccessCallback = decltype(successCallback)::FromCancelable(successCancelable);
+        auto outFailureCallback = decltype(failureCallback)::FromCancelable(failureCancelable);
+
+        NL_TEST_ASSERT(testSuite, outSuccessCallback == &successCallback);
+        NL_TEST_ASSERT(testSuite, outFailureCallback == &failureCallback);
+
+        outSuccessCallback->mCall(outSuccessCallback->mContext, kTestArgument);
+        outFailureCallback->mCall(outFailureCallback->mContext, kTestError);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+}
+
+void ShouldGetMultipleResponseCallbacks(nlTestSuite * testSuite, void * apContext)
+{
+    auto & callbacks = CHIPDeviceCallbacksMgr::GetInstance();
+
+    struct CallbackContext
+    {
+        nlTestSuite * const testSuite;
+    } callbackContext = { testSuite };
+
+    const auto onSuccess = [](void * opaqueContext, uint64_t value) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    const auto onFailure = [](void * opaqueContext, CHIP_ERROR error) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    Callback::Callback<SuccessCallback> successCallback{ onSuccess, &callbackContext };
+    Callback::Callback<FailureCallback> failureCallback{ onFailure, &callbackContext };
+
+    Callback::Callback<SuccessCallback> successCallback2{ onSuccess, &callbackContext };
+    Callback::Callback<FailureCallback> failureCallback2{ onFailure, &callbackContext };
+
+    Callback::Callback<SuccessCallback> successCallback3{ onSuccess, &callbackContext };
+    Callback::Callback<FailureCallback> failureCallback3{ onFailure, &callbackContext };
+
+    static constexpr NodeId kTestNodeId1    = 0x2f699f085d799846;
+    static constexpr NodeId kTestNodeId2    = 0xc354d359ee0b47f3;
+    static constexpr uint8_t kTestSequence1 = 0x8b;
+    static constexpr uint8_t kTestSequence2 = kTestSequence1 + 1;
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId1, kTestSequence1, successCallback.Cancel(), failureCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId2, kTestSequence1, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId1, kTestSequence2, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId1, kTestSequence1, successCallback.Cancel(), failureCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId2, kTestSequence1, successCallback2.Cancel(), failureCallback2.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId1, kTestSequence2, successCallback3.Cancel(), failureCallback3.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId2, kTestSequence1, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outSuccessCallback = decltype(successCallback2)::FromCancelable(successCancelable);
+        auto outFailureCallback = decltype(failureCallback2)::FromCancelable(failureCancelable);
+
+        NL_TEST_ASSERT(testSuite, outSuccessCallback == &successCallback2);
+        NL_TEST_ASSERT(testSuite, outFailureCallback == &failureCallback2);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId1, kTestSequence2, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outSuccessCallback = decltype(successCallback2)::FromCancelable(successCancelable);
+        auto outFailureCallback = decltype(failureCallback2)::FromCancelable(failureCancelable);
+
+        NL_TEST_ASSERT(testSuite, outSuccessCallback == &successCallback3);
+        NL_TEST_ASSERT(testSuite, outFailureCallback == &failureCallback3);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId1, kTestSequence1, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outSuccessCallback = decltype(successCallback)::FromCancelable(successCancelable);
+        auto outFailureCallback = decltype(failureCallback)::FromCancelable(failureCancelable);
+
+        NL_TEST_ASSERT(testSuite, outSuccessCallback == &successCallback);
+        NL_TEST_ASSERT(testSuite, outFailureCallback == &failureCallback);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId1, kTestSequence1, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId1, kTestSequence2, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId2, kTestSequence1, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+}
+
+void ShouldFailGetCanceledResponseCallback(nlTestSuite * testSuite, void * apContext)
+{
+    auto & callbacks = CHIPDeviceCallbacksMgr::GetInstance();
+
+    static constexpr NodeId kTestNodeId    = 0x9b3780f93739918d;
+    static constexpr uint8_t kTestSequence = 0x8b;
+
+    struct CallbackContext
+    {
+        nlTestSuite * const testSuite;
+    } callbackContext = { testSuite };
+
+    const auto onSuccess = [](void * opaqueContext, uint64_t value) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    const auto onFailure = [](void * opaqueContext, CHIP_ERROR error) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    Callback::Callback<SuccessCallback> successCallback{ onSuccess, &callbackContext };
+    Callback::Callback<FailureCallback> failureCallback{ onFailure, &callbackContext };
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddResponseCallback(kTestNodeId, kTestSequence, successCallback.Cancel(), failureCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outSuccessCallback = decltype(successCallback)::FromCancelable(successCancelable);
+        auto outFailureCallback = decltype(failureCallback)::FromCancelable(failureCancelable);
+
+        NL_TEST_ASSERT(testSuite, outSuccessCallback == &successCallback);
+        NL_TEST_ASSERT(testSuite, outFailureCallback == &failureCallback);
+    }
+
+    {
+        Callback::Cancelable * successCancelable = nullptr;
+        Callback::Cancelable * failureCancelable = nullptr;
+        CHIP_ERROR error = callbacks.GetResponseCallback(kTestNodeId, kTestSequence, &successCancelable, &failureCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+    }
+}
+
+void ShouldGetSingleReportCallback(nlTestSuite * testSuite, void * apContext)
+{
+    auto & callbacks = CHIPDeviceCallbacksMgr::GetInstance();
+
+    static constexpr NodeId kTestNodeId           = 0x9b3780f93739918d;
+    static constexpr EndpointId kTestEndpointId   = 0x20;
+    static constexpr ClusterId kTestClusterId     = 0x9103;
+    static constexpr AttributeId kTestAttributeId = 0x2232;
+
+    struct CallbackContext
+    {
+        nlTestSuite * const testSuite;
+    } callbackContext = { testSuite };
+
+    const auto onReport = [](void * opaqueContext, uint64_t value) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    Callback::Callback<SuccessCallback> reportCallback{ onReport, &callbackContext };
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+        NL_TEST_ASSERT(testSuite, reportCancelable == nullptr);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, reportCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outReportCallback = decltype(reportCallback)::FromCancelable(reportCancelable);
+
+        NL_TEST_ASSERT(testSuite, outReportCallback == &reportCallback);
+    }
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outReportCallback = decltype(reportCallback)::FromCancelable(reportCancelable);
+
+        NL_TEST_ASSERT(testSuite, outReportCallback == &reportCallback);
+    }
+}
+
+void ShouldFailGetCanceledReportCallback(nlTestSuite * testSuite, void * apContext)
+{
+    auto & callbacks = CHIPDeviceCallbacksMgr::GetInstance();
+
+    static constexpr NodeId kTestNodeId           = 0x9b3780f93739918d;
+    static constexpr EndpointId kTestEndpointId   = 0x20;
+    static constexpr ClusterId kTestClusterId     = 0x9103;
+    static constexpr AttributeId kTestAttributeId = 0x2232;
+
+    struct CallbackContext
+    {
+        nlTestSuite * const testSuite;
+    } callbackContext = { testSuite };
+
+    const auto onReport = [](void * opaqueContext, uint64_t value) {
+        CallbackContext & context = *static_cast<CallbackContext *>(opaqueContext);
+
+        // Not called.
+        NL_TEST_ASSERT(context.testSuite, false);
+    };
+
+    Callback::Callback<SuccessCallback> reportCallback{ onReport, &callbackContext };
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+        NL_TEST_ASSERT(testSuite, reportCancelable == nullptr);
+    }
+
+    {
+        CHIP_ERROR error =
+            callbacks.AddReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, reportCallback.Cancel());
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+    }
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_NO_ERROR);
+
+        auto outReportCallback = decltype(reportCallback)::FromCancelable(reportCancelable);
+
+        NL_TEST_ASSERT(testSuite, outReportCallback == &reportCallback);
+    }
+
+    reportCallback.Cancel();
+
+    {
+        Callback::Cancelable * reportCancelable = nullptr;
+        CHIP_ERROR error =
+            callbacks.GetReportCallback(kTestNodeId, kTestEndpointId, kTestClusterId, kTestAttributeId, &reportCancelable);
+        NL_TEST_ASSERT(testSuite, error == CHIP_ERROR_KEY_NOT_FOUND);
+        NL_TEST_ASSERT(testSuite, reportCancelable == nullptr);
+    }
+}
+
+} // namespace
+} // namespace app
+} // namespace chip
+
+const nlTest sTests[] = {
+    NL_TEST_DEF("ShouldGetSingleResponseCallback", chip::app::ShouldGetSingleResponseCallback),             //
+    NL_TEST_DEF("ShouldGetMultipleResponseCallbacks", chip::app::ShouldGetMultipleResponseCallbacks),       //
+    NL_TEST_DEF("ShouldFailGetCanceledResponseCallback", chip::app::ShouldFailGetCanceledResponseCallback), //
+    NL_TEST_DEF("ShouldGetSingleReportCallback", chip::app::ShouldGetSingleReportCallback),                 //
+    NL_TEST_DEF("ShouldFailGetCanceledReportCallback", chip::app::ShouldFailGetCanceledReportCallback),     //
+    NL_TEST_SENTINEL(),                                                                                     //
+};
+
+int TestCHIPDeviceCallbacksMgr()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "TestCHIPDeviceCallbacksMgr",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestCHIPDeviceCallbacksMgr)

--- a/src/app/util/BUILD.gn
+++ b/src/app/util/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+source_set("device_callbacks_manager") {
+  sources = [
+    "CHIPDeviceCallbacksMgr.cpp",
+    "CHIPDeviceCallbacksMgr.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+
+  cflags = [ "-Wconversion" ]
+}

--- a/src/app/util/CHIPDeviceCallbacksMgr.cpp
+++ b/src/app/util/CHIPDeviceCallbacksMgr.cpp
@@ -64,8 +64,9 @@ CHIP_ERROR CHIPDeviceCallbacksMgr::AddResponseCallback(NodeId nodeId, uint8_t se
     VerifyOrReturnError(onFailureCallback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ResponseCallbackInfo info = { nodeId, sequenceNumber };
-    memcpy(&onSuccessCallback->mInfoPtr, &info, sizeof(info));
-    memcpy(&onFailureCallback->mInfoPtr, &info, sizeof(info));
+    static_assert(sizeof(onSuccessCallback->mInfo) >= sizeof(info), "Callback info too large");
+    memcpy(&onSuccessCallback->mInfo, &info, sizeof(info));
+    memcpy(&onFailureCallback->mInfo, &info, sizeof(info));
 
     // If some callbacks have already been registered for the same ResponseCallbackInfo, it usually means that the response
     // has not been received for a previous command with the same sequenceNumber. Cancel the previously registered callbacks.
@@ -106,7 +107,8 @@ CHIP_ERROR CHIPDeviceCallbacksMgr::AddReportCallback(NodeId nodeId, EndpointId e
     VerifyOrReturnError(onReportCallback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ReportCallbackInfo info = { nodeId, endpointId, clusterId, attributeId };
-    memmove(&onReportCallback->mInfoPtr, &info, sizeof(info));
+    static_assert(sizeof(onReportCallback->mInfo) >= sizeof(info), "Callback info too large");
+    memcpy(&onReportCallback->mInfo, &info, sizeof(info));
 
     // If a callback has already been registered for the same ReportCallbackInfo, let's cancel it.
     CancelCallback(info, mReports);

--- a/src/app/util/CHIPDeviceCallbacksMgr.h
+++ b/src/app/util/CHIPDeviceCallbacksMgr.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <app/util/basic-types.h>
 #include <core/CHIPCallback.h>
 #include <core/CHIPError.h>
@@ -81,7 +83,11 @@ private:
         Callback::Cancelable * ca = &queue;
         while (ca != nullptr && ca->mNext != &queue)
         {
-            if (*reinterpret_cast<T *>(&ca->mNext->mInfoPtr) == info)
+            T callbackInfo;
+            static_assert(std::is_pod<T>::value, "Callback info must be POD");
+            static_assert(sizeof(ca->mNext->mInfo) >= sizeof(callbackInfo), "Callback info too large");
+            memcpy(&callbackInfo, ca->mNext->mInfo, sizeof(callbackInfo));
+            if (callbackInfo == info)
             {
                 *callback = ca->mNext;
                 return CHIP_NO_ERROR;

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -18,7 +18,6 @@ static_library("controller") {
   output_name = "libChipController"
 
   sources = [
-    "${chip_root}/src/app/util/CHIPDeviceCallbacksMgr.cpp",
     "AbstractMdnsDiscoveryController.cpp",
     "CHIPCluster.cpp",
     "CHIPCluster.h",
@@ -38,6 +37,7 @@ static_library("controller") {
 
   public_deps = [
     "${chip_root}/src/app",
+    "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/mdns",
     "${chip_root}/src/lib/support",

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -49,9 +49,7 @@ public:
      */
     Cancelable * mNext;
     Cancelable * mPrev;
-
-    void * mInfoPtr;
-    uint64_t mInfoScalar;
+    alignas(uint64_t) char mInfo[16];
 
     /**
      * @brief when non-null, indicates the Callback is registered with


### PR DESCRIPTION
#### Problem

The code in CHIPDeviceCallbacksMgr is storing information about each
registered callback in some inline space reserved for this purpose.

However, the space consists of two separate scalar fields (mInfoPtr and
mInfoScalar). Type punning these fields as a struct is undefined
behavior in C++. In fact these structures do not even fit on 32 bit
platforms without relying on padding that's added between the fields.

GCC can diagnose the invalid casts used here and issues the following
diagnostic (unless strict aliasing is disabled, which it is currently in
all builds except ESP32):

```
../third_party/connectedhomeip/src/app/util/CHIPDeviceCallbacksMgr.h: In instantiation of 'CHIP_ERROR chip::app::CHIPDeviceCallbacksMgr::GetCallback(T&, chip::Callback::CallbackDeque&, chip::Callback::Cancelable**) [with T = {anonymous}::ReportCallbackInfo; CHIP_ERROR = int]':
../third_party/connectedhomeip/src/app/util/CHIPDeviceCallbacksMgr.cpp:123:5:   required from here
../third_party/connectedhomeip/src/app/util/CHIPDeviceCallbacksMgr.h:84:52: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
```

#### Change overview

Use a character array instead and add a static_assert that the data
fits. Placing structures in character arrays is legal as C++ has
an explicit carve-out for this case.

This fixes the same issue as #6410 without introducing an allocation
which isn't clear how to ensure is freed.

#### Testing

Added TestCHIPDeviceCallbacksMgr