### PR TITLE
[msg] Reorder header bits to match spec.

### DIFF
--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
         packetHeader.SetDestinationNodeId(state->GetPeerNodeId());
     }
 
-    packetHeader.GetFlags().Set(Header::FlagValues::kSecure);
+    packetHeader.GetFlags().Set(Header::FlagValues::kEncryptedMessage);
 
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(msgBuf));
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -315,7 +315,7 @@ void SecureSessionMgr::OnMessageReceived(const PeerAddress & peerAddress, System
 
     ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
 
-    if (packetHeader.GetFlags().Has(Header::FlagValues::kSecure))
+    if (packetHeader.GetFlags().Has(Header::FlagValues::kEncryptedMessage))
     {
         SecureMessageDispatch(packetHeader, peerAddress, std::move(msg));
     }

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -78,14 +78,14 @@ constexpr size_t kVendorIdSizeBytes = 2;
 constexpr size_t kAckIdSizeBytes = 4;
 
 /// Mask to extract just the version part from a 16bit header prefix.
-constexpr uint16_t kVersionMask = 0xF000;
+constexpr uint16_t kVersionMask = 0x00F0;
 /// Shift to convert to/from a masked version 16bit value to a 4bit version.
-constexpr int kVersionShift = 12;
+constexpr int kVersionShift = 4;
 
 /// Mask to extract just the encryption type part from a 16bit header prefix.
-constexpr uint16_t kEncryptionTypeMask = 0xF0;
-/// Shift to convert to/from a masked encryption type 16bit value to a 4bit encryption type.
-constexpr int kEncryptionTypeShift = 4;
+constexpr uint16_t kEncryptionTypeMask = 0x3000;
+/// Shift to convert to/from a masked encryption type 16bit value to a 2bit encryption type.
+constexpr int kEncryptionTypeShift = 12;
 
 } // namespace
 
@@ -131,12 +131,6 @@ uint16_t MessageAuthenticationCode::TagLenForEncryptionType(Header::EncryptionTy
 {
     switch (encType)
     {
-    case Header::EncryptionType::kAESCCMTagLen8:
-        return 8;
-
-    case Header::EncryptionType::kAESCCMTagLen12:
-        return 12;
-
     case Header::EncryptionType::kAESCCMTagLen16:
         return 16;
 
@@ -158,8 +152,8 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     version = ((header & kVersionMask) >> kVersionShift);
     VerifyOrExit(version == kHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
 
+    mFlags.SetRaw(header);
     mEncryptionType = static_cast<Header::EncryptionType>((header & kEncryptionTypeMask) >> kEncryptionTypeShift);
-    mFlags.SetRaw(header & Header::kFlagsMask);
 
     err = reader.Read32(&mMessageId).StatusCode();
     SuccessOrExit(err);

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -47,8 +47,8 @@ namespace Header {
 
 enum class EncryptionType
 {
-    kEncryptionTypeNone  = 0,
-    kAESCCMTagLen16 = 1,
+    kEncryptionTypeNone = 0,
+    kAESCCMTagLen16     = 1,
 };
 
 /**

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -47,9 +47,8 @@ namespace Header {
 
 enum class EncryptionType
 {
-    kAESCCMTagLen8  = 0,
-    kAESCCMTagLen12 = 1,
-    kAESCCMTagLen16 = 2,
+    kEncryptionTypeNone  = 0,
+    kAESCCMTagLen16 = 1,
 };
 
 /**
@@ -74,16 +73,19 @@ enum class ExFlagValues : uint8_t
 enum class FlagValues : uint16_t
 {
     /// Header flag specifying that a destination node id is included in the header.
-    kDestinationNodeIdPresent = 0x0100,
+    kDestinationNodeIdPresent = 0x0001,
+
+    /// Header flag specifying that a destination group id is included in the header.
+    kDestinationGroupIdPresent = 0x0002,
 
     /// Header flag specifying that a source node id is included in the header.
-    kSourceNodeIdPresent = 0x0200,
+    kSourceNodeIdPresent = 0x0004,
 
     /// Header flag specifying that it is a control message for secure session.
-    kSecureSessionControlMessage = 0x0800,
+    kSecureSessionControlMessage = 0x4000,
 
     /// Header flag specifying that it is a encrypted message.
-    kSecure = 0x0001,
+    kEncryptedMessage = 0x0100,
 
 };
 
@@ -97,7 +99,6 @@ using ExFlags = BitFlags<ExFlagValues>;
 //                      |   |            +---Encrypted
 //                      |   +----------------Control message (TODO: Implement this)
 //                      +--------------------Privacy enhancements (TODO: Implement this)
-static constexpr uint16_t kFlagsMask = 0x0F01;
 
 } // namespace Header
 


### PR DESCRIPTION
#### Problem
The SDK message header flags do not match the specification.

#### Change overview
In order to write tools that dissect the Matter message format, this PR attempts to align the SDK implementation with the latest specification of the message flags and security flags fields.  This PR is a minimal change set.  Follow on tasks include:
- encode / decode paths should handle message and security flags as separate bytes rather than as a combined, little-endian uint16
- combine kEncryptionType and kEncryptedMessage -- currently trivial attempts to do so fail PASE and MRP unit tests.  The EncryptionType field is not at the proper specification location, and the kEncryptedMessage flag is a correct yet simplified view of the field.
- clean up encode/decode code paths so header processing is simplified and done in one place in all cases.

Fixes #7772. Fixes #7773. Fixes #7774. 

#### Testing
The existing CI does a good job of validating encode / decode paths for the header flags.