### PR TITLE
[cleanup] Remove code for encoding ember response commands

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
@@ -133,19 +133,6 @@ bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::Command * commandObj,
     }
     else
     {
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_GET_LOG_RECORD_RESPONSE_COMMAND_ID, "vwuuuvs", entry.logEntryId, entry.timestamp,
-                                      entry.eventType, entry.source, entry.eventId, entry.userId, entry.pin);
-
-            status = emberAfSendResponse();
-            if (status != EMBER_SUCCESS)
-            {
-                emberAfDoorLockClusterPrintln("Failed to send GetLogRecordResponse: 0x%X", status);
-            }
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                                  ZCL_GET_LOG_RECORD_RESPONSE_COMMAND_ID,

--- a/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
@@ -120,15 +120,6 @@ void emAfPluginDoorLockServerInitSchedule(void)
 #endif
 }
 
-static void sendResponse(const char * responseName)
-{
-    EmberStatus status = emberAfSendResponse();
-    if (status != EMBER_SUCCESS)
-    {
-        emberAfDoorLockClusterPrintln("Failed to send %s: 0x%X", responseName, status);
-    }
-}
-
 bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
                                                       uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t stopHour,
                                                       uint8_t stopMinute)
@@ -156,13 +147,7 @@ bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * comma
         emberAfDoorLockClusterPrintln("***RX SET WEEKDAY SCHEDULE***");
         printWeekdayScheduleTable();
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", status);
-        emberAfSendResponse();
-    }
-    else
+
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -206,15 +191,7 @@ bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::Command * comma
         zclStatus = (!entry->inUse ? EMBER_ZCL_STATUS_NOT_FOUND
                                    : (entry->userId != userId ? EMBER_ZCL_STATUS_NOT_FOUND : EMBER_ZCL_STATUS_SUCCESS));
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_GET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID, "uvuuuuuu", scheduleId, userId, zclStatus,
-                                  entry->daysMask, entry->startHour, entry->startMinute, entry->stopHour, entry->stopMinute);
 
-        sendResponse("GetWeekdayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -252,14 +229,6 @@ bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::Command * com
         emAfPluginDoorLockServerSetPinUserType(userId, EMBER_ZCL_DOOR_LOCK_USER_TYPE_UNRESTRICTED);
     }
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", zclStatus);
-
-        sendResponse("ClearWeekdayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -295,14 +264,7 @@ bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::Command * comma
         yeardayScheduleTable[scheduleId].inUse          = true;
         status                                          = 0x00; // success (per 7.3.2.17.15)
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", status);
 
-        sendResponse("SetYeardayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -344,15 +306,6 @@ bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::Command * comma
         }
     }
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_GET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID, "uvuww", scheduleId, userId, zclStatus,
-                                  entry->localStartTime, entry->localEndTime);
-
-        sendResponse("GetYeardayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -389,14 +342,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::Command * com
         emAfPluginDoorLockServerSetPinUserType(userId, EMBER_ZCL_DOOR_LOCK_USER_TYPE_UNRESTRICTED);
         status = 0x00; // success (per 7.3.2.17.17)
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", status);
 
-        sendResponse("ClearYeardayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -435,14 +381,7 @@ bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::Command * comma
         holidayScheduleTable[holidayScheduleId].inUse = true;
         status                                        = 0x00; // success (per 7.3.2.17.18)
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", status);
 
-        sendResponse("SetHolidayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -483,15 +422,6 @@ bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::Command * comma
         }
     }
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_GET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID, "uuwwu", holidayScheduleId, zclStatus,
-                                  entry->localStartTime, entry->localEndTime, entry->operatingModeDuringHoliday);
-
-        sendResponse("GetHolidayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
@@ -527,14 +457,7 @@ bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::Command * com
         holidayScheduleTable[holidayScheduleId].inUse = false;
         status                                        = 0x00; // success (per 7.3.2.17.20)
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID, "u", status);
 
-        sendResponse("ClearYeardayScheduleResponse");
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -226,17 +226,7 @@ bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::Command * commandObj, 
     if (emAfPluginDoorLockServerCheckForSufficientSpace(userId, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE))
     {
         EmberAfPluginDoorLockServerUser * user = &pinUserTable[userId];
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_GET_USER_TYPE_RESPONSE_COMMAND_ID, "vu", userId, user->type);
-            EmberStatus status = emberAfSendResponse();
-            if (status != EMBER_SUCCESS)
-            {
-                emberAfDoorLockClusterPrintln("Failed to send GetUserTypeResponse: 0x%X", status);
-            }
-        }
-        else
+
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                                  ZCL_GET_USER_TYPE_RESPONSE_COMMAND_ID,
@@ -264,18 +254,7 @@ bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::Command * commandObj, 
     uint8_t status = (emAfPluginDoorLockServerSetPinUserType(userId, static_cast<EmberAfDoorLockUserType>(userType))
                           ? 0x00   // success (per 7.3.2.17.21)
                           : 0x01); // failure (per 7.3.2.17.21)
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_USER_TYPE_RESPONSE_COMMAND_ID, "u", status);
 
-        EmberStatus emberStatus = emberAfSendResponse();
-        if (emberStatus != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send SetUserTypeResponse: 0x%X", emberStatus);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_USER_TYPE_RESPONSE_COMMAND_ID,
@@ -317,13 +296,7 @@ bool emberAfDoorLockClusterSetPinCallback(chip::app::Command * commandObj, uint1
     // send response
     uint8_t status = setUser(userId, userStatus, userType, pin, pinUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE);
     uint16_t rfProgrammingEventMask = 0xffff; // send event by default
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_PIN_RESPONSE_COMMAND_ID, "u", status);
-        emberAfSendResponse();
-    }
-    else
+
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -375,15 +348,6 @@ bool emberAfDoorLockClusterGetPinCallback(chip::app::Command * commandObj, uint1
     CHIP_ERROR err     = CHIP_NO_ERROR;
     if (getUser(userId, pinUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE, &user))
     {
-        uint8_t fakePin = 0x00;
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_GET_PIN_RESPONSE_COMMAND_ID, "vuus", userId, user.status, user.type,
-                                      (getSendPinOverTheAir() ? user.code.pin : &fakePin));
-            status = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                                  ZCL_GET_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -429,18 +393,6 @@ bool emberAfDoorLockClusterClearPinCallback(chip::app::Command * commandObj, uin
     uint16_t rfProgrammingEventMask = 0xffff; // event sent by default
     uint8_t userPin                 = 0x00;   // Zero length Zigbee string
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_PIN_RESPONSE_COMMAND_ID, "u", status);
-
-        EmberStatus emberStatus = emberAfSendResponse();
-        if (emberStatus != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send ClearPinResponse: 0x%X", emberStatus);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -485,17 +437,6 @@ bool emberAfDoorLockClusterClearAllPinsCallback(chip::app::Command * commandObj)
     }
 
     // 7.3.2.17.9 says that "0x00" indicates success.
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID, "u", 0x00);
-        EmberStatus status = emberAfSendResponse();
-        if (status != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send ClearAllPins: 0x%X", status);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID,
@@ -523,18 +464,7 @@ bool emberAfDoorLockClusterSetRfidCallback(chip::app::Command * commandObj, uint
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status =
         setUser(userId, userStatus, userType, rfid, rfidUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE);
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_SET_RFID_RESPONSE_COMMAND_ID, "u", status);
 
-        EmberStatus emberStatus = emberAfSendResponse();
-        if (emberStatus != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send SetRfidResponse: 0x%X", emberStatus);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_RFID_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -559,13 +489,6 @@ bool emberAfDoorLockClusterGetRfidCallback(chip::app::Command * commandObj, uint
     CHIP_ERROR err     = CHIP_NO_ERROR;
     if (getUser(userId, rfidUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE, &user))
     {
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                      ZCL_GET_RFID_RESPONSE_COMMAND_ID, "vuus", userId, user.status, user.type, user.code.pin);
-            status = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                                  ZCL_GET_RFID_RESPONSE_COMMAND_ID,
@@ -602,19 +525,6 @@ bool emberAfDoorLockClusterClearRfidCallback(chip::app::Command * commandObj, ui
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status = clearUserPinOrRfid(userId, rfidUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE);
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_RFID_RESPONSE_COMMAND_ID, "u", status);
-
-        EmberStatus emberStatus = emberAfSendResponse();
-
-        if (emberStatus != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send ClearRfidResponse: 0x%X", emberStatus);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_RFID_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -641,17 +551,6 @@ bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::Command * commandObj
     }
 
     // 7.3.2.17.26 says that "0x00" indicates success.
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_CLEAR_ALL_RFIDS_RESPONSE_COMMAND_ID, "u", 0x00);
-        EmberStatus status = emberAfSendResponse();
-        if (status != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send ClearAllRfidsResponse: 0x%X", status);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_ALL_RFIDS_RESPONSE_COMMAND_ID,
@@ -749,14 +648,6 @@ bool emberAfDoorLockClusterLockDoorCallback(chip::app::Command * commandObj, uin
     }
 
     // send response
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_LOCK_DOOR_RESPONSE_COMMAND_ID, "u",
-                                  doorLocked ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
-        emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_LOCK_DOOR_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -819,14 +710,6 @@ bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::Command * commandObj, u
                                     &lockStateUnlocked, ZCL_INT8U_ATTRIBUTE_TYPE);
     }
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_UNLOCK_DOOR_RESPONSE_COMMAND_ID, "u",
-                                  doorUnlocked ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
-        emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_UNLOCK_DOOR_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -1018,17 +901,6 @@ bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::Command * comman
         status = 0x01; // failure (per 7.3.2.17.4)
     }
 
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_DOOR_LOCK_CLUSTER_ID,
-                                  ZCL_UNLOCK_WITH_TIMEOUT_RESPONSE_COMMAND_ID, "u", status);
-        EmberStatus emberStatus = emberAfSendResponse();
-        if (emberStatus != EMBER_SUCCESS)
-        {
-            emberAfDoorLockClusterPrintln("Failed to send UnlockWithTimeoutResponse: 0x%X", status);
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_UNLOCK_WITH_TIMEOUT_RESPONSE_COMMAND_ID,

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -168,13 +168,7 @@ bool emberAfGroupsClusterAddGroupCallback(chip::app::Command * commandObj, Group
     {
         return true;
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_GROUPS_CLUSTER_ID,
-                                  ZCL_ADD_GROUP_RESPONSE_COMMAND_ID, "uv", status, groupId);
-        emberAfSendResponse();
-    }
-    else
+
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
                                              ZCL_ADD_GROUP_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -196,7 +190,6 @@ exit:
 bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, GroupId groupId)
 {
     EmberAfStatus status                                          = EMBER_ZCL_STATUS_NOT_FOUND;
-    EmberStatus sendStatus                                        = EMBER_SUCCESS;
     CHIP_ERROR err                                                = CHIP_NO_ERROR;
     uint8_t groupName[ZCL_GROUPS_CLUSTER_MAXIMUM_NAME_LENGTH + 1] = { 0 };
 
@@ -216,13 +209,7 @@ bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, Grou
     {
         status = EMBER_ZCL_STATUS_SUCCESS;
     }
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_GROUPS_CLUSTER_ID,
-                                  ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID, "uvs", status, groupId, groupName);
-        sendStatus = emberAfSendResponse();
-    }
-    else
+
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
                                              ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -233,10 +220,6 @@ bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, Grou
         SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
         SuccessOrExit(err = writer->PutString(TLV::ContextTag(2), reinterpret_cast<char *>(&groupName[1]), groupName[0]));
         SuccessOrExit(err = commandObj->FinishCommand());
-    }
-    if (EMBER_SUCCESS != sendStatus)
-    {
-        emberAfGroupsClusterPrintln("Groups: failed to send %s response: 0x%x", "view_group", sendStatus);
     }
 exit:
     if (err != CHIP_NO_ERROR)
@@ -313,13 +296,6 @@ bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command * command
         // added.  Each group requires a binding and, because the binding table is
         // used for other purposes besides groups, we can't be sure what the
         // capacity will be in the future.
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_GROUPS_CLUSTER_ID,
-                                      ZCL_GET_GROUP_MEMBERSHIP_RESPONSE_COMMAND_ID, "uub", 0xFF, count, list, listLen);
-            status = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
                                                  ZCL_GET_GROUP_MEMBERSHIP_RESPONSE_COMMAND_ID,
@@ -353,8 +329,7 @@ exit:
 bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, GroupId groupId)
 {
     EmberAfStatus status;
-    EmberStatus sendStatus = EMBER_SUCCESS;
-    CHIP_ERROR err         = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     emberAfGroupsClusterPrintln("RX: RemoveGroup 0x%2x", groupId);
 
@@ -371,13 +346,6 @@ bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, Gr
     // associated with it. ZCL6: 3.6.2.3.5: "Note that if a group is
     // removed the scenes associated with that group SHOULD be removed."
     emberAfScenesClusterRemoveScenesInGroupCallback(emberAfCurrentEndpoint(), groupId);
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_GROUPS_CLUSTER_ID,
-                                  ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID, "uv", status, groupId);
-        sendStatus = emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
                                              ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID,
@@ -388,10 +356,6 @@ bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, Gr
         SuccessOrExit(err = writer->Put(TLV::ContextTag(0), status));
         SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
         SuccessOrExit(err = commandObj->FinishCommand());
-    }
-    if (EMBER_SUCCESS != sendStatus)
-    {
-        emberAfGroupsClusterPrintln("Groups: failed to send %s response: 0x%x", "remove_group", sendStatus);
     }
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -155,13 +155,6 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::Command * commandObj
     }
 
     emberAfIdentifyClusterPrintln("Identifying for %d more seconds", identifyTime);
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_IDENTIFY_CLUSTER_ID,
-                                  ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID, "v", identifyTime);
-        sendStatus = emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_IDENTIFY_CLUSTER_ID,
                                              ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID,
@@ -180,10 +173,6 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "Failed to encode response command.");
-    }
-    if (EMBER_SUCCESS != sendStatus)
-    {
-        emberAfIdentifyClusterPrintln("Identify: failed to send %s response: 0x%x", "query", sendStatus);
     }
     return true;
 }

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -257,14 +257,6 @@ bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * 
 
     // Return FabricId - we are temporarily using commissioner nodeId (retrieved via emberAfCurrentCommand()->SourceNodeId()) as
     // fabricId until addOptCert + fabricIndex are implemented. Once they are, this method and its response will go away.
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT),
-                                  ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID, ZCL_SET_FABRIC_RESPONSE_COMMAND_ID, "y",
-                                  emberAfCurrentCommand()->SourceNodeId());
-        sendStatus = emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
                                              ZCL_SET_FABRIC_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -750,7 +750,7 @@ bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, con
     if (enhanced)
     {
         entry.transitionTime      = transitionTime / 10;
-        entry.transitionTime100ms = (uint8_t) (transitionTime - entry.transitionTime * 10);
+        entry.transitionTime100ms = (uint8_t)(transitionTime - entry.transitionTime * 10);
     }
     else
     {

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -227,9 +227,8 @@ bool emberAfScenesClusterViewSceneCallback(chip::app::Command * commandObj, Grou
 
 bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId)
 {
-    EmberAfStatus status   = EMBER_ZCL_STATUS_NOT_FOUND;
-    EmberStatus sendStatus = EMBER_SUCCESS;
-    CHIP_ERROR err         = CHIP_NO_ERROR;
+    EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
 
     emberAfScenesClusterPrintln("RX: RemoveScene 0x%2x, 0x%x", groupId, sceneId);
 
@@ -260,13 +259,6 @@ bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, Gr
     // single device.
     if (emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST || emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST_REPLY)
     {
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_SCENES_CLUSTER_ID,
-                                      ZCL_REMOVE_SCENE_RESPONSE_COMMAND_ID, "uvu", status, groupId, sceneId);
-            sendStatus = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                                  ZCL_REMOVE_SCENE_RESPONSE_COMMAND_ID,
@@ -279,10 +271,6 @@ bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, Gr
             SuccessOrExit(err = writer->Put(TLV::ContextTag(2), sceneId));
             SuccessOrExit(err = commandObj->FinishCommand());
         }
-        if (EMBER_SUCCESS != sendStatus)
-        {
-            emberAfScenesClusterPrintln("Scenes: failed to send %s response: 0x%x", "remove_scene", sendStatus);
-        }
     }
 exit:
     if (err != CHIP_NO_ERROR)
@@ -294,9 +282,8 @@ exit:
 
 bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj, GroupId groupId)
 {
-    EmberAfStatus status   = EMBER_ZCL_STATUS_INVALID_FIELD;
-    EmberStatus sendStatus = EMBER_SUCCESS;
-    CHIP_ERROR err         = CHIP_NO_ERROR;
+    EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_FIELD;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
 
     emberAfScenesClusterPrintln("RX: RemoveAllScenes 0x%2x", groupId);
 
@@ -322,15 +309,6 @@ bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj
     // to a single device.
     if (emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST || emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST_REPLY)
     {
-
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_SCENES_CLUSTER_ID,
-                                      ZCL_REMOVE_ALL_SCENES_RESPONSE_COMMAND_ID, "uv", status, groupId);
-
-            sendStatus = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                                  ZCL_REMOVE_ALL_SCENES_RESPONSE_COMMAND_ID,
@@ -341,10 +319,6 @@ bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj
             SuccessOrExit(err = writer->Put(TLV::ContextTag(0), status));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
             SuccessOrExit(err = commandObj->FinishCommand());
-        }
-        if (EMBER_SUCCESS != sendStatus)
-        {
-            emberAfScenesClusterPrintln("Scenes: failed to send %s response: 0x%x", "remove_all_scenes", sendStatus);
         }
     }
 exit:
@@ -358,8 +332,7 @@ exit:
 bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId)
 {
     EmberAfStatus status;
-    EmberStatus sendStatus = EMBER_SUCCESS;
-    CHIP_ERROR err         = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     emberAfScenesClusterPrintln("RX: StoreScene 0x%2x, 0x%x", groupId, sceneId);
     status = emberAfScenesClusterStoreCurrentSceneCallback(emberAfCurrentEndpoint(), groupId, sceneId);
 
@@ -367,14 +340,6 @@ bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, Gro
     // single device.
     if (emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST || emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST_REPLY)
     {
-
-        if (commandObj == nullptr)
-        {
-            emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_SCENES_CLUSTER_ID,
-                                      ZCL_STORE_SCENE_RESPONSE_COMMAND_ID, "uvu", status, groupId, sceneId);
-            sendStatus = emberAfSendResponse();
-        }
-        else
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                                  ZCL_STORE_SCENE_RESPONSE_COMMAND_ID,
@@ -386,10 +351,6 @@ bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, Gro
             SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
             SuccessOrExit(err = writer->Put(TLV::ContextTag(2), sceneId));
             SuccessOrExit(err = commandObj->FinishCommand());
-        }
-        if (EMBER_SUCCESS != sendStatus)
-        {
-            emberAfScenesClusterPrintln("Scenes: failed to send %s response: 0x%x", "store_scene", sendStatus);
         }
     }
 exit:
@@ -436,10 +397,9 @@ bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, Gr
 
 bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::Command * commandObj, GroupId groupId)
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
-    EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
-    EmberStatus sendStatus = EMBER_SUCCESS;
-    uint8_t sceneCount     = 0;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    uint8_t sceneCount   = 0;
     uint8_t sceneList[EMBER_AF_PLUGIN_SCENES_TABLE_SIZE];
 
     emberAfScenesClusterPrintln("RX: GetSceneMembership 0x%2x", groupId);
@@ -469,29 +429,6 @@ bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::Command * command
         }
     }
 
-    if (commandObj == nullptr)
-    {
-        // The status, capacity, and group id are always included in the response, but
-        // the scene count and scene list are only included if the group id matched.
-        emberAfFillExternalBuffer(
-            (ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT | EMBER_AF_DEFAULT_RESPONSE_POLICY_RESPONSES),
-            ZCL_SCENES_CLUSTER_ID, ZCL_GET_SCENE_MEMBERSHIP_RESPONSE_COMMAND_ID, "uuv", status,
-            (EMBER_AF_PLUGIN_SCENES_TABLE_SIZE - emberAfPluginScenesServerNumSceneEntriesInUse()), // capacity
-            groupId);
-
-        // Get Scene Membership commands are only responded to when they are
-        // addressed to a single device or when an entry in the table matches.
-        if (emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST ||
-            emberAfCurrentCommand()->type == EMBER_INCOMING_UNICAST_REPLY || sceneCount != 0)
-        {
-            sendStatus = emberAfSendResponse();
-            if (EMBER_SUCCESS != sendStatus)
-            {
-                emberAfScenesClusterPrintln("Scenes: failed to send %s response: 0x%x", "get_scene_membership", sendStatus);
-            }
-        }
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                              ZCL_GET_SCENE_MEMBERSHIP_RESPONSE_COMMAND_ID,
@@ -763,7 +700,6 @@ bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, con
     CHIP_ERROR err = CHIP_NO_ERROR;
     EmberAfSceneTableEntry entry;
     EmberAfStatus status;
-    EmberStatus sendStatus         = EMBER_SUCCESS;
     bool enhanced                  = (cmd->commandId == ZCL_ENHANCED_ADD_SCENE_COMMAND_ID);
     uint16_t extensionFieldSetsLen = static_cast<uint16_t>(
         cmd->bufLen -
@@ -814,7 +750,7 @@ bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, con
     if (enhanced)
     {
         entry.transitionTime      = transitionTime / 10;
-        entry.transitionTime100ms = (uint8_t)(transitionTime - entry.transitionTime * 10);
+        entry.transitionTime100ms = (uint8_t) (transitionTime - entry.transitionTime * 10);
     }
     else
     {
@@ -1072,15 +1008,6 @@ kickout:
     {
         return true;
     }
-
-    if (commandObj == nullptr)
-    {
-        emberAfFillExternalBuffer((ZCL_CLUSTER_SPECIFIC_COMMAND | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT), ZCL_SCENES_CLUSTER_ID,
-                                  (enhanced ? ZCL_ENHANCED_ADD_SCENE_RESPONSE_COMMAND_ID : ZCL_ADD_SCENE_RESPONSE_COMMAND_ID),
-                                  "uvu", status, groupId, sceneId);
-        sendStatus = emberAfSendResponse();
-    }
-    else
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                              ZCL_ADD_SCENE_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
@@ -1095,10 +1022,6 @@ kickout:
         SuccessOrExit(err = writer->Put(TLV::ContextTag(1), groupId));
         SuccessOrExit(err = writer->Put(TLV::ContextTag(2), sceneId));
         SuccessOrExit(err = commandObj->FinishCommand());
-    }
-    if (EMBER_SUCCESS != sendStatus)
-    {
-        emberAfScenesClusterPrintln("Scenes: failed to send %s response: 0x%x", "add_scene", sendStatus);
     }
 
 exit:


### PR DESCRIPTION
#### Problem
There are a few command handlers still have logic for encoding ember responses.

#### Change overview

Remove them.

There are a few code using `emberAfSendImmediateDefaultResponse`, which is a adapted function that will call im default response encoding.

#### Testing
- code cleanup