### PR TITLE
Support async NOC generation via op cred delegate API

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -96,14 +96,9 @@ using namespace chip::Encoding;
 
 constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondPerSecond;
 
-// TODO - Reduce memory requirement for generating x509 certificates
-// As per specifications (section 6.3.7. Trusted Root CA Certificates), DER certs
-// should require 600 bytes. Currently, due to ASN writer overheads, a larger buffer
-// is needed, even though the generated certificate fits in 600 bytes limit.
-constexpr uint32_t kMaxCHIPDERCertLength = 1024;
-constexpr uint32_t kMaxCHIPCSRLength     = 1024;
+constexpr uint32_t kMaxCHIPCSRLength = 1024;
 
-DeviceController::DeviceController()
+DeviceController::DeviceController() : mLocalNOCCallback(OnLocalNOCGenerated, this)
 {
     mState                    = State::NotInitialized;
     mSessionMgr               = nullptr;
@@ -215,34 +210,25 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams par
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceController::GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, MutableByteSpan & cert)
+CHIP_ERROR DeviceController::GenerateOperationalCertificates(const ByteSpan & noc, MutableByteSpan & cert)
 {
-    // This code requires about 2K RAM to generate the certificates.
+    // This code requires about 1K RAM to generate the certificates.
     // The code would run as part of commissioner applications, so RAM requirements should be fine.
     // Need to analyze if this requirement could be better managed by using static memory pools.
-    chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
-    ReturnErrorCodeIf(!noc.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-
-    uint32_t nocLen = 0;
-    ChipLogProgress(Controller, "Generating operational certificate for device " ChipLogFormatX64, ChipLogValueX64(deviceId));
-    ReturnErrorOnFailure(mOperationalCredentialsDelegate->GenerateNodeOperationalCertificate(
-        PeerId().SetNodeId(deviceId), CSR, 1, noc.Get(), kMaxCHIPDERCertLength, nocLen));
-
-    ReturnErrorCodeIf(nocLen == 0, CHIP_ERROR_CERT_NOT_FOUND);
-
     chip::Platform::ScopedMemoryBuffer<uint8_t> ica;
     ReturnErrorCodeIf(!ica.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
 
-    uint32_t icaLen = 0;
+    MutableByteSpan icaCertSpan(ica.Get(), kMaxCHIPDERCertLength);
+
     ChipLogProgress(Controller, "Getting intermediate CA certificate from the issuer");
-    CHIP_ERROR err = mOperationalCredentialsDelegate->GetIntermediateCACertificate(0, ica.Get(), kMaxCHIPDERCertLength, icaLen);
+    CHIP_ERROR err = mOperationalCredentialsDelegate->GetIntermediateCACertificate(0, icaCertSpan);
     ChipLogProgress(Controller, "GetIntermediateCACertificate returned %" PRId32, err);
     if (err == CHIP_ERROR_INTERMEDIATE_CA_NOT_REQUIRED)
     {
         // This implies that the commissioner application uses root CA to sign the operational
         // certificates, and an intermediate CA is not needed. It's not an error condition, so
         // let's just send operational certificate and root CA certificate to the device.
-        icaLen = 0;
+        icaCertSpan.reduce_size(0);
         ChipLogProgress(Controller, "Intermediate CA is not needed");
     }
     else if (err != CHIP_NO_ERROR)
@@ -250,9 +236,39 @@ CHIP_ERROR DeviceController::GenerateOperationalCertificates(const ByteSpan & CS
         return err;
     }
 
-    ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(ByteSpan(noc.Get(), nocLen), ByteSpan(ica.Get(), icaLen), cert));
+    ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(noc, icaCertSpan, cert));
 
     return CHIP_NO_ERROR;
+}
+
+void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+
+    Transport::AdminPairingInfo * const admin = controller->mAdmins.FindAdminWithId(controller->mAdminId);
+
+    uint32_t chipCertAllocatedLen = kMaxCHIPCertLength * 2;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
+
+    VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(chipCert.Alloc(chipCertAllocatedLen), err = CHIP_ERROR_NO_MEMORY);
+
+    {
+        MutableByteSpan chipCertSpan(chipCert.Get(), chipCertAllocatedLen);
+        err = controller->GenerateOperationalCertificates(noc, chipCertSpan);
+        SuccessOrExit(err);
+
+        err = admin->SetOperationalCert(chipCertSpan);
+        SuccessOrExit(err);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed in generating local operational credentials. Error %s", ErrorStr(err));
+    }
 }
 
 CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * admin)
@@ -274,12 +290,11 @@ CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * 
             ChipLogProgress(Controller, "Getting root certificate for the controller from the issuer");
             chip::Platform::ScopedMemoryBuffer<uint8_t> rootCert;
             ReturnErrorCodeIf(!rootCert.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-            uint32_t rootCertLen = 0;
-
-            ReturnErrorOnFailure(
-                mOperationalCredentialsDelegate->GetRootCACertificate(0, rootCert.Get(), kMaxCHIPDERCertLength, rootCertLen));
-            ReturnErrorOnFailure(
-                ConvertX509CertToChipCert(rootCert.Get(), rootCertLen, chipCert.Get(), chipCertAllocatedLen, chipCertLen));
+            MutableByteSpan rootCertSpan(rootCert.Get(), kMaxCHIPDERCertLength);
+            ReturnErrorOnFailure(mOperationalCredentialsDelegate->GetRootCACertificate(0, rootCertSpan));
+            VerifyOrReturnError(CanCastTo<uint32_t>(rootCertSpan.size()), CHIP_ERROR_INVALID_ARGUMENT);
+            ReturnErrorOnFailure(ConvertX509CertToChipCert(rootCertSpan.data(), static_cast<uint32_t>(rootCertSpan.size()),
+                                                           chipCert.Get(), chipCertAllocatedLen, chipCertLen));
 
             ReturnErrorOnFailure(admin->SetRootCert(ByteSpan(chipCert.Get(), chipCertLen)));
         }
@@ -295,9 +310,8 @@ CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * 
             // TODO - Match the generated cert against CSR and operational keypair
             //        Make sure it chains back to the trusted root.
             ChipLogProgress(Controller, "Generating operational certificate for the controller");
-            MutableByteSpan chipCertSpan(chipCert.Get(), chipCertAllocatedLen);
-            ReturnErrorOnFailure(GenerateOperationalCertificates(ByteSpan(CSR.Get(), csrLength), mLocalDeviceId, chipCertSpan));
-            ReturnErrorOnFailure(admin->SetOperationalCert(chipCertSpan));
+            ReturnErrorOnFailure(mOperationalCredentialsDelegate->GenerateNodeOperationalCertificate(
+                Optional<NodeId>(mLocalDeviceId), 0, ByteSpan(CSR.Get(), csrLength), 1, &mLocalNOCCallback));
         }
 
         ReturnErrorOnFailure(mAdmins.Store(admin->GetAdminId()));
@@ -802,7 +816,7 @@ DeviceCommissioner::DeviceCommissioner() :
     mOpCertResponseCallback(OnOperationalCertificateAddResponse, this), mRootCertResponseCallback(OnRootCertSuccessResponse, this),
     mOnCSRFailureCallback(OnCSRFailureResponse, this), mOnCertFailureCallback(OnAddOpCertFailureResponse, this),
     mOnRootCertFailureCallback(OnRootCertFailureResponse, this), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
-    mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mDeviceNOCCallback(OnDeviceNOCGenerated, this)
 {
     mPairingDelegate      = nullptr;
     mDeviceBeingPaired    = kNumMaxActiveDevices;
@@ -1217,6 +1231,41 @@ void DeviceCommissioner::OnOperationalCertificateSigningRequest(void * context, 
     }
 }
 
+void DeviceCommissioner::OnDeviceNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
+
+    uint32_t chipCertAllocatedLen = kMaxCHIPCertLength * 2;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
+
+    Device * device = nullptr;
+    VerifyOrExit(commissioner->mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(commissioner->mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
+
+    device = &commissioner->mActiveDevices[commissioner->mDeviceBeingPaired];
+
+    VerifyOrExit(chipCert.Alloc(chipCertAllocatedLen), err = CHIP_ERROR_NO_MEMORY);
+
+    {
+        MutableByteSpan chipCertSpan(chipCert.Get(), chipCertAllocatedLen);
+        err = commissioner->GenerateOperationalCertificates(noc, chipCertSpan);
+        SuccessOrExit(err);
+
+        ChipLogProgress(Controller, "Sending operational certificate to the device");
+        err = commissioner->SendOperationalCertificate(device, chipCertSpan);
+        SuccessOrExit(err);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed in generating device's operational credentials. Error %s", ErrorStr(err));
+        commissioner->OnSessionEstablishmentError(err);
+    }
+}
+
 CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & CSR, const ByteSpan & CSRNonce, const ByteSpan & VendorReserved1,
                                             const ByteSpan & VendorReserved2, const ByteSpan & VendorReserved3,
                                             const ByteSpan & Signature)
@@ -1237,12 +1286,8 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & CSR, const ByteSpan
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipOpCert;
     ReturnErrorCodeIf(!chipOpCert.Alloc(kMaxCHIPCertLength * 2), CHIP_ERROR_NO_MEMORY);
 
-    MutableByteSpan chipCertSpan(chipOpCert.Get(), kMaxCHIPCertLength * 2);
-
-    ReturnErrorOnFailure(GenerateOperationalCertificates(CSR, device->GetDeviceId(), chipCertSpan));
-
-    ChipLogProgress(Controller, "Sending operational certificate to the device");
-    ReturnErrorOnFailure(SendOperationalCertificate(device, chipCertSpan));
+    ReturnErrorOnFailure(mOperationalCredentialsDelegate->GenerateNodeOperationalCertificate(
+        Optional<NodeId>(device->GetDeviceId()), 0, CSR, 1, &mDeviceNOCCallback));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1235,7 +1235,7 @@ void DeviceCommissioner::OnDeviceNOCGenerated(void * context, const ByteSpan & n
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
+    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     // The operational certificate array can contain upto 2 certificates (NOC, and ICAC)
     // The memory is allocated to account for both these certificates.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -245,7 +245,7 @@ void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    DeviceController * controller = reinterpret_cast<DeviceController *>(context);
+    DeviceController * controller = static_cast<DeviceController *>(context);
 
     Transport::AdminPairingInfo * const admin = controller->mAdmins.FindAdminWithId(controller->mAdminId);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -241,7 +241,7 @@ CHIP_ERROR DeviceController::GenerateOperationalCertificates(const ByteSpan & no
     return CHIP_NO_ERROR;
 }
 
-void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId)
+void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -1231,7 +1231,7 @@ void DeviceCommissioner::OnOperationalCertificateSigningRequest(void * context, 
     }
 }
 
-void DeviceCommissioner::OnDeviceNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId)
+void DeviceCommissioner::OnDeviceNOCGenerated(void * context, const ByteSpan & noc)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -368,7 +368,7 @@ private:
 
     CHIP_ERROR LoadLocalCredentials(Transport::AdminPairingInfo * admin);
 
-    static void OnLocalNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId);
+    static void OnLocalNOCGenerated(void * context, const ByteSpan & noc);
     Callback::Callback<NOCGenerated> mLocalNOCCallback;
 };
 
@@ -605,7 +605,7 @@ private:
     static void OnDeviceConnectedFn(void * context, Device * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
 
-    static void OnDeviceNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId);
+    static void OnDeviceNOCGenerated(void * context, const ByteSpan & noc);
 
     /**
      * @brief

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -352,7 +352,7 @@ protected:
     // array can contain up to two certificates (node operational certificate, and ICA certificate).
     // If the certificate issuer doesn't require an ICA (i.e. NOC is signed by the root CA), the array
     // will have only one certificate (node operational certificate).
-    CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & CSR, NodeId deviceId, MutableByteSpan & cert);
+    CHIP_ERROR GenerateOperationalCertificates(const ByteSpan & noc, MutableByteSpan & cert);
 
 private:
     //////////// ExchangeDelegate Implementation ///////////////
@@ -367,6 +367,9 @@ private:
     void ReleaseAllDevices();
 
     CHIP_ERROR LoadLocalCredentials(Transport::AdminPairingInfo * admin);
+
+    static void OnLocalNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId);
+    Callback::Callback<NOCGenerated> mLocalNOCCallback;
 };
 
 /**
@@ -602,6 +605,8 @@ private:
     static void OnDeviceConnectedFn(void * context, Device * device);
     static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
 
+    static void OnDeviceNOCGenerated(void * context, const ByteSpan & noc, const PeerId & deviceId);
+
     /**
      * @brief
      *   This function processes the CSR sent by the device.
@@ -632,6 +637,8 @@ private:
 
     Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+
+    Callback::Callback<NOCGenerated> mDeviceNOCCallback;
 
     PASESession mPairingSession;
 };

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -91,8 +91,7 @@ ExampleOperationalCredentialsIssuer::GenerateNodeOperationalCertificate(const Op
     ReturnErrorOnFailure(NewNodeOperationalX509Cert(request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuer, noc.Get(),
                                                     kMaxCHIPDERCertLength, nocLen));
 
-    onNOCGenerated->mCall(onNOCGenerated->mContext, ByteSpan(noc.Get(), nocLen),
-                          PeerId().SetNodeId(assignedId).SetFabricId(fabricId));
+    onNOCGenerated->mCall(onNOCGenerated->mContext, ByteSpan(noc.Get(), nocLen));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -64,22 +64,22 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 }
 
 CHIP_ERROR
-ExampleOperationalCredentialsIssuer::GenerateNodeOperationalCertificate(const Optional<NodeId> & deviceId, FabricId fabricId,
-                                                                        const ByteSpan & csr, int64_t serialNumber,
+ExampleOperationalCredentialsIssuer::GenerateNodeOperationalCertificate(const Optional<NodeId> & nodeId, FabricId fabricId,
+                                                                        const ByteSpan & csr, const ByteSpan & DAC,
                                                                         Callback::Callback<NOCGenerated> * onNOCGenerated)
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
     NodeId assignedId;
-    if (deviceId.HasValue())
+    if (nodeId.HasValue())
     {
-        assignedId = deviceId.Value();
+        assignedId = nodeId.Value();
     }
     else
     {
         assignedId = mNextAvailableNodeId++;
     }
 
-    X509CertRequestParams request = { serialNumber, mIssuerId, mNow, mNow + mValidity, true, fabricId, true, assignedId };
+    X509CertRequestParams request = { 1, mIssuerId, mNow, mNow + mValidity, true, fabricId, true, assignedId };
 
     P256PublicKey pubkey;
     ReturnErrorOnFailure(VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -43,10 +43,10 @@ class DLL_EXPORT ExampleOperationalCredentialsIssuer : public OperationalCredent
 public:
     virtual ~ExampleOperationalCredentialsIssuer() {}
 
-    CHIP_ERROR GenerateNodeOperationalCertificate(const PeerId & peerId, const ByteSpan & csr, int64_t serialNumber,
-                                                  uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+    CHIP_ERROR GenerateNodeOperationalCertificate(const Optional<NodeId> & deviceId, FabricId fabricId, const ByteSpan & csr,
+                                                  int64_t serialNumber, Callback::Callback<NOCGenerated> * onNOCGenerated) override;
 
-    CHIP_ERROR GetRootCACertificate(FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+    CHIP_ERROR GetRootCACertificate(FabricId fabricId, MutableByteSpan & outCert) override;
 
     /**
      * @brief Initialize the issuer with the keypair in the storage.
@@ -75,6 +75,8 @@ private:
 
     // By default, let's set validity to 10 years
     uint32_t mValidity = 365 * 24 * 60 * 60 * 10;
+
+    NodeId mNextAvailableNodeId = 1;
 };
 
 } // namespace Controller

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -43,8 +43,8 @@ class DLL_EXPORT ExampleOperationalCredentialsIssuer : public OperationalCredent
 public:
     virtual ~ExampleOperationalCredentialsIssuer() {}
 
-    CHIP_ERROR GenerateNodeOperationalCertificate(const Optional<NodeId> & deviceId, FabricId fabricId, const ByteSpan & csr,
-                                                  int64_t serialNumber, Callback::Callback<NOCGenerated> * onNOCGenerated) override;
+    CHIP_ERROR GenerateNodeOperationalCertificate(const Optional<NodeId> & nodeId, FabricId fabricId, const ByteSpan & csr,
+                                                  const ByteSpan & DAC, Callback::Callback<NOCGenerated> * onNOCGenerated) override;
 
     CHIP_ERROR GetRootCACertificate(FabricId fabricId, MutableByteSpan & outCert) override;
 

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -29,7 +29,7 @@
 namespace chip {
 namespace Controller {
 
-typedef void (*NOCGenerated)(void * context, const ByteSpan & noc, const PeerId & nodeId);
+typedef void (*NOCGenerated)(void * context, const ByteSpan & noc);
 
 constexpr uint32_t kMaxCHIPDERCertLength = 600;
 

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -29,13 +29,9 @@
 namespace chip {
 namespace Controller {
 
-typedef void (*NOCGenerated)(void * context, const ByteSpan & noc, const PeerId & deviceId);
+typedef void (*NOCGenerated)(void * context, const ByteSpan & noc, const PeerId & nodeId);
 
-// TODO - Reduce memory requirement for generating x509 certificates
-// As per specifications (section 6.3.7. Trusted Root CA Certificates), DER certs
-// should require 600 bytes. Currently, due to ASN writer overheads, a larger buffer
-// is needed, even though the generated certificate fits in 600 bytes limit.
-constexpr uint32_t kMaxCHIPDERCertLength = 1024;
+constexpr uint32_t kMaxCHIPDERCertLength = 600;
 
 /// Callbacks for CHIP operational credentials generation
 class DLL_EXPORT OperationalCredentialsDelegate
@@ -54,17 +50,17 @@ public:
      *
      *   The delegate will call `onNOCGenerated` when the NOC is ready.
      *
-     * @param[in] deviceId        Optional device ID. If provided, the generated NOC must use the provided ID.
+     * @param[in] nodeId          Optional node ID. If provided, the generated NOC must use the provided ID.
      *                            If ID is not provided, the delegate must generate one.
      * @param[in] fabricId        Fabric ID for which the certificate is being requested.
      * @param[in] csr             Certificate Signing Request from the node in DER format.
-     * @param[in] serialNumber    Serial number to assign to the new certificate.
+     * @param[in] DAC             Device attestation certificate received from the device being commissioned
      * @param[in] onNOCGenerated  Callback handler to provide generated NOC to the caller of GenerateNodeOperationalCertificate()
      *
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
      */
-    virtual CHIP_ERROR GenerateNodeOperationalCertificate(const Optional<NodeId> & deviceId, FabricId fabricId,
-                                                          const ByteSpan & csr, int64_t serialNumber,
+    virtual CHIP_ERROR GenerateNodeOperationalCertificate(const Optional<NodeId> & nodeId, FabricId fabricId, const ByteSpan & csr,
+                                                          const ByteSpan & DAC,
                                                           Callback::Callback<NOCGenerated> * onNOCGenerated) = 0;
 
     /**

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -57,11 +57,12 @@ public:
     void OnPairingDeleted(CHIP_ERROR error) override;
 
     // OperationalCredentialsDelegate implementation
-    CHIP_ERROR GenerateNodeOperationalCertificate(const chip::PeerId & peerId, const chip::ByteSpan & csr, int64_t serialNumber,
-                                                  uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+    CHIP_ERROR
+    GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & nodeId, chip::FabricId fabricId,
+                                       const chip::ByteSpan & csr, const chip::ByteSpan & DAC,
+                                       chip::Callback::Callback<chip::Controller::NOCGenerated> * onNOCGenerated) override;
 
-    CHIP_ERROR GetRootCACertificate(chip::FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize,
-                                    uint32_t & outCertLen) override;
+    CHIP_ERROR GetRootCACertificate(chip::FabricId fabricId, chip::MutableByteSpan & outCert) override;
 
     // DeviceStatusDelegate implementation
     void OnMessage(chip::System::PacketBufferHandle && msg) override;
@@ -96,6 +97,8 @@ private:
 
     JavaVM * mJavaVM       = nullptr;
     jobject mJavaObjectRef = nullptr;
+
+    chip::NodeId mNextAvailableNodeId = 1;
 
     AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller, pthread_mutex_t * stackLock) :
         mController(std::move(controller)), mStackLock(stackLock)

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -225,6 +225,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
             = chip::RendezvousParameters().SetSetupPINCode(setupPINCode).SetDiscriminator(discriminator);
 
         if ([self isRunning]) {
+            _operationalCredentialsDelegate->SetDeviceID(deviceID);
             errorCode = self.cppCommissioner->PairDevice(deviceID, params);
         }
         success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
@@ -256,6 +257,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
                                                 .SetDiscriminator(discriminator)
                                                 .SetPeerAddress(peerAddress);
         if ([self isRunning]) {
+            _operationalCredentialsDelegate->SetDeviceID(deviceID);
             errorCode = self.cppCommissioner->PairDevice(deviceID, params);
         }
         success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
@@ -281,6 +283,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         chip::Inet::IPAddress::FromString([address UTF8String], addr);
 
         if ([self isRunning]) {
+            _operationalCredentialsDelegate->SetDeviceID(deviceID);
             errorCode = _cppCommissioner->PairTestDeviceWithoutSecurity(
                 deviceID, chip::Transport::PeerAddress::UDP(addr, port), serializedTestDevice);
         }
@@ -302,6 +305,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     if (setupPayload) {
         uint16_t discriminator = setupPayload.discriminator.unsignedShortValue;
         uint32_t setupPINCode = setupPayload.setUpPINCode.unsignedIntValue;
+        _operationalCredentialsDelegate->SetDeviceID(deviceID);
         didSucceed = [self pairDevice:deviceID discriminator:discriminator setupPINCode:setupPINCode error:error];
     } else {
         CHIP_LOG_ERROR("Failed to create CHIPSetupPayload for pairing with error %@", *error);
@@ -337,6 +341,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     }
     dispatch_sync(_chipWorkQueue, ^{
         if ([self isRunning]) {
+            _operationalCredentialsDelegate->ResetDeviceID();
             errorCode = self.cppCommissioner->StopPairing(deviceID);
         }
         success = ![self checkForError:errorCode logMsg:kErrorStopPairing error:error];

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -33,8 +33,8 @@ public:
 
     CHIP_ERROR init(CHIPPersistentStorageDelegateBridge * storage);
 
-    CHIP_ERROR GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & deviceId, chip::FabricId fabricId,
-        const chip::ByteSpan & csr, int64_t serialNumber,
+    CHIP_ERROR GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & nodeId, chip::FabricId fabricId,
+        const chip::ByteSpan & csr, const chip::ByteSpan & DAC,
         chip::Callback::Callback<chip::Controller::NOCGenerated> * onNOCGenerated) override;
 
     CHIP_ERROR GetRootCACertificate(chip::FabricId fabricId, chip::MutableByteSpan & outCert) override;

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -33,11 +33,14 @@ public:
 
     CHIP_ERROR init(CHIPPersistentStorageDelegateBridge * storage);
 
-    CHIP_ERROR GenerateNodeOperationalCertificate(const chip::PeerId & peerId, const chip::ByteSpan & csr, int64_t serialNumber,
-        uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+    CHIP_ERROR GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & deviceId, chip::FabricId fabricId,
+        const chip::ByteSpan & csr, int64_t serialNumber,
+        chip::Callback::Callback<chip::Controller::NOCGenerated> * onNOCGenerated) override;
 
-    CHIP_ERROR GetRootCACertificate(
-        chip::FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+    CHIP_ERROR GetRootCACertificate(chip::FabricId fabricId, chip::MutableByteSpan & outCert) override;
+
+    void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
+    void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 
 private:
     CHIP_ERROR GenerateKeys();
@@ -61,6 +64,8 @@ private:
     id mKeySize = @256;
 
     CHIPPersistentStorageDelegateBridge * mStorage;
+
+    chip::NodeId mDeviceBeingPaired = chip::kUndefinedNodeId;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -232,8 +232,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificat
         return err;
     }
 
-    onNOCGenerated->mCall(
-        onNOCGenerated->mContext, chip::ByteSpan(noc, nocLen), chip::PeerId().SetNodeId(assignedId).SetFabricId(fabricId));
+    onNOCGenerated->mCall(onNOCGenerated->mContext, chip::ByteSpan(noc, nocLen));
 
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -186,8 +186,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & deviceId,
-    chip::FabricId fabricId, const chip::ByteSpan & csr, int64_t serialNumber,
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & nodeId,
+    chip::FabricId fabricId, const chip::ByteSpan & csr, const chip::ByteSpan & DAC,
     chip::Callback::Callback<chip::Controller::NOCGenerated> * onNOCGenerated)
 {
     uint32_t validityStart, validityEnd;
@@ -203,8 +203,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificat
     }
 
     chip::NodeId assignedId;
-    if (deviceId.HasValue()) {
-        assignedId = deviceId.Value();
+    if (nodeId.HasValue()) {
+        assignedId = nodeId.Value();
     } else {
         if (mDeviceBeingPaired == chip::kUndefinedNodeId) {
             return CHIP_ERROR_INCORRECT_STATE;
@@ -213,7 +213,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificat
     }
 
     chip::Credentials::X509CertRequestParams request
-        = { serialNumber, mIssuerId, validityStart, validityEnd, true, fabricId, true, assignedId };
+        = { 1, mIssuerId, validityStart, validityEnd, true, fabricId, true, assignedId };
 
     chip::Crypto::P256PublicKey pubkey;
     CHIP_ERROR err = chip::Crypto::VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey);

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -186,8 +186,9 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificate(const chip::PeerId & peerId,
-    const chip::ByteSpan & csr, int64_t serialNumber, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen)
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificate(const chip::Optional<chip::NodeId> & deviceId,
+    chip::FabricId fabricId, const chip::ByteSpan & csr, int64_t serialNumber,
+    chip::Callback::Callback<chip::Controller::NOCGenerated> * onNOCGenerated)
 {
     uint32_t validityStart, validityEnd;
 
@@ -201,8 +202,18 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificat
         return CHIP_ERROR_INTERNAL;
     }
 
+    chip::NodeId assignedId;
+    if (deviceId.HasValue()) {
+        assignedId = deviceId.Value();
+    } else {
+        if (mDeviceBeingPaired == chip::kUndefinedNodeId) {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+        assignedId = mDeviceBeingPaired;
+    }
+
     chip::Credentials::X509CertRequestParams request
-        = { serialNumber, mIssuerId, validityStart, validityEnd, true, peerId.GetFabricId(), true, peerId.GetNodeId() };
+        = { serialNumber, mIssuerId, validityStart, validityEnd, true, fabricId, true, assignedId };
 
     chip::Crypto::P256PublicKey pubkey;
     CHIP_ERROR err = chip::Crypto::VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey);
@@ -210,12 +221,24 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNodeOperationalCertificat
         return err;
     }
 
-    return chip::Credentials::NewNodeOperationalX509Cert(
-        request, chip::Credentials::CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuerKey, certBuf, certBufSize, outCertLen);
+    NSMutableData * nocBuffer = [[NSMutableData alloc] initWithLength:chip::Controller::kMaxCHIPDERCertLength];
+    uint32_t nocLen = 0;
+
+    uint8_t * noc = (uint8_t *) [nocBuffer mutableBytes];
+
+    err = chip::Credentials::NewNodeOperationalX509Cert(request, chip::Credentials::CertificateIssuerLevel::kIssuerIsRootCA, pubkey,
+        mIssuerKey, noc, chip::Controller::kMaxCHIPDERCertLength, nocLen);
+    if (err != CHIP_NO_ERROR) {
+        return err;
+    }
+
+    onNOCGenerated->mCall(
+        onNOCGenerated->mContext, chip::ByteSpan(noc, nocLen), chip::PeerId().SetNodeId(assignedId).SetFabricId(fabricId));
+
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::GetRootCACertificate(
-    chip::FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen)
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GetRootCACertificate(chip::FabricId fabricId, chip::MutableByteSpan & outCert)
 {
     // TODO: Don't generate root certificate unless there's none, or the current is expired.
     uint32_t validityStart, validityEnd;
@@ -232,7 +255,13 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GetRootCACertificate(
 
     chip::Credentials::X509CertRequestParams request = { 0, mIssuerId, validityStart, validityEnd, true, fabricId, false, 0 };
 
-    return chip::Credentials::NewRootX509Cert(request, mIssuerKey, certBuf, certBufSize, outCertLen);
+    size_t outCertSize = (outCert.size() > UINT32_MAX) ? UINT32_MAX : outCert.size();
+    uint32_t outCertLen = 0;
+    ReturnErrorOnFailure(
+        chip::Credentials::NewRootX509Cert(request, mIssuerKey, outCert.data(), static_cast<uint32_t>(outCertSize), outCertLen));
+    outCert.reduce_size(outCertLen);
+
+    return CHIP_NO_ERROR;
 }
 
 bool CHIPOperationalCredentialsDelegate::ToChipEpochTime(uint32_t offset, uint32_t & epoch)


### PR DESCRIPTION
#### Problem
The `OperationalCredentialDelegate` requires NOC to be generated synchronously. Some CA implementations may not support such design. The delegate should provide a callback mechanism so that the NOC can be provided to the controller layer once CA has generated it.

#### Change overview
Updated `OperationalCredentialDelegate` API to take a callback which the delegate implementation will call on NOC generation. Updated `ExampleOperationalCredentialsIssuer` and `CHIPOperationalCredentialsDelegate` to the new interface.

#### Testing
Tested commissioning flow using Python controller, chip-tool and iOS CHIPTool apps.