### PR TITLE
ESP32: Fixes for CI esp32 build

### DIFF
--- a/scripts/examples/esp_example.sh
+++ b/scripts/examples/esp_example.sh
@@ -40,10 +40,6 @@ for sdkconfig in "$root"/sdkconfig*.defaults; do
     (
         cd "$root"
         idf.py -D SDKCONFIG_DEFAULTS="$sdkconfig_name" build
-    )
-    (
-        cd "$root"
-        idf.py build "$@"
     ) || {
         echo "build $sdkconfig_name failed"
         exit 1


### PR DESCRIPTION
#### Problem
`idf.py build` was executed unnecessarily two times with the same sdkconfig.

#### Change overview
Removed the duplicate.

#### Testing
Successful CI
