### PR TITLE
Restart operational advertisements when we get a new opcert.

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -26,6 +26,7 @@
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/common/gen/command-id.h>
+#include <app/server/Mdns.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
@@ -350,6 +351,12 @@ bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::Command * 
 
     VerifyOrExit(admin->SetOperationalCert(OperationalCert) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
     VerifyOrExit(GetGlobalAdminPairingTable().Store(admin->GetAdminId()) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+
+    // We have a new operational identity and should start advertising it.  We
+    // can't just wait until we get network configuration commands, because we
+    // might be on the operational network already, in which case we are
+    // expected to be live with our new identity at this point.
+    chip::app::Mdns::StartServer();
 
 exit:
     emberAfSendImmediateDefaultResponse(status);


### PR DESCRIPTION
Per the spec, the commissioning flow goes like this:

1. Various steps.
2. Install a new opcert.
3. Optionally configure and enable a network.
4. Discover each other on the operational network.

This means when the commissionnee gets a new opcert it needs to start
operational advertisement (if it's able to), because it doesn't know
whether the next step on the part of the commissioner will be network
config or operational discovery.

In particular, adding a new opcert adds a new fabric and node id, so
we need to redo our operational advertisements in the case when we are
already on the operational network to advertise the new operational
identity.

#### Problem
When doing onnetwork pairing, the device does not start advertising its new operational identity, so the commissioner can't discover what port it's using for the new fabric.

#### Change overview
Ensure that we start advertising once we get a new opcert.

#### Testing
Manually tested that:
1. ble pairing from chip-tool to all-clusters-app on an m5stack still works correctly.
2. onnetwork pairing from chip-tool to all-clusters-app running on the same device (so at IP ::1) still works correctly.

There is no automated testing for this yet, but if this is not done then we can't change the "tests" CI job to do operational discovery and stand up CASE.  Once that happens, this PR's change will be tested in CI.  Doing that depends on #7865, which is why I'm not making that change in this PR so far.