### PR TITLE
Add -Wconversion to various things in src/app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -138,7 +138,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0000: // accepts header list
         {
-            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, index - 1);
+            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, static_cast<uint16_t>(index - 1));
             if (entryOffset == 0)
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid.", index);
@@ -155,7 +155,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
 
-            entryLength = acceptsHeaderListSpan->size();
+            if (!CanCastTo<uint16_t>(acceptsHeaderListSpan->size()))
+            {
+                ChipLogError(Zcl, "Span size %zu is too large", acceptsHeaderListSpan->size());
+                return 0;
+            }
+            entryLength = static_cast<uint16_t>(acceptsHeaderListSpan->size());
             break;
         }
         case 0x0001: // supported streaming types
@@ -548,7 +553,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         }
         case 0x001B: // list_octet_string
         {
-            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, index - 1);
+            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, static_cast<uint16_t>(index - 1));
             if (entryOffset == 0)
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid.", index);
@@ -565,7 +570,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
 
-            entryLength = listOctetStringSpan->size();
+            if (!CanCastTo<uint16_t>(listOctetStringSpan->size()))
+            {
+                ChipLogError(Zcl, "Span size %zu is too large", listOctetStringSpan->size());
+                return 0;
+            }
+            entryLength = static_cast<uint16_t>(listOctetStringSpan->size());
             break;
         }
         case 0x001C: // list_struct_octet_string

--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -627,6 +627,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
     }
 }

--- a/examples/lighting-app/qpg6100/src/AppTask.cpp
+++ b/examples/lighting-app/qpg6100/src/AppTask.cpp
@@ -457,7 +457,7 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
     }
 
     newValue = LightingMgr().GetLevel();
@@ -466,6 +466,6 @@ void AppTask::UpdateClusterState(void)
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating level %" PRIx32, status);
+        ChipLogError(NotSpecified, "ERR: updating level %" PRIx8, status);
     }
 }

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -635,6 +635,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
     }
 }

--- a/examples/lock-app/qpg6100/src/AppTask.cpp
+++ b/examples/lock-app/qpg6100/src/AppTask.cpp
@@ -490,6 +490,6 @@ void AppTask::UpdateClusterState(void)
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx32, status);
+        ChipLogError(NotSpecified, "ERR: updating on/off %" PRIx8, status);
     }
 }

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -138,7 +138,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0000: // accepts header list
         {
-            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, index - 1);
+            entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, static_cast<uint16_t>(index - 1));
             if (entryOffset == 0)
             {
                 ChipLogError(Zcl, "Index %" PRId32 " is invalid.", index);
@@ -155,7 +155,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
 
-            entryLength = acceptsHeaderListSpan->size();
+            if (!CanCastTo<uint16_t>(acceptsHeaderListSpan->size()))
+            {
+                ChipLogError(Zcl, "Span size %zu is too large", acceptsHeaderListSpan->size());
+                return 0;
+            }
+            entryLength = static_cast<uint16_t>(acceptsHeaderListSpan->size());
             break;
         }
         case 0x0001: // supported streaming types

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -183,6 +183,12 @@ template("chip_data_model") {
       public_deps += [ "${chip_root}/src/app/server" ]
     }
 
+    if (!defined(cflags)) {
+      cflags = []
+    }
+
+    cflags += [ "-Wconversion" ]
+
     if (!defined(public_configs)) {
       public_configs = []
     }

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -196,7 +196,7 @@ static uint16_t readColorTemperature(EndpointId endpoint)
 static uint16_t readColorTemperatureMin(EndpointId endpoint)
 {
     uint16_t colorTemperatureMin;
-    EmberStatus status;
+    EmberAfStatus status;
 
     status =
         emberAfReadServerAttribute(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID, ZCL_COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN_ATTRIBUTE_ID,
@@ -213,7 +213,7 @@ static uint16_t readColorTemperatureMin(EndpointId endpoint)
 static uint16_t readColorTemperatureMax(EndpointId endpoint)
 {
     uint16_t colorTemperatureMax;
-    EmberStatus status;
+    EmberAfStatus status;
 
     status =
         emberAfReadServerAttribute(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID, ZCL_COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX_ATTRIBUTE_ID,
@@ -230,7 +230,7 @@ static uint16_t readColorTemperatureMax(EndpointId endpoint)
 static uint16_t readColorTemperatureCoupleToLevelMin(EndpointId endpoint)
 {
     uint16_t colorTemperatureCoupleToLevelMin;
-    EmberStatus status;
+    EmberAfStatus status;
 
     status = emberAfReadServerAttribute(endpoint, ZCL_COLOR_CONTROL_CLUSTER_ID,
                                         ZCL_COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS_ATTRIBUTE_ID,
@@ -248,7 +248,7 @@ static uint16_t readColorTemperatureCoupleToLevelMin(EndpointId endpoint)
 static uint8_t readLevelControlCurrentLevel(EndpointId endpoint)
 {
     uint8_t currentLevel;
-    EmberStatus status;
+    EmberAfStatus status;
 
     status = emberAfReadServerAttribute(endpoint, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID,
                                         (uint8_t *) &currentLevel, sizeof(uint8_t));

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -595,13 +595,13 @@ static void printSuccessOrFailure(bool success)
 static bool verifyPin(uint8_t * pin, uint8_t * userId)
 {
     bool pinRequired = false;
-    EmberStatus status;
+    EmberAfStatus status;
     uint8_t i;
 
     status =
         emberAfReadServerAttribute(DOOR_LOCK_SERVER_ENDPOINT, ZCL_DOOR_LOCK_CLUSTER_ID,
                                    ZCL_REQUIRE_PIN_FOR_RF_OPERATION_ATTRIBUTE_ID, (uint8_t *) &pinRequired, sizeof(pinRequired));
-    if (EMBER_SUCCESS != status || !pinRequired)
+    if (EMBER_ZCL_STATUS_SUCCESS != status || !pinRequired)
     {
         return true;
     }

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -108,7 +108,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Loop through admins
-    uint32_t fabricIndex = 0;
+    int32_t fabricIndex = 0;
     for (auto & pairing : GetGlobalAdminPairingTable())
     {
         NodeId nodeId               = pairing.GetNodeId();

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -855,8 +855,8 @@ bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, con
             entry.hasOccupiedCoolingSetpointValue = true;
             entry.occupiedCoolingSetpointValue =
                 (int16_t) emberAfGetInt16u(extensionFieldSets, extensionFieldSetsIndex, extensionFieldSetsLen);
-            extensionFieldSetsIndex += 2;
-            length -= 2;
+            extensionFieldSetsIndex = static_cast<uint16_t>(extensionFieldSetsIndex + 2);
+            length                  = static_cast<uint8_t>(length - 2);
             if (length < 2)
             {
                 break;
@@ -864,8 +864,8 @@ bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, con
             entry.hasOccupiedHeatingSetpointValue = true;
             entry.occupiedHeatingSetpointValue =
                 (int16_t) emberAfGetInt16u(extensionFieldSets, extensionFieldSetsIndex, extensionFieldSetsLen);
-            extensionFieldSetsIndex += 2;
-            length -= 2;
+            extensionFieldSetsIndex = static_cast<uint16_t>(extensionFieldSetsIndex + 2);
+            length                  = static_cast<uint8_t>(length - 2);
             if (length < 1)
             {
                 break;

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -43,6 +43,8 @@ static_library("server") {
 
   public_configs = [ ":server_config" ]
 
+  cflags = [ "-Wconversion" ]
+
   public_deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/lib/mdns",

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -145,10 +145,11 @@ CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string
                         CHIP_ERROR_BUFFER_TOO_SMALL);
 
     const int writtenDataSize = snprintf(aQRCodeUrl, aUrlMaxSize, "%s%s", kQrCodeBaseUrl, kUrlDataAssignmentPhrase);
-    VerifyOrReturnError((writtenDataSize > 0) && (writtenDataSize < static_cast<int>(aUrlMaxSize)),
+    VerifyOrReturnError((writtenDataSize > 0) && (static_cast<size_t>(writtenDataSize) < aUrlMaxSize),
                         CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    return EncodeQRCodeToUrl(aQRCode.c_str(), aQRCode.size(), aQRCodeUrl + writtenDataSize, aUrlMaxSize - writtenDataSize);
+    return EncodeQRCodeToUrl(aQRCode.c_str(), aQRCode.size(), aQRCodeUrl + writtenDataSize,
+                             aUrlMaxSize - static_cast<size_t>(writtenDataSize));
 }
 
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
@@ -186,7 +187,7 @@ CHIP_ERROR EncodeQRCodeToUrl(const char * aQRCode, size_t aLen, char * aUrl, siz
 
     for (i = 0; i < aLen; ++i)
     {
-        unsigned char c = aQRCode[i];
+        char c = aQRCode[i];
         if (isCharUnreservedInRfc3986(c))
         {
 

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -53,6 +53,8 @@ executable("chip-im-responder") {
     "${chip_root}/src/system",
   ]
 
+  cflags = [ "-Wconversion" ]
+
   output_dir = root_out_dir
 }
 

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -132,7 +132,7 @@ MockEventGeneratorImpl::MockEventGeneratorImpl(void) :
 {}
 
 CHIP_ERROR MockEventGeneratorImpl::Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator,
-                                        int aDelayBetweenEvents, bool aWraparound)
+                                        uint32_t aDelayBetweenEvents, bool aWraparound)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
     mpExchangeMgr      = apExchangeMgr;

--- a/src/app/tests/integration/MockEvents.h
+++ b/src/app/tests/integration/MockEvents.h
@@ -50,28 +50,28 @@ class MockEventGenerator
 public:
     static MockEventGenerator * GetInstance(void);
     virtual CHIP_ERROR Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator,
-                            int aDelayBetweenEvents, bool aWraparound) = 0;
-    virtual void SetEventGeneratorStop()                               = 0;
-    virtual bool IsEventGeneratorStopped()                             = 0;
-    virtual ~MockEventGenerator()                                      = default;
+                            uint32_t aDelayBetweenEvents, bool aWraparound) = 0;
+    virtual void SetEventGeneratorStop()                                    = 0;
+    virtual bool IsEventGeneratorStopped()                                  = 0;
+    virtual ~MockEventGenerator()                                           = default;
 };
 
 class MockEventGeneratorImpl : public MockEventGenerator
 {
 public:
     MockEventGeneratorImpl(void);
-    CHIP_ERROR Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator, int aDelayBetweenEvents,
-                    bool aWraparound);
+    CHIP_ERROR Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator,
+                    uint32_t aDelayBetweenEvents, bool aWraparound);
     void SetEventGeneratorStop();
     bool IsEventGeneratorStopped();
 
 private:
     static void HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState, chip::System::Error aErr);
     chip::Messaging::ExchangeManager * mpExchangeMgr;
-    int mTimeBetweenEvents; //< delay, in miliseconds, between events.
-    bool mEventWraparound;  //< does the event generator run indefinitely, or does it stop after iterating through its states
+    uint32_t mTimeBetweenEvents; //< delay, in miliseconds, between events.
+    bool mEventWraparound;       //< does the event generator run indefinitely, or does it stop after iterating through its states
     EventGenerator * mpEventGenerator; //< the event generator to use
-    int32_t mEventsLeft;
+    size_t mEventsLeft;
 };
 
 enum LivenessDeviceStatus

--- a/src/app/util/af-enums.h
+++ b/src/app/util/af-enums.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-enum EmberAfStatus : uint32_t
+enum EmberAfStatus : uint8_t
 {
     EMBER_ZCL_STATUS_SUCCESS                     = 0x00,
     EMBER_ZCL_STATUS_FAILURE                     = 0x01,

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -72,6 +72,8 @@
 #include <app/util/debug-printing.h>
 #include <app/util/ember-print.h>
 
+#include <lib/support/SafeInt.h>
+
 /** @name Attribute Storage */
 // @{
 
@@ -496,21 +498,26 @@ bool emberAfIsTypeSigned(EmberAfAttributeType dataType);
  * @brief Function that extracts a 64-bit integer from the message buffer
  */
 uint64_t emberAfGetInt64u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
+#define emberAfGetInt64s(message, currentIndex, msgLen) chip::CastToSigned(emberAfGetInt64u(message, currentIndex, msgLen))
 
 /**
  * @brief Function that extracts a 32-bit integer from the message buffer
  */
 uint32_t emberAfGetInt32u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
+#define emberAfGetInt32s(message, currentIndex, msgLen) chip::CastToSigned(emberAfGetInt32u(message, currentIndex, msgLen))
 
 /**
  * @brief Function that extracts a 24-bit integer from the message buffer
  */
 uint32_t emberAfGetInt24u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
+#define emberAfGetInt24s(message, currentIndex, msgLen) chip::CastToSigned(emberAfGetInt24u(message, currentIndex, msgLen))
 
 /**
  * @brief Function that extracts a 16-bit integer from the message buffer
  */
 uint16_t emberAfGetInt16u(const uint8_t * message, uint16_t currentIndex, uint16_t msgLen);
+#define emberAfGetInt16s(message, currentIndex, msgLen) chip::CastToSigned(emberAfGetInt16u(message, currentIndex, msgLen))
+
 /**
  * @brief Function that extracts a ZCL string from the message buffer
  */
@@ -529,6 +536,7 @@ uint8_t emberAfGetDate(uint8_t * message, uint16_t currentIndex, uint16_t msgLen
  * @brief Macro for consistency, that extracts single byte out of the message
  */
 #define emberAfGetInt8u(message, currentIndex, msgLen) message[currentIndex]
+#define emberAfGetInt8s(message, currentIndex, msgLen) chip::CastToSigned(emberAfGetInt8u(message, currentIndex, msgLen))
 
 /**
  * @brief Macro for consistency that copies a uint8_t from variable into buffer.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -167,7 +167,7 @@ uint8_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
     {
         if (emAfEndpoints[index].endpoint == id)
         {
-            return index - FIXED_ENDPOINT_COUNT;
+            return static_cast<uint8_t>(index - FIXED_ENDPOINT_COUNT);
         }
     }
     return 0xFF;
@@ -176,12 +176,14 @@ uint8_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
 EmberAfStatus emberAfSetDynamicEndpoint(uint8_t index, EndpointId id, EmberAfEndpointType * ep, uint16_t deviceId,
                                         uint8_t deviceVersion)
 {
-    index += FIXED_ENDPOINT_COUNT;
+    auto realIndex = index + FIXED_ENDPOINT_COUNT;
 
-    if (index >= MAX_ENDPOINT_COUNT)
+    if (realIndex >= MAX_ENDPOINT_COUNT)
     {
         return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
     }
+
+    index = static_cast<uint8_t>(realIndex);
 
     for (uint8_t i = FIXED_ENDPOINT_COUNT; i < MAX_ENDPOINT_COUNT; i++)
     {
@@ -213,7 +215,7 @@ EndpointId emberAfClearDynamicEndpoint(uint8_t index)
 {
     EndpointId ep = 0;
 
-    index += FIXED_ENDPOINT_COUNT;
+    index = static_cast<uint8_t>(index + FIXED_ENDPOINT_COUNT);
 
     if ((index < MAX_ENDPOINT_COUNT) && (emAfEndpoints[index].endpoint != 0) && (emberAfEndpointIndexIsEnabled(index)))
     {

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -366,7 +366,7 @@ void emberAfRetrieveAttributeAndCraftResponse(EndpointId endpoint, ClusterId clu
     else
     {
         emberAfPutInt16uInResp(attrId);
-        emberAfPutInt8uInResp(status);
+        emberAfPutStatusInResp(status);
         emberAfAttributesPrintln("READ: clus %2x, attr %2x failed %x", clusterId, attrId, status);
         emberAfAttributesFlush();
         return;

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -46,7 +46,8 @@ void SetupEmberAfObjects(Command * command, ClusterId clusterId, CommandId comma
     imCompatibilityEmberApsFrame.clusterId           = clusterId;
     imCompatibilityEmberApsFrame.destinationEndpoint = endpointId;
     imCompatibilityEmberApsFrame.sourceEndpoint      = 1; // source endpoint is fixed to 1 for now.
-    imCompatibilityEmberApsFrame.sequence = (commandExchangeCtx != nullptr ? commandExchangeCtx->GetExchangeId() & 0xFF : 0);
+    imCompatibilityEmberApsFrame.sequence =
+        (commandExchangeCtx != nullptr ? static_cast<uint8_t>(commandExchangeCtx->GetExchangeId() & 0xFF) : 0);
 
     imCompatibilityEmberAfCluster.commandId      = commandId;
     imCompatibilityEmberAfCluster.apsFrame       = &imCompatibilityEmberApsFrame;

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -182,6 +182,11 @@ void emberAfPutInt16sInResp(int16_t value)
     emberAfPutInt16uInResp(static_cast<uint16_t>(value));
 }
 
+void emberAfPutStatusInResp(EmberAfStatus value)
+{
+    emberAfPutInt8uInResp(static_cast<std::underlying_type_t<EmberAfStatus>>(value));
+}
+
 // ------------------------------------
 // Utilities for reading from RAM buffers (reading from incoming message
 // buffer)

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -267,7 +267,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             {
                 numFailures++;
                 // Write to the response buffer - status and then attrID
-                emberAfPutInt8uInResp(status);
+                emberAfPutStatusInResp(status);
                 emberAfPutInt16uInResp(attrId);
 
                 emberAfAttributesPrintln("WRITE: clus %2x attr %2x ", clusterId, attrId);
@@ -375,7 +375,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
                 {
                     numFailures++;
                     // write to the response buffer - status and then attrID
-                    emberAfPutInt8uInResp(status);
+                    emberAfPutStatusInResp(status);
                     emberAfPutInt16uInResp(attrId);
                     emberAfAttributesPrintln("FAIL %x", status);
                 }
@@ -390,7 +390,7 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
                 numFailures++;
                 status = EMBER_ZCL_STATUS_INVALID_VALUE;
                 // write to the response buffer - status and then attrID
-                emberAfPutInt8uInResp(status);
+                emberAfPutStatusInResp(status);
                 emberAfPutInt16uInResp(attrId);
                 emberAfAttributesPrintln("FAIL %x", status);
                 // size exceeds buffer, terminate loop

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -846,7 +846,7 @@ EmberStatus emberAfSendDefaultResponseWithCallback(const EmberAfClusterCommand *
     emberAfPutInt8uInResp(cmd->seqNum);
     emberAfPutInt8uInResp(ZCL_DEFAULT_RESPONSE_COMMAND_ID);
     emberAfPutInt8uInResp(cmd->commandId);
-    emberAfPutInt8uInResp(status);
+    emberAfPutStatusInResp(status);
 
     prepareForResponse(cmd);
     return emberAfSendResponseWithCallback(callback);

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -189,6 +189,7 @@ uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length);
 uint8_t * emberAfPutStringInResp(const uint8_t * buffer);
 uint8_t * emberAfPutDateInResp(EmberAfDate * value);
 void emberAfPutInt16sInResp(int16_t value);
+void emberAfPutStatusInResp(EmberAfStatus value);
 
 bool emberAfIsThisMyEui64(EmberEUI64 eui64);
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -413,7 +413,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                                 {{#chip_attribute_list_entryTypes}}
                                 {{#if (isString type)}}
                                 CHECK_STATUS(ReadByteSpan(message, {{size}}, &data[i].{{name}}));
-                                messageLen -= {{size}};
+                                messageLen = static_cast<uint16_t>(messageLen - {{size}});
                                 {{else}}
                                 CHECK_MESSAGE_LENGTH({{size}});
                                 data[i].{{name}} = emberAfGet{{asReadType type}}(message, 0, {{size}});
@@ -424,7 +424,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                                 {{#if (isString type)}}
                                 CHECK_STATUS(ReadByteSpan(message, messageLen, &data[i]));
                                 uint16_t entryLength = static_cast<uint16_t>(data[i].size() + kByteSpanSizeLengthInBytes);
-                                messageLen -= entryLength;
+                                messageLen = static_cast<uint16_t>(messageLen - entryLength);
                                 message += entryLength;
                                 {{else}}
                                 CHECK_MESSAGE_LENGTH({{size}});

--- a/src/app/zap-templates/templates/app/attribute-size-src.zapt
+++ b/src/app/zap-templates/templates/app/attribute-size-src.zapt
@@ -98,7 +98,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 {{/chip_attribute_list_entryTypes}}
                 {{else}}
                 {{#if (isString type)}}
-                entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, index - 1);
+                entryOffset = GetByteSpanOffsetFromIndex(write ? dest : src, am->size, static_cast<uint16_t>(index - 1));
                 if (entryOffset == 0)
                 {
                     ChipLogError(Zcl, "Index %" PRId32 " is invalid.", index);
@@ -113,7 +113,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                     return 0;
                 }
 
-                entryLength = {{asCamelCased name}}Span->size();
+                if (!CanCastTo<uint16_t>({{asCamelCased name}}Span->size()))
+                {
+                    ChipLogError(Zcl, "Span size %zu is too large", {{asCamelCased name}}Span->size());
+                    return 0;
+                }
+                entryLength = static_cast<uint16_t>({{asCamelCased name}}Span->size());
                 {{else}}
                 copyListMember(dest, src, write, &entryOffset, entryLength); // {{type}}
                 {{/if}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -132,18 +132,23 @@ function asReadType(type)
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
       case 'int8_t':
+        return 'Int8s';
       case 'uint8_t':
         return 'Int8u';
       case 'int16_t':
+        return 'Int16s';
       case 'uint16_t':
         return 'Int16u';
       case 'int24_t':
+        return 'Int24s';
       case 'uint24_t':
         return 'Int24u';
       case 'int32_t':
+        return 'Int32s';
       case 'uint32_t':
         return 'Int32u';
       case 'int64_t':
+        return 'Int64s';
       case 'uint64_t':
         return 'Int64u';
       default:

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -455,7 +455,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].outputType = emberAfGetInt8u(message, 0, 1);
                             message += 1;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].name));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -476,7 +476,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                         {
                             CHECK_STATUS(ReadByteSpan(message, messageLen, &data[i]));
                             uint16_t entryLength = static_cast<uint16_t>(data[i].size() + kByteSpanSizeLengthInBytes);
-                            messageLen -= entryLength;
+                            messageLen           = static_cast<uint16_t>(messageLen - entryLength);
                             message += entryLength;
                         }
 
@@ -581,10 +581,10 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                         for (size_t i = 0; i < count; i++)
                         {
                             CHECK_STATUS(ReadByteSpan(message, 18, &data[i].label));
-                            messageLen -= 18;
+                            messageLen = static_cast<uint16_t>(messageLen - 18);
                             message += 18;
                             CHECK_STATUS(ReadByteSpan(message, 18, &data[i].value));
-                            messageLen -= 18;
+                            messageLen = static_cast<uint16_t>(messageLen - 18);
                             message += 18;
                         }
 
@@ -604,7 +604,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                         for (size_t i = 0; i < count; i++)
                         {
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].Name));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                             CHECK_MESSAGE_LENGTH(1);
                             data[i].FabricConnected = emberAfGetInt8u(message, 0, 1);
@@ -667,7 +667,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].GroupKeyIndex = emberAfGetInt16u(message, 0, 2);
                             message += 2;
                             CHECK_STATUS(ReadByteSpan(message, 18, &data[i].GroupKeyRoot));
-                            messageLen -= 18;
+                            messageLen = static_cast<uint16_t>(messageLen - 18);
                             message += 18;
                             CHECK_MESSAGE_LENGTH(8);
                             data[i].GroupKeyEpochStartTime = emberAfGetInt64u(message, 0, 8);
@@ -699,10 +699,10 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].inputType = emberAfGetInt8u(message, 0, 1);
                             message += 1;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].name));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].description));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -731,7 +731,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].NodeId = emberAfGetInt64u(message, 0, 8);
                             message += 8;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].Label));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -758,13 +758,13 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].minorNumber = emberAfGetInt16u(message, 0, 2);
                             message += 2;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].name));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].callSign));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].affiliateCallSign));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -787,7 +787,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].identifier = emberAfGetInt8u(message, 0, 1);
                             message += 1;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].name));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -824,7 +824,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                         {
                             CHECK_STATUS(ReadByteSpan(message, messageLen, &data[i]));
                             uint16_t entryLength = static_cast<uint16_t>(data[i].size() + kByteSpanSizeLengthInBytes);
-                            messageLen -= entryLength;
+                            messageLen           = static_cast<uint16_t>(messageLen - entryLength);
                             message += entryLength;
                         }
 
@@ -842,7 +842,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].fabricIndex = emberAfGetInt64u(message, 0, 8);
                             message += 8;
                             CHECK_STATUS(ReadByteSpan(message, 34, &data[i].operationalCert));
-                            messageLen -= 34;
+                            messageLen = static_cast<uint16_t>(messageLen - 34);
                             message += 34;
                         }
 
@@ -881,10 +881,10 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].LQI = emberAfGetInt8u(message, 0, 1);
                             message += 1;
                             CHECK_MESSAGE_LENGTH(1);
-                            data[i].AverageRssi = emberAfGetInt8u(message, 0, 1);
+                            data[i].AverageRssi = emberAfGetInt8s(message, 0, 1);
                             message += 1;
                             CHECK_MESSAGE_LENGTH(1);
-                            data[i].LastRssi = emberAfGetInt8u(message, 0, 1);
+                            data[i].LastRssi = emberAfGetInt8s(message, 0, 1);
                             message += 1;
                             CHECK_MESSAGE_LENGTH(1);
                             data[i].FrameErrorRate = emberAfGetInt8u(message, 0, 1);


### PR DESCRIPTION
#### Problem
We are not using `-Wconversion` to build things in `src/app`, so we won't catch problems as we start changing the sizes of things like cluster/endpoint/attribute ids.

#### Change overview
Add `-Wconversion` to some of the relevant .gn/.gni files, fix resulting problems.

#### Testing
Compiled the code on esp32, Mac, nrfconnect.