### PR TITLE
Level cluster Step/Move commands reverted to random value after transition

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -706,6 +706,9 @@ static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uin
     // OnLevel is not used for Move commands.
     state->useOnLevel = false;
 
+    // storedLevel is not use for Move commands.
+    state->storedLevel = INVALID_STORED_LEVEL;
+
     // The setup was successful, so mark the new state as active and return.
     schedule(endpoint, state->eventDurationMs);
     status = EMBER_ZCL_STATUS_SUCCESS;
@@ -825,6 +828,9 @@ static void stepHandler(CommandId commandId, uint8_t stepMode, uint8_t stepSize,
 
     // OnLevel is not used for Step commands.
     state->useOnLevel = false;
+
+    // storedLevel is not used for Step commands
+    state->storedLevel = INVALID_STORED_LEVEL;
 
     // The setup was successful, so mark the new state as active and return.
     schedule(endpoint, state->eventDurationMs);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -706,7 +706,7 @@ static void moveHandler(CommandId commandId, uint8_t moveMode, uint8_t rate, uin
     // OnLevel is not used for Move commands.
     state->useOnLevel = false;
 
-    // storedLevel is not use for Move commands.
+    // storedLevel is not used for Move commands.
     state->storedLevel = INVALID_STORED_LEVEL;
 
     // The setup was successful, so mark the new state as active and return.


### PR DESCRIPTION
#### Problem
A `Step` command did not execute as expected.
The transition happens, but when reaching the desired value it fell back to the original one.

After examination of the level-control-server.cpp code it seems a variable `storedLevel` is the source.
This variable is part of the state for the LevelControl cluster in case an Effect is requested (07-5123-04 (ZigBee Cluster Library doc), section 3.10.2.1.1.). The currentLevel is backed up there to restore after the effect has finished.

Backup point:
https://github.com/project-chip/connectedhomeip/blob/ed677f04ae8187098130f3701b5583f8db56a55e/src/app/clusters/level-control/level-control.cpp#L938

Restore point after transition:
https://github.com/project-chip/connectedhomeip/blob/ed677f04ae8187098130f3701b5583f8db56a55e/src/app/clusters/level-control/level-control.cpp#L260

An `INVALID_STORED_LEVEL` is set in other commands (`MoveToLevel`/...) to skip the revert step.
For example:
https://github.com/project-chip/connectedhomeip/blob/ed677f04ae8187098130f3701b5583f8db56a55e/src/app/clusters/level-control/level-control.cpp#L414

However, in case of `Step`/`Move` command this variable was not initialized to prevent this reverting/setting.

#### Change overview
Assigning INVALID_STORED_LEVEL to the `storedLevel` variable where missing.

#### Testing
Setup:
- chip-device-ctrl on RPi4 (TE3 image) + qpg6100 lighting-application
Scenario:
- factory reset - move through commissioning of device
- Issue step command - `zcl LevelControl Step 101 1 0 stepMode=1 stepSize=64 transitionTime=20 optionMask=0 optionOverride=0'
- Read out CurrentLevel value - `zclread LevelControl CurrentLevel 101 1 0`
- Check logging
  - transition is printed for each step
  - which levels are set to light
- Check LED behavior visually - not jumping back/erratic
