### PR TITLE
Duplicate MRP message handling and test

### DIFF
--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -1786,6 +1786,14 @@ typedef CHIP_CONFIG_ERROR_TYPE CHIP_ERROR;
 #define CHIP_ERROR_INTERMEDIATE_CA_NOT_REQUIRED                      _CHIP_ERROR(190)
 
 /**
+ * @def CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED
+ *
+ * @brief
+ *   The received message is a duplicate of a previously received message.
+ */
+#define CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED                      _CHIP_ERROR(191)
+
+/**
  *  @}
  */
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -118,6 +118,8 @@ public:
      *
      *  @param[in]    peerAddress   The address of the sender
      *
+     *  @param[in]    msgFlags      The message flags corresponding to the received message
+     *
      *  @param[in]    msgBuf        A handle to the packet buffer holding the CHIP message.
      *
      *  @retval  #CHIP_ERROR_INVALID_ARGUMENT               if an invalid argument was passed to this HandleMessage API.
@@ -126,7 +128,8 @@ public:
      *                                                       protocol layer.
      */
     CHIP_ERROR HandleMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                             const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msgBuf);
+                             const Transport::PeerAddress & peerAddress, MessageFlags msgFlags,
+                             System::PacketBufferHandle && msgBuf);
 
     ExchangeDelegate * GetDelegate() const { return mDelegate; }
     void SetDelegate(ExchangeDelegate * delegate) { mDelegate = delegate; }

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <lib/core/ReferenceCounted.h>
+#include <messaging/Flags.h>
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
@@ -59,7 +60,7 @@ public:
                                            const EncryptedPacketBufferHandle & preparedMessage) const                       = 0;
 
     virtual CHIP_ERROR OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
-                                         const Transport::PeerAddress & peerAddress,
+                                         const Transport::PeerAddress & peerAddress, MessageFlags msgFlags,
                                          ReliableMessageContext * reliableMessageContext);
 
 protected:

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -49,7 +49,7 @@ static constexpr int16_t kAnyMessageType = -1;
  *    It works on be behalf of higher layers, creating ExchangeContexts and
  *    handling the registration/unregistration of unsolicited message handlers.
  */
-class DLL_EXPORT ExchangeManager : public SecureSessionMgrDelegate, public TransportMgrDelegate
+class DLL_EXPORT ExchangeManager : public SecureSessionMgrDelegate
 {
     friend class ExchangeContext;
 
@@ -242,21 +242,17 @@ private:
     CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
-    void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * msgLayer) override;
+    void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source) override;
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SecureSessionHandle session,
-                           const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf,
-                           SecureSessionMgr * msgLayer) override;
+                           const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+                           System::PacketBufferHandle && msgBuf) override;
 
-    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override;
+    void OnNewConnection(SecureSessionHandle session) override;
 #if CHIP_CONFIG_TEST
 public: // Allow OnConnectionExpired to be called directly from tests.
 #endif  // CHIP_CONFIG_TEST
-    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
-
-    // TransportMgrDelegate interface for rendezvous sessions
-private:
-    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf) override;
+    void OnConnectionExpired(SecureSessionHandle session) override;
 };
 
 } // namespace Messaging

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -141,7 +141,7 @@ void CheckSessionExpirationBasics(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * ec1 = ctx.NewExchangeToLocal(&sendDelegate);
 
     // Expire the session this exchange is supposedly on.
-    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession(), &ctx.GetSecureSessionManager());
+    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession());
 
     MockAppDelegate receiveDelegate;
     CHIP_ERROR err =
@@ -171,7 +171,7 @@ void CheckSessionExpirationTimeout(nlTestSuite * inSuite, void * inContext)
 
     // Expire the session this exchange is supposedly on.  This should close the
     // exchange.
-    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession(), &ctx.GetSecureSessionManager());
+    ctx.GetExchangeManager().OnConnectionExpired(ec1->GetSecureSession());
     NL_TEST_ASSERT(inSuite, sendDelegate.IsOnResponseTimeoutCalled);
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -549,6 +549,7 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
 
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    exchange->Close();
 
     // Ensure the message was sent
     // The ack was dropped, and message was added to the retransmit table
@@ -558,6 +559,9 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
 
     // Let's not drop the duplicate message
     mockReceiver.mDropAckResponse = false;
+
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
@@ -570,9 +574,6 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 
     mockReceiver.CloseExchangeIfNeeded();
-
-    rm->ClearRetransTable(rc);
-    exchange->Close();
 }
 
 void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuite, void * inContext)
@@ -709,11 +710,16 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+    exchange->Close();
+
     // Ensure the message was sent
     // The ack was dropped, and message was added to the retransmit table
     NL_TEST_ASSERT(inSuite, gLoopback.mSendMessageCount == 1);
     NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
+
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Let's not drop the duplicate message
     mockReceiver.mDropAckResponse = false;
@@ -730,9 +736,6 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 
     mockReceiver.CloseExchangeIfNeeded();
-
-    rm->ClearRetransTable(rc);
-    exchange->Close();
 }
 
 void CheckSendStandaloneAckMessage(nlTestSuite * inSuite, void * inContext)

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -49,10 +49,11 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::SendPreparedMessage(SecureSessi
 
 CHIP_ERROR SessionEstablishmentExchangeDispatch::OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
                                                                    const Transport::PeerAddress & peerAddress,
+                                                                   Messaging::MessageFlags msgFlags,
                                                                    ReliableMessageContext * reliableMessageContext)
 {
     mPeerAddress = peerAddress;
-    return ExchangeMessageDispatch::OnMessageReceived(payloadHeader, messageId, peerAddress, reliableMessageContext);
+    return ExchangeMessageDispatch::OnMessageReceived(payloadHeader, messageId, peerAddress, msgFlags, reliableMessageContext);
 }
 
 bool SessionEstablishmentExchangeDispatch::MessagePermitted(uint16_t protocol, uint8_t type)

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -48,7 +48,7 @@ public:
     CHIP_ERROR SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override;
 
     CHIP_ERROR OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
-                                 const Transport::PeerAddress & peerAddress,
+                                 const Transport::PeerAddress & peerAddress, Messaging::MessageFlags msgFlags,
                                  Messaging::ReliableMessageContext * reliableMessageContext) override;
 
     const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -101,7 +101,7 @@ public:
             }
             if (mSynced.mWindow.test(offset))
             {
-                return CHIP_ERROR_INVALID_ARGUMENT; // duplicated, in window
+                return CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED; // duplicated, in window
             }
         }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -333,7 +333,7 @@ void SecureSessionMgr::MessageDispatch(const PacketHeader & packetHeader, const 
         PayloadHeader payloadHeader;
         ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
         mCB->OnMessageReceived(packetHeader, payloadHeader, SecureSessionHandle(), peerAddress,
-                               SecureSessionMgrDelegate::DuplicateMessage::kNo, std::move(msg));
+                               SecureSessionMgrDelegate::DuplicateMessage::No, std::move(msg));
     }
 }
 
@@ -352,7 +352,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     NodeId localNodeId;
     FabricId fabricId;
 
-    SecureSessionMgrDelegate::DuplicateMessage isDuplicate = SecureSessionMgrDelegate::DuplicateMessage::kNo;
+    SecureSessionMgrDelegate::DuplicateMessage isDuplicate = SecureSessionMgrDelegate::DuplicateMessage::No;
 
     VerifyOrExit(!msg.IsNull(), ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
 
@@ -395,7 +395,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
         {
             ChipLogDetail(Inet, "Received a duplicate message");
-            isDuplicate = SecureSessionMgrDelegate::DuplicateMessage::kYes;
+            isDuplicate = SecureSessionMgrDelegate::DuplicateMessage::Yes;
             err         = CHIP_NO_ERROR;
         }
         if (err != CHIP_NO_ERROR)
@@ -437,7 +437,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decode(state, payloadHeader, packetHeader, msg),
                  ChipLogError(Inet, "Secure transport received message, but failed to decode it, discarding"));
 
-    if (isDuplicate == SecureSessionMgrDelegate::DuplicateMessage::kYes && !payloadHeader.NeedsAck())
+    if (isDuplicate == SecureSessionMgrDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {
         // If it's a duplicate message, but doesn't require an ack, let's drop it right here to save CPU
         // cycles on further message processing.

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -125,8 +125,8 @@ class DLL_EXPORT SecureSessionMgrDelegate
 public:
     enum class DuplicateMessage : uint8_t
     {
-        kYes,
-        kNo,
+        Yes,
+        No,
     };
 
     /**

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -123,6 +123,12 @@ private:
 class DLL_EXPORT SecureSessionMgrDelegate
 {
 public:
+    enum class DuplicateMessage : uint8_t
+    {
+        kYes,
+        kNo,
+    };
+
     /**
      * @brief
      *   Called when a new message is received. The function must internally release the
@@ -132,12 +138,12 @@ public:
      * @param payloadHeader The payload header
      * @param session       The handle to the secure session
      * @param source        The sender's address
+     * @param isDuplicate   The message is a duplicate of previously received message
      * @param msgBuf        The received message
-     * @param mgr           A pointer to the SecureSessionMgr
      */
     virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                   SecureSessionHandle session, const Transport::PeerAddress & source,
-                                   System::PacketBufferHandle && msgBuf, SecureSessionMgr * mgr)
+                                   SecureSessionHandle session, const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+                                   System::PacketBufferHandle && msgBuf)
     {}
 
     /**
@@ -146,27 +152,24 @@ public:
      *
      * @param error   error code
      * @param source  network entity that sent the message
-     * @param mgr     A pointer to the SecureSessionMgr
      */
-    virtual void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * mgr) {}
+    virtual void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source) {}
 
     /**
      * @brief
      *   Called when a new pairing is being established
      *
      * @param session The handle to the secure session
-     * @param mgr     A pointer to the SecureSessionMgr
      */
-    virtual void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) {}
+    virtual void OnNewConnection(SecureSessionHandle session) {}
 
     /**
      * @brief
      *   Called when a new connection is closing
      *
      * @param session The handle to the secure session
-     * @param mgr     A pointer to the SecureSessionMgr
      */
-    virtual void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) {}
+    virtual void OnConnectionExpired(SecureSessionHandle session) {}
 
     virtual ~SecureSessionMgrDelegate() {}
 };

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -94,8 +94,8 @@ class TestSessMgrCallback : public SecureSessionMgrDelegate
 {
 public:
     void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
-                           const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf,
-                           SecureSessionMgr * mgr) override
+                           const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+                           System::PacketBufferHandle && msgBuf) override
     {
         NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
         NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
@@ -117,7 +117,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override
+    void OnNewConnection(SecureSessionHandle session) override
     {
         // Preset the MessageCounter
         if (NewConnectionHandlerCallCount == 0)
@@ -126,7 +126,7 @@ public:
             mLocalToRemoteSession = session;
         NewConnectionHandlerCallCount++;
     }
-    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override {}
+    void OnConnectionExpired(SecureSessionHandle session) override {}
 
     nlTestSuite * mSuite = nullptr;
     SecureSessionHandle mRemoteToLocalSession;


### PR DESCRIPTION
#### Problem
If the MRP ack is lost, the retransmitted MRP message doesn't trigger an ack. The message counter check detects the retransmitted message as duplicate, and drops it before it could reach MRP layer.

#### Change overview
Detect and mark the message as duplicate. If the message requires MRP ack, let it go up the stack to the MRP layer.
The MRP and exchange layer sends the ack for the message, and drops it.

#### Testing
Added a new unit test `CheckDuplicateMessage` to test this condition.
Also tested E2E flow using Python controller and chip-tool apps.