### PR TITLE
Remove int cast from ParseValueWithType value argument

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -131,7 +131,7 @@ def FormatZCLArguments(args, command):
             raise ParsingError("Argument should in key=value format")
         key, value = kvPair.split("=", 1)
         valueType = command.get(key, None)
-        commandArgs[key] = ParseValueWithType(int(value), valueType)
+        commandArgs[key] = ParseValueWithType(value, valueType)
     return commandArgs
 
 


### PR DESCRIPTION
#### Problem
The parsing of zcl commands keys,  for example ` zcl NetworkCommissioning AddThreadNetwork` and `zcl NetworkCommissioning EnableNetwork` fails due to a wrong cast.
```
 File "/home/ubuntu/connectedhomeip/out/python_env/bin/chip-device-ctrl", line 133, in FormatZCLArguments
    commandArgs[key] = ParseValueWithType(int(value), valueType)
ValueError: invalid literal for int() with base 10: 'hex:0e080000000000000000000300000b35060004001fffe00208dead00beef00cafe0708fddead00beef00000510aa07f8a9b0a93b1ededc340e97df803b030a4f70656e5468726561640102cd53041024a811ad6fbab60d97de6176db21ebcb0c040
invalid literal for int() with base 10: 'hex:0e080000000000000000000300000b35060004001fffe00208dead00beef00cafe0708fddead00beef00000510aa07f8a9b0a93b1ededc340e97df803b030a4f70656e5468726561640102cd53041024a811ad6fbab60d97de6176db21ebcb0c040
```

This issue was, I think,  mistakenly added in #7780 

#### Change overview
In Function `FormatZCLArguments`, remove the int cast from `ParseValueWithType` Value argument.
The Cast is done inside the function if the given type is a int and should not be done for other types anyway.

#### Testing
Rebuilt the controller and completed the comissioning flow
