### PR TITLE
ESP32: Add support for flashing using .flash.py

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -35,3 +35,38 @@ endif()
 project(chip-all-clusters-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+idf_build_get_property(build_dir BUILD_DIR)
+idf_build_get_property(project_path PROJECT_DIR)
+idf_build_get_property(sdkconfig SDKCONFIG)
+idf_build_get_property(idf_path IDF_PATH)
+
+add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+    COMMAND ${python}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
+            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+            --port "$ENV{ESPPORT}"
+            --baud "$ENV{ESPBAUD}"
+            --before ${CONFIG_ESPTOOLPY_BEFORE}
+            --after ${CONFIG_ESPTOOLPY_AFTER}
+            --application "${CMAKE_PROJECT_NAME}.bin"
+            --bootloader "bootloader/bootloader.bin"
+            --partition "partition_table/partition-table.bin"
+            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
+            --use-parttool ${idf_path}/components/partition_table/parttool.py
+            --use-sdkconfig ${project_path}/sdkconfig
+    WORKING_DIRECTORY ${build_dir}
+    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
+    VERBATIM)
+
+add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -12,6 +12,7 @@ control.
         -   [Setting up Python Controller](#setting-up-python-controller)
         -   [Commissioning over BLE](#commissioning-over-ble)
         -   [Cluster control](#cluster-control)
+    -   [Flashing app using script](#flashing-app-using-script)
     -   [Note](#note)
 
 ---
@@ -213,6 +214,25 @@ commissioning and cluster control.
     device to be On or Off.
 
     `chip-device-ctrl > zcl OnOff Off 135246 1 0`
+
+### Flashing app using script
+
+-   Follow these steps to use `${app_name}.flash.py`.
+
+    -   First set IDF target, run set-target with one of the commands.
+
+            $ idf.py set-target esp32
+            $ idf.py set-target esp32c3
+
+    -   Execute below sequence of commands
+
+```
+        $ export ESPPORT=/dev/tty.SLAB_USBtoUART
+        $ export ESPBAUD=${baud_value}
+        $ idf.py build
+        $ idf.py flashing_script
+        $ python ${app_name}.flash.py
+```
 
 ### Note
 

--- a/examples/persistent-storage/esp32/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/CMakeLists.txt
@@ -25,3 +25,38 @@ set(EXTRA_COMPONENT_DIRS
 project(persistent-storage)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+idf_build_get_property(build_dir BUILD_DIR)
+idf_build_get_property(project_path PROJECT_DIR)
+idf_build_get_property(sdkconfig SDKCONFIG)
+idf_build_get_property(idf_path IDF_PATH)
+
+add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+    COMMAND ${python}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
+            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+            --port "$ENV{ESPPORT}"
+            --baud "$ENV{ESPBAUD}"
+            --before ${CONFIG_ESPTOOLPY_BEFORE}
+            --after ${CONFIG_ESPTOOLPY_AFTER}
+            --application "${CMAKE_PROJECT_NAME}.bin"
+            --bootloader "bootloader/bootloader.bin"
+            --partition "partition_table/partition-table.bin"
+            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
+            --use-parttool ${idf_path}/components/partition_table/parttool.py
+            --use-sdkconfig ${project_path}/sdkconfig
+    WORKING_DIRECTORY ${build_dir}
+    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
+    VERBATIM)
+
+add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -10,6 +10,7 @@ An example testing and demonstrating the key value storage API.
         -   [Building](#building)
         -   [Flashing the Application](#flashing-the-application)
         -   [Viewing Logging Output](#viewing-logging-output)
+        -   [Flashing app using script](#flashing-app-using-script)
 
 <hr>
 
@@ -105,6 +106,25 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     before the device shows up on `/dev/tty`.
 
 <a name="view-logging"></a>
+
+### Flashing app using script
+
+-   Follow these steps to use `${app_name}.flash.py`.
+
+    -   First set IDF target, run set-target with one of the commands.
+
+            $ idf.py set-target esp32
+            $ idf.py set-target esp32c3
+
+    -   Execute below sequence of commands
+
+```
+        $ export ESPPORT=/dev/tty.SLAB_USBtoUART
+        $ export ESPBAUD=${baud_value}
+        $ idf.py build
+        $ idf.py flashing_script
+        $ python ${app_name}.flash.py
+```
 
 ### Viewing Logging Output
 

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -26,3 +26,48 @@ set(EXTRA_COMPONENT_DIRS
 project(chip-pigweed-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+idf_build_get_property(build_dir BUILD_DIR)
+idf_build_get_property(project_path PROJECT_DIR)
+idf_build_get_property(sdkconfig SDKCONFIG)
+idf_build_get_property(idf_path IDF_PATH)
+
+add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/echo_test.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/../mobly_tests/echo_test.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/echo_test_config.yml"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/echo_test_config.yml" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+    COMMAND ${python}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
+            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+            --port "$ENV{ESPPORT}"
+            --baud "$ENV{ESPBAUD}"
+            --before ${CONFIG_ESPTOOLPY_BEFORE}
+            --after ${CONFIG_ESPTOOLPY_AFTER}
+            --application "${CMAKE_PROJECT_NAME}.bin"
+            --bootloader "bootloader/bootloader.bin"
+            --partition "partition_table/partition-table.bin"
+            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
+            --use-parttool ${idf_path}/components/partition_table/parttool.py
+            --use-sdkconfig ${project_path}/sdkconfig
+    WORKING_DIRECTORY ${build_dir}
+    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
+    VERBATIM)
+
+add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py" "${build_dir}/echo_test.py" "${build_dir}/echo_test_config.yml")

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -101,6 +101,25 @@ To download and install packages.
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
     before the device shows up on `/dev/tty`.
 
+### Flashing app using script
+
+-   Follow these steps to use `${app_name}.flash.py`.
+
+    -   First set IDF target, run set-target with one of the commands.
+
+            $ idf.py set-target esp32
+            $ idf.py set-target esp32c3
+
+    -   Execute below sequence of commands
+
+```
+        $ export ESPPORT=/dev/tty.SLAB_USBtoUART
+        $ export ESPBAUD=${baud_value}
+        $ idf.py build
+        $ idf.py flashing_script
+        $ python ${app_name}.flash.py
+```
+
 ## Testing the Example Application
 
 Run the following command to start an interactive Python shell, where the Echo

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -36,3 +36,38 @@ set(EXTRA_COMPONENT_DIRS
 project(chip-temperature-measurement-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+idf_build_get_property(build_dir BUILD_DIR)
+idf_build_get_property(project_path PROJECT_DIR)
+idf_build_get_property(sdkconfig SDKCONFIG)
+idf_build_get_property(idf_path IDF_PATH)
+
+add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
+    WORKING_DIRECTORY ${build_dir}
+    VERBATIM)
+
+add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+    COMMAND ${python}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
+            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+            --port "$ENV{ESPPORT}"
+            --baud "$ENV{ESPBAUD}"
+            --before ${CONFIG_ESPTOOLPY_BEFORE}
+            --after ${CONFIG_ESPTOOLPY_AFTER}
+            --application "${CMAKE_PROJECT_NAME}.bin"
+            --bootloader "bootloader/bootloader.bin"
+            --partition "partition_table/partition-table.bin"
+            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
+            --use-parttool ${idf_path}/components/partition_table/parttool.py
+            --use-sdkconfig ${project_path}/sdkconfig
+    WORKING_DIRECTORY ${build_dir}
+    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
+    VERBATIM)
+
+add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -10,6 +10,7 @@ This example is meant to represent a minimal-sized application.
         -   [Setting up Python Controller](#setting-up-python-controller)
         -   [Commissioning over BLE](#commissioning-over-ble)
         -   [Cluster control](#cluster-control)
+    -   [Flashing app using script](#flashing-app-using-script)
     -   [Optimization](#optimization)
 
 ---
@@ -184,6 +185,25 @@ commissioning and cluster control.
 -   The demo application supports TemperatureMeasurement and Basic cluster.
 
     `chip-device-ctrl > zcl Basic MfgSpecificPing 135246 1 0`
+
+### Flashing app using script
+
+-   Follow these steps to use `${app_name}.flash.py`.
+
+    -   First set IDF target, run set-target with one of the commands.
+
+            $ idf.py set-target esp32
+            $ idf.py set-target esp32c3
+
+    -   Execute below sequence of commands
+
+```
+        $ export ESPPORT=/dev/tty.SLAB_USBtoUART
+        $ export ESPBAUD=${baud_value}
+        $ idf.py build
+        $ idf.py flashing_script
+        $ python ${app_name}.flash.py
+```
 
 ## Optimization
 

--- a/scripts/flashing/esp32_firmware_utils.py
+++ b/scripts/flashing/esp32_firmware_utils.py
@@ -227,10 +227,11 @@ ESP32_OPTIONS = {
         },
         'bootloader_offset': {
             'help': 'Bootloader offset',
-            'default': '0x1000',
+            'default': None,
             'argparse': {
                 'metavar': 'OFFSET'
             },
+            'sdkconfig': 'CONFIG_BOOTLOADER_OFFSET_IN_FLASH',
         },
         'partition': {
             'help': 'Partition table image',


### PR DESCRIPTION
#### Problem
* The support for flashing using `${app_name}.flash.py` was removed here #7034 .

#### Change overview
* It adds the necessary changes to `CMakeLists.txt` to build the target for `flashing_script`.
* Made necessary changes in `esp32_firmware_utils.py` to make this script usable for ESP32 and ESP32C3 board.

#### Testing
* Build the `all-clusters-app` using `idf.py build`.
* Generate `chip-all-clusters-app.flash.py` using `idf.py flashing_script`
* Run `python ./build/chip-all-clusters-app.flash.py`
* Run `idf.py monitor`
* Same steps were executed for other esp32 examples too.