### PR TITLE
Remove ServiceEvents() call from Android and Python controllers

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -111,13 +111,6 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
         return nullptr;
     }
 
-    *errInfoOnFailure = wrapper->Controller()->ServiceEvents();
-
-    if (*errInfoOnFailure != CHIP_NO_ERROR)
-    {
-        return nullptr;
-    }
-
     return wrapper.release();
 }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -165,7 +165,6 @@ CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceC
 
     (*outDevCtrl)->SetUdpListenPort(CHIP_PORT + 1);
     ReturnErrorOnFailure((*outDevCtrl)->Init(localDeviceId, initParams));
-    ReturnErrorOnFailure((*outDevCtrl)->ServiceEvents());
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
* #7804
* In the Android controller there is no device layer, so `ServiceEvents()` does nothing
#### Change overview
Remove `ServiceEvents()` from both controller apps
Fixes #7804 

#### Testing
Commissioned m5stack running all-clusters-app and sent zcl commands in chip-device-ctrl and Android CHIPTool
