### PR TITLE
[crypto] Fix CASE on some embedded platforms

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -559,7 +559,8 @@ exit:
 
 CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
 {
-#if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_ALT)
+// TODO: Enable ECDH_derive_secret for Qorvo when their mbedTLS static libraries are updated
+#if defined(MBEDTLS_ECDH_C) && !defined(QORVO_CRYPTO_ENGINE)
     CHIP_ERROR error     = CHIP_NO_ERROR;
     int result           = 0;
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();


### PR DESCRIPTION
#### Problem
Establishing a CASE session requires support for `P256Keypair::ECDH_derive_secret()` function which was
disabled for platforms which define MBEDTLS_ECP_ALT. It is quite common on embedded devices equipped with
dedicated crypto chips to provide custom ECP implementation. As a result, an attempt to resolve a device address or send a ZCL message would fail for nRF Connect-based accessories (other platforms such as Qorvo are probably affected, too).

#### Change overview
Unblock `P256Keypair::ECDH_derive_secret()` for platforms which provide a custom ECP implementation.

#### Testing
Tested commissioning + ZCL commands using the Python controller and nRF Connect Lock Example.