### PR TITLE
Mark UDP socket as ready for write in send msg.

### DIFF
--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -649,6 +649,10 @@ INET_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBuff
     SuccessOrExit(res);
 
     res = IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
+
+    // Wait for ability to write on this endpoint.
+    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
+    mSocket.OnRequestCallbackOnPendingWrite();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK


### PR DESCRIPTION
#### Problem

When SendMsg is called, it may create a new socket which is
not part of the files monitored by the system. The FD won't
be added to this list until select (or other monitoring mechanism)
unblock.

#### Change overview
This patch ensure that a socket created with SendMsg is added
immediately to the list of FD being monitored.
It mirrors what is done in the Listen function.

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
> Tested on Mbed OS (see https://github.com/project-chip/connectedhomeip/pull/7926). Without this patch MDNS messages are not sent immediately (or even not sent at all if the endpoint is destroyed before the current `select` _unblock_). 
