### PR TITLE
Fix compilation error in lock-app and temperature-measurement-app

### DIFF
--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -58,13 +58,9 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 -   Configuration Options
 
-        To choose from the different configuration options, run menuconfig.
-
-          $ idf.py menuconfig
-
-        Select ESP32 based `Device Type` through `Demo`->`Device Type`.
-        The device types that are currently supported include `ESP32-DevKitC` (default),
-        and `M5Stack`
+    This application uses `ESP32-DevKitC` as a default device type. To use other
+    ESP32 based device types, please refer
+    [examples/all-clusters-app/esp32](https://github.com/project-chip/connectedhomeip/tree/master/examples/all-clusters-app/esp32)
 
 -   To build the demo application.
 
@@ -194,10 +190,8 @@ commissioning and cluster control.
 ### Example Demo
 
 This demo app illustrates controlling OnOff cluster (Server) attributes of an
-endpoint and lock/unlock status of door using LED's. For `ESP32-DevKitC` and
-`ESP32-WROVER-KIT_V4.1`, a GPIO (configurable through `LOCK_STATE_LED` in
-`main/include/AppConfig.h`) is updated through the on/off/toggle commands from
-the `python-controller`. For `M5Stack`, a builtin LED can be used.
-
-If you wish to see the actual effect of the commands on `ESP32-DevKitC` and
-`ESP32-WROVER-KIT_V4.1`, you will have to connect an external LED to GPIO.
+endpoint and lock/unlock status of door using LED's. For `ESP32-DevKitC`, a GPIO
+(configurable through `LOCK_STATE_LED` in `main/include/AppConfig.h`) is updated
+through the on/off/toggle commands from the `python-controller`. If you wish to
+see the actual effect of the commands on `ESP32-DevKitC`, you will have to
+connect an external LED to GPIO.

--- a/examples/lock-app/esp32/main/CMakeLists.txt
+++ b/examples/lock-app/esp32/main/CMakeLists.txt
@@ -146,6 +146,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/diagnostic-logs-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/on-off-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"

--- a/examples/lock-app/esp32/main/Kconfig.projbuild
+++ b/examples/lock-app/esp32/main/Kconfig.projbuild
@@ -21,19 +21,6 @@
 menu "Demo"
 
     choice
-        prompt "Device Type"
-        default DEVICE_TYPE_ESP32_DEVKITC
-        help
-            Specifies the type of ESP32 device.
-
-            Note that the "ESP32-DevKitC" choice is compatible with a number of clone devices
-            available from third-party manufacturers.
-
-        config DEVICE_TYPE_ESP32_DEVKITC
-            bool "ESP32-DevKitC"
-    endchoice
-
-    choice
       prompt "Rendezvous Mode"
       default RENDEZVOUS_MODE_BLE
       help
@@ -65,15 +52,6 @@ menu "Demo"
         help
             The IPV4 Address of the ECHO Server.
 
-    # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
-    # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
-    # define that is produced is needed to configure the TFT library correctly.
-    config TFT_PREDEFINED_DISPLAY_TYPE
-        int
-        range 0 5
-        default 3 if DEVICE_TYPE_M5STACK
-        default 0 if DEVICE_TYPE_ESP32_DEVKITC
-
     config RENDEZVOUS_MODE
        int
        range 0 8
@@ -82,14 +60,6 @@ menu "Demo"
        default 2 if RENDEZVOUS_MODE_BLE
        default 4 if RENDEZVOUS_MODE_THREAD
        default 8 if RENDEZVOUS_MODE_ETHERNET
-
-    config DISPLAY_AUTO_OFF
-        bool "Automatically turn off the M5Stack's Display after a few seconds"
-        default "y"
-        depends on DEVICE_TYPE_M5STACK
-        help
-            To reduce wear and heat the M5Stack's Display is automatically switched off after a few seconds
-
 
 endmenu
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -58,13 +58,9 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 -   Configuration Options
 
-        To choose from the different configuration options, run menuconfig
-
-          $ idf.py menuconfig
-
-        Select ESP32 based `Device Type` through `Demo`->`Device Type`.
-        The device types that are currently supported include `ESP32-DevKitC` (default),
-        and `M5Stack`
+    This application uses `ESP32-DevKitC` as a default device type. To use other
+    ESP32 based device types, please refer
+    [examples/all-clusters-app/esp32](https://github.com/project-chip/connectedhomeip/tree/master/examples/all-clusters-app/esp32)
 
 -   To build the demo application.
 

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -29,6 +29,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/diagnostic-logs-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"

--- a/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
+++ b/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
@@ -21,21 +21,6 @@
 menu "Demo"
 
     choice
-        prompt "Device Type"
-        default DEVICE_TYPE_ESP32_DEVKITC
-        help
-            Specifies the type of ESP32 device.
-
-            Note that the "ESP32-DevKitC" choice is compatible with a number of clone devices
-            available from third-party manufacturers.
-
-        config DEVICE_TYPE_ESP32_DEVKITC
-            bool "ESP32-DevKitC"
-        config DEVICE_TYPE_M5STACK
-            bool "M5Stack"
-    endchoice
-
-    choice
       prompt "Rendezvous Mode"
       default RENDEZVOUS_MODE_BLE
       help
@@ -67,15 +52,6 @@ menu "Demo"
         help
             The IPV4 Address of the ECHO Server.
 
-    # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
-    # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
-    # define that is produced is needed to configure the TFT library correctly.
-    config TFT_PREDEFINED_DISPLAY_TYPE
-        int
-        range 0 5
-        default 3 if DEVICE_TYPE_M5STACK
-        default 0 if DEVICE_TYPE_ESP32_DEVKITC
-
     config RENDEZVOUS_MODE
        int
        range 0 8
@@ -84,13 +60,5 @@ menu "Demo"
        default 2 if RENDEZVOUS_MODE_BLE
        default 4 if RENDEZVOUS_MODE_THREAD
        default 8 if RENDEZVOUS_MODE_ETHERNET
-
-    config DISPLAY_AUTO_OFF
-        bool "Automatically turn off the M5Stack's Display after a few seconds"
-        default "y"
-        depends on DEVICE_TYPE_M5STACK
-        help
-            To reduce wear and heat the M5Stack's Display is automatically switched off after a few seconds
-
 
 endmenu


### PR DESCRIPTION
#### Problem
1. Compilation fails for Lock app and Temperature App after merge: #7423 
2. M5stack or other device types support is mentioned in readme of both apps but actually not present
#### Change overview
* Added path to diagnostic-logs-server cluster in CMakelist.txt for both apps 
* Removed other device types from readme and Kconfig.projbuild

#### Testing
* Tested with chip-device-ctrl