### PR TITLE
[nrfconnect] Reduce build command length

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -47,30 +47,30 @@ list(APPEND CHIP_CFLAGS_CC)
 list(APPEND CHIP_LIBRARIES)
 
 # GN meta-build system arguments passed to the make_gn_args.py script
-list(APPEND CHIP_GN_ARGS)
+string(APPEND CHIP_GN_ARGS)
 
 # ==============================================================================
 # Helper macros
 # ==============================================================================
 
 macro(chip_gn_arg_import FILE)
-    list(APPEND CHIP_GN_ARGS --module "${FILE}")
+    string(APPEND CHIP_GN_ARGS "--module\n\"${FILE}\"\n")
 endmacro()
 
 macro(chip_gn_arg_string ARG STRING)
-    list(APPEND CHIP_GN_ARGS --arg-string "${ARG}" "${STRING}")
+    string(APPEND CHIP_GN_ARGS "--arg-string\n${ARG}\n${STRING}\n")
 endmacro()
 
 macro(chip_gn_arg_bool ARG BOOLEAN)
     if (${BOOLEAN})
-        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "true")
+        string(APPEND CHIP_GN_ARGS "--arg\n${ARG}\ntrue\n")
     else()
-        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "false")
+        string(APPEND CHIP_GN_ARGS "--arg\n${ARG}\nfalse\n")
     endif()
 endmacro()
 
 macro(chip_gn_arg_cflags ARG CFLAGS)
-    list(APPEND CHIP_GN_ARGS --arg-cflags "${ARG}" "${CFLAGS}")
+    string(APPEND CHIP_GN_ARGS "--arg-cflags\n${ARG}\n${CFLAGS}\n")
 endmacro()
 
 # ==============================================================================
@@ -216,6 +216,8 @@ elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
 endif()
 
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/args.tmp" CONTENT ${CHIP_GN_ARGS})
+
 # ==============================================================================
 # Define 'chip-gn' target that builds CHIP library(ies) with GN build system
 # ==============================================================================
@@ -225,7 +227,7 @@ ExternalProject_Add(
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
     CONFIGURE_COMMAND       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
-                                ${CHIP_GN_ARGS} > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
+                                @${CMAKE_CURRENT_BINARY_DIR}/args.tmp > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
                             ${GN_EXECUTABLE}
                                 --root=${CHIP_ROOT}
                                 --root-target=${GN_ROOT_TARGET}

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -54,7 +54,7 @@ string(APPEND CHIP_GN_ARGS)
 # ==============================================================================
 
 macro(chip_gn_arg_import FILE)
-    string(APPEND CHIP_GN_ARGS "--module\n\"${FILE}\"\n")
+    string(APPEND CHIP_GN_ARGS "--module\n${FILE}\n")
 endmacro()
 
 macro(chip_gn_arg_string ARG STRING)
@@ -226,19 +226,19 @@ ExternalProject_Add(
     PREFIX                  ${CMAKE_CURRENT_BINARY_DIR}
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
-    CONFIGURE_COMMAND       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
-                                @${CMAKE_CURRENT_BINARY_DIR}/args.tmp > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
+    CONFIGURE_COMMAND       ""
+    BUILD_COMMAND           ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
+                                @args.tmp > args.gn &&
                             ${GN_EXECUTABLE}
                                 --root=${CHIP_ROOT}
                                 --root-target=${GN_ROOT_TARGET}
                                 --dotfile=${GN_ROOT_TARGET}/.gn
                                 --script-executable=${Python3_EXECUTABLE}
                                 --export-compile-commands
-                                gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
-    BUILD_COMMAND           ninja
+                                gen --check --fail-on-unused-args . &&
+                            ninja
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
-    CONFIGURE_ALWAYS        TRUE
     BUILD_ALWAYS            TRUE
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD     TRUE

--- a/config/nrfconnect/chip-module/make_gn_args.py
+++ b/config/nrfconnect/chip-module/make_gn_args.py
@@ -53,7 +53,7 @@ def write_gn_args(args):
         sys.stdout.write('{} = filter_exclude(string_split("{}"), [{}])\n'.format(key, value, cflag_excludes))
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     parser.add_argument('--module', action='store')
     parser.add_argument('--arg', action='append', nargs=2, default=[])
     parser.add_argument('--arg-string', action='append', nargs=2, default=[])


### PR DESCRIPTION
#### Problem
nRF Connect examples no longer compile on Windows due to too long build command.

#### Change overview
Switch from passing arguments to the `make_gn_args.py` script directly to using the `@file` parameter where `file` is a text file containing all the arguments (common approach on Windows).

#### Testing
Verified that nRF Connect examples build on Windows and run correctly on hardware.