### PR TITLE
Fix memory leaks and unnecessary use of packet buffers

### DIFF
--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -636,6 +636,7 @@ static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         NL_TEST_ASSERT(inSuite, certType == testCase.ExpectedCertType);
+        certSet.Release();
     }
 }
 
@@ -682,6 +683,7 @@ static void TestChipCert_CertId(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         NL_TEST_ASSERT(inSuite, chipId == testCase.ExpectedCertId);
+        certSet.Release();
     }
 }
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -309,6 +309,8 @@ private:
     P256PublicKey mPublicKey;
     P256KeypairContext mKeypair;
     bool mInitialized = false;
+
+    void Clear();
 };
 
 /**

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -921,6 +921,9 @@ exit:
 CHIP_ERROR P256Keypair::Initialize()
 {
     ERR_clear_error();
+
+    Clear();
+
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
     EC_KEY * ec_key  = nullptr;
@@ -988,6 +991,8 @@ exit:
 CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 {
     Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
+
+    Clear();
 
     BIGNUM * pvt_key     = nullptr;
     EC_GROUP * group     = nullptr;
@@ -1064,13 +1069,19 @@ exit:
     return error;
 }
 
-P256Keypair::~P256Keypair()
+void P256Keypair::Clear()
 {
     if (mInitialized)
     {
         EC_KEY * ec_key = to_EC_KEY(&mKeypair);
         EC_KEY_free(ec_key);
+        mInitialized = false;
     }
+}
+
+P256Keypair::~P256Keypair()
+{
+    Clear();
 }
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -615,6 +615,8 @@ CHIP_ERROR P256Keypair::Initialize()
 
     size_t pubkey_size = 0;
 
+    Clear();
+
     mbedtls_ecp_group_id group = MapECPGroupId(mPublicKey.Type());
 
     mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
@@ -677,6 +679,8 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     int result       = 0;
     CHIP_ERROR error = CHIP_NO_ERROR;
 
+    Clear();
+
     mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
     mbedtls_ecp_keypair_init(keypair);
 
@@ -702,13 +706,19 @@ exit:
     return error;
 }
 
-P256Keypair::~P256Keypair()
+void P256Keypair::Clear()
 {
     if (mInitialized)
     {
         mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
         mbedtls_ecp_keypair_free(keypair);
+        mInitialized = false;
     }
+}
+
+P256Keypair::~P256Keypair()
+{
+    Clear();
 }
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length)
@@ -937,8 +947,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const uint8_t * key, size_t key_le
 
     result = mbedtls_md_hmac_finish(&hmac_ctx, Uint8::to_uchar(out));
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    return error;
 
 exit:
     _log_mbedTLS_error(result);

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -56,6 +56,8 @@ public:
         return mPairingSession.GetMessageDispatch(reliableMessageManager, sessionMgr);
     }
 
+    CASESession & GetSession() { return mPairingSession; }
+
 private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -35,6 +35,7 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
+#include <support/ScopedBuffer.h>
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
@@ -277,7 +278,6 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
 
 CHIP_ERROR CASESession::DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role)
 {
-    System::PacketBufferHandle msg_salt;
     uint16_t saltlen;
 
     (void) kKDFSEInfo;
@@ -288,18 +288,17 @@ CHIP_ERROR CASESession::DeriveSecureSession(SecureSession & session, SecureSessi
     // Generate Salt for Encryption keys
     saltlen = kSHA256_Hash_Length;
 
-    msg_salt = System::PacketBufferHandle::New(saltlen);
-    VerifyOrReturnError(!msg_salt.IsNull(), CHIP_SYSTEM_ERROR_NO_MEMORY);
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
+    ReturnErrorCodeIf(!msg_salt.Alloc(saltlen), CHIP_ERROR_NO_MEMORY);
     {
-        Encoding::LittleEndian::BufferWriter bbuf(msg_salt->Start(), saltlen);
+        Encoding::LittleEndian::BufferWriter bbuf(msg_salt.Get(), saltlen);
         // TODO: Add IPK to Salt
         bbuf.Put(mMessageDigest, sizeof(mMessageDigest));
 
         VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
     }
 
-    ReturnErrorOnFailure(session.InitFromSecret(ByteSpan(mSharedSecret, mSharedSecret.Length()),
-                                                ByteSpan(msg_salt->Start(), saltlen),
+    ReturnErrorOnFailure(session.InitFromSecret(ByteSpan(mSharedSecret, mSharedSecret.Length()), ByteSpan(msg_salt.Get(), saltlen),
                                                 SecureSession::SessionInfoType::kSessionEstablishment, role));
 
     return CHIP_NO_ERROR;
@@ -427,15 +426,15 @@ CHIP_ERROR CASESession::SendSigmaR2()
     System::PacketBufferHandle msg_R2;
     uint16_t data_len;
 
-    System::PacketBufferHandle msg_rand;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_rand;
 
-    System::PacketBufferHandle msg_R2_Signed;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Signed;
     uint16_t msg_r2_signed_len;
 
-    System::PacketBufferHandle msg_R2_Encrypted;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Encrypted;
     size_t msg_r2_signed_enc_len;
 
-    System::PacketBufferHandle msg_salt;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
     uint16_t saltlen;
 
     uint8_t sr2k[kAEADKeySize];
@@ -447,19 +446,13 @@ CHIP_ERROR CASESession::SendSigmaR2()
 
     saltlen = kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length;
 
-    msg_salt = System::PacketBufferHandle::New(saltlen);
-    VerifyOrExit(!msg_salt.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_salt->SetDataLength(saltlen);
-
-    msg_rand = System::PacketBufferHandle::New(kSigmaParamRandomNumberSize);
-    VerifyOrExit(!msg_rand.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
+    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(msg_rand.Alloc(kSigmaParamRandomNumberSize), err = CHIP_ERROR_NO_MEMORY);
 
     // Step 1
     // Fill in the random value
-    err = DRBG_get_bytes(msg_rand->Start(), kSigmaParamRandomNumberSize);
+    err = DRBG_get_bytes(msg_rand.Get(), kSigmaParamRandomNumberSize);
     SuccessOrExit(err);
-
-    msg_rand->SetDataLength(kSigmaParamRandomNumberSize);
 
     // Step 3
     // hardcoded to use a p256keypair
@@ -474,10 +467,14 @@ CHIP_ERROR CASESession::SendSigmaR2()
     SuccessOrExit(err);
 
     // Step 5
-    err = ConstructSaltSigmaR2(msg_rand, mEphemeralKey.Pubkey(), mIPK, sizeof(mIPK), msg_salt);
-    SuccessOrExit(err);
+    {
+        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
+        err = ConstructSaltSigmaR2(ByteSpan(msg_rand.Get(), kSigmaParamRandomNumberSize), mEphemeralKey.Pubkey(), mIPK,
+                                   sizeof(mIPK), saltSpan);
+        SuccessOrExit(err);
+    }
 
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt->Start(), saltlen, kKDFSR2Info, kKDFInfoLength, sr2k,
+    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR2Info, kKDFInfoLength, sr2k,
                             kAEADKeySize);
     SuccessOrExit(err);
 
@@ -485,11 +482,10 @@ CHIP_ERROR CASESession::SendSigmaR2()
     msg_r2_signed_len =
         static_cast<uint16_t>(sizeof(uint16_t) + mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2);
 
-    msg_R2_Signed = System::PacketBufferHandle::New(msg_r2_signed_len);
-    VerifyOrExit(!msg_R2_Signed.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
+    VerifyOrExit(msg_R2_Signed.Alloc(msg_r2_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
     {
-        Encoding::LittleEndian::BufferWriter bbuf(msg_R2_Signed->Start(), msg_r2_signed_len);
+        Encoding::LittleEndian::BufferWriter bbuf(msg_R2_Signed.Get(), msg_r2_signed_len);
 
         bbuf.Put(mEphemeralKey.Pubkey(), mEphemeralKey.Pubkey().Length());
         bbuf.Put16(mOpCredSet->GetDevOpCredLen(mTrustedRootId));
@@ -499,20 +495,16 @@ CHIP_ERROR CASESession::SendSigmaR2()
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
 
-    msg_R2_Signed->SetDataLength(msg_r2_signed_len);
-
     // Step 7
-    err = mOpCredSet->SignMsg(mTrustedRootId, msg_R2_Signed->Start(), msg_R2_Signed->DataLength(), sigmaR2Signature);
+    err = mOpCredSet->SignMsg(mTrustedRootId, msg_R2_Signed.Get(), msg_r2_signed_len, sigmaR2Signature);
     SuccessOrExit(err);
 
     // Step 8
     msg_r2_signed_enc_len = sizeof(uint16_t) + mOpCredSet->GetDevOpCredLen(mTrustedRootId) + sigmaR2Signature.Length();
 
-    msg_R2_Encrypted = System::PacketBufferHandle::New(msg_r2_signed_enc_len);
-    VerifyOrExit(!msg_R2_Encrypted.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-
+    VerifyOrExit(msg_R2_Encrypted.Alloc(msg_r2_signed_enc_len), err = CHIP_ERROR_NO_MEMORY);
     {
-        Encoding::LittleEndian::BufferWriter bbuf(msg_R2_Encrypted->Start(), msg_r2_signed_enc_len);
+        Encoding::LittleEndian::BufferWriter bbuf(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len);
 
         bbuf.Put16(mOpCredSet->GetDevOpCredLen(mTrustedRootId));
         bbuf.Put(mOpCredSet->GetDevOpCred(mTrustedRootId), mOpCredSet->GetDevOpCredLen(mTrustedRootId));
@@ -521,11 +513,9 @@ CHIP_ERROR CASESession::SendSigmaR2()
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
 
-    msg_R2_Encrypted->SetDataLength(static_cast<uint16_t>(msg_r2_signed_enc_len));
-
     // Step 9
-    err = AES_CCM_encrypt(msg_R2_Encrypted->Start(), msg_r2_signed_enc_len, nullptr, 0, sr2k, kAEADKeySize, kIVSR2, kIVLength,
-                          msg_R2_Encrypted->Start(), tag, sizeof(tag));
+    err = AES_CCM_encrypt(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len, nullptr, 0, sr2k, kAEADKeySize, kIVSR2, kIVLength,
+                          msg_R2_Encrypted.Get(), tag, sizeof(tag));
     SuccessOrExit(err);
 
     data_len = static_cast<uint16_t>(kSigmaParamRandomNumberSize + sizeof(uint16_t) + kTrustedRootIdSize + kP256_PublicKey_Length +
@@ -539,13 +529,13 @@ CHIP_ERROR CASESession::SendSigmaR2()
     {
         Encoding::LittleEndian::BufferWriter bbuf(msg_R2->Start(), data_len);
 
-        bbuf.Put(msg_rand->Start(), kSigmaParamRandomNumberSize);
+        bbuf.Put(msg_rand.Get(), kSigmaParamRandomNumberSize);
         // Responder's session ID
         bbuf.Put16(mConnectionState.GetLocalKeyID());
         // Step 2
         bbuf.Put(mTrustedRootId.mId, mTrustedRootId.mLen);
         bbuf.Put(mEphemeralKey.Pubkey(), mEphemeralKey.Pubkey().Length());
-        bbuf.Put(msg_R2_Encrypted->Start(), msg_r2_signed_enc_len);
+        bbuf.Put(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len);
         bbuf.Put(tag, sizeof(tag));
 
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
@@ -589,10 +579,10 @@ CHIP_ERROR CASESession::HandleSigmaR2(const System::PacketBufferHandle & msg)
     const uint8_t * buf = msg->Start();
     size_t buflen       = msg->DataLength();
 
-    System::PacketBufferHandle msg_salt;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
     uint16_t saltlen;
 
-    System::PacketBufferHandle msg_R2_Signed;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Signed;
     uint16_t msg_r2_signed_len;
 
     uint8_t sr2k[kAEADKeySize];
@@ -645,17 +635,19 @@ CHIP_ERROR CASESession::HandleSigmaR2(const System::PacketBufferHandle & msg)
     // Step 3
     saltlen = kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length;
 
-    msg_salt = System::PacketBufferHandle::New(saltlen);
-    VerifyOrExit(!msg_salt.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_salt->SetDataLength(saltlen);
+    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
 
     err = ComputeIPK(mConnectionState.GetPeerKeyID(), mRemoteIPK, sizeof(mRemoteIPK));
     SuccessOrExit(err);
 
-    err = ConstructSaltSigmaR2(msg, mRemotePubKey, mRemoteIPK, sizeof(mRemoteIPK), msg_salt);
-    SuccessOrExit(err);
+    {
+        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
+        err = ConstructSaltSigmaR2(ByteSpan(msg->Start(), msg->DataLength()), mRemotePubKey, mRemoteIPK, sizeof(mRemoteIPK),
+                                   saltSpan);
+        SuccessOrExit(err);
+    }
 
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt->Start(), saltlen, kKDFSR2Info, kKDFInfoLength, sr2k,
+    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR2Info, kKDFInfoLength, sr2k,
                             kAEADKeySize);
     SuccessOrExit(err);
 
@@ -680,16 +672,17 @@ CHIP_ERROR CASESession::HandleSigmaR2(const System::PacketBufferHandle & msg)
     // Step 6 - Construct msg_R2_Signed and validate the signature in msg_r2_encrypted
     msg_r2_signed_len = static_cast<uint16_t>(sizeof(uint16_t) + remoteDeviceOpCertLen + kP256_PublicKey_Length * 2);
 
-    msg_R2_Signed = System::PacketBufferHandle::New(msg_r2_signed_len);
-    VerifyOrExit(!msg_R2_Signed.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_R2_Signed->SetDataLength(msg_r2_signed_len);
+    VerifyOrExit(msg_R2_Signed.Alloc(msg_r2_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
     sigLen = buflen - kSigmaParamRandomNumberSize - sizeof(encryptionKeyId) - kTrustedRootIdSize - kP256_PublicKey_Length -
         sizeof(uint16_t) - remoteDeviceOpCertLen - kTAGSize;
-    err = ConstructSignedCredentials(&buf, remoteDeviceOpCert, remoteDeviceOpCertLen, msg_R2_Signed, sigmaR2SignedData, sigLen);
-    SuccessOrExit(err);
+    {
+        MutableByteSpan msg_R2_Span(msg_R2_Signed.Get(), msg_r2_signed_len);
+        err = ConstructSignedCredentials(&buf, remoteDeviceOpCert, remoteDeviceOpCertLen, msg_R2_Span, sigmaR2SignedData, sigLen);
+        SuccessOrExit(err);
+    }
 
-    err = remoteCredential.ECDSA_validate_msg_signature(msg_R2_Signed->Start(), msg_r2_signed_len, sigmaR2SignedData);
+    err = remoteCredential.ECDSA_validate_msg_signature(msg_R2_Signed.Get(), msg_r2_signed_len, sigmaR2SignedData);
     SuccessOrExit(err);
 
 exit:
@@ -715,15 +708,15 @@ CHIP_ERROR CASESession::SendSigmaR3()
     System::PacketBufferHandle msg_R3;
     uint16_t data_len;
 
-    System::PacketBufferHandle msg_R3_Encrypted;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Encrypted;
     uint16_t msg_r3_encrypted_len;
 
-    System::PacketBufferHandle msg_salt;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
     uint16_t saltlen;
 
     uint8_t sr3k[kAEADKeySize];
 
-    System::PacketBufferHandle msg_R3_Signed;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Signed;
     uint16_t msg_r3_signed_len;
 
     P256ECDSASignature sigmaR3Signature;
@@ -736,14 +729,14 @@ CHIP_ERROR CASESession::SendSigmaR3()
     saltlen = kIPKSize + kSHA256_Hash_Length;
 
     ChipLogDetail(SecureChannel, "Sending SigmaR3");
-    msg_salt = System::PacketBufferHandle::New(saltlen);
-    VerifyOrExit(!msg_salt.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_salt->SetDataLength(saltlen);
+    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
 
-    err = ConstructSaltSigmaR3(mIPK, sizeof(mIPK), msg_salt);
-    SuccessOrExit(err);
-
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt->Start(), saltlen, kKDFSR3Info, kKDFInfoLength, sr3k,
+    {
+        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
+        err = ConstructSaltSigmaR3(mIPK, sizeof(mIPK), saltSpan);
+        SuccessOrExit(err);
+    }
+    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR3Info, kKDFInfoLength, sr3k,
                             kAEADKeySize);
     SuccessOrExit(err);
 
@@ -751,11 +744,10 @@ CHIP_ERROR CASESession::SendSigmaR3()
     msg_r3_signed_len =
         static_cast<uint16_t>(sizeof(uint16_t) + mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2);
 
-    msg_R3_Signed = System::PacketBufferHandle::New(msg_r3_signed_len);
-    VerifyOrExit(!msg_R3_Signed.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
+    VerifyOrExit(msg_R3_Signed.Alloc(msg_r3_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
     {
-        Encoding::LittleEndian::BufferWriter bbuf(msg_R3_Signed->Start(), msg_r3_signed_len);
+        Encoding::LittleEndian::BufferWriter bbuf(msg_R3_Signed.Get(), msg_r3_signed_len);
 
         bbuf.Put(mEphemeralKey.Pubkey(), mEphemeralKey.Pubkey().Length());
         bbuf.Put16(mOpCredSet->GetDevOpCredLen(mTrustedRootId));
@@ -765,21 +757,18 @@ CHIP_ERROR CASESession::SendSigmaR3()
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
 
-    msg_R3_Signed->SetDataLength(msg_r3_signed_len);
-
     // Step 3
-    err = mOpCredSet->SignMsg(mTrustedRootId, msg_R3_Signed->Start(), msg_R3_Signed->DataLength(), sigmaR3Signature);
+    err = mOpCredSet->SignMsg(mTrustedRootId, msg_R3_Signed.Get(), msg_r3_signed_len, sigmaR3Signature);
     SuccessOrExit(err);
 
     // Step 4
     msg_r3_encrypted_len = static_cast<uint16_t>(sizeof(uint16_t) + mOpCredSet->GetDevOpCredLen(mTrustedRootId) +
                                                  static_cast<uint16_t>(sigmaR3Signature.Length()));
 
-    msg_R3_Encrypted = System::PacketBufferHandle::New(msg_r3_encrypted_len);
-    VerifyOrExit(!msg_R3_Encrypted.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
+    VerifyOrExit(msg_R3_Encrypted.Alloc(msg_r3_encrypted_len), err = CHIP_ERROR_NO_MEMORY);
 
     {
-        Encoding::LittleEndian::BufferWriter bbuf(msg_R3_Encrypted->Start(), msg_r3_encrypted_len);
+        Encoding::LittleEndian::BufferWriter bbuf(msg_R3_Encrypted.Get(), msg_r3_encrypted_len);
 
         bbuf.Put16(mOpCredSet->GetDevOpCredLen(mTrustedRootId));
         bbuf.Put(mOpCredSet->GetDevOpCred(mTrustedRootId), mOpCredSet->GetDevOpCredLen(mTrustedRootId));
@@ -788,11 +777,9 @@ CHIP_ERROR CASESession::SendSigmaR3()
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
 
-    msg_R3_Encrypted->SetDataLength(msg_r3_encrypted_len);
-
     // Step 5
-    err = AES_CCM_encrypt(msg_R3_Encrypted->Start(), msg_r3_encrypted_len, nullptr, 0, sr3k, kAEADKeySize, kIVSR3, kIVLength,
-                          msg_R3_Encrypted->Start(), tag, sizeof(tag));
+    err = AES_CCM_encrypt(msg_R3_Encrypted.Get(), msg_r3_encrypted_len, nullptr, 0, sr3k, kAEADKeySize, kIVSR3, kIVLength,
+                          msg_R3_Encrypted.Get(), tag, sizeof(tag));
     SuccessOrExit(err);
 
     // Step 6
@@ -804,7 +791,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
     {
         Encoding::LittleEndian::BufferWriter bbuf(msg_R3->Start(), data_len);
 
-        bbuf.Put(msg_R3_Encrypted->Start(), msg_R3_Encrypted->DataLength());
+        bbuf.Put(msg_R3_Encrypted.Get(), msg_r3_encrypted_len);
         bbuf.Put(tag, sizeof(tag));
 
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
@@ -847,7 +834,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(const System::PacketBufferHandle & msg)
 
     const uint8_t * buf = msg->Start();
 
-    System::PacketBufferHandle msg_R3_Signed;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Signed;
     uint16_t msg_r3_signed_len;
 
     uint8_t sr3k[kAEADKeySize];
@@ -860,7 +847,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(const System::PacketBufferHandle & msg)
     const uint8_t * remoteDeviceOpCert;
     uint16_t remoteDeviceOpCertLen;
 
-    System::PacketBufferHandle msg_salt;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
     uint16_t saltlen;
 
     uint8_t * tag = msg->Start() + msg->DataLength() - kTAGSize;
@@ -874,17 +861,18 @@ CHIP_ERROR CASESession::HandleSigmaR3(const System::PacketBufferHandle & msg)
     // Step 1
     saltlen = kIPKSize + kSHA256_Hash_Length;
 
-    msg_salt = System::PacketBufferHandle::New(saltlen);
-    VerifyOrExit(!msg_salt.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_salt->SetDataLength(saltlen);
+    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
 
     err = ComputeIPK(mConnectionState.GetPeerKeyID(), mRemoteIPK, sizeof(mRemoteIPK));
     SuccessOrExit(err);
 
-    err = ConstructSaltSigmaR3(mRemoteIPK, sizeof(mRemoteIPK), msg_salt);
-    SuccessOrExit(err);
+    {
+        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
+        err = ConstructSaltSigmaR3(mRemoteIPK, sizeof(mRemoteIPK), saltSpan);
+        SuccessOrExit(err);
+    }
 
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt->Start(), saltlen, kKDFSR3Info, kKDFInfoLength, sr3k,
+    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR3Info, kKDFInfoLength, sr3k,
                             kAEADKeySize);
     SuccessOrExit(err);
 
@@ -905,15 +893,15 @@ CHIP_ERROR CASESession::HandleSigmaR3(const System::PacketBufferHandle & msg)
     // Step 4
     msg_r3_signed_len = static_cast<uint16_t>(sizeof(uint16_t) + remoteDeviceOpCertLen + kP256_PublicKey_Length * 2);
 
-    msg_R3_Signed = System::PacketBufferHandle::New(msg_r3_signed_len);
-    VerifyOrExit(!msg_R3_Signed.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-    msg_R3_Signed->SetDataLength(msg_r3_signed_len);
+    VerifyOrExit(msg_R3_Signed.Alloc(msg_r3_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
     sigLen = msg->DataLength() - sizeof(uint16_t) - remoteDeviceOpCertLen - kTAGSize;
-    err    = ConstructSignedCredentials(&buf, remoteDeviceOpCert, remoteDeviceOpCertLen, msg_R3_Signed, sigmaR3SignedData, sigLen);
-    SuccessOrExit(err);
-
-    err = remoteCredential.ECDSA_validate_msg_signature(msg_R3_Signed->Start(), msg_r3_signed_len, sigmaR3SignedData);
+    {
+        MutableByteSpan msg_R3_Span(msg_R3_Signed.Get(), msg_r3_signed_len);
+        err = ConstructSignedCredentials(&buf, remoteDeviceOpCert, remoteDeviceOpCertLen, msg_R3_Span, sigmaR3SignedData, sigLen);
+        SuccessOrExit(err);
+    }
+    err = remoteCredential.ECDSA_validate_msg_signature(msg_R3_Signed.Get(), msg_r3_signed_len, sigmaR3SignedData);
     SuccessOrExit(err);
 
     err = mCommissioningHash.Finish(mMessageDigest);
@@ -988,15 +976,15 @@ CHIP_ERROR CASESession::FindValidTrustedRoot(const uint8_t ** msgIterator, uint3
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::ConstructSaltSigmaR2(const System::PacketBufferHandle & rand, const P256PublicKey & pubkey,
-                                             const uint8_t * ipk, size_t ipkLen, System::PacketBufferHandle & salt)
+CHIP_ERROR CASESession::ConstructSaltSigmaR2(const ByteSpan & rand, const P256PublicKey & pubkey, const uint8_t * ipk,
+                                             size_t ipkLen, MutableByteSpan & salt)
 {
     uint8_t md[kSHA256_Hash_Length];
-    memset(salt->Start(), 0, salt->DataLength());
-    Encoding::LittleEndian::BufferWriter bbuf(salt->Start(), salt->DataLength());
+    memset(salt.data(), 0, salt.size());
+    Encoding::LittleEndian::BufferWriter bbuf(salt.data(), salt.size());
 
     bbuf.Put(ipk, ipkLen);
-    bbuf.Put(rand->Start(), kSigmaParamRandomNumberSize);
+    bbuf.Put(rand.data(), kSigmaParamRandomNumberSize);
     bbuf.Put(pubkey, pubkey.Length());
     ReturnErrorOnFailure(mCommissioningHash.Finish(md));
     bbuf.Put(md, kSHA256_Hash_Length);
@@ -1007,11 +995,11 @@ CHIP_ERROR CASESession::ConstructSaltSigmaR2(const System::PacketBufferHandle & 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::ConstructSaltSigmaR3(const uint8_t * ipk, size_t ipkLen, System::PacketBufferHandle & salt)
+CHIP_ERROR CASESession::ConstructSaltSigmaR3(const uint8_t * ipk, size_t ipkLen, MutableByteSpan & salt)
 {
     uint8_t md[kSHA256_Hash_Length];
-    memset(salt->Start(), 0, salt->DataLength());
-    Encoding::LittleEndian::BufferWriter bbuf(salt->Start(), salt->DataLength());
+    memset(salt.data(), 0, salt.size());
+    Encoding::LittleEndian::BufferWriter bbuf(salt.data(), salt.size());
 
     bbuf.Put(ipk, ipkLen);
     ReturnErrorOnFailure(mCommissioningHash.Finish(md));
@@ -1062,11 +1050,11 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t ** msgIte
 }
 
 CHIP_ERROR CASESession::ConstructSignedCredentials(const uint8_t ** msgIterator, const uint8_t * responderOpCert,
-                                                   uint16_t responderOpCertLen, System::PacketBufferHandle & signedCredentials,
+                                                   uint16_t responderOpCertLen, MutableByteSpan & signedCredentials,
                                                    P256ECDSASignature & signature, size_t sigLen)
 {
     {
-        Encoding::LittleEndian::BufferWriter bbuf(signedCredentials->Start(), signedCredentials->DataLength());
+        Encoding::LittleEndian::BufferWriter bbuf(signedCredentials.data(), signedCredentials.size());
 
         bbuf.Put(mRemotePubKey, mRemotePubKey.Length());
         bbuf.Put16(responderOpCertLen);

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -217,13 +217,13 @@ private:
     CHIP_ERROR HandleSigmaR1Resume_and_SendSigmaR2Resume(const PacketHeader & header, const System::PacketBufferHandle & msg);
 
     CHIP_ERROR FindValidTrustedRoot(const uint8_t ** msgIterator, uint32_t nTrustedRoots);
-    CHIP_ERROR ConstructSaltSigmaR2(const System::PacketBufferHandle & rand, const P256PublicKey & pubkey, const uint8_t * ipk,
-                                    size_t ipkLen, System::PacketBufferHandle & salt);
+    CHIP_ERROR ConstructSaltSigmaR2(const ByteSpan & rand, const P256PublicKey & pubkey, const uint8_t * ipk, size_t ipkLen,
+                                    MutableByteSpan & salt);
     CHIP_ERROR Validate_and_RetrieveResponderID(const uint8_t ** msgIterator, P256PublicKey & responderID,
                                                 const uint8_t ** responderOpCert, uint16_t & responderOpCertLen);
-    CHIP_ERROR ConstructSaltSigmaR3(const uint8_t * ipk, size_t ipkLen, System::PacketBufferHandle & salt);
+    CHIP_ERROR ConstructSaltSigmaR3(const uint8_t * ipk, size_t ipkLen, MutableByteSpan & salt);
     CHIP_ERROR ConstructSignedCredentials(const uint8_t ** msgIterator, const uint8_t * responderOpCert,
-                                          uint16_t responderOpCertLen, System::PacketBufferHandle & signedCredentials,
+                                          uint16_t responderOpCertLen, MutableByteSpan & signedCredentials,
                                           P256ECDSASignature & signature, size_t sigLen);
     CHIP_ERROR ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen);
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -29,10 +29,12 @@
 #include <credentials/CHIPCert.h>
 #include <credentials/CHIPOperationalCredentials.h>
 #include <messaging/tests/MessagingContext.h>
+#include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/CASESession.h>
 #include <stdarg.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 #include <support/UnitTestRegistration.h>
 
 #include "credentials/tests/CHIPCert_test_vectors.h"
@@ -56,7 +58,9 @@ public:
     {
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;
-        HandleMessageReceived(address, std::move(msgBuf));
+
+        System::PacketBufferHandle receivedMessage = msgBuf.CloneData();
+        HandleMessageReceived(address, std::move(receivedMessage));
 
         return CHIP_NO_ERROR;
     }
@@ -101,6 +105,67 @@ public:
     uint32_t mNumPairingErrors   = 0;
     uint32_t mNumPairingComplete = 0;
 };
+
+static CHIP_ERROR InitCredentialSets()
+{
+    CertificateKeyId trustedRootId = { .mId = sTestCert_Root01_SubjectKeyId, .mLen = sTestCert_Root01_SubjectKeyId_Len };
+
+    commissionerDevOpCred.Release();
+    accessoryDevOpCred.Release();
+    commissionerCertificateSet.Release();
+    accessoryCertificateSet.Release();
+
+    ReturnErrorOnFailure(
+        commissionerOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
+
+    memcpy((uint8_t *) (commissionerOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+    memcpy((uint8_t *) (commissionerOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+           sTestCert_Node01_01_PrivateKey_Len);
+
+    ReturnErrorOnFailure(commissionerOpKeys.Deserialize(commissionerOpKeysSerialized));
+
+    ReturnErrorOnFailure(
+        accessoryOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
+
+    memcpy((uint8_t *) (accessoryOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+    memcpy((uint8_t *) (accessoryOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+           sTestCert_Node01_01_PrivateKey_Len);
+
+    ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
+
+    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
+
+    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
+
+    // Add the trusted root certificate to the certificate set.
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+
+    ReturnErrorOnFailure(commissionerDevOpCred.Init(&commissionerCertificateSet, 1));
+
+    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
+                                                            static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
+
+    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCredKeypair(trustedRootId, &commissionerOpKeys));
+
+    ReturnErrorOnFailure(accessoryDevOpCred.Init(&accessoryCertificateSet, 1));
+
+    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
+                                                         static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
+
+    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCredKeypair(trustedRootId, &accessoryOpKeys));
+
+    return CHIP_NO_ERROR;
+}
 
 void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 {
@@ -158,6 +223,8 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     CASESessionSerializable serializableCommissioner;
     CASESessionSerializable serializableAccessory;
 
+    NL_TEST_ASSERT(inSuite, InitCredentialSets() == CHIP_NO_ERROR);
+
     gLoopback.mSentMessageCount = 0;
     NL_TEST_ASSERT(inSuite, pairingCommissioner.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, pairingAccessory.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
@@ -190,6 +257,144 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     TestCASESecurePairingDelegate delegateCommissioner;
     CASESession pairingCommissioner;
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
+}
+
+class TestPersistentStorageDelegate : public PersistentStorageDelegate
+{
+public:
+    TestPersistentStorageDelegate()
+    {
+        memset(keys, 0, sizeof(keys));
+        memset(keysize, 0, sizeof(keysize));
+        memset(values, 0, sizeof(values));
+        memset(valuesize, 0, sizeof(valuesize));
+    }
+
+    ~TestPersistentStorageDelegate()
+    {
+        for (int i = 0; i < 16; i++)
+        {
+            if (keys[i] != nullptr)
+            {
+                chip::Platform::MemoryFree(keys[i]);
+            }
+            if (values[i] != nullptr)
+            {
+                chip::Platform::MemoryFree(values[i]);
+            }
+        }
+    }
+
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    {
+        for (int i = 0; i < 16; i++)
+        {
+            if (keys[i] != nullptr && keysize[i] != 0 && size >= valuesize[i])
+            {
+                if (memcmp(key, keys[i], keysize[i]) == 0)
+                {
+                    memcpy(buffer, values[i], valuesize[i]);
+                    size = valuesize[i];
+                    return CHIP_NO_ERROR;
+                }
+            }
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
+    {
+        for (int i = 0; i < 16; i++)
+        {
+            if (keys[i] == nullptr && keysize[i] == 0 && valuesize[i] == 0)
+            {
+                keysize[i] = static_cast<uint16_t>(strlen(key));
+                keysize[i]++;
+                keys[i] = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(keysize[i]));
+                strcpy(keys[i], key);
+                values[i] = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(size));
+                memcpy(values[i], value, size);
+                valuesize[i] = size;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SyncDeleteKeyValue(const char * key) override { return CHIP_NO_ERROR; }
+
+private:
+    char * keys[16];
+    void * values[16];
+    uint16_t keysize[16];
+    uint16_t valuesize[16];
+};
+
+CASEServer gPairingServer;
+
+void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
+{
+    TestCASESecurePairingDelegate delegateCommissioner;
+    CASESession pairingCommissioner;
+
+    AdminPairingTable adminTable;
+    TestPersistentStorageDelegate storageDelegate;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    gLoopback.mSentMessageCount = 0;
+    NL_TEST_ASSERT(inSuite, pairingCommissioner.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, gPairingServer.GetSession().MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
+
+    SessionIDAllocator idAllocator;
+
+    adminTable.Init(&storageDelegate);
+
+    AdminPairingInfo * admin = adminTable.AssignAdminId(0);
+
+    NL_TEST_ASSERT(inSuite, admin->SetOperationalKey(accessoryOpKeys) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, admin->SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)) == CHIP_NO_ERROR);
+
+    uint8_t chipCert[kMaxCHIPCertLength * 2];
+    MutableByteSpan chipCertSpan(chipCert, sizeof(chipCert));
+    NL_TEST_ASSERT(inSuite,
+                   ConvertX509CertsToChipCertArray(ByteSpan(sTestCert_Node01_01_DER, sTestCert_Node01_01_DER_Len),
+                                                   ByteSpan(sTestCert_ICA01_DER, sTestCert_ICA01_DER_Len),
+                                                   chipCertSpan) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, admin->SetOperationalCert(chipCertSpan) == CHIP_NO_ERROR);
+
+    adminTable.Store(0);
+    adminTable.ReleaseAdminId(0);
+
+    adminTable.LoadFromStorage(0);
+    admin = adminTable.FindAdminWithId(0);
+
+    ChipCertificateSet certificates;
+    OperationalCredentialSet credentials;
+    CertificateKeyId rootKeyId;
+    NL_TEST_ASSERT(inSuite, admin->GetCredentials(credentials, certificates, rootKeyId) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite,
+                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &gTransportMgr,
+                                                                &ctx.GetSecureSessionManager(), &adminTable,
+                                                                &idAllocator) == CHIP_NO_ERROR);
+
+    ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(&pairingCommissioner);
+
+    NL_TEST_ASSERT(inSuite,
+                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &credentials, 1, 0,
+                                                        contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
+    NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
+
+    CASESession pairingCommissioner1;
+    NL_TEST_ASSERT(inSuite, pairingCommissioner1.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
+    ExchangeContext * contextCommissioner1 = ctx.NewExchangeToLocal(&pairingCommissioner1);
+
+    NL_TEST_ASSERT(inSuite,
+                   pairingCommissioner1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &credentials, 1, 0,
+                                                         contextCommissioner1, &delegateCommissioner) == CHIP_NO_ERROR);
 }
 
 void CASE_SecurePairingDeserialize(nlTestSuite * inSuite, void * inContext, CASESession & pairingCommissioner,
@@ -258,6 +463,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("WaitInit",    CASE_SecurePairingWaitTest),
     NL_TEST_DEF("Start",       CASE_SecurePairingStartTest),
     NL_TEST_DEF("Handshake",   CASE_SecurePairingHandshakeTest),
+    NL_TEST_DEF("ServerHandshake", CASE_SecurePairingHandshakeServerTest),
     NL_TEST_DEF("Serialize",   CASE_SecurePairingSerializeTest),
 
     NL_TEST_SENTINEL()
@@ -286,8 +492,6 @@ int CASE_TestSecurePairing_Setup(void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    CertificateKeyId trustedRootId = { .mId = sTestCert_Root01_SubjectKeyId, .mLen = sTestCert_Root01_SubjectKeyId_Len };
-
     ReturnErrorOnFailure(chip::Platform::MemoryInit());
 
     gTransportMgr.Init(&gLoopback);
@@ -302,56 +506,7 @@ int CASE_TestSecurePairing_Setup(void * inContext)
 
     gTransportMgr.SetSecureSessionMgr(&ctx.GetSecureSessionManager());
 
-    ReturnErrorOnFailure(
-        commissionerOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
-
-    memcpy((uint8_t *) (commissionerOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (commissionerOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
-           sTestCert_Node01_01_PrivateKey_Len);
-
-    ReturnErrorOnFailure(commissionerOpKeys.Deserialize(commissionerOpKeysSerialized));
-
-    ReturnErrorOnFailure(
-        accessoryOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
-
-    memcpy((uint8_t *) (accessoryOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (accessoryOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
-           sTestCert_Node01_01_PrivateKey_Len);
-
-    ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
-
-    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
-
-    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
-
-    // Add the trusted root certificate to the certificate set.
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
-                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
-                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
-                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
-                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(commissionerDevOpCred.Init(&commissionerCertificateSet, 1));
-
-    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                                            static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
-
-    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCredKeypair(trustedRootId, &commissionerOpKeys));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.Init(&accessoryCertificateSet, 1));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                                         static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCredKeypair(trustedRootId, &accessoryOpKeys));
-
-    return CHIP_NO_ERROR;
+    return InitCredentialSets();
 }
 
 /**


### PR DESCRIPTION
#### Problem
The available heap of the device reduces after every CASE session setup. After a few iterations, the packet buffer pool gets depleted as well. 

#### Change overview
1. Add a new unit test in `TestCASESession` that exercises the full sessions setup flow. It includes use of CASEServer, AdminPairingTable, StorageDelegate and performs multiple session setup using the same instance of CASEServer.
2. Some of the internal buffers in `CASESession` were being allocated using `PacketBufferHandle`. Replaced them with `ScopedMemoryBuffer` and `ByteSpan/MutableByteSpan`.
3. If the `Keypair` is already initialized free the previous keypair before reinitializing or deserializing another keypair in it.

#### Testing
`TestCASESession->CASE_SecurePairingHandshakeServerTest()` to test the repeated session setup. Used `valgrind` to detect leaks, fix and confirm the leaks are fixed.

Tested E2E session setup using `chip-tool`. The memory leak had more impact with the use of `chip-tool` as every run of it creates a new CASE session with the device. Confirmed that heap is not depleted after repeated CASE Session setups.

Tested E2E session setup with Python controller app as well.
