### PR TITLE
Add common 3rd party warnings config target

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -161,9 +161,27 @@ config("disabled_warnings") {
   }
 }
 
+config("warnings_common") {
+  cflags = [ "-Wall" ]
+
+  ldflags = []
+  if (treat_warnings_as_errors) {
+    cflags += [ "-Werror" ]
+    ldflags += [ "-Werror" ]
+  }
+
+  if (current_os != "mac" && current_os != "ios") {
+    ldflags += [ "-Wl,--fatal-warnings" ]
+  }
+
+  if (current_os != "mac" && current_os != "ios" && current_os != "linux" &&
+      current_os != "win") {
+    cflags += [ "-Wstack-usage=8192" ]
+  }
+}
+
 config("strict_warnings") {
   cflags = [
-    "-Wall",
     "-Wextra",
     "-Wshadow",
     "-Wunreachable-code",
@@ -172,11 +190,6 @@ config("strict_warnings") {
   cflags_cc = [ "-Wnon-virtual-dtor" ]
 
   ldflags = []
-
-  if (treat_warnings_as_errors) {
-    cflags += [ "-Werror" ]
-    ldflags += [ "-Werror" ]
-  }
 
   if (is_clang) {
     cflags += [
@@ -193,18 +206,27 @@ config("strict_warnings") {
 
 config("warnings_default") {
   configs = [
+    ":warnings_common",
     ":strict_warnings",
     ":disabled_warnings",
   ]
+}
 
-  if (current_os != "mac" && current_os != "ios") {
-    ldflags = [ "-Wl,--fatal-warnings" ]
-  }
+config("disabled_warnings_third_party") {
+  cflags = [
+    "-Wno-unused",
+    "-Wno-format",
+    "-Wno-maybe-uninitialized",
+    "-Wno-address",
+  ]
+}
 
-  if (current_os != "mac" && current_os != "ios" && current_os != "linux" &&
-      current_os != "win") {
-    cflags = [ "-Wstack-usage=8192" ]
-  }
+config("warnings_third_party") {
+  configs = [
+    ":warnings_common",
+    ":disabled_warnings",
+    ":disabled_warnings_third_party",
+  ]
 }
 
 config("symbols_default") {

--- a/build_overrides/lwip.gni
+++ b/build_overrides/lwip.gni
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+
 declare_args() {
   # Root directory for lwIP.
   lwip_root = "//third_party/lwip"
 }
+
+lwip_remove_configs = [ "${build_root}/config/compiler:warnings_default" ]
+lwip_add_configs = [ "${build_root}/config/compiler:warnings_third_party" ]

--- a/examples/build_overrides/lwip.gni
+++ b/examples/build_overrides/lwip.gni
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+
 declare_args() {
   # Root directory for lwIP.
   lwip_root = "//third_party/connectedhomeip/third_party/lwip"
 }
+
+lwip_remove_configs = [ "${build_root}/config/compiler:warnings_default" ]
+lwip_add_configs = [ "${build_root}/config/compiler:warnings_third_party" ]

--- a/third_party/lwip/lwip.gni
+++ b/third_party/lwip/lwip.gni
@@ -53,17 +53,6 @@ template("lwip_target") {
     lwip_6lowpan = false
   }
 
-  config("${lwip_target_name}_warnings") {
-    cflags = [
-      "-Wno-address",
-      "-Wno-format",
-      "-Wno-type-limits",
-      "-Wno-unused-variable",
-      "-Wno-maybe-uninitialized",
-      "-Wno-format-type-confusion",
-    ]
-  }
-
   config("${lwip_target_name}_base_config") {
     include_dirs = [ "${lwip_root}/repo/lwip/src/include" ]
   }
@@ -212,8 +201,12 @@ template("lwip_target") {
       sources += [ "${_lwip_root}/src/netif/lowpan6.c" ]
     }
 
-    # Relax warnings for third_party code.
-    configs += [ ":${lwip_target_name}_warnings" ]
+    if (defined(lwip_remove_configs)) {
+      configs -= lwip_remove_configs
+    }
+    if (defined(lwip_add_configs)) {
+      configs += lwip_add_configs
+    }
 
     public_configs += [ ":${lwip_target_name}_base_config" ]
   }


### PR DESCRIPTION
There is an idiom for relaxing warnings for third party in GN:

  configs -= [ "//buildsys/1st_party_warnings" ]
  configs += [ "//buildsys/3rd_party_warnings" ]

The trouble is that "//buildsys/1st_party_warnings" is an object from
the core build system that we have to name which introduces some
coupling (e.g., projects may have the same pattern with different target
names and this would not work). To minimize this coupling, indirect this
through the build_overrides directory where the top level project can
provide suitable targets (or not, if the defaults already work).

This is provided for discussion in issue #7935