### PR TITLE
CASESession: Fix IPK size, it should be 16 bytes not 32

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -52,7 +52,7 @@ constexpr uint16_t kSigmaParamRandomNumberSize = 32;
 constexpr uint16_t kTrustedRootIdSize          = 20;
 constexpr uint16_t kMaxTrustedRootIds          = 5;
 
-constexpr uint16_t kIPKSize = 32;
+constexpr uint16_t kIPKSize = 16;
 
 using namespace Crypto;
 using namespace Credentials;


### PR DESCRIPTION
#### Problem
The IPK size was incorrect, it was declared as 32 bytes instead of 16 in CASESession.h. The spec is very clear about this and leaves no room for ambiguity. Like all symmetric keys in Matter, the IPK must be 16 bytes in length. See e.g. 11.22.7.8 AddOpCert command description:

"The IPK SHALL be provided as an octet string of length CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES."

#### Change overview
Conform the IPK size definition to the specification.

#### Testing
* CASE is not fully enabled yet and the operational credentials server does not yet verify the IPK length, so regular operation is unaffected by this change. However the IPK size must be corrected before continuing hookup.
