### PR TITLE
Use GetConnectedDevice in TestCommand to wait for CASE session

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR TestCommand::Run()
 
 void TestCommand::OnDeviceConnectedFn(void * context, chip::Controller::Device * device)
 {
-    TestCommand * command = reinterpret_cast<TestCommand *>(context);
+    auto * command = static_cast<TestCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Device connected, but cannot run the test, as the context is null"));
     command->mDevice = device;
     command->NextTest();
@@ -41,4 +41,7 @@ void TestCommand::OnDeviceConnectedFn(void * context, chip::Controller::Device *
 void TestCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error)
 {
     ChipLogError(chipTool, "Failed in connecting to the device %" PRIu64 ". Error %d", deviceId, error);
+    auto * command = static_cast<TestCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Test command context is null"));
+    command->SetCommandExitStatus(error);
 }

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -24,9 +24,21 @@ CHIP_ERROR TestCommand::Run()
 
     auto * ctx = GetExecContext();
 
-    err = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
+    err = ctx->commissioner->GetConnectedDevice(ctx->remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
     ReturnErrorOnFailure(err);
 
-    NextTest();
     return CHIP_NO_ERROR;
+}
+
+void TestCommand::OnDeviceConnectedFn(void * context, chip::Controller::Device * device)
+{
+    TestCommand * command = reinterpret_cast<TestCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Device connected, but cannot run the test, as the context is null"));
+    command->mDevice = device;
+    command->NextTest();
+}
+
+void TestCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error)
+{
+    ChipLogError(chipTool, "Failed in connecting to the device %" PRIu64 ". Error %d", deviceId, error);
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -24,7 +24,10 @@
 class TestCommand : public Command
 {
 public:
-    TestCommand(const char * commandName) : Command(commandName) {}
+    TestCommand(const char * commandName) :
+        Command(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+    {}
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
@@ -34,4 +37,10 @@ public:
 
 protected:
     ChipDevice * mDevice;
+
+    static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
+    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+
+    chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 };


### PR DESCRIPTION
#### Problem
Fixes #7860 chip-tool tests TestCluster is broken after "Enable CASE session establishment

#### Change overview
Use `GetConnectedDevice()` API to get a callback on CASE session establishment, for test commands.

#### Testing
Ran the tests using `chip-tool tests TestCluster`
Note: need this PR to fix some packet buffer and memory leaks. https://github.com/project-chip/connectedhomeip/pull/7852
Without #7852, the device may reboot after a few CASE session establishments due to memory allocation failures.
