### PR TITLE
Reset all device objects on controller shutdown

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -411,6 +411,8 @@ void Device::Reset()
     }
 
     SetActive(false);
+    mCASESession.Clear();
+
     mState          = ConnectionState::NotConnected;
     mSessionManager = nullptr;
     mStatusDelegate = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -316,6 +316,11 @@ CHIP_ERROR DeviceController::Shutdown()
 
     ChipLogDetail(Controller, "Shutting down the controller");
 
+    for (uint32_t i = 0; i < kNumMaxActiveDevices; i++)
+    {
+        mActiveDevices[i].Reset();
+    }
+
 #if CONFIG_DEVICE_LAYER
     //
     // We can safely call PlatformMgr().Shutdown(), which like DeviceController::Shutdown(),


### PR DESCRIPTION
#### Problem
Fixes #7892

#### Change overview
The device objects were getting destructed as part of DeviceController destructor. If the CASE Session was in progress, the device object tries to clear the state. That required it to access some of the system layer objects that were already freed as part of controller shutdown (that happened before the destructor was called).

This change clears the device objects as part of the controller shutdown. It clears all the state that may require access to system level objects, so that the device destructor doesn't need to access that state.

#### Testing
Tested using patch mentioned in #7892.
Reproduced the crash, fixed the problem and tested that the crash is gone.
