### PR TITLE
Fix Darwin implementation of RunEventLoop to return when StopEventLoopTask is called.

### DIFF
--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -85,12 +85,63 @@ public:
 
     typedef void (*EventHandlerFunct)(const ChipDeviceEvent * event, intptr_t arg);
 
+    /**
+     * InitChipStack() initializes the PlatformManager.  After calling that, a
+     * consumer is allowed to call either StartEventLoopTask or RunEventLoop to
+     * process pending work.  Calling both is not allowed: it must be one or the
+     * other.
+     */
     CHIP_ERROR InitChipStack();
     CHIP_ERROR AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
     void RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0);
+    /**
+     * ScheduleWork can be called after InitChipStack has been called.  Calls
+     * that happen before either StartEventLoopTask or RunEventLoop will queue
+     * the work up but that work will NOT run until one of those functions is
+     * called.
+     */
     void ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg = 0);
+    /**
+     * Process work items until StopEventLoopTask is called.  RunEventLoop will
+     * not return until work item processing is stopped.  Once it returns it
+     * guarantees that no more work items will be processed unless there's
+     * another call to RunEventLoop.
+     *
+     * Consumers that call RunEventLoop must not call StartEventLoopTask.
+     *
+     * Consumers that call RunEventLoop must ensure that RunEventLoop returns
+     * before calling Shutdown.
+     */
     void RunEventLoop();
+    /**
+     * Process work items until StopEventLoopTask is called.
+     *
+     * StartEventLoopTask processes items asynchronously.  It can return before
+     * any items are processed, or after some items have been processed, or
+     * while an item is being processed, or even after StopEventLoopTask() has
+     * been called (e.g. if ScheduleWork() was called with a work item that
+     * calls StopEventLoopTask before StartEventLoopTask was called).
+     *
+     * Consumers that call StartEventLoopTask must not call RunEventLoop.
+     *
+     * Consumers that call StartEventLoopTask must ensure that they call
+     * StopEventLoopTask before calling Shutdown.
+     */
     CHIP_ERROR StartEventLoopTask();
+    /**
+     * Stop processing of work items by the event loop.
+     *
+     * If called from outside work item processing, StopEventLoopTask guarantees
+     * that any currently-executing work item completes execution and no more
+     * work items will run before it returns.  This is generally how
+     * StopEventLoopTask is used in conjunction with StartEventLoopTask.
+     *
+     * If called from inside work item processing, StopEventLoopTask makes no
+     * guarantees about exactly when work item processing will stop.  What it
+     * does guarantee is that if it is used this way in conjunction with
+     * RunEventLoop then all work item processing will stop before RunEventLoop
+     * returns.
+     */
     CHIP_ERROR StopEventLoopTask();
     void LockChipStack();
     bool TryLockChipStack();

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -44,6 +44,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     err = Internal::PosixConfig::Init();
     SuccessOrExit(err);
 
+    mRunLoopSem = dispatch_semaphore_create(0);
+
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl<PlatformManagerImpl>::_InitChipStack();
@@ -68,26 +70,43 @@ CHIP_ERROR PlatformManagerImpl::_StartEventLoopTask()
 
 CHIP_ERROR PlatformManagerImpl::_StopEventLoopTask()
 {
-
     if (mIsWorkQueueRunning == true)
     {
         mIsWorkQueueRunning = false;
-
-        // dispatch_sync is used in order to guarantee serialization of the caller with
-        // respect to any tasks that might already be on the queue, or running.
-        dispatch_sync(mWorkQueue, ^{
-            dispatch_suspend(mWorkQueue);
-        });
+        if (dispatch_get_current_queue() != mWorkQueue)
+        {
+            // dispatch_sync is used in order to guarantee serialization of the caller with
+            // respect to any tasks that might already be on the queue, or running.
+            dispatch_sync(mWorkQueue, ^{
+                dispatch_suspend(mWorkQueue);
+            });
+        }
+        else
+        {
+            // We are called from a task running on our work queue.  Dispatch async,
+            // so we don't deadlock ourselves.  Note that we do have to dispatch to
+            // guarantee that we don't signal the semaphore until we have ensured
+            // that no more tasks will run on the queue.
+            dispatch_async(mWorkQueue, ^{
+                dispatch_suspend(mWorkQueue);
+                dispatch_semaphore_signal(mRunLoopSem);
+            });
+        }
     }
 
     return CHIP_NO_ERROR;
-};
+}
 
 void PlatformManagerImpl::_RunEventLoop()
 {
     _StartEventLoopTask();
-    CFRunLoopRun();
-};
+
+    //
+    // Block on the semaphore till we're signalled to stop by
+    // _StopEventLoopTask()
+    //
+    dispatch_semaphore_wait(mRunLoopSem, DISPATCH_TIME_FOREVER);
+}
 
 CHIP_ERROR PlatformManagerImpl::_Shutdown()
 {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -80,7 +80,10 @@ private:
     static PlatformManagerImpl sInstance;
 
     dispatch_queue_t mWorkQueue = nullptr;
-    bool mIsWorkQueueRunning    = false;
+    // Semaphore used to implement blocking behavior in _RunEventLoop.
+    dispatch_semaphore_t mRunLoopSem;
+
+    bool mIsWorkQueueRunning = false;
 
     inline ImplClass * Impl() { return static_cast<PlatformManagerImpl *>(this); }
 };


### PR DESCRIPTION
#### Problem
Darwin impl of RunEventLoop never returns, even if a task calls StopEventLoopTask.

#### Change overview
1. Document the PlatformManager API a bit better.
2. Fix Darwin implementation to align with the documentation.

#### Testing
* Added some unit tests for the defined behavior.
* Ensured that basic tests in `./scripts/tests/test_suites.sh` pass.