### PR TITLE
Don't send piggybacked acks when they are not needed.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -237,7 +237,6 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, Secu
 
     SetDropAckDebug(false);
     SetAckPending(false);
-    SetPeerRequestedAck(false);
     SetMsgRcvdFromPeer(false);
     SetAutoRequestAck(true);
 

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -43,16 +43,14 @@ enum class MessageFlagValues : uint32_t
     kMessageEncoded = 0x00001000,
     /**< Indicates that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
     kDefaultMulticastSourceAddress = 0x00002000,
-    /**< Indicates that the sender of the  message requested an acknowledgment. */
-    kPeerRequestedAck = 0x00004000,
     /**< Indicates that the message is a duplicate of a previously received message. */
-    kDuplicateMessage = 0x00008000,
+    kDuplicateMessage = 0x00004000,
     /**< Indicates that the peer's group key message counter is not synchronized. */
-    kPeerGroupMsgIdNotSynchronized = 0x00010000,
+    kPeerGroupMsgIdNotSynchronized = 0x00008000,
     /**< Indicates that the source of the message is the initiator of the CHIP exchange. */
-    kFromInitiator = 0x00020000,
+    kFromInitiator = 0x00010000,
     /**< Indicates that message is being sent/received via the local ephemeral UDP port. */
-    kViaEphemeralUDPPort = 0x00040000,
+    kViaEphemeralUDPPort = 0x00020000,
 };
 
 using MessageFlags = BitFlags<MessageFlagValues>;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -116,7 +116,6 @@ void ReliableMessageMgr::ExecuteActions()
 #endif
                 // Send the Ack in a SecureChannel::StandaloneAck message
                 rc->SendStandaloneAckMessage();
-                rc->SetAckPending(false);
             }
         }
     });


### PR DESCRIPTION
We used to set a persistent flag on reliable message contexts that
would cause them to send piggyback acks with all responses after that
point.  Stop doing that.

Also simplify the handling of the IsAckPending state.  It gets set to
true when we set a pending ack id, gets set to false when someone
takes that ack id from us (e.g. to send the ack).  This ensures that
SendStandaloneAckMessage() clears the IsAckPending() state (which it
already did, but that was not very obvious).

Fixes https://github.com/project-chip/connectedhomeip/issues/7339

#### Problem
We are sending acks when we don't need to (and arguably should not), and causing duplicate acks to appear on the other side, which can cause problems.

#### Change overview
Ensure that we only send an ack when we actually have an ack pending.

#### Testing
New unit tests were added to cover the failure modes I was aware of that were caused by this problem.  Existing unit tests were run and pass.