### PR TITLE
Move the temporary fabricSecret bit to be a CASESession member.

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -39,9 +39,6 @@
 
 namespace chip {
 
-// TODO: Remove Later
-static P256ECDHDerivedSecret fabricSecret;
-
 constexpr uint8_t kIPKInfo[] = { 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x50, 0x72, 0x6f,
                                  0x74, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x4b, 0x65, 0x79 };
 
@@ -76,11 +73,11 @@ CASESession::CASESession()
 {
     mTrustedRootId.mId = nullptr;
     // dummy initialization REMOVE LATER
-    for (size_t i = 0; i < fabricSecret.Capacity(); i++)
+    for (size_t i = 0; i < mFabricSecret.Capacity(); i++)
     {
-        fabricSecret[i] = static_cast<uint8_t>(i);
+        mFabricSecret[i] = static_cast<uint8_t>(i);
     }
-    fabricSecret.SetLength(fabricSecret.Capacity());
+    mFabricSecret.SetLength(mFabricSecret.Capacity());
 }
 
 CASESession::~CASESession()
@@ -1088,7 +1085,7 @@ CHIP_ERROR CASESession::ConstructSignedCredentials(const uint8_t ** msgIterator,
 CHIP_ERROR CASESession::ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen)
 {
     HKDF_sha_crypto mHKDF;
-    ReturnErrorOnFailure(mHKDF.HKDF_SHA256(fabricSecret, fabricSecret.Length(), reinterpret_cast<const uint8_t *>(&sessionID),
+    ReturnErrorOnFailure(mHKDF.HKDF_SHA256(mFabricSecret, mFabricSecret.Length(), reinterpret_cast<const uint8_t *>(&sessionID),
                                            sizeof(sessionID), kIPKInfo, sizeof(kIPKInfo), ipk, ipkLen));
 
     return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -249,6 +249,8 @@ private:
     Hash_SHA256_stream mCommissioningHash;
     P256PublicKey mRemotePubKey;
     P256Keypair mEphemeralKey;
+    // TODO: Remove mFabricSecret later
+    P256ECDHDerivedSecret mFabricSecret;
     P256ECDHDerivedSecret mSharedSecret;
     OperationalCredentialSet * mOpCredSet;
     CertificateKeyId mTrustedRootId;


### PR DESCRIPTION
Right now it's a static and our example apps have the CASESession as a
static in a different file (via CASEServer).  At least on Linux the
static initializer for the CASEServer runs first, the CASESession
constructor runs, sets up the fabricSecret, then the
P256ECDHDerivedSecret constructor runs and sets its length to 0.  And
then trying to use that fabricSecret later on fails.

Making the fabricSecret a member of CASESession ensures its
constructor runs before the logic in the CASESession constructor.

#### Problem
all-clusters-app is not able to actually send a SigmaR2 message, because IPK generation fails.

#### Change overview
Fix things so that IPK generation succeeds.

#### Testing
Manual for now, but https://github.com/project-chip/connectedhomeip/pull/7896 will end up testing this in CI; this issue is one of the things causing tests there to fail.