### PR TITLE
[QPG6100] Fix sync of cluster attributes on manual change of light status

### DIFF
--- a/examples/lighting-app/qpg6100/src/AppTask.cpp
+++ b/examples/lighting-app/qpg6100/src/AppTask.cpp
@@ -185,8 +185,10 @@ void AppTask::AppTaskMain(void * pvParameter)
 void AppTask::LightingActionEventHandler(AppEvent * aEvent)
 {
     LightingManager::Action_t action;
+
     if (aEvent->Type == AppEvent::kEventType_Button)
     {
+        // Toggle light
         if (LightingMgr().IsTurnedOn())
         {
             action = LightingManager::OFF_ACTION;
@@ -195,25 +197,30 @@ void AppTask::LightingActionEventHandler(AppEvent * aEvent)
         {
             action = LightingManager::ON_ACTION;
         }
+
+        sAppTask.mSyncClusterToButtonAction = true;
         LightingMgr().InitiateAction(action, 0, 0, 0);
     }
     if (aEvent->Type == AppEvent::kEventType_Level && aEvent->ButtonEvent.Action != 0)
     {
+        // Toggle Dimming of light between 2 fixed levels
         uint8_t val = 0x0;
         val         = LightingMgr().GetLevel() == 0x7f ? 0x1 : 0x7f;
         action      = LightingManager::LEVEL_ACTION;
+
+        sAppTask.mSyncClusterToButtonAction = true;
         LightingMgr().InitiateAction(action, 0, 1, &val);
     }
-    return;
 }
 
 void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
 {
-    ChipLogProgress(NotSpecified, "ButtonEventHandler %d, %d", btnIdx, btnPressed);
     if (btnIdx != APP_ON_OFF_BUTTON && btnIdx != APP_FUNCTION_BUTTON && btnIdx != APP_LEVEL_BUTTON)
     {
         return;
     }
+
+    ChipLogProgress(NotSpecified, "ButtonEventHandler %d, %d", btnIdx, btnPressed);
 
     AppEvent button_event              = {};
     button_event.Type                  = AppEvent::kEventType_Button;
@@ -222,21 +229,26 @@ void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
 
     if (btnIdx == APP_ON_OFF_BUTTON && btnPressed == true)
     {
+        // Hand off to Light handler - On/Off light
         button_event.Handler = LightingActionEventHandler;
-        sAppTask.PostEvent(&button_event);
     }
     else if (btnIdx == APP_LEVEL_BUTTON)
     {
+        // Hand off to Light handler - Change level of light
         button_event.Type    = AppEvent::kEventType_Level;
         button_event.Handler = LightingActionEventHandler;
-        sAppTask.PostEvent(&button_event);
     }
     else if (btnIdx == APP_FUNCTION_BUTTON)
     {
-        button_event.Type    = AppEvent::kEventType_Level;
+        // Hand off to Functionality handler - depends on duration of press
         button_event.Handler = FunctionHandler;
-        sAppTask.PostEvent(&button_event);
     }
+    else
+    {
+        return;
+    }
+
+    sAppTask.PostEvent(&button_event);
 }
 
 void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, chip::System::Error aError)
@@ -430,10 +442,17 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     }
 }
 
+/**
+ * Update cluster status after application level changes
+ */
 void AppTask::UpdateClusterState(void)
 {
-    uint8_t newValue = !LightingMgr().IsTurnedOn();
+    uint8_t newValue;
+
+    ChipLogProgress(NotSpecified, "UpdateClusterState");
+
     // write the new on/off value
+    newValue             = LightingMgr().IsTurnedOn();
     EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
@@ -441,10 +460,8 @@ void AppTask::UpdateClusterState(void)
         ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
     }
 
-    ChipLogProgress(NotSpecified, "UpdateClusterState");
     newValue = LightingMgr().GetLevel();
-    // TODO understand well enough to implement the level cluster ZCL_CURRENT_LEVEL_ATTRIBUTE_ID
-    status = emberAfWriteAttribute(1, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    status   = emberAfWriteAttribute(1, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                    (uint8_t *) &newValue, ZCL_DATA8_ATTRIBUTE_TYPE);
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/examples/lighting-app/qpg6100/src/LightingManager.cpp
+++ b/examples/lighting-app/qpg6100/src/LightingManager.cpp
@@ -55,16 +55,16 @@ bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint16_t 
     switch (aAction)
     {
     case ON_ACTION:
-        ChipLogProgress(NotSpecified, "LightingManager::InitiateAction(ON_ACTION)");
+        ChipLogProgress(NotSpecified, "LightMgr:ON: %s->ON", mState == kState_On ? "ON" : "OFF");
         break;
     case OFF_ACTION:
-        ChipLogProgress(NotSpecified, "LightingManager::InitiateAction(OFF_ACTION)");
+        ChipLogProgress(NotSpecified, "LightMgr:OFF: %s->OFF", mState == kState_On ? "ON" : "OFF");
         break;
     case LEVEL_ACTION:
-        ChipLogProgress(NotSpecified, "LightingManager::InitiateAction(LEVEL_ACTION)");
+        ChipLogProgress(NotSpecified, "LightMgr:LEVEL: lev:%u->%u", mLevel, *value);
         break;
     default:
-        ChipLogProgress(NotSpecified, "LightingManager::InitiateAction(unknown)");
+        ChipLogProgress(NotSpecified, "LightMgr:Unknown");
         break;
     }
 

--- a/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
@@ -42,8 +42,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
             return;
         }
 
-        LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION, AppEvent::kEventType_Level,
-                                     size, value);
+        LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION, 0, size, value);
     }
     else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
     {
@@ -53,10 +52,10 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
             return;
         }
 
-        ChipLogProgress(Zcl, "Value: %u, length %u", *value, size);
         if (size == 1)
         {
-            LightingMgr().InitiateAction(LightingManager::LEVEL_ACTION, AppEvent::kEventType_Level, size, value);
+            ChipLogProgress(Zcl, "New level: %u", *value);
+            LightingMgr().InitiateAction(LightingManager::LEVEL_ACTION, 0, size, value);
         }
         else
         {


### PR DESCRIPTION
#### Problem
Manual manipulation of the light's on/off or level state should be reflected in the respective cluster attributes.
A local sync back of the state towards the attributes on the button action was missing.

#### Change overview
* Calling sync of light OnOff/Level cluster status depending on the button actions.
* Cleanup logging LightingManager/Attribute updates

#### Testing
* Setup: chip-device-ctrl  (TE3 image)+ qpg6100 lighting-app
* Scenario:
  * OnOff read-out - `zclread OnOff OnOff 1 1 0`
  * Light OnOff status manipulated by button press
  * OnOff read-out - check if correctly changed
  * CurrentLevel read-out - `zclread LevelControl CurrentLevel 1 1 0`
  * Light level manipulated by button
  * CurrentLevel read-out - check if correctly changed