### PR TITLE
Throw exception instead of return 0 for get-fabricid in case of error

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -233,15 +233,15 @@ class ChipDeviceController(object):
     def GetFabricId(self):
         fabricid = c_uint64(0)
 
-        error = self._ChipStack.Call(
+        res = self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_GetFabricId(
                 self.devCtrl, pointer(fabricid))
         )
 
-        if error == 0:
+        if res == 0:
             return fabricid.value
         else:
-            return 0
+            raise self._ChipStack.ErrorToException(res)
 
     def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args, blocking=False):
         device = c_void_p(None)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
Currently, get-fabricid command always return a value, it return 0 in case of error or no fabric is provisioned. We can not differentiate between error and no fabric provisioned from the return value if it is 0.

#### Change overview
Throw exception instead of return 0 for get-fabricid in case of error

#### Testing
How was this tested? (at least one bullet point required)
1. Inject debug code in stack to return error unconditionally for GetFabricId.
2. Run get-faricid from chip-device-ctrl and confirm error message is printed out.
```
chip-device-ctrl > get-fabricid
An exception occurred during reading FabricID:
CHIP Error 4003 (0x00000FA3): Incorrect state
chip-device-ctrl > 
 
```