### PR TITLE
Use chip::ByteSpan for CHAR_STRING and update the tree accordingly

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -2851,7 +2851,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::DoorLock::Commands::Ids::LockDoor: {
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2882,8 +2882,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2904,7 +2903,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterLockDoorCallback(aEndpointId, apCommandObj, const_cast<uint8_t *>(PIN));
+                wasHandled = emberAfDoorLockClusterLockDoorCallback(aEndpointId, apCommandObj, PIN);
             }
             break;
         }
@@ -2984,7 +2983,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -3024,8 +3023,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3046,8 +3044,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterSetPinCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                  const_cast<uint8_t *>(pin));
+                wasHandled = emberAfDoorLockClusterSetPinCallback(aEndpointId, apCommandObj, userId, userStatus, userType, pin);
             }
             break;
         }
@@ -3056,7 +3053,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * id;
+            chip::ByteSpan id;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -3096,8 +3093,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.Get(id);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3118,8 +3114,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterSetRfidCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                   const_cast<uint8_t *>(id));
+                wasHandled = emberAfDoorLockClusterSetRfidCallback(aEndpointId, apCommandObj, userId, userStatus, userType, id);
             }
             break;
         }
@@ -3341,7 +3336,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::DoorLock::Commands::Ids::UnlockDoor: {
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3372,8 +3367,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3394,14 +3388,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(aEndpointId, apCommandObj, const_cast<uint8_t *>(PIN));
+                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(aEndpointId, apCommandObj, PIN);
             }
             break;
         }
         case Clusters::DoorLock::Commands::Ids::UnlockWithTimeout: {
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3435,8 +3429,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3457,8 +3450,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(aEndpointId, apCommandObj, timeoutInSeconds,
-                                                                             const_cast<uint8_t *>(pin));
+                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(aEndpointId, apCommandObj, timeoutInSeconds, pin);
             }
             break;
         }
@@ -3633,7 +3625,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -3669,8 +3661,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -3697,8 +3688,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -3751,7 +3742,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::Groups::Commands::Ids::AddGroup: {
             expectArgumentCount = 2;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::ByteSpan groupName;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3785,8 +3776,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3807,15 +3797,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfGroupsClusterAddGroupCallback(aEndpointId, apCommandObj, groupId, const_cast<uint8_t *>(groupName));
+                wasHandled = emberAfGroupsClusterAddGroupCallback(aEndpointId, apCommandObj, groupId, groupName);
             }
             break;
         }
         case Clusters::Groups::Commands::Ids::AddGroupIfIdentifying: {
             expectArgumentCount = 2;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::ByteSpan groupName;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3849,8 +3838,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3871,8 +3859,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(aEndpointId, apCommandObj, groupId,
-                                                                               const_cast<uint8_t *>(groupName));
+                wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(aEndpointId, apCommandObj, groupId, groupName);
             }
             break;
         }
@@ -5674,7 +5661,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t hardwareVersion;
             uint32_t currentVersion;
             uint8_t protocolsSupported;
-            const uint8_t * location;
+            chip::ByteSpan location;
             bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
@@ -5725,8 +5712,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(protocolsSupported);
                     break;
                 case 6:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(location);
+                    TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 7:
                     TLVUnpackError = aDataTlv.Get(requestorCanConsent);
@@ -5755,7 +5741,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(
                     aEndpointId, apCommandObj, vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported,
-                    const_cast<uint8_t *>(location), requestorCanConsent, metadataForProvider);
+                    location, requestorCanConsent, metadataForProvider);
             }
             break;
         }
@@ -6172,7 +6158,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -6203,8 +6189,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -6225,8 +6210,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }
@@ -6339,7 +6323,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t groupId;
             uint8_t sceneId;
             uint16_t transitionTime;
-            const uint8_t * sceneName;
+            chip::ByteSpan sceneName;
             /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets;
             bool argExists[5];
 
@@ -6380,8 +6364,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(transitionTime);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.Get(sceneName);
                     break;
                 case 4:
                     // Just for compatibility, we will add array type support in IM later.
@@ -6407,7 +6390,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 5 == validArgumentCount)
             {
                 wasHandled = emberAfScenesClusterAddSceneCallback(aEndpointId, apCommandObj, groupId, sceneId, transitionTime,
-                                                                  const_cast<uint8_t *>(sceneName), extensionFieldSets);
+                                                                  sceneName, extensionFieldSets);
             }
             break;
         }

--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -118,7 +118,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
                            &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,7 +255,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan * labelSpan = &entry->label; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
@@ -263,7 +263,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            ByteSpan * valueSpan = &entry->value; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -292,7 +292,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -403,7 +403,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
                            &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                     // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -411,7 +411,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            ByteSpan * descriptionSpan = &entry->description; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -447,7 +447,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -480,7 +480,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
                            &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                       // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -488,7 +488,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            ByteSpan * callSignSpan = &entry->callSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
@@ -496,7 +496,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -528,7 +528,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
                            &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -2365,10 +2365,10 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: TV Channel (server) */                                                                        \
-            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(5906) },       /* tv channel list */                        \
-            { 0x0001, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6160) }, /* tv channel lineup */                      \
-            { 0x0002, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6192) }, /* current tv channel */                     \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },           /* ClusterRevision */                        \
+            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(5906) },      /* tv channel list */                         \
+            { 0x0001, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6160) }, /* tv channel lineup */                       \
+            { 0x0002, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6192) }, /* current tv channel */                      \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Target Navigator (server) */                                                                  \
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(6224) }, /* target navigator list */                        \

--- a/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -480,8 +480,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -508,8 +507,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -2096,7 +2095,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2127,8 +2126,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2149,8 +2147,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/bridge-app/bridge-common/gen/attribute-size.cpp
+++ b/examples/bridge-app/bridge-common/gen/attribute-size.cpp
@@ -155,7 +155,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan * labelSpan = &entry->label; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
@@ -163,7 +163,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            ByteSpan * valueSpan = &entry->value; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -192,7 +192,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -246,7 +246,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -140,7 +140,7 @@ static void OnCharStringAttributeResponse(void * context, const chip::ByteSpan v
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnAccountLoginClusterGetSetupPINResponse(void * context, uint8_t * setupPIN)
+static void OnAccountLoginClusterGetSetupPINResponse(void * context, chip::ByteSpan setupPIN)
 {
     ChipLogProgress(chipTool, "AccountLoginClusterGetSetupPINResponse");
 
@@ -148,7 +148,7 @@ static void OnAccountLoginClusterGetSetupPINResponse(void * context, uint8_t * s
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_t status, uint8_t * data)
+static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_t status, chip::ByteSpan data)
 {
     ChipLogProgress(chipTool, "ApplicationLauncherClusterLaunchAppResponse");
 
@@ -156,7 +156,7 @@ static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnContentLauncherClusterLaunchContentResponse(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+static void OnContentLauncherClusterLaunchContentResponse(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(chipTool, "ContentLauncherClusterLaunchContentResponse");
 
@@ -164,7 +164,7 @@ static void OnContentLauncherClusterLaunchContentResponse(void * context, uint8_
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnContentLauncherClusterLaunchURLResponse(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+static void OnContentLauncherClusterLaunchURLResponse(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(chipTool, "ContentLauncherClusterLaunchURLResponse");
 
@@ -238,7 +238,7 @@ static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t 
 }
 
 static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType,
-                                                  uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                                                  uint8_t source, uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetLogRecordResponse");
 
@@ -246,7 +246,8 @@ static void OnDoorLockClusterGetLogRecordResponse(void * context, uint16_t logEn
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
+                                            chip::ByteSpan pin)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetPinResponse");
 
@@ -254,7 +255,8 @@ static void OnDoorLockClusterGetPinResponse(void * context, uint16_t userId, uin
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+static void OnDoorLockClusterGetRfidResponse(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
+                                             chip::ByteSpan rfid)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetRfidResponse");
 
@@ -361,7 +363,7 @@ static void OnDoorLockClusterUnlockWithTimeoutResponse(void * context, uint8_t s
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGeneralCommissioningClusterArmFailSafeResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnGeneralCommissioningClusterArmFailSafeResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "GeneralCommissioningClusterArmFailSafeResponse");
 
@@ -369,7 +371,7 @@ static void OnGeneralCommissioningClusterArmFailSafeResponse(void * context, uin
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGeneralCommissioningClusterCommissioningCompleteResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnGeneralCommissioningClusterCommissioningCompleteResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "GeneralCommissioningClusterCommissioningCompleteResponse");
 
@@ -377,7 +379,7 @@ static void OnGeneralCommissioningClusterCommissioningCompleteResponse(void * co
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGeneralCommissioningClusterSetRegulatoryConfigResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnGeneralCommissioningClusterSetRegulatoryConfigResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "GeneralCommissioningClusterSetRegulatoryConfigResponse");
 
@@ -410,7 +412,7 @@ static void OnGroupsClusterRemoveGroupResponse(void * context, uint8_t status, u
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGroupsClusterViewGroupResponse(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
+static void OnGroupsClusterViewGroupResponse(void * context, uint8_t status, uint16_t groupId, chip::ByteSpan groupName)
 {
     ChipLogProgress(chipTool, "GroupsClusterViewGroupResponse");
 
@@ -522,7 +524,7 @@ static void OnMediaPlaybackClusterMediaStopResponse(void * context, uint8_t medi
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterAddThreadNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterAddThreadNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterAddThreadNetworkResponse");
 
@@ -530,7 +532,7 @@ static void OnNetworkCommissioningClusterAddThreadNetworkResponse(void * context
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterAddWiFiNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterAddWiFiNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterAddWiFiNetworkResponse");
 
@@ -538,7 +540,7 @@ static void OnNetworkCommissioningClusterAddWiFiNetworkResponse(void * context, 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterDisableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterDisableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterDisableNetworkResponse");
 
@@ -546,7 +548,7 @@ static void OnNetworkCommissioningClusterDisableNetworkResponse(void * context, 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterEnableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterEnableNetworkResponse");
 
@@ -554,7 +556,7 @@ static void OnNetworkCommissioningClusterEnableNetworkResponse(void * context, u
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterRemoveNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterRemoveNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterRemoveNetworkResponse");
 
@@ -563,7 +565,7 @@ static void OnNetworkCommissioningClusterRemoveNetworkResponse(void * context, u
 }
 
 static void
-OnNetworkCommissioningClusterScanNetworksResponse(void * context, uint8_t errorCode, uint8_t * debugText,
+OnNetworkCommissioningClusterScanNetworksResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText,
                                                   /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
                                                   /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
@@ -573,7 +575,7 @@ OnNetworkCommissioningClusterScanNetworksResponse(void * context, uint8_t errorC
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterUpdateThreadNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterUpdateThreadNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterUpdateThreadNetworkResponse");
 
@@ -581,7 +583,7 @@ static void OnNetworkCommissioningClusterUpdateThreadNetworkResponse(void * cont
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnNetworkCommissioningClusterUpdateWiFiNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+static void OnNetworkCommissioningClusterUpdateWiFiNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "NetworkCommissioningClusterUpdateWiFiNetworkResponse");
 
@@ -598,7 +600,7 @@ static void OnOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponse(void * 
 }
 
 static void OnOtaSoftwareUpdateProviderClusterQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime,
-                                                                 uint8_t * imageURI, uint32_t softwareVersion,
+                                                                 chip::ByteSpan imageURI, uint32_t softwareVersion,
                                                                  chip::ByteSpan updateToken, bool userConsentNeeded,
                                                                  chip::ByteSpan metadataForRequestor)
 {
@@ -669,7 +671,7 @@ static void OnScenesClusterStoreSceneResponse(void * context, uint8_t status, ui
 }
 
 static void OnScenesClusterViewSceneResponse(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId,
-                                             uint16_t transitionTime, uint8_t * sceneName,
+                                             uint16_t transitionTime, chip::ByteSpan sceneName,
                                              /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     ChipLogProgress(chipTool, "ScenesClusterViewSceneResponse");
@@ -688,7 +690,7 @@ static void OnTvChannelClusterChangeChannelResponse(void * context,
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8_t status, uint8_t * data)
+static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8_t status, chip::ByteSpan data)
 {
     ChipLogProgress(chipTool, "TargetNavigatorClusterNavigateTargetResponse");
 
@@ -734,7 +736,7 @@ static void OnAudioOutputAudioOutputListListAttributeResponse(void * context, ui
         ChipLogProgress(chipTool, "AudioOutputInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  index: %" PRIu8 "", entries[i].index);
         ChipLogProgress(chipTool, "  outputType: %" PRIu8 "", entries[i].outputType);
-        ChipLogProgress(Zcl, "  name: %zu", entries[i].name.size());
+        ChipLogProgress(Zcl, " name: %.*s", static_cast<uint16_t>(entries[i].name.size()), entries[i].name.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -828,8 +830,8 @@ static void OnFixedLabelLabelListListAttributeResponse(void * context, uint16_t 
     for (uint16_t i = 0; i < count; i++)
     {
         ChipLogProgress(chipTool, "LabelStruct[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  label: %zu", entries[i].label.size());
-        ChipLogProgress(Zcl, "  value: %zu", entries[i].value.size());
+        ChipLogProgress(Zcl, " label: %.*s", static_cast<uint16_t>(entries[i].label.size()), entries[i].label.data());
+        ChipLogProgress(Zcl, " value: %.*s", static_cast<uint16_t>(entries[i].value.size()), entries[i].value.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -844,7 +846,7 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(void * co
     for (uint16_t i = 0; i < count; i++)
     {
         ChipLogProgress(chipTool, "NetworkInterfaceType[%" PRIu16 "]:", i);
-        ChipLogProgress(Zcl, "  Name: %zu", entries[i].Name.size());
+        ChipLogProgress(Zcl, " Name: %.*s", static_cast<uint16_t>(entries[i].Name.size()), entries[i].Name.data());
         ChipLogProgress(chipTool, "  FabricConnected: %d", entries[i].FabricConnected);
         ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv4: %d", entries[i].OffPremiseServicesReachableIPv4);
         ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv6: %d", entries[i].OffPremiseServicesReachableIPv6);
@@ -899,8 +901,9 @@ static void OnMediaInputMediaInputListListAttributeResponse(void * context, uint
         ChipLogProgress(chipTool, "MediaInputInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  index: %" PRIu8 "", entries[i].index);
         ChipLogProgress(chipTool, "  inputType: %" PRIu8 "", entries[i].inputType);
-        ChipLogProgress(Zcl, "  name: %zu", entries[i].name.size());
-        ChipLogProgress(Zcl, "  description: %zu", entries[i].description.size());
+        ChipLogProgress(Zcl, " name: %.*s", static_cast<uint16_t>(entries[i].name.size()), entries[i].name.data());
+        ChipLogProgress(Zcl, " description: %.*s", static_cast<uint16_t>(entries[i].description.size()),
+                        entries[i].description.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -917,7 +920,7 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(void * cont
         ChipLogProgress(chipTool, "  FabricId: %" PRIu64 "", entries[i].FabricId);
         ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entries[i].VendorId);
         ChipLogProgress(chipTool, "  NodeId: %" PRIu64 "", entries[i].NodeId);
-        ChipLogProgress(Zcl, "  Label: %zu", entries[i].Label.size());
+        ChipLogProgress(Zcl, " Label: %.*s", static_cast<uint16_t>(entries[i].Label.size()), entries[i].Label.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -933,9 +936,10 @@ static void OnTvChannelTvChannelListListAttributeResponse(void * context, uint16
         ChipLogProgress(chipTool, "TvChannelInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  majorNumber: %" PRIu16 "", entries[i].majorNumber);
         ChipLogProgress(chipTool, "  minorNumber: %" PRIu16 "", entries[i].minorNumber);
-        ChipLogProgress(Zcl, "  name: %zu", entries[i].name.size());
-        ChipLogProgress(Zcl, "  callSign: %zu", entries[i].callSign.size());
-        ChipLogProgress(Zcl, "  affiliateCallSign: %zu", entries[i].affiliateCallSign.size());
+        ChipLogProgress(Zcl, " name: %.*s", static_cast<uint16_t>(entries[i].name.size()), entries[i].name.data());
+        ChipLogProgress(Zcl, " callSign: %.*s", static_cast<uint16_t>(entries[i].callSign.size()), entries[i].callSign.data());
+        ChipLogProgress(Zcl, " affiliateCallSign: %.*s", static_cast<uint16_t>(entries[i].affiliateCallSign.size()),
+                        entries[i].affiliateCallSign.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -951,7 +955,7 @@ static void OnTargetNavigatorTargetNavigatorListListAttributeResponse(void * con
     {
         ChipLogProgress(chipTool, "NavigateTargetTargetInfo[%" PRIu16 "]:", i);
         ChipLogProgress(chipTool, "  identifier: %" PRIu8 "", entries[i].identifier);
-        ChipLogProgress(Zcl, "  name: %zu", entries[i].name.size());
+        ChipLogProgress(Zcl, " name: %.*s", static_cast<uint16_t>(entries[i].name.size()), entries[i].name.data());
     }
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
@@ -16840,8 +16844,8 @@ public:
     }
 
 private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
+    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
+        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
 };
@@ -16874,8 +16878,8 @@ public:
     }
 
 private:
-    chip::Callback::Callback<OctetStringAttributeCallback> * onSuccessCallback =
-        new chip::Callback::Callback<OctetStringAttributeCallback>(OnOctetStringAttributeResponse, this);
+    chip::Callback::Callback<CharStringAttributeCallback> * onSuccessCallback =
+        new chip::Callback::Callback<CharStringAttributeCallback>(OnCharStringAttributeResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -332,7 +332,7 @@ void PairingCommand::OnDefaultFailureResponse(void * context, uint8_t status)
     command->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
 }
 
-void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "AddNetworkResponse");
 
@@ -365,7 +365,7 @@ void PairingCommand::OnAddNetworkResponse(void * context, uint8_t errorCode, uin
     }
 }
 
-void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(chipTool, "EnableNetworkResponse");
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -121,8 +121,8 @@ public:
 
     /////////// Network Commissioning Callbacks /////////
     static void OnDefaultFailureResponse(void * context, uint8_t status);
-    static void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
-    static void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
+    static void OnAddNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText);
+    static void OnEnableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText);
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -147,8 +147,7 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
         {{#if (isOctetString type)}}
         ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", entries[i].{{name}}.size());
         {{else if (isCharString type)}}
-        // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
-        // ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", entries[i].{{name}}.size(), entries[i].{{name}}.data());
+        ChipLogProgress(Zcl, " {{asSymbol label}}: %.*s", static_cast<uint16_t>(entries[i].{{name}}.size()), entries[i].{{name}}.data());
         {{else}}
         ChipLogProgress(chipTool, "  {{name}}: {{asPrintFormat type}}", entries[i].{{name}});
         {{/if}}
@@ -157,7 +156,7 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
         {{#if (isOctetString type)}}
         ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", entries[i].size());
         {{else if (isCharString type)}}
-        ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", entries[i].size(), entries[i].data());
+        ChipLogProgress(Zcl, " {{asSymbol label}}: %.*s", static_cast<uint16_t>(entries[i].size()), entries[i].data());
         {{else}}
         ChipLogProgress(chipTool, "{{type}}[%" PRIu16 "]: {{asPrintFormat type}}", i, entries[i]);
         {{/if}}

--- a/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
@@ -1951,7 +1951,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -1987,8 +1987,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -2015,8 +2014,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -3603,7 +3602,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3634,8 +3633,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3656,8 +3654,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/lighting-app/lighting-common/gen/attribute-size.cpp
+++ b/examples/lighting-app/lighting-common/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -480,8 +480,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -508,8 +507,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -1575,7 +1574,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -1606,8 +1605,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1628,8 +1626,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/lock-app/lock-common/gen/attribute-size.cpp
+++ b/examples/lock-app/lock-common/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
@@ -453,7 +453,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -489,8 +489,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -517,8 +516,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -2046,7 +2045,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2077,8 +2076,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2099,8 +2097,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/pump-app/pump-common/gen/attribute-size.cpp
+++ b/examples/pump-app/pump-common/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
@@ -453,7 +453,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -489,8 +489,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -517,8 +516,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -1524,7 +1523,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -1555,8 +1554,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1577,8 +1575,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
@@ -444,7 +444,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -480,8 +480,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -508,8 +507,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -1381,7 +1380,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -1412,8 +1411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1434,8 +1432,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
@@ -2472,7 +2472,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::DoorLock::Commands::Ids::LockDoor: {
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2503,8 +2503,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2525,7 +2524,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterLockDoorCallback(aEndpointId, apCommandObj, const_cast<uint8_t *>(PIN));
+                wasHandled = emberAfDoorLockClusterLockDoorCallback(aEndpointId, apCommandObj, PIN);
             }
             break;
         }
@@ -2605,7 +2604,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2645,8 +2644,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2667,8 +2665,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterSetPinCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                  const_cast<uint8_t *>(pin));
+                wasHandled = emberAfDoorLockClusterSetPinCallback(aEndpointId, apCommandObj, userId, userStatus, userType, pin);
             }
             break;
         }
@@ -2677,7 +2674,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * id;
+            chip::ByteSpan id;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -2717,8 +2714,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.Get(id);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2739,8 +2735,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterSetRfidCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                   const_cast<uint8_t *>(id));
+                wasHandled = emberAfDoorLockClusterSetRfidCallback(aEndpointId, apCommandObj, userId, userStatus, userType, id);
             }
             break;
         }
@@ -2962,7 +2957,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::DoorLock::Commands::Ids::UnlockDoor: {
             expectArgumentCount = 1;
-            const uint8_t * PIN;
+            chip::ByteSpan PIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -2993,8 +2988,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.Get(PIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3015,14 +3009,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(aEndpointId, apCommandObj, const_cast<uint8_t *>(PIN));
+                wasHandled = emberAfDoorLockClusterUnlockDoorCallback(aEndpointId, apCommandObj, PIN);
             }
             break;
         }
         case Clusters::DoorLock::Commands::Ids::UnlockWithTimeout: {
             expectArgumentCount = 2;
             uint16_t timeoutInSeconds;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3056,8 +3050,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3078,8 +3071,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(aEndpointId, apCommandObj, timeoutInSeconds,
-                                                                             const_cast<uint8_t *>(pin));
+                wasHandled = emberAfDoorLockClusterUnlockWithTimeoutCallback(aEndpointId, apCommandObj, timeoutInSeconds, pin);
             }
             break;
         }
@@ -3203,7 +3195,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -3239,8 +3231,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -3267,8 +3258,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -3321,7 +3312,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::Groups::Commands::Ids::AddGroup: {
             expectArgumentCount = 2;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::ByteSpan groupName;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3355,8 +3346,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3377,15 +3367,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfGroupsClusterAddGroupCallback(aEndpointId, apCommandObj, groupId, const_cast<uint8_t *>(groupName));
+                wasHandled = emberAfGroupsClusterAddGroupCallback(aEndpointId, apCommandObj, groupId, groupName);
             }
             break;
         }
         case Clusters::Groups::Commands::Ids::AddGroupIfIdentifying: {
             expectArgumentCount = 2;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::ByteSpan groupName;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3419,8 +3408,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3441,8 +3429,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(aEndpointId, apCommandObj, groupId,
-                                                                               const_cast<uint8_t *>(groupName));
+                wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(aEndpointId, apCommandObj, groupId, groupName);
             }
             break;
         }
@@ -5244,7 +5231,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t hardwareVersion;
             uint32_t currentVersion;
             uint8_t protocolsSupported;
-            const uint8_t * location;
+            chip::ByteSpan location;
             bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
@@ -5295,8 +5282,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(protocolsSupported);
                     break;
                 case 6:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(location);
+                    TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 7:
                     TLVUnpackError = aDataTlv.Get(requestorCanConsent);
@@ -5325,7 +5311,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(
                     aEndpointId, apCommandObj, vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported,
-                    const_cast<uint8_t *>(location), requestorCanConsent, metadataForProvider);
+                    location, requestorCanConsent, metadataForProvider);
             }
             break;
         }
@@ -5742,7 +5728,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -5773,8 +5759,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -5795,8 +5780,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }
@@ -5909,7 +5893,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t groupId;
             uint8_t sceneId;
             uint16_t transitionTime;
-            const uint8_t * sceneName;
+            chip::ByteSpan sceneName;
             /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets;
             bool argExists[5];
 
@@ -5950,8 +5934,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(transitionTime);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.Get(sceneName);
                     break;
                 case 4:
                     // Just for compatibility, we will add array type support in IM later.
@@ -5977,7 +5960,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 5 == validArgumentCount)
             {
                 wasHandled = emberAfScenesClusterAddSceneCallback(aEndpointId, apCommandObj, groupId, sceneId, transitionTime,
-                                                                  const_cast<uint8_t *>(sceneName), extensionFieldSets);
+                                                                  sceneName, extensionFieldSets);
             }
             break;
         }

--- a/examples/thermostat/thermostat-common/gen/attribute-size.cpp
+++ b/examples/thermostat/thermostat-common/gen/attribute-size.cpp
@@ -118,7 +118,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
                            &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,7 +255,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _LabelStruct
             _LabelStruct * entry = reinterpret_cast<_LabelStruct *>(write ? src : dest);
-            ByteSpan * labelSpan = &entry->label; // OCTET_STRING
+            ByteSpan * labelSpan = &entry->label; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, labelSpan) : ReadByteSpan(src + entryOffset, 18, labelSpan)))
             {
@@ -263,7 +263,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset          = static_cast<uint16_t>(entryOffset + 18);
-            ByteSpan * valueSpan = &entry->value; // OCTET_STRING
+            ByteSpan * valueSpan = &entry->value; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 18, valueSpan) : ReadByteSpan(src + entryOffset, 18, valueSpan)))
             {
@@ -292,7 +292,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -403,7 +403,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
                            &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                     // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -411,7 +411,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            ByteSpan * descriptionSpan = &entry->description; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -447,7 +447,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -480,7 +480,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
                            &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                       // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -488,7 +488,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            ByteSpan * callSignSpan = &entry->callSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
@@ -496,7 +496,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -528,7 +528,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
                            &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/examples/thermostat/thermostat-common/gen/endpoint_config.h
+++ b/examples/thermostat/thermostat-common/gen/endpoint_config.h
@@ -2186,10 +2186,10 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: TV Channel (server) */                                                                        \
-            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(5902) },       /* tv channel list */                        \
-            { 0x0001, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6156) }, /* tv channel lineup */                      \
-            { 0x0002, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6188) }, /* current tv channel */                     \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },           /* ClusterRevision */                        \
+            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(5902) },      /* tv channel list */                         \
+            { 0x0001, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6156) }, /* tv channel lineup */                       \
+            { 0x0002, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(6188) }, /* current tv channel */                      \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Target Navigator (server) */                                                                  \
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(6220) }, /* target navigator list */                        \

--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -63,7 +63,7 @@ bool audioOutputClusterSelectOutput(uint8_t index)
     // TODO: Insert code here
     return true;
 }
-bool audioOutputClusterRenameOutput(uint8_t index, uint8_t * name)
+bool audioOutputClusterRenameOutput(uint8_t index, chip::ByteSpan name)
 {
     // TODO: Insert code here
     return true;

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -104,10 +104,10 @@ static void sendResponse(const char * responseName, ContentLaunchResponse launch
 }
 
 bool emberAfContentLauncherClusterLaunchContentCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                        bool autoplay, unsigned char * data)
+                                                        bool autoplay, chip::ByteSpan data)
 {
 
-    string dataString(reinterpret_cast<char *>(data));
+    string dataString(reinterpret_cast<char const *>(data.data()), data.size());
     list<EmberAfContentLaunchParamater> parameterList;
     ContentLaunchResponse response = ContentLauncherManager().proxyLaunchContentRequest(parameterList, autoplay, dataString);
     sendResponse("LaunchContent", response, ZCL_LAUNCH_CONTENT_RESPONSE_COMMAND_ID);
@@ -115,10 +115,10 @@ bool emberAfContentLauncherClusterLaunchContentCallback(chip::EndpointId endpoin
 }
 
 bool emberAfContentLauncherClusterLaunchURLCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                    unsigned char * contentUrl, unsigned char * displayString)
+                                                    chip::ByteSpan contentUrl, chip::ByteSpan displayString)
 {
-    string contentUrlString(reinterpret_cast<char *>(contentUrl));
-    string displayStringString(reinterpret_cast<char *>(displayString));
+    string contentUrlString(reinterpret_cast<char const *>(contentUrl.data()), contentUrl.size());
+    string displayStringString(reinterpret_cast<char const *>(displayString.data()), displayString.size());
     EmberAfContentLaunchBrandingInformation brandingInformation;
     ContentLaunchResponse response =
         ContentLauncherManager().proxyLaunchUrlRequest(contentUrlString, displayStringString, brandingInformation);

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -70,7 +70,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         {
         case Clusters::AccountLogin::Commands::Ids::GetSetupPIN: {
             expectArgumentCount = 1;
-            const uint8_t * tempAccountIdentifier;
+            chip::ByteSpan tempAccountIdentifier;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -101,8 +101,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(tempAccountIdentifier);
+                    TLVUnpackError = aDataTlv.Get(tempAccountIdentifier);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -123,15 +122,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfAccountLoginClusterGetSetupPINCallback(aEndpointId, apCommandObj,
-                                                                           const_cast<uint8_t *>(tempAccountIdentifier));
+                wasHandled = emberAfAccountLoginClusterGetSetupPINCallback(aEndpointId, apCommandObj, tempAccountIdentifier);
             }
             break;
         }
         case Clusters::AccountLogin::Commands::Ids::Login: {
             expectArgumentCount = 2;
-            const uint8_t * tempAccountIdentifier;
-            const uint8_t * setupPIN;
+            chip::ByteSpan tempAccountIdentifier;
+            chip::ByteSpan setupPIN;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -162,12 +160,10 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(tempAccountIdentifier);
+                    TLVUnpackError = aDataTlv.Get(tempAccountIdentifier);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(setupPIN);
+                    TLVUnpackError = aDataTlv.Get(setupPIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -188,8 +184,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfAccountLoginClusterLoginCallback(
-                    aEndpointId, apCommandObj, const_cast<uint8_t *>(tempAccountIdentifier), const_cast<uint8_t *>(setupPIN));
+                wasHandled = emberAfAccountLoginClusterLoginCallback(aEndpointId, apCommandObj, tempAccountIdentifier, setupPIN);
             }
             break;
         }
@@ -532,9 +527,9 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         {
         case Clusters::ApplicationLauncher::Commands::Ids::LaunchApp: {
             expectArgumentCount = 3;
-            const uint8_t * data;
+            chip::ByteSpan data;
             uint16_t catalogVendorId;
-            const uint8_t * applicationId;
+            chip::ByteSpan applicationId;
             bool argExists[3];
 
             memset(argExists, 0, sizeof argExists);
@@ -565,15 +560,13 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 case 1:
                     TLVUnpackError = aDataTlv.Get(catalogVendorId);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(applicationId);
+                    TLVUnpackError = aDataTlv.Get(applicationId);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -594,8 +587,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 3 == validArgumentCount)
             {
-                wasHandled = emberAfApplicationLauncherClusterLaunchAppCallback(
-                    aEndpointId, apCommandObj, const_cast<uint8_t *>(data), catalogVendorId, const_cast<uint8_t *>(applicationId));
+                wasHandled = emberAfApplicationLauncherClusterLaunchAppCallback(aEndpointId, apCommandObj, data, catalogVendorId,
+                                                                                applicationId);
             }
             break;
         }
@@ -648,7 +641,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::AudioOutput::Commands::Ids::RenameOutput: {
             expectArgumentCount = 2;
             uint8_t index;
-            const uint8_t * name;
+            chip::ByteSpan name;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -682,8 +675,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(index);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(name);
+                    TLVUnpackError = aDataTlv.Get(name);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -704,8 +696,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfAudioOutputClusterRenameOutputCallback(aEndpointId, apCommandObj, index, const_cast<uint8_t *>(name));
+                wasHandled = emberAfAudioOutputClusterRenameOutputCallback(aEndpointId, apCommandObj, index, name);
             }
             break;
         }
@@ -1009,7 +1000,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::ContentLauncher::Commands::Ids::LaunchContent: {
             expectArgumentCount = 2;
             bool autoPlay;
-            const uint8_t * data;
+            chip::ByteSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1043,8 +1034,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(autoPlay);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1065,15 +1055,14 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchContentCallback(aEndpointId, apCommandObj, autoPlay,
-                                                                                const_cast<uint8_t *>(data));
+                wasHandled = emberAfContentLauncherClusterLaunchContentCallback(aEndpointId, apCommandObj, autoPlay, data);
             }
             break;
         }
         case Clusters::ContentLauncher::Commands::Ids::LaunchURL: {
             expectArgumentCount = 2;
-            const uint8_t * contentURL;
-            const uint8_t * displayString;
+            chip::ByteSpan contentURL;
+            chip::ByteSpan displayString;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1104,12 +1093,10 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(contentURL);
+                    TLVUnpackError = aDataTlv.Get(contentURL);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(displayString);
+                    TLVUnpackError = aDataTlv.Get(displayString);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1130,8 +1117,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchURLCallback(
-                    aEndpointId, apCommandObj, const_cast<uint8_t *>(contentURL), const_cast<uint8_t *>(displayString));
+                wasHandled = emberAfContentLauncherClusterLaunchURLCallback(aEndpointId, apCommandObj, contentURL, displayString);
             }
             break;
         }
@@ -1367,7 +1353,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -1403,8 +1389,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -1431,8 +1416,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -2164,7 +2149,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::MediaInput::Commands::Ids::RenameInput: {
             expectArgumentCount = 2;
             uint8_t index;
-            const uint8_t * name;
+            chip::ByteSpan name;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -2198,8 +2183,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(index);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(name);
+                    TLVUnpackError = aDataTlv.Get(name);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2220,8 +2204,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled =
-                    emberAfMediaInputClusterRenameInputCallback(aEndpointId, apCommandObj, index, const_cast<uint8_t *>(name));
+                wasHandled = emberAfMediaInputClusterRenameInputCallback(aEndpointId, apCommandObj, index, name);
             }
             break;
         }
@@ -3377,7 +3360,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             uint16_t hardwareVersion;
             uint32_t currentVersion;
             uint8_t protocolsSupported;
-            const uint8_t * location;
+            chip::ByteSpan location;
             bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
@@ -3428,8 +3411,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(protocolsSupported);
                     break;
                 case 6:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(location);
+                    TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 7:
                     TLVUnpackError = aDataTlv.Get(requestorCanConsent);
@@ -3458,7 +3440,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(
                     aEndpointId, apCommandObj, vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported,
-                    const_cast<uint8_t *>(location), requestorCanConsent, metadataForProvider);
+                    location, requestorCanConsent, metadataForProvider);
             }
             break;
         }
@@ -3875,7 +3857,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -3906,8 +3888,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3928,8 +3909,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }
@@ -4039,7 +4019,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         {
         case Clusters::TvChannel::Commands::Ids::ChangeChannel: {
             expectArgumentCount = 1;
-            const uint8_t * match;
+            chip::ByteSpan match;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -4070,8 +4050,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(match);
+                    TLVUnpackError = aDataTlv.Get(match);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -4092,7 +4071,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfTvChannelClusterChangeChannelCallback(aEndpointId, apCommandObj, const_cast<uint8_t *>(match));
+                wasHandled = emberAfTvChannelClusterChangeChannelCallback(aEndpointId, apCommandObj, match);
             }
             break;
         }
@@ -4265,7 +4244,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::TargetNavigator::Commands::Ids::NavigateTarget: {
             expectArgumentCount = 2;
             uint8_t target;
-            const uint8_t * data;
+            chip::ByteSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -4299,8 +4278,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(target);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -4321,8 +4299,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfTargetNavigatorClusterNavigateTargetCallback(aEndpointId, apCommandObj, target,
-                                                                                 const_cast<uint8_t *>(data));
+                wasHandled = emberAfTargetNavigatorClusterNavigateTargetCallback(aEndpointId, apCommandObj, target, data);
             }
             break;
         }

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -118,7 +118,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->outputType, write ? (uint8_t *) &entry->outputType : src, write,
                            &entryOffset, sizeof(entry->outputType)); // AudioOutputType
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -255,7 +255,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -366,7 +366,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            sizeof(entry->index)); // INT8U
             copyListMember(write ? dest : (uint8_t *) &entry->inputType, write ? (uint8_t *) &entry->inputType : src, write,
                            &entryOffset, sizeof(entry->inputType)); // MediaInputType
-            ByteSpan * nameSpan = &entry->name;                     // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                     // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -374,7 +374,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * descriptionSpan = &entry->description; // OCTET_STRING
+            ByteSpan * descriptionSpan = &entry->description; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, descriptionSpan)
                        : ReadByteSpan(src + entryOffset, 34, descriptionSpan)))
@@ -410,7 +410,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {
@@ -443,7 +443,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->majorNumber)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->minorNumber, write ? (uint8_t *) &entry->minorNumber : src, write,
                            &entryOffset, sizeof(entry->minorNumber)); // INT16U
-            ByteSpan * nameSpan = &entry->name;                       // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                       // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {
@@ -451,7 +451,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset             = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * callSignSpan = &entry->callSign; // OCTET_STRING
+            ByteSpan * callSignSpan = &entry->callSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, callSignSpan) : ReadByteSpan(src + entryOffset, 34, callSignSpan)))
             {
@@ -459,7 +459,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
             entryOffset                      = static_cast<uint16_t>(entryOffset + 34);
-            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // OCTET_STRING
+            ByteSpan * affiliateCallSignSpan = &entry->affiliateCallSign; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, affiliateCallSignSpan)
                        : ReadByteSpan(src + entryOffset, 34, affiliateCallSignSpan)))
@@ -491,7 +491,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             _NavigateTargetTargetInfo * entry = reinterpret_cast<_NavigateTargetTargetInfo *>(write ? src : dest);
             copyListMember(write ? dest : (uint8_t *) &entry->identifier, write ? (uint8_t *) &entry->identifier : src, write,
                            &entryOffset, sizeof(entry->identifier)); // INT8U
-            ByteSpan * nameSpan = &entry->name;                      // OCTET_STRING
+            ByteSpan * nameSpan = &entry->name;                      // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, nameSpan) : ReadByteSpan(src + entryOffset, 34, nameSpan)))
             {

--- a/examples/tv-app/tv-common/gen/endpoint_config.h
+++ b/examples/tv-app/tv-common/gen/endpoint_config.h
@@ -1561,10 +1561,10 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: TV Channel (server) */                                                                        \
-            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(3482) },       /* tv channel list */                        \
-            { 0x0001, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(3736) }, /* tv channel lineup */                      \
-            { 0x0002, ZAP_TYPE(OCTET_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(3768) }, /* current tv channel */                     \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },           /* ClusterRevision */                        \
+            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(3482) },      /* tv channel list */                         \
+            { 0x0001, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(3736) }, /* tv channel lineup */                       \
+            { 0x0002, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(3768) }, /* current tv channel */                      \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Target Navigator (server) */                                                                  \
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(3800) }, /* target navigator list */                        \

--- a/examples/window-app/common/gen/IMClusterCommandHandler.cpp
+++ b/examples/window-app/common/gen/IMClusterCommandHandler.cpp
@@ -332,7 +332,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfig: {
             expectArgumentCount = 4;
             uint8_t location;
-            const uint8_t * countryCode;
+            chip::ByteSpan countryCode;
             uint64_t breadcrumb;
             uint32_t timeoutMs;
             bool argExists[4];
@@ -368,8 +368,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                     TLVUnpackError = aDataTlv.Get(location);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(countryCode);
+                    TLVUnpackError = aDataTlv.Get(countryCode);
                     break;
                 case 2:
                     TLVUnpackError = aDataTlv.Get(breadcrumb);
@@ -396,8 +395,8 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(
-                    aEndpointId, apCommandObj, location, const_cast<uint8_t *>(countryCode), breadcrumb, timeoutMs);
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(aEndpointId, apCommandObj, location,
+                                                                                           countryCode, breadcrumb, timeoutMs);
             }
             break;
         }
@@ -1403,7 +1402,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
         }
         case Clusters::OperationalCredentials::Commands::Ids::UpdateFabricLabel: {
             expectArgumentCount = 1;
-            const uint8_t * Label;
+            chip::ByteSpan Label;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -1434,8 +1433,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(Label);
+                    TLVUnpackError = aDataTlv.Get(Label);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1456,8 +1454,7 @@ void DispatchServerCommand(CommandHandler * apCommandObj, CommandId aCommandId, 
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj,
-                                                                                           const_cast<uint8_t *>(Label));
+                wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(aEndpointId, apCommandObj, Label);
             }
             break;
         }

--- a/examples/window-app/common/gen/attribute-size.cpp
+++ b/examples/window-app/common/gen/attribute-size.cpp
@@ -94,7 +94,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             entryOffset = static_cast<uint16_t>(entryOffset + ((index - 1) * entryLength));
             // Struct _NetworkInterfaceType
             _NetworkInterfaceType * entry = reinterpret_cast<_NetworkInterfaceType *>(write ? src : dest);
-            ByteSpan * NameSpan           = &entry->Name; // OCTET_STRING
+            ByteSpan * NameSpan           = &entry->Name; // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, NameSpan) : ReadByteSpan(src + entryOffset, 34, NameSpan)))
             {
@@ -148,7 +148,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
                            sizeof(entry->NodeId)); // NODE_ID
-            ByteSpan * LabelSpan = &entry->Label;  // OCTET_STRING
+            ByteSpan * LabelSpan = &entry->Label;  // CHAR_STRING
             if (CHIP_NO_ERROR !=
                 (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
             {

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -50,21 +50,21 @@ exit:
 }
 
 bool emberAfAccountLoginClusterGetSetupPINCallback(EndpointId endpoint, app::CommandHandler * command,
-                                                   uint8_t * tempAccountIdentifier)
+                                                   chip::ByteSpan tempAccountIdentifier)
 {
-    // TODO: char is not null terminated, verify this code once #7963 gets merged.
-    std::string tempAccountIdentifierString(reinterpret_cast<char *>(tempAccountIdentifier));
+    std::string tempAccountIdentifierString(reinterpret_cast<char const *>(tempAccountIdentifier.data()),
+                                            tempAccountIdentifier.size());
     std::string responseSetupPin = accountLoginClusterGetSetupPin(tempAccountIdentifierString, emberAfCurrentEndpoint());
     sendResponse(command, responseSetupPin.c_str());
     return true;
 }
 
-bool emberAfAccountLoginClusterLoginCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * tempAccountIdentifier,
-                                             uint8_t * tempSetupPin)
+bool emberAfAccountLoginClusterLoginCallback(EndpointId endpoint, app::CommandHandler * command,
+                                             chip::ByteSpan tempAccountIdentifier, chip::ByteSpan tempSetupPin)
 {
-    // TODO: char is not null terminated, verify this code once #7963 gets merged.
-    std::string tempAccountIdentifierString(reinterpret_cast<char *>(tempAccountIdentifier));
-    std::string tempSetupPinString(reinterpret_cast<char *>(tempSetupPin));
+    std::string tempAccountIdentifierString(reinterpret_cast<char const *>(tempAccountIdentifier.data()),
+                                            tempAccountIdentifier.size());
+    std::string tempSetupPinString(reinterpret_cast<char const *>(tempSetupPin.data()), tempSetupPin.size());
     bool isLoggedIn      = accountLoginClusterIsUserLoggedIn(tempAccountIdentifierString, tempSetupPinString);
     EmberAfStatus status = isLoggedIn ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_NOT_AUTHORIZED;
     if (!isLoggedIn)

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -34,13 +34,6 @@ using namespace chip;
 
 ApplicationLauncherResponse applicationLauncherClusterLaunchApp(EmberAfApplicationLauncherApp application, std::string data);
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t *, uint8_t *)
-{
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    emberAfSendImmediateDefaultResponse(status);
-    return true;
-}
-
 void sendResponse(app::CommandHandler * command, ApplicationLauncherResponse response)
 {
     CHIP_ERROR err                   = CHIP_NO_ERROR;
@@ -59,7 +52,7 @@ exit:
     }
 }
 
-EmberAfApplicationLauncherApp getApplicationFromCommand(uint16_t catalogVendorId, uint8_t * applicationId)
+EmberAfApplicationLauncherApp getApplicationFromCommand(uint16_t catalogVendorId, chip::ByteSpan applicationId)
 {
     EmberAfApplicationLauncherApp application = {};
     application.applicationId                 = applicationId;
@@ -67,13 +60,13 @@ EmberAfApplicationLauncherApp getApplicationFromCommand(uint16_t catalogVendorId
     return application;
 }
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * requestData,
-                                                        uint16_t requestApplicationCatalogVendorId, uint8_t * requestApplicationId)
+bool emberAfApplicationLauncherClusterLaunchAppCallback(EndpointId endpoint, app::CommandHandler * command,
+                                                        chip::ByteSpan requestData, uint16_t requestApplicationCatalogVendorId,
+                                                        chip::ByteSpan requestApplicationId)
 {
     EmberAfApplicationLauncherApp application = getApplicationFromCommand(requestApplicationCatalogVendorId, requestApplicationId);
-    // TODO: Char is not null terminated, verify this code once #7963 gets merged.
-    std::string reqestDataString(reinterpret_cast<char *>(requestData));
-    ApplicationLauncherResponse response = applicationLauncherClusterLaunchApp(application, reqestDataString);
+    std::string requestDataString(reinterpret_cast<const char *>(requestData.data()), requestData.size());
+    ApplicationLauncherResponse response = applicationLauncherClusterLaunchApp(application, requestDataString);
     sendResponse(command, response);
     return true;
 }

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -28,10 +28,10 @@
 using namespace chip;
 
 bool audioOutputClusterSelectOutput(uint8_t index);
-bool audioOutputClusterRenameOutput(uint8_t index, uint8_t * name);
+bool audioOutputClusterRenameOutput(uint8_t index, chip::ByteSpan name);
 
 bool emberAfAudioOutputClusterRenameOutputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t index,
-                                                   uint8_t * name)
+                                                   chip::ByteSpan name)
 {
     bool success         = audioOutputClusterRenameOutput(index, name);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -26,6 +26,11 @@
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/internal/DeviceControlServer.h>
+#include <support/CHIPMemString.h>
+#include <support/Span.h>
+#include <support/logging/CHIPLogging.h>
+
+constexpr uint8_t kMaxCountryCodeLen = 2;
 
 using namespace chip;
 
@@ -47,11 +52,15 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(EndpointId 
 }
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(EndpointId endpoint, app::CommandHandler * commandObj,
-                                                                   uint8_t location, uint8_t * countryCode, uint64_t breadcrumb,
-                                                                   uint32_t timeoutMs)
+                                                                   uint8_t location, chip::ByteSpan countryCode,
+                                                                   uint64_t breadcrumb, uint32_t timeoutMs)
 {
+    char countryCodePtr[kMaxCountryCodeLen + 1];
+    Platform::CopyString(countryCodePtr, sizeof(countryCodePtr), countryCode);
+    countryCodePtr[kMaxCountryCodeLen] = '\0';
+
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().SetRegulatoryConfig(
-        location, reinterpret_cast<const char *>(countryCode), breadcrumb);
+        location, reinterpret_cast<const char *>(countryCodePtr), breadcrumb);
 
     emberAfSendImmediateDefaultResponse(err == CHIP_NO_ERROR ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
 

--- a/src/app/clusters/groups-server/groups-server.h
+++ b/src/app/clusters/groups-server/groups-server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
+#include <support/Span.h>
 
 /** @brief Get Group Name
  *
@@ -28,7 +29,7 @@
  * @param groupId Group ID Ver.: always
  * @param groupName Group Name Ver.: always
  */
-void emberAfPluginGroupsServerGetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t * groupName);
+void emberAfPluginGroupsServerGetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, chip::ByteSpan * groupName);
 
 /** @brief Set Group Name
  *
@@ -38,7 +39,7 @@ void emberAfPluginGroupsServerGetGroupNameCallback(chip::EndpointId endpoint, ch
  * @param groupId Group ID Ver.: always
  * @param groupName Group Name Ver.: always
  */
-void emberAfPluginGroupsServerSetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, uint8_t * groupName);
+void emberAfPluginGroupsServerSetGroupNameCallback(chip::EndpointId endpoint, chip::GroupId groupId, chip::ByteSpan groupName);
 
 /** @brief Group Names Supported
  *

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -74,10 +74,10 @@ bool emberAfMediaInputClusterHideInputStatusCallback(EndpointId endpoint, app::C
     return true;
 }
 
-bool emberAfMediaInputClusterRenameInputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t input, uint8_t * name)
+bool emberAfMediaInputClusterRenameInputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t input,
+                                                 chip::ByteSpan name)
 {
-    // TODO: char is not null terminated, verify this code once #7963 gets merged.
-    std::string nameString(reinterpret_cast<char *>(name));
+    std::string nameString(reinterpret_cast<const char *>(name.data()), name.size());
     bool success         = mediaInputClusterRenameInput(input, nameString);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -237,7 +237,7 @@ exit:
 }
 
 bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(EndpointId endpoint, app::CommandHandler * commandObj,
-                                                                   uint8_t * Label)
+                                                                   chip::ByteSpan label)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: UpdateFabricLabel");
 
@@ -249,7 +249,7 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(EndpointId en
     VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Set Label on fabric
-    err = fabric->SetFabricLabel(Label);
+    err = fabric->SetFabricLabel(label);
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Persist updated fabric

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -154,7 +154,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
                                                                uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                                                uint16_t hardwareVersion, uint32_t currentVersion,
                                                                /* TODO(#8605): change this to list */ uint8_t protocolsSupported,
-                                                               uint8_t * location, bool clientCanConsent,
+                                                               chip::ByteSpan location, bool clientCanConsent,
                                                                ByteSpan metadataForProvider)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
@@ -167,11 +167,9 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
 
     ChipLogDetail(Zcl, "OTA Provider received QueryImage");
 
-    // TODO: (#7112) change location size checking once CHAR_STRING is supported
-    const uint8_t locationLen = emberAfStringLength(location);
-    if (locationLen != kLocationParamLength)
+    if (location.size() != kLocationParamLength)
     {
-        ChipLogError(Zcl, "expected location length %" PRIu8 ", got %" PRIu8, locationLen, kLocationParamLength);
+        ChipLogError(Zcl, "expected location length %zu, got %" PRIu8, location.size(), kLocationParamLength);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
     else if (metadataForProvider.size() > kMaxMetadataLen)
@@ -180,10 +178,8 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
 
-    ByteSpan locationSpan(location, locationLen);
-
     status = delegate->HandleQueryImage(vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported,
-                                        locationSpan, clientCanConsent, metadataForProvider);
+                                        location, clientCanConsent, metadataForProvider);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -81,8 +81,8 @@ extern EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[];
 #endif // Use tokens
 
 bool emberAfPluginScenesServerParseAddScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
-                                            chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                            uint8_t * extensionFieldSets);
+                                            chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime,
+                                            chip::ByteSpan sceneName, uint8_t * extensionFieldSets);
 bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
                                              chip::GroupId groupId, uint8_t sceneId);
 

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -53,10 +53,9 @@ exit:
 }
 
 bool emberAfTargetNavigatorClusterNavigateTargetCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t target,
-                                                         uint8_t * data)
+                                                         chip::ByteSpan data)
 {
-    // TODO: char is not null terminated, verify this code once #7963 gets merged.
-    std::string dataString(reinterpret_cast<char *>(data));
+    std::string dataString(reinterpret_cast<const char *>(data.data()), data.size());
     TargetNavigatorResponse response = targetNavigatorClusterNavigateTarget(target, dataString);
     sendResponse(command, response);
     return true;

--- a/src/app/clusters/tv-channel-server/tv-channel-server.cpp
+++ b/src/app/clusters/tv-channel-server/tv-channel-server.cpp
@@ -70,10 +70,9 @@ exit:
     }
 }
 
-bool emberAfTvChannelClusterChangeChannelCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * match)
+bool emberAfTvChannelClusterChangeChannelCallback(EndpointId endpoint, app::CommandHandler * command, chip::ByteSpan match)
 {
-    // TODO: char is not null terminated, verify this code once #7963 gets merged.
-    std::string matchString(reinterpret_cast<char *>(match));
+    std::string matchString(reinterpret_cast<const char *>(match.data()), match.size());
     // TODO: Enable this once struct as param is supported
     // EmberAfTvChannelInfo channelInfo = tvChannelClusterChangeChannel(matchString);
     // sendResponse(command, channelInfo);

--- a/src/app/common/gen/af-structs.h
+++ b/src/app/common/gen/af-structs.h
@@ -29,7 +29,7 @@
 typedef struct _ApplicationLauncherApp
 {
     uint16_t catalogVendorId;
-    uint8_t * applicationId;
+    chip::ByteSpan applicationId;
 } EmberAfApplicationLauncherApp;
 
 // Struct for AudioOutputInfo
@@ -69,14 +69,14 @@ typedef struct _ConfigureReportingStatusRecord
 // Struct for ContentLaunchAdditionalInfo
 typedef struct _ContentLaunchAdditionalInfo
 {
-    uint8_t * name;
-    uint8_t * value;
+    chip::ByteSpan name;
+    chip::ByteSpan value;
 } EmberAfContentLaunchAdditionalInfo;
 
 // Struct for ContentLaunchBrandingInformation
 typedef struct _ContentLaunchBrandingInformation
 {
-    uint8_t * providerName;
+    chip::ByteSpan providerName;
     uint8_t background;
     uint8_t logo;
     uint8_t progressBar;
@@ -87,8 +87,8 @@ typedef struct _ContentLaunchBrandingInformation
 // Struct for ContentLaunchDimension
 typedef struct _ContentLaunchDimension
 {
-    uint8_t * width;
-    uint8_t * height;
+    chip::ByteSpan width;
+    chip::ByteSpan height;
     uint8_t metric;
 } EmberAfContentLaunchDimension;
 
@@ -96,15 +96,15 @@ typedef struct _ContentLaunchDimension
 typedef struct _ContentLaunchParamater
 {
     uint8_t Type;
-    uint8_t * Value;
+    chip::ByteSpan Value;
     /* TYPE WARNING: array array defaults to */ uint8_t * ExternalIDList;
 } EmberAfContentLaunchParamater;
 
 // Struct for ContentLaunchStyleInformation
 typedef struct _ContentLaunchStyleInformation
 {
-    uint8_t * imageUrl;
-    uint8_t * color;
+    chip::ByteSpan imageUrl;
+    chip::ByteSpan color;
     uint8_t size;
 } EmberAfContentLaunchStyleInformation;
 
@@ -393,9 +393,9 @@ typedef struct _TvChannelInfo
 // Struct for TvChannelLineupInfo
 typedef struct _TvChannelLineupInfo
 {
-    uint8_t * operatorName;
-    uint8_t * lineupName;
-    uint8_t * postalCode;
+    chip::ByteSpan operatorName;
+    chip::ByteSpan lineupName;
+    chip::ByteSpan postalCode;
     uint8_t lineupInfoType;
 } EmberAfTvChannelLineupInfo;
 

--- a/src/app/common/gen/callback.h
+++ b/src/app/common/gen/callback.h
@@ -15260,7 +15260,7 @@ bool emberAfIdentifyClusterTriggerEffectCallback(chip::EndpointId endpoint, chip
  * @brief  Cluster AddGroup Command callback (from client)
  */
 bool emberAfGroupsClusterAddGroupCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t groupId,
-                                          uint8_t * groupName);
+                                          chip::ByteSpan groupName);
 /**
  * @brief  Cluster AddGroupResponse Command callback (from server)
  */
@@ -15274,7 +15274,7 @@ bool emberAfGroupsClusterViewGroupCallback(chip::EndpointId endpoint, chip::app:
  * @brief  Cluster ViewGroupResponse Command callback (from server)
  */
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t * groupName);
+                                                   uint16_t groupId, chip::ByteSpan groupName);
 /**
  * @brief  Cluster GetGroupMembership Command callback (from client)
  */
@@ -15304,12 +15304,12 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::EndpointId endpoint, chip
  * @brief  Cluster AddGroupIfIdentifying Command callback (from client)
  */
 bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                       uint16_t groupId, uint8_t * groupName);
+                                                       uint16_t groupId, chip::ByteSpan groupName);
 /**
  * @brief  Cluster AddScene Command callback (from client)
  */
 bool emberAfScenesClusterAddSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t groupId,
-                                          uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                          uint8_t sceneId, uint16_t transitionTime, chip::ByteSpan sceneName,
                                           /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief  Cluster AddSceneResponse Command callback (from server)
@@ -15325,7 +15325,8 @@ bool emberAfScenesClusterViewSceneCallback(chip::EndpointId endpoint, chip::app:
  * @brief  Cluster ViewSceneResponse Command callback (from server)
  */
 bool emberAfScenesClusterViewSceneResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                   chip::ByteSpan sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief  Cluster RemoveScene Command callback (from client)
@@ -15377,7 +15378,8 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::EndpointId end
  * @brief  Cluster EnhancedAddScene Command callback (from client)
  */
 bool emberAfScenesClusterEnhancedAddSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                  uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                                  uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                  chip::ByteSpan sceneName,
                                                   /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief  Cluster EnhancedAddSceneResponse Command callback (from server)
@@ -15394,7 +15396,7 @@ bool emberAfScenesClusterEnhancedViewSceneCallback(chip::EndpointId endpoint, ch
  */
 bool emberAfScenesClusterEnhancedViewSceneResponseCallback(
     chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId, uint8_t sceneId,
-    uint16_t transitionTime, uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
+    uint16_t transitionTime, chip::ByteSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 /**
  * @brief  Cluster CopyScene Command callback (from client)
  */
@@ -15730,7 +15732,7 @@ bool emberAfBasicClusterLeaveCallback(chip::EndpointId endpoint, chip::app::Comm
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
                                                                uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                                                uint16_t hardwareVersion, uint32_t currentVersion,
-                                                               uint8_t protocolsSupported, uint8_t * location,
+                                                               uint8_t protocolsSupported, chip::ByteSpan location,
                                                                bool requestorCanConsent, chip::ByteSpan metadataForProvider);
 /**
  * @brief  Cluster ApplyUpdateRequest Command callback (from client)
@@ -15749,7 +15751,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::En
  */
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::EndpointId endpoint,
                                                                        chip::app::CommandSender * commandObj, uint8_t status,
-                                                                       uint32_t delayedActionTime, uint8_t * imageURI,
+                                                                       uint32_t delayedActionTime, chip::ByteSpan imageURI,
                                                                        uint32_t softwareVersion, chip::ByteSpan updateToken,
                                                                        bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 /**
@@ -15775,19 +15777,20 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::EndpointId endp
  * @brief  Cluster ArmFailSafeResponse Command callback (from server)
  */
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                   uint8_t errorCode, uint8_t * debugText);
+                                                                   uint8_t errorCode, chip::ByteSpan debugText);
 /**
  * @brief  Cluster SetRegulatoryConfig Command callback (from client)
  */
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::EndpointId endpoint,
                                                                    chip::app::CommandHandler * commandObj, uint8_t location,
-                                                                   uint8_t * countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
+                                                                   chip::ByteSpan countryCode, uint64_t breadcrumb,
+                                                                   uint32_t timeoutMs);
 /**
  * @brief  Cluster SetRegulatoryConfigResponse Command callback (from server)
  */
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::EndpointId endpoint,
                                                                            chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                           uint8_t * debugText);
+                                                                           chip::ByteSpan debugText);
 /**
  * @brief  Cluster CommissioningComplete Command callback (from client)
  */
@@ -15798,7 +15801,7 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::Endpo
  */
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::EndpointId endpoint,
                                                                              chip::app::CommandSender * commandObj,
-                                                                             uint8_t errorCode, uint8_t * debugText);
+                                                                             uint8_t errorCode, chip::ByteSpan debugText);
 /**
  * @brief  Cluster ScanNetworks Command callback (from client)
  */
@@ -15808,7 +15811,7 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::EndpointId end
  * @brief  Cluster ScanNetworksResponse Command callback (from server)
  */
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
+    chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t errorCode, chip::ByteSpan debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 /**
@@ -15822,7 +15825,7 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::EndpointId e
  */
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::EndpointId endpoint,
                                                                       chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                      uint8_t * debugText);
+                                                                      chip::ByteSpan debugText);
 /**
  * @brief  Cluster UpdateWiFiNetwork Command callback (from client)
  */
@@ -15834,7 +15837,7 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::EndpointI
  */
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::EndpointId endpoint,
                                                                          chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                         uint8_t * debugText);
+                                                                         chip::ByteSpan debugText);
 /**
  * @brief  Cluster AddThreadNetwork Command callback (from client)
  */
@@ -15846,7 +15849,7 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::EndpointId
  */
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::EndpointId endpoint,
                                                                         chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                        uint8_t * debugText);
+                                                                        chip::ByteSpan debugText);
 /**
  * @brief  Cluster UpdateThreadNetwork Command callback (from client)
  */
@@ -15859,7 +15862,7 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::Endpoin
  */
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::EndpointId endpoint,
                                                                            chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                           uint8_t * debugText);
+                                                                           chip::ByteSpan debugText);
 /**
  * @brief  Cluster RemoveNetwork Command callback (from client)
  */
@@ -15870,7 +15873,7 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::EndpointId en
  */
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::EndpointId endpoint,
                                                                      chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                     uint8_t * debugText);
+                                                                     chip::ByteSpan debugText);
 /**
  * @brief  Cluster EnableNetwork Command callback (from client)
  */
@@ -15881,7 +15884,7 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::EndpointId en
  */
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::EndpointId endpoint,
                                                                      chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                     uint8_t * debugText);
+                                                                     chip::ByteSpan debugText);
 /**
  * @brief  Cluster DisableNetwork Command callback (from client)
  */
@@ -15892,7 +15895,7 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::EndpointId e
  */
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::EndpointId endpoint,
                                                                       chip::app::CommandSender * commandObj, uint8_t errorCode,
-                                                                      uint8_t * debugText);
+                                                                      chip::ByteSpan debugText);
 /**
  * @brief  Cluster GetLastNetworkCommissioningResult Command callback (from client)
  */
@@ -15991,7 +15994,7 @@ bool emberAfOperationalCredentialsClusterNOCResponseCallback(chip::EndpointId en
  * @brief  Cluster UpdateFabricLabel Command callback (from client)
  */
 bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::EndpointId endpoint,
-                                                                   chip::app::CommandHandler * commandObj, uint8_t * Label);
+                                                                   chip::app::CommandHandler * commandObj, chip::ByteSpan Label);
 /**
  * @brief  Cluster RemoveFabric Command callback (from client)
  */
@@ -16012,7 +16015,7 @@ bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(ch
 /**
  * @brief  Cluster LockDoor Command callback (from client)
  */
-bool emberAfDoorLockClusterLockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t * PIN);
+bool emberAfDoorLockClusterLockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, chip::ByteSpan PIN);
 /**
  * @brief  Cluster LockDoorResponse Command callback (from server)
  */
@@ -16021,7 +16024,8 @@ bool emberAfDoorLockClusterLockDoorResponseCallback(chip::EndpointId endpoint, c
 /**
  * @brief  Cluster UnlockDoor Command callback (from client)
  */
-bool emberAfDoorLockClusterUnlockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t * PIN);
+bool emberAfDoorLockClusterUnlockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+                                              chip::ByteSpan PIN);
 /**
  * @brief  Cluster UnlockDoorResponse Command callback (from server)
  */
@@ -16030,7 +16034,7 @@ bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::EndpointId endpoint,
 /**
  * @brief  Cluster Toggle Command callback (from client)
  */
-bool emberAfDoorLockClusterToggleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t * pin);
+bool emberAfDoorLockClusterToggleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, chip::ByteSpan pin);
 /**
  * @brief  Cluster ToggleResponse Command callback (from server)
  */
@@ -16039,7 +16043,7 @@ bool emberAfDoorLockClusterToggleResponseCallback(chip::EndpointId endpoint, chi
  * @brief  Cluster UnlockWithTimeout Command callback (from client)
  */
 bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                     uint16_t timeoutInSeconds, uint8_t * pin);
+                                                     uint16_t timeoutInSeconds, chip::ByteSpan pin);
 /**
  * @brief  Cluster UnlockWithTimeoutResponse Command callback (from server)
  */
@@ -16055,12 +16059,12 @@ bool emberAfDoorLockClusterGetLogRecordCallback(chip::EndpointId endpoint, chip:
  */
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                         uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin);
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin);
 /**
  * @brief  Cluster SetPin Command callback (from client)
  */
 bool emberAfDoorLockClusterSetPinCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId,
-                                          uint8_t userStatus, uint8_t userType, uint8_t * pin);
+                                          uint8_t userStatus, uint8_t userType, chip::ByteSpan pin);
 /**
  * @brief  Cluster SetPinResponse Command callback (from server)
  */
@@ -16073,7 +16077,7 @@ bool emberAfDoorLockClusterGetPinCallback(chip::EndpointId endpoint, chip::app::
  * @brief  Cluster GetPinResponse Command callback (from server)
  */
 bool emberAfDoorLockClusterGetPinResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint16_t userId,
-                                                  uint8_t userStatus, uint8_t userType, uint8_t * pin);
+                                                  uint8_t userStatus, uint8_t userType, chip::ByteSpan pin);
 /**
  * @brief  Cluster ClearPin Command callback (from client)
  */
@@ -16232,7 +16236,7 @@ bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::EndpointId endpoint
  * @brief  Cluster SetRfid Command callback (from client)
  */
 bool emberAfDoorLockClusterSetRfidCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId,
-                                           uint8_t userStatus, uint8_t userType, uint8_t * id);
+                                           uint8_t userStatus, uint8_t userType, chip::ByteSpan id);
 /**
  * @brief  Cluster SetRfidResponse Command callback (from server)
  */
@@ -16246,7 +16250,7 @@ bool emberAfDoorLockClusterGetRfidCallback(chip::EndpointId endpoint, chip::app:
  * @brief  Cluster GetRfidResponse Command callback (from server)
  */
 bool emberAfDoorLockClusterGetRfidResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                   uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid);
+                                                   uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid);
 /**
  * @brief  Cluster ClearRfid Command callback (from client)
  */
@@ -16269,15 +16273,15 @@ bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::EndpointId endpoi
  * @brief  Cluster OperationEventNotification Command callback (from server)
  */
 bool emberAfDoorLockClusterOperationEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                              uint8_t source, uint8_t eventCode, uint16_t userId, uint8_t * pin,
-                                                              uint32_t timeStamp, uint8_t * data);
+                                                              uint8_t source, uint8_t eventCode, uint16_t userId,
+                                                              chip::ByteSpan pin, uint32_t timeStamp, chip::ByteSpan data);
 /**
  * @brief  Cluster ProgrammingEventNotification Command callback (from server)
  */
 bool emberAfDoorLockClusterProgrammingEventNotificationCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t source, uint8_t eventCode, uint16_t userId, uint8_t * pin,
-                                                                uint8_t userType, uint8_t userStatus, uint32_t timeStamp,
-                                                                uint8_t * data);
+                                                                uint8_t source, uint8_t eventCode, uint16_t userId,
+                                                                chip::ByteSpan pin, uint8_t userType, uint8_t userStatus,
+                                                                uint32_t timeStamp, chip::ByteSpan data);
 /**
  * @brief  Cluster UpOrOpen Command callback (from client)
  */
@@ -16508,7 +16512,7 @@ bool emberAfIasZoneClusterInitiateTestModeResponseCallback(chip::EndpointId endp
  * @brief  Cluster Arm Command callback (from client)
  */
 bool emberAfIasAceClusterArmCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t armMode,
-                                     uint8_t * armDisarmCode, uint8_t zoneId);
+                                     chip::ByteSpan armDisarmCode, uint8_t zoneId);
 /**
  * @brief  Cluster ArmResponse Command callback (from server)
  */
@@ -16518,7 +16522,8 @@ bool emberAfIasAceClusterArmResponseCallback(chip::EndpointId endpoint, chip::ap
  * @brief  Cluster Bypass Command callback (from client)
  */
 bool emberAfIasAceClusterBypassCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t numberOfZones,
-                                        /* TYPE WARNING: array array defaults to */ uint8_t * zoneIds, uint8_t * armDisarmCode);
+                                        /* TYPE WARNING: array array defaults to */ uint8_t * zoneIds,
+                                        chip::ByteSpan armDisarmCode);
 /**
  * @brief  Cluster GetZoneIdMapResponse Command callback (from server)
  */
@@ -16537,7 +16542,7 @@ bool emberAfIasAceClusterEmergencyCallback(chip::EndpointId endpoint, chip::app:
  */
 bool emberAfIasAceClusterGetZoneInformationResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                             uint8_t zoneId, uint16_t zoneType, chip::NodeId ieeeAddress,
-                                                            uint8_t * zoneLabel);
+                                                            chip::ByteSpan zoneLabel);
 /**
  * @brief  Cluster Fire Command callback (from client)
  */
@@ -16546,7 +16551,7 @@ bool emberAfIasAceClusterFireCallback(chip::EndpointId endpoint, chip::app::Comm
  * @brief  Cluster ZoneStatusChanged Command callback (from server)
  */
 bool emberAfIasAceClusterZoneStatusChangedCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t zoneId,
-                                                   uint16_t zoneStatus, uint8_t audibleNotification, uint8_t * zoneLabel);
+                                                   uint16_t zoneStatus, uint8_t audibleNotification, chip::ByteSpan zoneLabel);
 /**
  * @brief  Cluster Panic Command callback (from client)
  */
@@ -16617,7 +16622,7 @@ bool emberAfIasWdClusterSquawkCallback(chip::EndpointId endpoint, chip::app::Com
  * @brief  Cluster ChangeChannel Command callback (from client)
  */
 bool emberAfTvChannelClusterChangeChannelCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                  uint8_t * match);
+                                                  chip::ByteSpan match);
 /**
  * @brief  Cluster ChangeChannelResponse Command callback (from server)
  */
@@ -16637,12 +16642,12 @@ bool emberAfTvChannelClusterSkipChannelCallback(chip::EndpointId endpoint, chip:
  * @brief  Cluster NavigateTarget Command callback (from client)
  */
 bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                         uint8_t target, uint8_t * data);
+                                                         uint8_t target, chip::ByteSpan data);
 /**
  * @brief  Cluster NavigateTargetResponse Command callback (from server)
  */
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                 uint8_t status, uint8_t * data);
+                                                                 uint8_t status, chip::ByteSpan data);
 /**
  * @brief  Cluster MediaPlay Command callback (from client)
  */
@@ -16761,7 +16766,7 @@ bool emberAfMediaInputClusterHideInputStatusCallback(chip::EndpointId endpoint, 
  * @brief  Cluster RenameInput Command callback (from client)
  */
 bool emberAfMediaInputClusterRenameInputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t index,
-                                                 uint8_t * name);
+                                                 chip::ByteSpan name);
 /**
  * @brief  Cluster Sleep Command callback (from client)
  */
@@ -16779,22 +16784,22 @@ bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::EndpointId endpoint,
  * @brief  Cluster LaunchContent Command callback (from client)
  */
 bool emberAfContentLauncherClusterLaunchContentCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        bool autoPlay, uint8_t * data);
+                                                        bool autoPlay, chip::ByteSpan data);
 /**
  * @brief  Cluster LaunchContentResponse Command callback (from server)
  */
 bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t * data, uint8_t contentLaunchStatus);
+                                                                chip::ByteSpan data, uint8_t contentLaunchStatus);
 /**
  * @brief  Cluster LaunchURL Command callback (from client)
  */
 bool emberAfContentLauncherClusterLaunchURLCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                    uint8_t * contentURL, uint8_t * displayString);
+                                                    chip::ByteSpan contentURL, chip::ByteSpan displayString);
 /**
  * @brief  Cluster LaunchURLResponse Command callback (from server)
  */
 bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                            uint8_t * data, uint8_t contentLaunchStatus);
+                                                            chip::ByteSpan data, uint8_t contentLaunchStatus);
 /**
  * @brief  Cluster SelectOutput Command callback (from client)
  */
@@ -16804,17 +16809,18 @@ bool emberAfAudioOutputClusterSelectOutputCallback(chip::EndpointId endpoint, ch
  * @brief  Cluster RenameOutput Command callback (from client)
  */
 bool emberAfAudioOutputClusterRenameOutputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t index,
-                                                   uint8_t * name);
+                                                   chip::ByteSpan name);
 /**
  * @brief  Cluster LaunchApp Command callback (from client)
  */
 bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t * data, uint16_t catalogVendorId, uint8_t * applicationId);
+                                                        chip::ByteSpan data, uint16_t catalogVendorId,
+                                                        chip::ByteSpan applicationId);
 /**
  * @brief  Cluster LaunchAppResponse Command callback (from server)
  */
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                                uint8_t status, uint8_t * data);
+                                                                uint8_t status, chip::ByteSpan data);
 /**
  * @brief  Cluster ChangeStatus Command callback (from client)
  */
@@ -16824,17 +16830,17 @@ bool emberAfApplicationBasicClusterChangeStatusCallback(chip::EndpointId endpoin
  * @brief  Cluster GetSetupPIN Command callback (from client)
  */
 bool emberAfAccountLoginClusterGetSetupPINCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                   uint8_t * tempAccountIdentifier);
+                                                   chip::ByteSpan tempAccountIdentifier);
 /**
  * @brief  Cluster GetSetupPINResponse Command callback (from server)
  */
 bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                           uint8_t * setupPIN);
+                                                           chip::ByteSpan setupPIN);
 /**
  * @brief  Cluster Login Command callback (from client)
  */
 bool emberAfAccountLoginClusterLoginCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                             uint8_t * tempAccountIdentifier, uint8_t * setupPIN);
+                                             chip::ByteSpan tempAccountIdentifier, chip::ByteSpan setupPIN);
 /**
  * @brief  Cluster Test Command callback (from client)
  */
@@ -16872,7 +16878,7 @@ bool emberAfTestClusterClusterTestAddArgumentsCallback(chip::EndpointId endpoint
 bool emberAfMessagingClusterDisplayMessageCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                    uint32_t messageId, uint8_t messageControl,
                                                    /* TYPE WARNING: utc defaults to */ uint8_t * startTime,
-                                                   uint16_t durationInMinutes, uint8_t * message,
+                                                   uint16_t durationInMinutes, chip::ByteSpan message,
                                                    uint8_t optionalExtendedMessageControl);
 /**
  * @brief  Cluster GetLastMessage Command callback (from client)
@@ -16896,7 +16902,7 @@ bool emberAfMessagingClusterMessageConfirmationCallback(chip::EndpointId endpoin
 bool emberAfMessagingClusterDisplayProtectedMessageCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
                                                             uint32_t messageId, uint8_t messageControl,
                                                             /* TYPE WARNING: utc defaults to */ uint8_t * startTime,
-                                                            uint16_t durationInMinutes, uint8_t * message,
+                                                            uint16_t durationInMinutes, chip::ByteSpan message,
                                                             uint8_t optionalExtendedMessageControl);
 /**
  * @brief  Cluster GetMessageCancellation Command callback (from client)

--- a/src/app/common/gen/client-command-macro.h
+++ b/src/app/common/gen/client-command-macro.h
@@ -2296,7 +2296,7 @@
  * Command: NOCResponse
  * @param StatusCode INT8U
  * @param FabricIndex INT8U
- * @param DebugText OCTET_STRING
+ * @param DebugText CHAR_STRING
  */
 #define emberAfFillCommandOperational                                                                                              \
     CredentialsClusterNOCResponse(StatusCode, FabricIndex, DebugText)                                                              \

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -48,6 +48,9 @@ function atomicType(arg)
   case 'octet_string':
   case 'long_octet_string':
     return 'chip::ByteSpan';
+  case 'char_string':
+  case 'long_char_string':
+    return 'chip::ByteSpan';
   case 'eui64':
     return 'chip::node_id';
   default:

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -1,11 +1,7 @@
 {{#if (zcl_command_arguments_count this.id)}}
 expectArgumentCount = {{ zcl_command_arguments_count this.id }};
 {{#zcl_command_arguments}}
-{{#if (isCharString type)}}
-const uint8_t * {{asSymbol label}};
-{{else}}
 {{asUnderlyingZclType type}} {{asSymbol label}};
-{{/if}}
 {{/zcl_command_arguments}}
 bool argExists[{{zcl_command_arguments_count this.id}}];
 
@@ -38,10 +34,7 @@ while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
   {
 {{#zcl_command_arguments}}
     case {{index}}:
-{{#if (isCharString type)}}
-      // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-      TLVUnpackError = aDataTlv.GetDataPtr({{asSymbol label}});
-{{else if isArray}}
+{{#if isArray}}
       // Just for compatibility, we will add array type support in IM later.
       TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>({{asSymbol label}}));
 {{else}}
@@ -71,7 +64,7 @@ if (CHIP_END_OF_TLV == TLVError)
 if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && {{zcl_command_arguments_count this.id}} == validArgumentCount)
 {
 {{/if}}
-wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(aEndpointId, apCommandObj{{#zcl_command_arguments}}, {{#if (isCharString type)}}const_cast<uint8_t*>({{asSymbol label}}){{else}}{{asSymbol label}}{{/if}}{{/zcl_command_arguments}});
+wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(aEndpointId, apCommandObj{{#zcl_command_arguments}}, {{asSymbol label}}{{/zcl_command_arguments}});
 {{#if (zcl_command_arguments_count this.id)}}
 }
 {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -842,8 +842,7 @@ bool emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Call
     {{#if (isOctetString type)}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", {{asSymbol label}}.size());
     {{else if (isCharString type)}}
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  {{asSymbol label}}: %.*s", {{asSymbol label}}.size(), {{asSymbol label}}.data());
+    ChipLogProgress(Zcl, " {{asSymbol label}}: %.*s", static_cast<uint16_t>({{asSymbol label}}.size()), {{asSymbol label}}.data());
     {{else}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: {{asPrintFormat type}}", {{asSymbol label}});
     {{/if}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -33,47 +33,6 @@ const kGlobalAttributes = [
   0xfffd, // FeatureMap
 ];
 
-// TODO Expose the readTypeLength as an additional member field of {{asUnderlyingZclType}} instead
-//      of having to call this method separately.
-function asReadTypeLength(type)
-{
-  const db = this.global.db;
-
-  if (StringHelper.isShortString(type)) {
-    return '1u';
-  }
-
-  if (StringHelper.isLongString(type)) {
-    return '2u';
-  }
-
-  function fn(pkgId)
-  {
-    const defaultResolver = zclQuery.selectAtomicType(db, pkgId, type);
-
-    const enumResolver = zclHelper.isEnum(db, type, pkgId).then(result => {
-      return result == 'unknown' ? null : zclQuery.selectEnumByName(db, type, pkgId).then(rec => {
-        return zclQuery.selectAtomicType(db, pkgId, rec.type);
-      });
-    });
-
-    const bitmapResolver = zclHelper.isBitmap(db, type, pkgId).then(result => {
-      return result == 'unknown' ? null : zclQuery.selectBitmapByName(db, pkgId, type).then(rec => {
-        return zclQuery.selectAtomicType(db, pkgId, rec.type);
-      });
-    });
-
-    const typeResolver = Promise.all([ defaultResolver, enumResolver, bitmapResolver ]);
-    return typeResolver.then(types => (types.find(type => type)).size);
-  }
-
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
-    console.log(err);
-    throw err;
-  });
-  return templateUtil.templatePromise(this.global, promise)
-}
-
 // TODO Expose the readType as an additional member field of {{asUnderlyingZclType}} instead
 //      of having to call this method separately.
 function asReadType(type)
@@ -340,7 +299,6 @@ function asMEI(prefix, suffix)
 //
 exports.asPrintFormat                     = asPrintFormat;
 exports.asReadType                        = asReadType;
-exports.asReadTypeLength                  = asReadTypeLength;
 exports.chip_endpoint_generated_functions = chip_endpoint_generated_functions
 exports.chip_endpoint_cluster_list        = chip_endpoint_cluster_list
 exports.asTypeLiteralSuffix               = asTypeLiteralSuffix;

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -44,7 +44,7 @@ limitations under the License.
   <struct name="AudioOutputInfo">
     <item name="index" type="INT8U"/>
     <item name="outputType" type="AudioOutputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="AudioOutputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -18,8 +18,8 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="LabelStruct">
-    <item name="label" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="value" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="label" type="CHAR_STRING" length="16"/>
+    <item name="value" type="CHAR_STRING" length="16"/>
   </struct>
 
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -61,8 +61,7 @@ limitations under the License.
     <item name="Thread" value="0x04"/>
   </enum>
   <struct name="NetworkInterfaceType">
-    <!-- TODO: CHAR_STRING not supported yet in structs. -->
-    <item name="Name" type="OCTET_STRING" length="32"/>
+    <item name="Name" type="CHAR_STRING" length="32"/>
     <item name="FabricConnected" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv4" type="BOOLEAN"/>
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -52,8 +52,8 @@ limitations under the License.
   <struct name="MediaInputInfo">
     <item name="index" type="INT8U"/>
     <item name="inputType" type="MediaInputType"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="description" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
+    <item name="description" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="MediaInputType" type="ENUM8">

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <item name="FabricId" type="FABRIC_ID"/>
     <item name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
     <item name="NodeId" type="NODE_ID"/>
-    <item name="Label" type="OCTET_STRING" length="32"/><!-- TODO: Add Label once CHAR_STRING or OCTET_STRING works -->
+    <item name="Label" type="CHAR_STRING" length="32"/>
   </struct>
 
   <enum name="NodeOperationalCertStatus" type="ENUM8">
@@ -73,12 +73,11 @@ limitations under the License.
       <arg name="NOCArray" type="OCTET_STRING"/>
     </command>
 
-    <!-- TODO: Change DebugText to CHAR_STRING once strings are supported in command/response fields -->
     <command source="server" code="0x08" name="NOCResponse" optional="false">
       <description>Response to AddNOC or UpdateNOC commands.</description>
       <arg name="StatusCode" type="INT8U"/>
       <arg name="FabricIndex" type="INT8U"/>
-      <arg name="DebugText" type="OCTET_STRING"/>
+      <arg name="DebugText" type="CHAR_STRING"/>
     </command>
 
     <command source="client" code="0x09" name="UpdateFabricLabel" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -18,8 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
   <struct name="ThreadMetrics">
     <item name="Id" type="INT64U"/>
-    <!-- TODO: CHAR_STRING not supported yet in structs. -->
-    <item name="Name" type="OCTET_STRING" length="8"/>
+    <item name="Name" type="CHAR_STRING" length="8"/>
     <item name="StackFreeCurrent" type="INT32U"/>
     <item name="StackFreeMinimum" type="INT32U"/>
     <item name="StackSize" type="INT32U"/>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -49,6 +49,6 @@ limitations under the License.
 
   <struct name="NavigateTargetTargetInfo">
       <item name="identifier" type="INT8U"/>
-      <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+      <item name="name" type="CHAR_STRING" length="32"/>
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
@@ -26,10 +26,8 @@ limitations under the License.
     <!-- TODO: Add feature map once it is supported -->
     <description>This cluster provides an interface for controlling the current TV Channel on a device.</description>
     <attribute side="server" code="0x0000" define="TV_CHANNEL_LIST" type="ARRAY" entryType="TvChannelInfo" length="254" writable="false" optional="false">tv channel list</attribute>
-    <!-- TODO: Covert this to stuct one it is supported -->
-    <attribute side="server" code="0x0001" define="TV_CHANNEL_LINEUP" type="OCTET_STRING" length="32" writable="false" optional="false">tv channel lineup</attribute>
-    <!-- TODO: Covert this to stuct one it is supported -->
-    <attribute side="server" code="0x0002" define="TV_CHANNEL_CURRENT_CHANNEL" type="OCTET_STRING" length="32" writable="false" optional="false">current tv channel</attribute>
+    <attribute side="server" code="0x0001" define="TV_CHANNEL_LINEUP" type="CHAR_STRING" length="32" writable="false" optional="false">tv channel lineup</attribute>
+    <attribute side="server" code="0x0002" define="TV_CHANNEL_CURRENT_CHANNEL" type="CHAR_STRING" length="32" writable="false" optional="false">current tv channel</attribute>
 
     <command source="client" code="0x00" name="ChangeChannel" optional="false">
       <description>Change the channel on the TV to the channel case-insensitive exact matching the value passed as an argument. </description>
@@ -58,9 +56,9 @@ limitations under the License.
   <struct name="TvChannelInfo">
     <item name="majorNumber" type="INT16U"/>
     <item name="minorNumber" type="INT16U"/>
-    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="callSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
-    <item name="affiliateCallSign" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <item name="name" type="CHAR_STRING" length="32"/>
+    <item name="callSign" type="CHAR_STRING" length="32"/>
+    <item name="affiliateCallSign" type="CHAR_STRING" length="32"/>
   </struct>
 
   <struct name="TvChannelLineupInfo">

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -1694,11 +1694,11 @@ void ThreadNetworkDiagnosticsClusterActiveNetworkFaultsListListAttributeFilter(T
     cb->mCall(cb->mContext, count, data);
 }
 
-bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t * setupPIN)
+bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
+                                                           chip::ByteSpan setupPIN)
 {
     ChipLogProgress(Zcl, "GetSetupPINResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  setupPIN: %.*s", setupPIN.size(), setupPIN.data());
+    ChipLogProgress(Zcl, " setupPIN: %.*s", static_cast<uint16_t>(setupPIN.size()), setupPIN.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("AccountLoginClusterGetSetupPINResponseCallback");
 
@@ -1709,12 +1709,11 @@ bool emberAfAccountLoginClusterGetSetupPINResponseCallback(EndpointId endpoint, 
 }
 
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                uint8_t status, uint8_t * data)
+                                                                uint8_t status, chip::ByteSpan data)
 {
     ChipLogProgress(Zcl, "LaunchAppResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, " data: %.*s", static_cast<uint16_t>(data.size()), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ApplicationLauncherClusterLaunchAppResponseCallback");
 
@@ -1725,11 +1724,10 @@ bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(EndpointId endpo
 }
 
 bool emberAfContentLauncherClusterLaunchContentResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                uint8_t * data, uint8_t contentLaunchStatus)
+                                                                chip::ByteSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchContentResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, " data: %.*s", static_cast<uint16_t>(data.size()), data.data());
     ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", contentLaunchStatus);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ContentLauncherClusterLaunchContentResponseCallback");
@@ -1740,12 +1738,11 @@ bool emberAfContentLauncherClusterLaunchContentResponseCallback(EndpointId endpo
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t * data,
-                                                            uint8_t contentLaunchStatus)
+bool emberAfContentLauncherClusterLaunchURLResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
+                                                            chip::ByteSpan data, uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchURLResponse:");
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, " data: %.*s", static_cast<uint16_t>(data.size()), data.data());
     ChipLogProgress(Zcl, "  contentLaunchStatus: %" PRIu8 "", contentLaunchStatus);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ContentLauncherClusterLaunchURLResponseCallback");
@@ -1871,7 +1868,7 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(EndpointId endpoin
 
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t logEntryId,
                                                         uint32_t timestamp, uint8_t eventType, uint8_t source,
-                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
 {
     ChipLogProgress(Zcl, "GetLogRecordResponse:");
     ChipLogProgress(Zcl, "  logEntryId: %" PRIu16 "", logEntryId);
@@ -1880,8 +1877,7 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app
     ChipLogProgress(Zcl, "  source: %" PRIu8 "", source);
     ChipLogProgress(Zcl, "  eventIdOrAlarmCode: %" PRIu8 "", eventIdOrAlarmCode);
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  pin: %.*s", pin.size(), pin.data());
+    ChipLogProgress(Zcl, " pin: %.*s", static_cast<uint16_t>(pin.size()), pin.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetLogRecordResponseCallback");
 
@@ -1892,14 +1888,13 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(EndpointId endpoint, app
 }
 
 bool emberAfDoorLockClusterGetPinResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t userId,
-                                                  uint8_t userStatus, uint8_t userType, uint8_t * pin)
+                                                  uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
 {
     ChipLogProgress(Zcl, "GetPinResponse:");
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
     ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", userStatus);
     ChipLogProgress(Zcl, "  userType: %" PRIu8 "", userType);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  pin: %.*s", pin.size(), pin.data());
+    ChipLogProgress(Zcl, " pin: %.*s", static_cast<uint16_t>(pin.size()), pin.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetPinResponseCallback");
 
@@ -1910,14 +1905,13 @@ bool emberAfDoorLockClusterGetPinResponseCallback(EndpointId endpoint, app::Comm
 }
 
 bool emberAfDoorLockClusterGetRfidResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint16_t userId,
-                                                   uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+                                                   uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
 {
     ChipLogProgress(Zcl, "GetRfidResponse:");
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
     ChipLogProgress(Zcl, "  userStatus: %" PRIu8 "", userStatus);
     ChipLogProgress(Zcl, "  userType: %" PRIu8 "", userType);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  rfid: %.*s", rfid.size(), rfid.data());
+    ChipLogProgress(Zcl, " rfid: %.*s", static_cast<uint16_t>(rfid.size()), rfid.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetRfidResponseCallback");
 
@@ -2102,12 +2096,11 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(EndpointId endpoint
 }
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                   uint8_t errorCode, uint8_t * debugText)
+                                                                   uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "ArmFailSafeResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterArmFailSafeResponseCallback");
 
@@ -2118,12 +2111,11 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(EndpointId en
 }
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                             uint8_t errorCode, uint8_t * debugText)
+                                                                             uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "CommissioningCompleteResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterCommissioningCompleteResponseCallback");
 
@@ -2134,12 +2126,11 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(End
 }
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "SetRegulatoryConfigResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GeneralCommissioningClusterSetRegulatoryConfigResponseCallback");
 
@@ -2197,13 +2188,12 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(EndpointId endpoint, app::C
 }
 
 bool emberAfGroupsClusterViewGroupResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t * groupName)
+                                                   uint16_t groupId, chip::ByteSpan groupName)
 {
     ChipLogProgress(Zcl, "ViewGroupResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  groupName: %.*s", groupName.size(), groupName.data());
+    ChipLogProgress(Zcl, " groupName: %.*s", static_cast<uint16_t>(groupName.size()), groupName.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GroupsClusterViewGroupResponseCallback");
 
@@ -2394,12 +2384,11 @@ bool emberAfMediaPlaybackClusterMediaStopResponseCallback(EndpointId endpoint, a
 }
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                        uint8_t errorCode, uint8_t * debugText)
+                                                                        uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "AddThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddThreadNetworkResponseCallback");
 
@@ -2410,12 +2399,11 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(Endpoint
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "AddWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterAddWiFiNetworkResponseCallback");
 
@@ -2426,12 +2414,11 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                      uint8_t errorCode, uint8_t * debugText)
+                                                                      uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "DisableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterDisableNetworkResponseCallback");
 
@@ -2442,12 +2429,11 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(EndpointId
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "EnableNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterEnableNetworkResponseCallback");
 
@@ -2458,12 +2444,11 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                     uint8_t errorCode, uint8_t * debugText)
+                                                                     uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "RemoveNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterRemoveNetworkResponseCallback");
 
@@ -2474,14 +2459,13 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(EndpointId 
 }
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
+    EndpointId endpoint, app::CommandSender * commandObj, uint8_t errorCode, chip::ByteSpan debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
     ChipLogProgress(Zcl, "ScanNetworksResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
     ChipLogProgress(Zcl, "  wifiScanResults: %p", wifiScanResults);
     ChipLogProgress(Zcl, "  threadScanResults: %p", threadScanResults);
 
@@ -2494,12 +2478,11 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 }
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                           uint8_t errorCode, uint8_t * debugText)
+                                                                           uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateThreadNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateThreadNetworkResponseCallback");
 
@@ -2510,12 +2493,11 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(Endpo
 }
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                         uint8_t errorCode, uint8_t * debugText)
+                                                                         uint8_t errorCode, chip::ByteSpan debugText)
 {
     ChipLogProgress(Zcl, "UpdateWiFiNetworkResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  debugText: %.*s", debugText.size(), debugText.data());
+    ChipLogProgress(Zcl, " debugText: %.*s", static_cast<uint16_t>(debugText.size()), debugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback");
 
@@ -2542,15 +2524,14 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(E
 
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
                                                                        uint8_t status, uint32_t delayedActionTime,
-                                                                       uint8_t * imageURI, uint32_t softwareVersion,
+                                                                       chip::ByteSpan imageURI, uint32_t softwareVersion,
                                                                        chip::ByteSpan updateToken, bool userConsentNeeded,
                                                                        chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(Zcl, "QueryImageResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", delayedActionTime);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  imageURI: %.*s", imageURI.size(), imageURI.data());
+    ChipLogProgress(Zcl, " imageURI: %.*s", static_cast<uint16_t>(imageURI.size()), imageURI.data());
     ChipLogProgress(Zcl, "  softwareVersion: %" PRIu32 "", softwareVersion);
     ChipLogProgress(Zcl, "  updateToken: %zu", updateToken.size());
     ChipLogProgress(Zcl, "  userConsentNeeded: %d", userConsentNeeded);
@@ -2571,7 +2552,7 @@ bool emberAfOperationalCredentialsClusterNOCResponseCallback(EndpointId endpoint
     ChipLogProgress(Zcl, "NOCResponse:");
     ChipLogProgress(Zcl, "  StatusCode: %" PRIu8 "", StatusCode);
     ChipLogProgress(Zcl, "  FabricIndex: %" PRIu8 "", FabricIndex);
-    ChipLogProgress(Zcl, "  DebugText: %zu", DebugText.size());
+    ChipLogProgress(Zcl, " DebugText: %.*s", static_cast<uint16_t>(DebugText.size()), DebugText.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("OperationalCredentialsClusterNOCResponseCallback");
 
@@ -2679,7 +2660,8 @@ bool emberAfScenesClusterStoreSceneResponseCallback(EndpointId endpoint, app::Co
 }
 
 bool emberAfScenesClusterViewSceneResponseCallback(EndpointId endpoint, app::CommandSender * commandObj, uint8_t status,
-                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+                                                   uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                                                   chip::ByteSpan sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     ChipLogProgress(Zcl, "ViewSceneResponse:");
@@ -2687,8 +2669,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(EndpointId endpoint, app::Com
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
     ChipLogProgress(Zcl, "  transitionTime: %" PRIu16 "", transitionTime);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  sceneName: %.*s", sceneName.size(), sceneName.data());
+    ChipLogProgress(Zcl, " sceneName: %.*s", static_cast<uint16_t>(sceneName.size()), sceneName.data());
     ChipLogProgress(Zcl, "  extensionFieldSets: %p", extensionFieldSets);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterViewSceneResponseCallback");
@@ -2716,12 +2697,11 @@ bool emberAfTvChannelClusterChangeChannelResponseCallback(EndpointId endpoint, a
 }
 
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(EndpointId endpoint, app::CommandSender * commandObj,
-                                                                 uint8_t status, uint8_t * data)
+                                                                 uint8_t status, chip::ByteSpan data)
 {
     ChipLogProgress(Zcl, "NavigateTargetResponse:");
     ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
-    // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits ByteSpan
-    // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
+    ChipLogProgress(Zcl, " data: %.*s", static_cast<uint16_t>(data.size()), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("TargetNavigatorClusterNavigateTargetResponseCallback");
 

--- a/src/controller/data_model/gen/CHIPClientCallbacks.h
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.h
@@ -82,10 +82,11 @@ typedef void (*ReadReportingConfigurationReportedCallback)(void * context, uint1
 typedef void (*ReadReportingConfigurationReceivedCallback)(void * context, uint16_t timeout);
 
 // Cluster Specific Response Callbacks
-typedef void (*AccountLoginClusterGetSetupPINResponseCallback)(void * context, uint8_t * setupPIN);
-typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t status, uint8_t * data);
-typedef void (*ContentLauncherClusterLaunchContentResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
-typedef void (*ContentLauncherClusterLaunchURLResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
+typedef void (*AccountLoginClusterGetSetupPINResponseCallback)(void * context, chip::ByteSpan setupPIN);
+typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t status, chip::ByteSpan data);
+typedef void (*ContentLauncherClusterLaunchContentResponseCallback)(void * context, chip::ByteSpan data,
+                                                                    uint8_t contentLaunchStatus);
+typedef void (*ContentLauncherClusterLaunchURLResponseCallback)(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus);
 typedef void (*DoorLockClusterClearAllPinsResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterClearAllRfidsResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterClearHolidayScheduleResponseCallback)(void * context, uint8_t status);
@@ -98,11 +99,11 @@ typedef void (*DoorLockClusterGetHolidayScheduleResponseCallback)(void * context
                                                                   uint8_t operatingModeDuringHoliday);
 typedef void (*DoorLockClusterGetLogRecordResponseCallback)(void * context, uint16_t logEntryId, uint32_t timestamp,
                                                             uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode,
-                                                            uint16_t userId, uint8_t * pin);
+                                                            uint16_t userId, chip::ByteSpan pin);
 typedef void (*DoorLockClusterGetPinResponseCallback)(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                                      uint8_t * pin);
+                                                      chip::ByteSpan pin);
 typedef void (*DoorLockClusterGetRfidResponseCallback)(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                                       uint8_t * rfid);
+                                                       chip::ByteSpan rfid);
 typedef void (*DoorLockClusterGetUserTypeResponseCallback)(void * context, uint16_t userId, uint8_t userType);
 typedef void (*DoorLockClusterGetWeekdayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint16_t userId,
                                                                   uint8_t status, uint8_t daysMask, uint8_t startHour,
@@ -118,16 +119,16 @@ typedef void (*DoorLockClusterSetWeekdayScheduleResponseCallback)(void * context
 typedef void (*DoorLockClusterSetYeardayScheduleResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterUnlockDoorResponseCallback)(void * context, uint8_t status);
 typedef void (*DoorLockClusterUnlockWithTimeoutResponseCallback)(void * context, uint8_t status);
-typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, chip::ByteSpan debugText);
 typedef void (*GeneralCommissioningClusterCommissioningCompleteResponseCallback)(void * context, uint8_t errorCode,
-                                                                                 uint8_t * debugText);
+                                                                                 chip::ByteSpan debugText);
 typedef void (*GeneralCommissioningClusterSetRegulatoryConfigResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
+                                                                               chip::ByteSpan debugText);
 typedef void (*GroupsClusterAddGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
 typedef void (*GroupsClusterGetGroupMembershipResponseCallback)(void * context, uint8_t capacity, uint8_t groupCount,
                                                                 /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
 typedef void (*GroupsClusterRemoveGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
-typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName);
+typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId, chip::ByteSpan groupName);
 typedef void (*IdentifyClusterIdentifyQueryResponseCallback)(void * context, uint16_t timeout);
 typedef void (*KeypadInputClusterSendKeyResponseCallback)(void * context, uint8_t status);
 typedef void (*MediaPlaybackClusterMediaFastForwardResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
@@ -141,22 +142,28 @@ typedef void (*MediaPlaybackClusterMediaSkipBackwardResponseCallback)(void * con
 typedef void (*MediaPlaybackClusterMediaSkipForwardResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaStartOverResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaStopResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
-typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
-typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
+typedef void (*NetworkCommissioningClusterAddThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                            chip::ByteSpan debugText);
+typedef void (*NetworkCommissioningClusterAddWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::ByteSpan debugText);
+typedef void (*NetworkCommissioningClusterDisableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                          chip::ByteSpan debugText);
+typedef void (*NetworkCommissioningClusterEnableNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::ByteSpan debugText);
+typedef void (*NetworkCommissioningClusterRemoveNetworkResponseCallback)(void * context, uint8_t errorCode,
+                                                                         chip::ByteSpan debugText);
 typedef void (*NetworkCommissioningClusterScanNetworksResponseCallback)(
-    void * context, uint8_t errorCode, uint8_t * debugText, /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
+    void * context, uint8_t errorCode, chip::ByteSpan debugText,
+    /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
 typedef void (*NetworkCommissioningClusterUpdateThreadNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                               uint8_t * debugText);
+                                                                               chip::ByteSpan debugText);
 typedef void (*NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback)(void * context, uint8_t errorCode,
-                                                                             uint8_t * debugText);
+                                                                             chip::ByteSpan debugText);
 typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback)(void * context, uint8_t action,
                                                                                    uint32_t delayedActionTime);
 typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(void * context, uint8_t status,
-                                                                           uint32_t delayedActionTime, uint8_t * imageURI,
+                                                                           uint32_t delayedActionTime, chip::ByteSpan imageURI,
                                                                            uint32_t softwareVersion, chip::ByteSpan updateToken,
                                                                            bool userConsentNeeded,
                                                                            chip::ByteSpan metadataForRequestor);
@@ -172,12 +179,12 @@ typedef void (*ScenesClusterRemoveAllScenesResponseCallback)(void * context, uin
 typedef void (*ScenesClusterRemoveSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
 typedef void (*ScenesClusterStoreSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
 typedef void (*ScenesClusterViewSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId,
-                                                       uint16_t transitionTime, uint8_t * sceneName,
+                                                       uint16_t transitionTime, chip::ByteSpan sceneName,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 typedef void (*TvChannelClusterChangeChannelResponseCallback)(void * context,
                                                               /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch,
                                                               uint8_t ErrorType);
-typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t status, uint8_t * data);
+typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t status, chip::ByteSpan data);
 typedef void (*TestClusterClusterTestAddArgumentsResponseCallback)(void * context, uint8_t returnValue);
 typedef void (*TestClusterClusterTestSpecificResponseCallback)(void * context, uint8_t returnValue);
 

--- a/src/controller/data_model/gen/CHIPClusters.cpp
+++ b/src/controller/data_model/gen/CHIPClusters.cpp
@@ -9599,7 +9599,7 @@ CHIP_ERROR TvChannelCluster::ReadAttributeTvChannelLineup(Callback::Cancelable *
     attributePath.mFieldId    = 0x00000001;
     attributePath.mFlags.Set(app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
+                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR TvChannelCluster::ReadAttributeCurrentTvChannel(Callback::Cancelable * onSuccessCallback,
@@ -9611,7 +9611,7 @@ CHIP_ERROR TvChannelCluster::ReadAttributeCurrentTvChannel(Callback::Cancelable 
     attributePath.mFieldId    = 0x00000002;
     attributePath.mFlags.Set(app::AttributePathParams::Flags::kFieldIdValid);
     return mDevice->SendReadAttributeRequest(attributePath, onSuccessCallback, onFailureCallback,
-                                             BasicAttributeFilter<OctetStringAttributeCallback>);
+                                             BasicAttributeFilter<CharStringAttributeCallback>);
 }
 
 CHIP_ERROR TvChannelCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,

--- a/src/controller/data_model/gen/IMClusterCommandHandler.cpp
+++ b/src/controller/data_model/gen/IMClusterCommandHandler.cpp
@@ -70,7 +70,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         {
         case Clusters::AccountLogin::Commands::Ids::GetSetupPINResponse: {
             expectArgumentCount = 1;
-            const uint8_t * setupPIN;
+            chip::ByteSpan setupPIN;
             bool argExists[1];
 
             memset(argExists, 0, sizeof argExists);
@@ -101,8 +101,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(setupPIN);
+                    TLVUnpackError = aDataTlv.Get(setupPIN);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -123,8 +122,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 1 == validArgumentCount)
             {
-                wasHandled = emberAfAccountLoginClusterGetSetupPINResponseCallback(aEndpointId, apCommandObj,
-                                                                                   const_cast<uint8_t *>(setupPIN));
+                wasHandled = emberAfAccountLoginClusterGetSetupPINResponseCallback(aEndpointId, apCommandObj, setupPIN);
             }
             break;
         }
@@ -176,7 +174,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         case Clusters::ApplicationLauncher::Commands::Ids::LaunchAppResponse: {
             expectArgumentCount = 2;
             uint8_t status;
-            const uint8_t * data;
+            chip::ByteSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -210,8 +208,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(status);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -232,8 +229,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfApplicationLauncherClusterLaunchAppResponseCallback(aEndpointId, apCommandObj, status,
-                                                                                        const_cast<uint8_t *>(data));
+                wasHandled = emberAfApplicationLauncherClusterLaunchAppResponseCallback(aEndpointId, apCommandObj, status, data);
             }
             break;
         }
@@ -285,7 +281,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         {
         case Clusters::ContentLauncher::Commands::Ids::LaunchContentResponse: {
             expectArgumentCount = 2;
-            const uint8_t * data;
+            chip::ByteSpan data;
             uint8_t contentLaunchStatus;
             bool argExists[2];
 
@@ -317,8 +313,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 case 1:
                     TLVUnpackError = aDataTlv.Get(contentLaunchStatus);
@@ -342,14 +337,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchContentResponseCallback(
-                    aEndpointId, apCommandObj, const_cast<uint8_t *>(data), contentLaunchStatus);
+                wasHandled = emberAfContentLauncherClusterLaunchContentResponseCallback(aEndpointId, apCommandObj, data,
+                                                                                        contentLaunchStatus);
             }
             break;
         }
         case Clusters::ContentLauncher::Commands::Ids::LaunchURLResponse: {
             expectArgumentCount = 2;
-            const uint8_t * data;
+            chip::ByteSpan data;
             uint8_t contentLaunchStatus;
             bool argExists[2];
 
@@ -381,8 +376,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                 switch (currentDecodeTagId)
                 {
                 case 0:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 case 1:
                     TLVUnpackError = aDataTlv.Get(contentLaunchStatus);
@@ -406,8 +400,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfContentLauncherClusterLaunchURLResponseCallback(
-                    aEndpointId, apCommandObj, const_cast<uint8_t *>(data), contentLaunchStatus);
+                wasHandled =
+                    emberAfContentLauncherClusterLaunchURLResponseCallback(aEndpointId, apCommandObj, data, contentLaunchStatus);
             }
             break;
         }
@@ -945,7 +939,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             uint8_t source;
             uint8_t eventIdOrAlarmCode;
             uint16_t userId;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[7];
 
             memset(argExists, 0, sizeof argExists);
@@ -994,8 +988,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(userId);
                     break;
                 case 6:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1017,8 +1010,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 7 == validArgumentCount)
             {
                 wasHandled = emberAfDoorLockClusterGetLogRecordResponseCallback(aEndpointId, apCommandObj, logEntryId, timestamp,
-                                                                                eventType, source, eventIdOrAlarmCode, userId,
-                                                                                const_cast<uint8_t *>(pin));
+                                                                                eventType, source, eventIdOrAlarmCode, userId, pin);
             }
             break;
         }
@@ -1027,7 +1019,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * pin;
+            chip::ByteSpan pin;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -1067,8 +1059,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.Get(pin);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1089,8 +1080,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterGetPinResponseCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                          const_cast<uint8_t *>(pin));
+                wasHandled =
+                    emberAfDoorLockClusterGetPinResponseCallback(aEndpointId, apCommandObj, userId, userStatus, userType, pin);
             }
             break;
         }
@@ -1099,7 +1090,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             uint16_t userId;
             uint8_t userStatus;
             uint8_t userType;
-            const uint8_t * rfid;
+            chip::ByteSpan rfid;
             bool argExists[4];
 
             memset(argExists, 0, sizeof argExists);
@@ -1139,8 +1130,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(userType);
                     break;
                 case 3:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(rfid);
+                    TLVUnpackError = aDataTlv.Get(rfid);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -1161,8 +1151,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
-                wasHandled = emberAfDoorLockClusterGetRfidResponseCallback(aEndpointId, apCommandObj, userId, userStatus, userType,
-                                                                           const_cast<uint8_t *>(rfid));
+                wasHandled =
+                    emberAfDoorLockClusterGetRfidResponseCallback(aEndpointId, apCommandObj, userId, userStatus, userType, rfid);
             }
             break;
         }
@@ -1960,7 +1950,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         case Clusters::GeneralCommissioning::Commands::Ids::ArmFailSafeResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -1994,8 +1984,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2016,15 +2005,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(aEndpointId, apCommandObj, errorCode,
-                                                                                           const_cast<uint8_t *>(debugText));
+                wasHandled =
+                    emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(aEndpointId, apCommandObj, errorCode, debugText);
             }
             break;
         }
         case Clusters::GeneralCommissioning::Commands::Ids::CommissioningCompleteResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -2058,8 +2047,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2080,15 +2068,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(aEndpointId, apCommandObj,
+                                                                                                     errorCode, debugText);
             }
             break;
         }
         case Clusters::GeneralCommissioning::Commands::Ids::SetRegulatoryConfigResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -2122,8 +2110,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2144,8 +2131,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(aEndpointId, apCommandObj,
+                                                                                                   errorCode, debugText);
             }
             break;
         }
@@ -2391,7 +2378,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             expectArgumentCount = 3;
             uint8_t status;
             uint16_t groupId;
-            const uint8_t * groupName;
+            chip::ByteSpan groupName;
             bool argExists[3];
 
             memset(argExists, 0, sizeof argExists);
@@ -2428,8 +2415,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(groupId);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.Get(groupName);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -2450,8 +2436,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 3 == validArgumentCount)
             {
-                wasHandled = emberAfGroupsClusterViewGroupResponseCallback(aEndpointId, apCommandObj, status, groupId,
-                                                                           const_cast<uint8_t *>(groupName));
+                wasHandled = emberAfGroupsClusterViewGroupResponseCallback(aEndpointId, apCommandObj, status, groupId, groupName);
             }
             break;
         }
@@ -3397,7 +3382,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         case Clusters::NetworkCommissioning::Commands::Ids::AddThreadNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3431,8 +3416,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3453,15 +3437,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(aEndpointId, apCommandObj,
+                                                                                                errorCode, debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::AddWiFiNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3495,8 +3479,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3518,14 +3501,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(aEndpointId, apCommandObj, errorCode,
-                                                                                              const_cast<uint8_t *>(debugText));
+                                                                                              debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::DisableNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3559,8 +3542,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3582,14 +3564,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(aEndpointId, apCommandObj, errorCode,
-                                                                                              const_cast<uint8_t *>(debugText));
+                                                                                              debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::EnableNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3623,8 +3605,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3646,14 +3627,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(aEndpointId, apCommandObj, errorCode,
-                                                                                             const_cast<uint8_t *>(debugText));
+                                                                                             debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::RemoveNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3687,8 +3668,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3710,14 +3690,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(aEndpointId, apCommandObj, errorCode,
-                                                                                             const_cast<uint8_t *>(debugText));
+                                                                                             debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::ScanNetworksResponse: {
             expectArgumentCount = 4;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults;
             /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults;
             bool argExists[4];
@@ -3753,8 +3733,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 case 2:
                     // Just for compatibility, we will add array type support in IM later.
@@ -3784,14 +3763,14 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 4 == validArgumentCount)
             {
                 wasHandled = emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText), wifiScanResults, threadScanResults);
+                    aEndpointId, apCommandObj, errorCode, debugText, wifiScanResults, threadScanResults);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::UpdateThreadNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3825,8 +3804,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3847,15 +3825,15 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(aEndpointId, apCommandObj,
+                                                                                                   errorCode, debugText);
             }
             break;
         }
         case Clusters::NetworkCommissioning::Commands::Ids::UpdateWiFiNetworkResponse: {
             expectArgumentCount = 2;
             uint8_t errorCode;
-            const uint8_t * debugText;
+            chip::ByteSpan debugText;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -3889,8 +3867,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(errorCode);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.Get(debugText);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -3911,8 +3888,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(
-                    aEndpointId, apCommandObj, errorCode, const_cast<uint8_t *>(debugText));
+                wasHandled = emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(aEndpointId, apCommandObj,
+                                                                                                 errorCode, debugText);
             }
             break;
         }
@@ -4029,7 +4006,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             expectArgumentCount = 7;
             uint8_t status;
             uint32_t delayedActionTime;
-            const uint8_t * imageURI;
+            chip::ByteSpan imageURI;
             uint32_t softwareVersion;
             chip::ByteSpan updateToken;
             bool userConsentNeeded;
@@ -4070,8 +4047,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(delayedActionTime);
                     break;
                 case 2:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(imageURI);
+                    TLVUnpackError = aDataTlv.Get(imageURI);
                     break;
                 case 3:
                     TLVUnpackError = aDataTlv.Get(softwareVersion);
@@ -4105,8 +4081,8 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 7 == validArgumentCount)
             {
                 wasHandled = emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(
-                    aEndpointId, apCommandObj, status, delayedActionTime, const_cast<uint8_t *>(imageURI), softwareVersion,
-                    updateToken, userConsentNeeded, metadataForRequestor);
+                    aEndpointId, apCommandObj, status, delayedActionTime, imageURI, softwareVersion, updateToken, userConsentNeeded,
+                    metadataForRequestor);
             }
             break;
         }
@@ -4674,7 +4650,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             uint16_t groupId;
             uint8_t sceneId;
             uint16_t transitionTime;
-            const uint8_t * sceneName;
+            chip::ByteSpan sceneName;
             /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets;
             bool argExists[6];
 
@@ -4718,8 +4694,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(transitionTime);
                     break;
                 case 4:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.Get(sceneName);
                     break;
                 case 5:
                     // Just for compatibility, we will add array type support in IM later.
@@ -4745,8 +4720,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 6 == validArgumentCount)
             {
                 wasHandled = emberAfScenesClusterViewSceneResponseCallback(aEndpointId, apCommandObj, status, groupId, sceneId,
-                                                                           transitionTime, const_cast<uint8_t *>(sceneName),
-                                                                           extensionFieldSets);
+                                                                           transitionTime, sceneName, extensionFieldSets);
             }
             break;
         }
@@ -4907,7 +4881,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
         case Clusters::TargetNavigator::Commands::Ids::NavigateTargetResponse: {
             expectArgumentCount = 2;
             uint8_t status;
-            const uint8_t * data;
+            chip::ByteSpan data;
             bool argExists[2];
 
             memset(argExists, 0, sizeof argExists);
@@ -4941,8 +4915,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
                     TLVUnpackError = aDataTlv.Get(status);
                     break;
                 case 1:
-                    // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = aDataTlv.GetDataPtr(data);
+                    TLVUnpackError = aDataTlv.Get(data);
                     break;
                 default:
                     // Unsupported tag, ignore it.
@@ -4963,8 +4936,7 @@ void DispatchClientCommand(CommandSender * apCommandObj, CommandId aCommandId, E
 
             if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && 2 == validArgumentCount)
             {
-                wasHandled = emberAfTargetNavigatorClusterNavigateTargetResponseCallback(aEndpointId, apCommandObj, status,
-                                                                                         const_cast<uint8_t *>(data));
+                wasHandled = emberAfTargetNavigatorClusterNavigateTargetResponseCallback(aEndpointId, apCommandObj, status, data);
             }
             break;
         }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -534,8 +534,8 @@ JNI_METHOD(void, sendCommand)(JNIEnv * env, jobject self, jlong handle, jlong de
 
 namespace {
 
-void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
-void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
+void OnAddNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText);
+void OnEnableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText);
 void OnNetworkCommissioningFailed(void * context, uint8_t errorCode);
 
 // Context used for processing "AddThreadNetwork" and "EnableNetwork" commands.
@@ -568,7 +568,7 @@ void FinishCommissioning(NetworkCommissioningCtx * ctx, CHIP_ERROR err)
     delete ctx;
 }
 
-void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void OnAddNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     NetworkCommissioningCtx * ctx            = static_cast<NetworkCommissioningCtx *>(context);
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(ctx->mHandle);
@@ -589,7 +589,7 @@ exit:
     }
 }
 
-void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+void OnEnableNetworkResponse(void * context, uint8_t errorCode, chip::ByteSpan debugText)
 {
     NetworkCommissioningCtx * ctx = static_cast<NetworkCommissioningCtx *>(context);
     FinishCommissioning(ctx, CHIP_NO_ERROR);

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -350,8 +350,8 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess method"));
 
-        UtfString valueStr(env, value);
-        env->CallVoidMethod(javaCallbackRef, javaMethod, valueStr.jniValue());
+        jstring valueStr = env->NewString(reinterpret_cast<const jchar *>(value.data()), value.size());
+        env->CallVoidMethod(javaCallbackRef, javaMethod, valueStr);
     }
 
 private:
@@ -890,7 +890,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * setupPIN)
+    static void CallbackFn(void * context, chip::ByteSpan setupPIN)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -898,8 +898,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPAccountLoginClusterGetSetupPINResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString setupPINStr(env, "");
+        jstring setupPINStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -912,7 +911,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, setupPINStr.jniValue());
+        setupPINStr = env->NewString(reinterpret_cast<const jchar *>(setupPIN.data()), setupPIN.size());
+        VerifyOrExit(setupPINStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, setupPINStr);
+
+        env->DeleteLocalRef(setupPINStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -961,7 +966,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::ByteSpan data)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -969,8 +974,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPApplicationLauncherClusterLaunchAppResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        jstring dataStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -983,7 +987,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr.jniValue());
+        dataStr = env->NewString(reinterpret_cast<const jchar *>(data.data()), data.size());
+        VerifyOrExit(dataStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr);
+
+        env->DeleteLocalRef(dataStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1032,7 +1042,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1040,8 +1050,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchContentResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        jstring dataStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1054,7 +1063,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
+        dataStr = env->NewString(reinterpret_cast<const jchar *>(data.data()), data.size());
+        VerifyOrExit(dataStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr, static_cast<jint>(contentLaunchStatus));
+
+        env->DeleteLocalRef(dataStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1103,7 +1118,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1111,8 +1126,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPContentLauncherClusterLaunchURLResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        jstring dataStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1125,7 +1139,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue(), static_cast<jint>(contentLaunchStatus));
+        dataStr = env->NewString(reinterpret_cast<const jchar *>(data.data()), data.size());
+        VerifyOrExit(dataStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr, static_cast<jint>(contentLaunchStatus));
+
+        env->DeleteLocalRef(dataStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1725,7 +1745,7 @@ public:
     };
 
     static void CallbackFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-                           uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+                           uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1733,8 +1753,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetLogRecordResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString pinStr(env, "");
+        jstring pinStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1748,9 +1767,15 @@ public:
             JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJIIIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
+        pinStr = env->NewString(reinterpret_cast<const jchar *>(pin.data()), pin.size());
+        VerifyOrExit(pinStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(logEntryId), static_cast<jlong>(timestamp),
                             static_cast<jint>(eventType), static_cast<jint>(source), static_cast<jint>(eventIdOrAlarmCode),
-                            static_cast<jint>(userId), pinStr.jniValue());
+                            static_cast<jint>(userId), pinStr);
+
+        env->DeleteLocalRef(pinStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1798,7 +1823,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1806,8 +1831,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetPinResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString pinStr(env, "");
+        jstring pinStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1820,8 +1844,14 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
+        pinStr = env->NewString(reinterpret_cast<const jchar *>(pin.data()), pin.size());
+        VerifyOrExit(pinStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
-                            static_cast<jint>(userType), pinStr.jniValue());
+                            static_cast<jint>(userType), pinStr);
+
+        env->DeleteLocalRef(pinStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1869,7 +1899,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1877,8 +1907,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPDoorLockClusterGetRfidResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString rfidStr(env, "");
+        jstring rfidStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -1891,8 +1920,14 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
+        rfidStr = env->NewString(reinterpret_cast<const jchar *>(rfid.data()), rfid.size());
+        VerifyOrExit(rfidStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(userId), static_cast<jint>(userStatus),
-                            static_cast<jint>(userType), rfidStr.jniValue());
+                            static_cast<jint>(userType), rfidStr);
+
+        env->DeleteLocalRef(rfidStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2768,7 +2803,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2776,8 +2811,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterArmFailSafeResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2790,7 +2824,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2839,7 +2879,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2847,8 +2887,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2861,7 +2900,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2910,7 +2955,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2918,8 +2963,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -2932,7 +2976,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -3189,7 +3239,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, chip::ByteSpan groupName)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3197,8 +3247,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPGroupsClusterViewGroupResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString groupNameStr(env, "");
+        jstring groupNameStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -3211,8 +3260,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
-                            groupNameStr.jniValue());
+        groupNameStr = env->NewString(reinterpret_cast<const jchar *>(groupName.data()), groupName.size());
+        VerifyOrExit(groupNameStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId), groupNameStr);
+
+        env->DeleteLocalRef(groupNameStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4151,7 +4205,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4159,8 +4213,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4173,7 +4226,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4222,7 +4281,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4230,8 +4289,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4244,7 +4302,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4293,7 +4357,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4301,8 +4365,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterDisableNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4315,7 +4378,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4364,7 +4433,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4372,8 +4441,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterEnableNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4386,7 +4454,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4435,7 +4509,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4443,8 +4517,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterRemoveNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4457,7 +4530,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4506,7 +4585,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText,
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText,
                            /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
                            /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
     {
@@ -4516,8 +4595,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterScanNetworksResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4530,12 +4608,18 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue()
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr
                             // wifiScanResults: /* TYPE WARNING: array array defaults to */ uint8_t *
                             // Conversion from this type to Java is not properly implemented yet
                             // threadScanResults: /* TYPE WARNING: array array defaults to */ uint8_t *
                             // Conversion from this type to Java is not properly implemented yet
         );
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4584,7 +4668,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4592,8 +4676,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4606,7 +4689,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4655,7 +4744,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4663,8 +4752,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString debugTextStr(env, "");
+        jstring debugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4677,7 +4765,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr.jniValue());
+        debugTextStr = env->NewString(reinterpret_cast<const jchar *>(debugText.data()), debugText.size());
+        VerifyOrExit(debugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(errorCode), debugTextStr);
+
+        env->DeleteLocalRef(debugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4795,8 +4889,9 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-                           chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, chip::ByteSpan imageURI,
+                           uint32_t softwareVersion, chip::ByteSpan updateToken, bool userConsentNeeded,
+                           chip::ByteSpan metadataForRequestor)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4804,8 +4899,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString imageURIStr(env, "");
+        jstring imageURIStr;
         jbyteArray updateTokenArr;
         jbyteArray metadataForRequestorArr;
 
@@ -4821,6 +4915,9 @@ public:
                                                       &javaMethod);
         SuccessOrExit(err);
 
+        imageURIStr = env->NewString(reinterpret_cast<const jchar *>(imageURI.data()), imageURI.size());
+        VerifyOrExit(imageURIStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
         updateTokenArr = env->NewByteArray(updateToken.size());
         VerifyOrExit(updateTokenArr != nullptr, err = CHIP_ERROR_NO_MEMORY);
         env->ExceptionClear();
@@ -4834,9 +4931,10 @@ public:
         VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jlong>(delayedActionTime),
-                            imageURIStr.jniValue(), static_cast<jlong>(softwareVersion), updateTokenArr,
+                            imageURIStr, static_cast<jlong>(softwareVersion), updateTokenArr,
                             static_cast<jboolean>(userConsentNeeded), metadataForRequestorArr);
 
+        env->DeleteLocalRef(imageURIStr);
         env->DeleteLocalRef(updateTokenArr);
         env->DeleteLocalRef(metadataForRequestorArr);
 
@@ -4895,7 +4993,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPOperationalCredentialsClusterNOCResponseCallback * cppCallback = nullptr;
-        jbyteArray DebugTextArr;
+        jstring DebugTextStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -4905,19 +5003,17 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II[B)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        DebugTextArr = env->NewByteArray(DebugText.size());
-        VerifyOrExit(DebugTextArr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        DebugTextStr = env->NewString(reinterpret_cast<const jchar *>(DebugText.data()), DebugText.size());
+        VerifyOrExit(DebugTextStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
         env->ExceptionClear();
-        env->SetByteArrayRegion(DebugTextArr, 0, DebugText.size(), reinterpret_cast<const jbyte *>(DebugText.data()));
-        VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(StatusCode), static_cast<jint>(FabricIndex),
-                            DebugTextArr);
+                            DebugTextStr);
 
-        env->DeleteLocalRef(DebugTextArr);
+        env->DeleteLocalRef(DebugTextStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5401,7 +5497,7 @@ public:
     };
 
     static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                           uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+                           chip::ByteSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5409,8 +5505,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPScenesClusterViewSceneResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString sceneNameStr(env, "");
+        jstring sceneNameStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -5423,11 +5518,17 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
+        sceneNameStr = env->NewString(reinterpret_cast<const jchar *>(sceneName.data()), sceneName.size());
+        VerifyOrExit(sceneNameStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
-                            static_cast<jint>(sceneId), static_cast<jint>(transitionTime), sceneNameStr.jniValue()
+                            static_cast<jint>(sceneId), static_cast<jint>(transitionTime), sceneNameStr
                             // extensionFieldSets: /* TYPE WARNING: array array defaults to */ uint8_t *
                             // Conversion from this type to Java is not properly implemented yet
         );
+
+        env->DeleteLocalRef(sceneNameStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5549,7 +5650,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::ByteSpan data)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5557,8 +5658,7 @@ public:
         jobject javaCallbackRef;
         jmethodID javaMethod;
         CHIPTargetNavigatorClusterNavigateTargetResponseCallback * cppCallback = nullptr;
-        // ByteSpan is not properly returned yet, temporarily use empty string
-        UtfString dataStr(env, "");
+        jstring dataStr;
 
         VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -5571,7 +5671,13 @@ public:
         err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr.jniValue());
+        dataStr = env->NewString(reinterpret_cast<const jchar *>(data.data()), data.size());
+        VerifyOrExit(dataStr != nullptr, err = CHIP_ERROR_NO_MEMORY);
+        env->ExceptionClear();
+
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr);
+
+        env->DeleteLocalRef(dataStr);
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5856,15 +5962,14 @@ public:
             ChipLogError(Zcl,
                          "Could not find class chip/devicecontroller/ChipClusters$AudioOutputCluster$AudioOutputListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(II[B)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find AudioOutputListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
             jint index      = entries[i].index;
             jint outputType = entries[i].outputType;
-            jbyteArray name = env->NewByteArray(entries[i].name.size());
-            env->SetByteArrayRegion(name, 0, entries[i].name.size(), reinterpret_cast<const jbyte *>(entries[i].name.data()));
+            jstring name    = env->NewString(reinterpret_cast<const jchar *>(entries[i].name.data()), entries[i].name.size());
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, index, outputType, name);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create AudioOutputListAttribute object"));
@@ -6365,15 +6470,13 @@ public:
             err == CHIP_NO_ERROR,
             ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$FixedLabelCluster$LabelListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "([B[B)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find LabelListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jbyteArray label = env->NewByteArray(entries[i].label.size());
-            env->SetByteArrayRegion(label, 0, entries[i].label.size(), reinterpret_cast<const jbyte *>(entries[i].label.data()));
-            jbyteArray value = env->NewByteArray(entries[i].value.size());
-            env->SetByteArrayRegion(value, 0, entries[i].value.size(), reinterpret_cast<const jbyte *>(entries[i].value.data()));
+            jstring label = env->NewString(reinterpret_cast<const jchar *>(entries[i].label.data()), entries[i].label.size());
+            jstring value = env->NewString(reinterpret_cast<const jchar *>(entries[i].value.data()), entries[i].value.size());
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, label, value);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create LabelListAttribute object"));
@@ -6451,13 +6554,12 @@ public:
                 Zcl,
                 "Could not find class chip/devicecontroller/ChipClusters$GeneralDiagnosticsCluster$NetworkInterfacesAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "([BZZZ[BI)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(Ljava/lang/String;ZZZ[BI)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find NetworkInterfacesAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jbyteArray name = env->NewByteArray(entries[i].Name.size());
-            env->SetByteArrayRegion(name, 0, entries[i].Name.size(), reinterpret_cast<const jbyte *>(entries[i].Name.data()));
+            jstring name = env->NewString(reinterpret_cast<const jchar *>(entries[i].Name.data()), entries[i].Name.size());
             jboolean fabricConnected                 = entries[i].FabricConnected;
             jboolean offPremiseServicesReachableIPv4 = entries[i].OffPremiseServicesReachableIPv4;
             jboolean offPremiseServicesReachableIPv6 = entries[i].OffPremiseServicesReachableIPv6;
@@ -6711,18 +6813,16 @@ public:
             err == CHIP_NO_ERROR,
             ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$MediaInputCluster$MediaInputListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(II[B[B)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;Ljava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find MediaInputListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jint index      = entries[i].index;
-            jint inputType  = entries[i].inputType;
-            jbyteArray name = env->NewByteArray(entries[i].name.size());
-            env->SetByteArrayRegion(name, 0, entries[i].name.size(), reinterpret_cast<const jbyte *>(entries[i].name.data()));
-            jbyteArray description = env->NewByteArray(entries[i].description.size());
-            env->SetByteArrayRegion(description, 0, entries[i].description.size(),
-                                    reinterpret_cast<const jbyte *>(entries[i].description.data()));
+            jint index     = entries[i].index;
+            jint inputType = entries[i].inputType;
+            jstring name   = env->NewString(reinterpret_cast<const jchar *>(entries[i].name.data()), entries[i].name.size());
+            jstring description =
+                env->NewString(reinterpret_cast<const jchar *>(entries[i].description.data()), entries[i].description.size());
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, index, inputType, name, description);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create MediaInputListAttribute object"));
@@ -6799,16 +6899,15 @@ public:
             ChipLogError(
                 Zcl, "Could not find class chip/devicecontroller/ChipClusters$OperationalCredentialsCluster$FabricsListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JIJ[B)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JIJLjava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find FabricsListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jlong fabricId   = entries[i].FabricId;
-            jint vendorId    = entries[i].VendorId;
-            jlong nodeId     = entries[i].NodeId;
-            jbyteArray label = env->NewByteArray(entries[i].Label.size());
-            env->SetByteArrayRegion(label, 0, entries[i].Label.size(), reinterpret_cast<const jbyte *>(entries[i].Label.data()));
+            jlong fabricId = entries[i].FabricId;
+            jint vendorId  = entries[i].VendorId;
+            jlong nodeId   = entries[i].NodeId;
+            jstring label  = env->NewString(reinterpret_cast<const jchar *>(entries[i].Label.data()), entries[i].Label.size());
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, fabricId, vendorId, nodeId, label);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create FabricsListAttribute object"));
@@ -6883,21 +6982,19 @@ public:
             err == CHIP_NO_ERROR,
             ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters$TvChannelCluster$TvChannelListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(II[B[B[B)V");
+        jmethodID attributeCtor =
+            env->GetMethodID(attributeClass, "<init>", "(IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find TvChannelListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
             jint majorNumber = entries[i].majorNumber;
             jint minorNumber = entries[i].minorNumber;
-            jbyteArray name  = env->NewByteArray(entries[i].name.size());
-            env->SetByteArrayRegion(name, 0, entries[i].name.size(), reinterpret_cast<const jbyte *>(entries[i].name.data()));
-            jbyteArray callSign = env->NewByteArray(entries[i].callSign.size());
-            env->SetByteArrayRegion(callSign, 0, entries[i].callSign.size(),
-                                    reinterpret_cast<const jbyte *>(entries[i].callSign.data()));
-            jbyteArray affiliateCallSign = env->NewByteArray(entries[i].affiliateCallSign.size());
-            env->SetByteArrayRegion(affiliateCallSign, 0, entries[i].affiliateCallSign.size(),
-                                    reinterpret_cast<const jbyte *>(entries[i].affiliateCallSign.data()));
+            jstring name     = env->NewString(reinterpret_cast<const jchar *>(entries[i].name.data()), entries[i].name.size());
+            jstring callSign =
+                env->NewString(reinterpret_cast<const jchar *>(entries[i].callSign.data()), entries[i].callSign.size());
+            jstring affiliateCallSign = env->NewString(reinterpret_cast<const jchar *>(entries[i].affiliateCallSign.data()),
+                                                       entries[i].affiliateCallSign.size());
 
             jobject attributeObj =
                 env->NewObject(attributeClass, attributeCtor, majorNumber, minorNumber, name, callSign, affiliateCallSign);
@@ -6976,14 +7073,13 @@ public:
                 Zcl,
                 "Could not find class chip/devicecontroller/ChipClusters$TargetNavigatorCluster$TargetNavigatorListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(I[B)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ILjava/lang/String;)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find TargetNavigatorListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
             jint identifier = entries[i].identifier;
-            jbyteArray name = env->NewByteArray(entries[i].name.size());
-            env->SetByteArrayRegion(name, 0, entries[i].name.size(), reinterpret_cast<const jbyte *>(entries[i].name.data()));
+            jstring name    = env->NewString(reinterpret_cast<const jchar *>(entries[i].name.data()), entries[i].name.size());
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, identifier, name);
             VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create TargetNavigatorListAttribute object"));
@@ -23232,7 +23328,7 @@ JNI_METHOD(void, TvChannelCluster, readTvChannelListAttribute)(JNIEnv * env, job
 JNI_METHOD(void, TvChannelCluster, readTvChannelLineupAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    CHIPOctetStringAttributeCallback * onSuccess = new CHIPOctetStringAttributeCallback(callback);
+    CHIPCharStringAttributeCallback * onSuccess = new CHIPCharStringAttributeCallback(callback);
     if (!onSuccess)
     {
         ReturnIllegalStateException(env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY.AsInteger());
@@ -23269,7 +23365,7 @@ JNI_METHOD(void, TvChannelCluster, readTvChannelLineupAttribute)(JNIEnv * env, j
 JNI_METHOD(void, TvChannelCluster, readCurrentTvChannelAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    CHIPOctetStringAttributeCallback * onSuccess = new CHIPOctetStringAttributeCallback(callback);
+    CHIPCharStringAttributeCallback * onSuccess = new CHIPCharStringAttributeCallback(callback);
     if (!onSuccess)
     {
         ReturnIllegalStateException(env, callback, "Error creating native success callback", CHIP_ERROR_NO_MEMORY.AsInteger());

--- a/src/controller/java/gen/ChipClusters.java
+++ b/src/controller/java/gen/ChipClusters.java
@@ -344,9 +344,9 @@ public class ChipClusters {
     public static class AudioOutputListAttribute {
       public int index;
       public int outputType;
-      public byte[] name;
+      public String name;
 
-      public AudioOutputListAttribute(int index, int outputType, byte[] name) {
+      public AudioOutputListAttribute(int index, int outputType, String name) {
         this.index = index;
         this.outputType = outputType;
         this.name = name;
@@ -2468,10 +2468,10 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class LabelListAttribute {
-      public byte[] label;
-      public byte[] value;
+      public String label;
+      public String value;
 
-      public LabelListAttribute(byte[] label, byte[] value) {
+      public LabelListAttribute(String label, String value) {
         this.label = label;
         this.value = value;
       }
@@ -2638,7 +2638,7 @@ public class ChipClusters {
     public native long initWithDevice(long devicePtr, int endpointId);
 
     public static class NetworkInterfacesAttribute {
-      public byte[] name;
+      public String name;
       public boolean fabricConnected;
       public boolean offPremiseServicesReachableIPv4;
       public boolean offPremiseServicesReachableIPv6;
@@ -2646,7 +2646,7 @@ public class ChipClusters {
       public int type;
 
       public NetworkInterfacesAttribute(
-          byte[] name,
+          String name,
           boolean fabricConnected,
           boolean offPremiseServicesReachableIPv4,
           boolean offPremiseServicesReachableIPv6,
@@ -3112,10 +3112,10 @@ public class ChipClusters {
     public static class MediaInputListAttribute {
       public int index;
       public int inputType;
-      public byte[] name;
-      public byte[] description;
+      public String name;
+      public String description;
 
-      public MediaInputListAttribute(int index, int inputType, byte[] name, byte[] description) {
+      public MediaInputListAttribute(int index, int inputType, String name, String description) {
         this.index = index;
         this.inputType = inputType;
         this.name = name;
@@ -3830,7 +3830,7 @@ public class ChipClusters {
         long chipClusterPtr, NOCResponseCallback callback, byte[] nOCArray);
 
     public interface NOCResponseCallback {
-      void onSuccess(int StatusCode, int FabricIndex, byte[] DebugText);
+      void onSuccess(int StatusCode, int FabricIndex, String DebugText);
 
       void onError(Exception error);
     }
@@ -3845,9 +3845,9 @@ public class ChipClusters {
       public long fabricId;
       public int vendorId;
       public long nodeId;
-      public byte[] label;
+      public String label;
 
-      public FabricsListAttribute(long fabricId, int vendorId, long nodeId, byte[] label) {
+      public FabricsListAttribute(long fabricId, int vendorId, long nodeId, String label) {
         this.fabricId = fabricId;
         this.vendorId = vendorId;
         this.nodeId = nodeId;
@@ -4309,16 +4309,16 @@ public class ChipClusters {
     public static class TvChannelListAttribute {
       public int majorNumber;
       public int minorNumber;
-      public byte[] name;
-      public byte[] callSign;
-      public byte[] affiliateCallSign;
+      public String name;
+      public String callSign;
+      public String affiliateCallSign;
 
       public TvChannelListAttribute(
           int majorNumber,
           int minorNumber,
-          byte[] name,
-          byte[] callSign,
-          byte[] affiliateCallSign) {
+          String name,
+          String callSign,
+          String affiliateCallSign) {
         this.majorNumber = majorNumber;
         this.minorNumber = minorNumber;
         this.name = name;
@@ -4337,11 +4337,11 @@ public class ChipClusters {
       readTvChannelListAttribute(chipClusterPtr, callback);
     }
 
-    public void readTvChannelLineupAttribute(OctetStringAttributeCallback callback) {
+    public void readTvChannelLineupAttribute(CharStringAttributeCallback callback) {
       readTvChannelLineupAttribute(chipClusterPtr, callback);
     }
 
-    public void readCurrentTvChannelAttribute(OctetStringAttributeCallback callback) {
+    public void readCurrentTvChannelAttribute(CharStringAttributeCallback callback) {
       readCurrentTvChannelAttribute(chipClusterPtr, callback);
     }
 
@@ -4353,10 +4353,10 @@ public class ChipClusters {
         long chipClusterPtr, TvChannelListAttributeCallback callback);
 
     private native void readTvChannelLineupAttribute(
-        long chipClusterPtr, OctetStringAttributeCallback callback);
+        long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void readCurrentTvChannelAttribute(
-        long chipClusterPtr, OctetStringAttributeCallback callback);
+        long chipClusterPtr, CharStringAttributeCallback callback);
 
     private native void readClusterRevisionAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
@@ -4385,9 +4385,9 @@ public class ChipClusters {
 
     public static class TargetNavigatorListAttribute {
       public int identifier;
-      public byte[] name;
+      public String name;
 
-      public TargetNavigatorListAttribute(int identifier, byte[] name) {
+      public TargetNavigatorListAttribute(int identifier, String name) {
         this.identifier = identifier;
         this.name = name;
       }

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -276,8 +276,8 @@ class CHIP{{chipCallback.name}}AttributeCallback : public Callback::Callback<{{c
             err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
             VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess method"));
 
-            UtfString valueStr(env, value);
-            env->CallVoidMethod(javaCallbackRef, javaMethod, valueStr.jniValue());
+            jstring valueStr = env->NewString(reinterpret_cast<const jchar *>(value.data()), value.size());
+            env->CallVoidMethod(javaCallbackRef, javaMethod, valueStr);
             {{/if}}
         }
 
@@ -327,8 +327,7 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
             {{else if (isShortString type)}}
-            // ByteSpan is not properly returned yet, temporarily use empty string
-            UtfString {{asSymbol label}}Str(env, "");
+            jstring {{asSymbol label}}Str;
             {{/if}}
             {{/chip_cluster_response_arguments}}
 
@@ -350,6 +349,10 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
             env->ExceptionClear();
             env->SetByteArrayRegion({{asSymbol label}}Arr, 0, {{asSymbol label}}.size(), reinterpret_cast<const jbyte *>({{asSymbol label}}.data()));
             VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
+            {{else if (isCharString type)}}
+            {{asSymbol label}}Str = env->NewString(reinterpret_cast<const jchar *>({{asSymbol label}}.data()), {{asSymbol label}}.size());
+            VerifyOrExit({{asSymbol label}}Str != nullptr, err = CHIP_ERROR_NO_MEMORY);
+            env->ExceptionClear();
             {{/if}}
             {{/chip_cluster_response_arguments}}
 
@@ -361,7 +364,7 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
                 {{else if (isOctetString type)}}
                 , {{asSymbol label}}Arr
                 {{else if (isShortString type)}}
-                , {{asSymbol label}}Str.jniValue()
+                , {{asSymbol label}}Str
                 {{else}}
                 , static_cast<{{asJniBasicTypeForZclType type}}>({{asSymbol label}})
                 {{/if}}
@@ -371,6 +374,8 @@ class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callba
             {{#chip_cluster_response_arguments}}
             {{#if (isOctetString type)}}
             env->DeleteLocalRef({{asSymbol label}}Arr);
+            {{else if (isCharString type)}}
+            env->DeleteLocalRef({{asSymbol label}}Str);
             {{/if}}
             {{/chip_cluster_response_arguments}}
 
@@ -458,7 +463,7 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
                 jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entries[i].{{name}}.size());
                 env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entries[i].{{name}}.size(), reinterpret_cast<const jbyte *>(entries[i].{{name}}.data()));
                 {{else if (isCharString type)}}
-                // Implement after ByteSpan is emitted instead of uint8_t *.
+                jstring {{asLowerCamelCase name}} = env->NewString(reinterpret_cast<const jchar *>(entries[i].{{name}}.data()), entries[i].{{name}}.size());
                 {{else}}
                 {{asJniBasicType type}} {{asLowerCamelCase name}} = entries[i].{{name}};
                 {{/if}}
@@ -477,7 +482,7 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
                 jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entries[i].size());
                 env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entries[i].size(), reinterpret_cast<const jbyte *>(entries[i].data()));
                 {{else if (isCharString type)}}
-                // Implement after ByteSpan is emitted instead of uint8_t *
+                jstring {{asLowerCamelCase name}} = env->NewString(reinterpret_cast<const jchar *>(entries[i].{{name}}.data()), entries[i].{{name}}.size());
                 {{else}}
                 jclass entryTypeCls;
                 JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", entryTypeCls);

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -122,7 +122,7 @@ public class ChipClusters {
       {{#if (isOctetString type)}}
       public byte[] {{asLowerCamelCase name}};
       {{else if (isCharString type)}}
-      // Add String member here after ByteSpan is properly emitted in C++ layer
+      public String {{asLowerCamelCase name}};
       {{else}}
       public {{asJavaBasicType label type}} {{asLowerCamelCase name}};
       {{/if}}
@@ -133,7 +133,7 @@ public class ChipClusters {
         {{#if (isOctetString type)}}
         byte[] {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{else if (isCharString type)}}
-        // Add String field here after ByteSpan is properly emitted in C++ layer
+        String {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{else}}
         {{asJavaBasicType label type}} {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{/if}}

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -4396,7 +4396,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TvChannel_TvChannelLineup(ch
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TvChannelCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.ReadAttributeTvChannelLineup(gOctetStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel())
+    return cluster.ReadAttributeTvChannelLineup(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel())
         .AsInteger();
 }
 
@@ -4407,7 +4407,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TvChannel_CurrentTvChannel(c
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TvChannelCluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.ReadAttributeCurrentTvChannel(gOctetStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel())
+    return cluster.ReadAttributeCurrentTvChannel(gCharStringAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel())
         .AsInteger();
 }
 

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -2556,12 +2556,12 @@ class ChipClusters:
                 0x00000001: {
                     "attributeName": "TvChannelLineup",
                     "attributeId": 0x00000001,
-                    "type": "bytes",
+                    "type": "str",
                 },
                 0x00000002: {
                     "attributeName": "CurrentTvChannel",
                     "attributeId": 0x00000002,
-                    "type": "bytes",
+                    "type": "str",
                 },
                 0x0000FFFD: {
                     "attributeName": "ClusterRevision",

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -464,14 +464,16 @@ public:
 
     ~CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t * setupPIN)
+    static void CallbackFn(void * context, chip::ByteSpan setupPIN)
     {
         CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge * callback
             = reinterpret_cast<CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
-                    @"setupPIN" : [NSString stringWithFormat:@"%s", setupPIN],
+                    @"setupPIN" : [[NSString alloc] initWithBytes:setupPIN.data()
+                                                           length:setupPIN.size()
+                                                         encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -496,7 +498,7 @@ public:
 
     ~CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::ByteSpan data)
     {
         CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge * callback
             = reinterpret_cast<CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge *>(context);
@@ -504,7 +506,7 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"status" : [NSNumber numberWithUnsignedChar:status],
-                    @"data" : [NSString stringWithFormat:@"%s", data],
+                    @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -529,14 +531,14 @@ public:
 
     ~CHIPContentLauncherClusterLaunchContentResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
     {
         CHIPContentLauncherClusterLaunchContentResponseCallbackBridge * callback
             = reinterpret_cast<CHIPContentLauncherClusterLaunchContentResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
-                    @"data" : [NSString stringWithFormat:@"%s", data],
+                    @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
                     @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
                 });
                 callback->Cancel();
@@ -562,14 +564,14 @@ public:
 
     ~CHIPContentLauncherClusterLaunchURLResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t * data, uint8_t contentLaunchStatus)
+    static void CallbackFn(void * context, chip::ByteSpan data, uint8_t contentLaunchStatus)
     {
         CHIPContentLauncherClusterLaunchURLResponseCallbackBridge * callback
             = reinterpret_cast<CHIPContentLauncherClusterLaunchURLResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
-                    @"data" : [NSString stringWithFormat:@"%s", data],
+                    @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
                     @"contentLaunchStatus" : [NSNumber numberWithUnsignedChar:contentLaunchStatus],
                 });
                 callback->Cancel();
@@ -855,7 +857,7 @@ public:
     ~CHIPDoorLockClusterGetLogRecordResponseCallbackBridge() {};
 
     static void CallbackFn(void * context, uint16_t logEntryId, uint32_t timestamp, uint8_t eventType, uint8_t source,
-        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
+        uint8_t eventIdOrAlarmCode, uint16_t userId, chip::ByteSpan pin)
     {
         CHIPDoorLockClusterGetLogRecordResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterGetLogRecordResponseCallbackBridge *>(context);
@@ -868,7 +870,7 @@ public:
                     @"source" : [NSNumber numberWithUnsignedChar:source],
                     @"eventIdOrAlarmCode" : [NSNumber numberWithUnsignedChar:eventIdOrAlarmCode],
                     @"userId" : [NSNumber numberWithUnsignedShort:userId],
-                    @"pin" : [NSString stringWithFormat:@"%s", pin],
+                    @"pin" : [[NSString alloc] initWithBytes:pin.data() length:pin.size() encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -892,7 +894,7 @@ public:
 
     ~CHIPDoorLockClusterGetPinResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * pin)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan pin)
     {
         CHIPDoorLockClusterGetPinResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterGetPinResponseCallbackBridge *>(context);
@@ -902,7 +904,7 @@ public:
                     @"userId" : [NSNumber numberWithUnsignedShort:userId],
                     @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
                     @"userType" : [NSNumber numberWithUnsignedChar:userType],
-                    @"pin" : [NSString stringWithFormat:@"%s", pin],
+                    @"pin" : [[NSString alloc] initWithBytes:pin.data() length:pin.size() encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -926,7 +928,7 @@ public:
 
     ~CHIPDoorLockClusterGetRfidResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, uint8_t * rfid)
+    static void CallbackFn(void * context, uint16_t userId, uint8_t userStatus, uint8_t userType, chip::ByteSpan rfid)
     {
         CHIPDoorLockClusterGetRfidResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterGetRfidResponseCallbackBridge *>(context);
@@ -936,7 +938,7 @@ public:
                     @"userId" : [NSNumber numberWithUnsignedShort:userId],
                     @"userStatus" : [NSNumber numberWithUnsignedChar:userStatus],
                     @"userType" : [NSNumber numberWithUnsignedChar:userType],
-                    @"rfid" : [NSString stringWithFormat:@"%s", rfid],
+                    @"rfid" : [[NSString alloc] initWithBytes:rfid.data() length:rfid.size() encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -1353,7 +1355,7 @@ public:
 
     ~CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGeneralCommissioningClusterArmFailSafeResponseCallbackBridge *>(context);
@@ -1361,7 +1363,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -1386,7 +1390,7 @@ public:
 
     ~CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGeneralCommissioningClusterCommissioningCompleteResponseCallbackBridge *>(context);
@@ -1394,7 +1398,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -1419,7 +1425,7 @@ public:
 
     ~CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseCallbackBridge *>(context);
@@ -1427,7 +1433,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -1551,7 +1559,7 @@ public:
 
     ~CHIPGroupsClusterViewGroupResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, chip::ByteSpan groupName)
     {
         CHIPGroupsClusterViewGroupResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGroupsClusterViewGroupResponseCallbackBridge *>(context);
@@ -1560,7 +1568,9 @@ public:
                 callback->mHandler(nil, @ {
                     @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
-                    @"groupName" : [NSString stringWithFormat:@"%s", groupName],
+                    @"groupName" : [[NSString alloc] initWithBytes:groupName.data()
+                                                            length:groupName.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2000,7 +2010,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterAddThreadNetworkResponseCallbackBridge *>(context);
@@ -2008,7 +2018,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2033,7 +2045,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterAddWiFiNetworkResponseCallbackBridge *>(context);
@@ -2041,7 +2053,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2066,7 +2080,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterDisableNetworkResponseCallbackBridge *>(context);
@@ -2074,7 +2088,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2099,7 +2115,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterEnableNetworkResponseCallbackBridge *>(context);
@@ -2107,7 +2123,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2132,7 +2150,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterRemoveNetworkResponseCallbackBridge *>(context);
@@ -2140,7 +2158,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2165,7 +2185,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterScanNetworksResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText,
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText,
         /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
         /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
     {
@@ -2175,7 +2195,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                     // wifiScanResults: /* TYPE WARNING: array array defaults to */ uint8_t *
                     // Conversion from this type to Objc is not properly implemented yet
                     // threadScanResults: /* TYPE WARNING: array array defaults to */ uint8_t *
@@ -2204,7 +2226,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterUpdateThreadNetworkResponseCallbackBridge *>(context);
@@ -2212,7 +2234,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2237,7 +2261,7 @@ public:
 
     ~CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t errorCode, uint8_t * debugText)
+    static void CallbackFn(void * context, uint8_t errorCode, chip::ByteSpan debugText)
     {
         CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge * callback
             = reinterpret_cast<CHIPNetworkCommissioningClusterUpdateWiFiNetworkResponseCallbackBridge *>(context);
@@ -2245,7 +2269,9 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"errorCode" : [NSNumber numberWithUnsignedChar:errorCode],
-                    @"debugText" : [NSString stringWithFormat:@"%s", debugText],
+                    @"debugText" : [[NSString alloc] initWithBytes:debugText.data()
+                                                            length:debugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2303,8 +2329,8 @@ public:
 
     ~CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-        chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, chip::ByteSpan imageURI,
+        uint32_t softwareVersion, chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge * callback
             = reinterpret_cast<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge *>(context);
@@ -2313,7 +2339,9 @@ public:
                 callback->mHandler(nil, @ {
                     @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"delayedActionTime" : [NSNumber numberWithUnsignedLong:delayedActionTime],
-                    @"imageURI" : [NSString stringWithFormat:@"%s", imageURI],
+                    @"imageURI" : [[NSString alloc] initWithBytes:imageURI.data()
+                                                           length:imageURI.size()
+                                                         encoding:NSUTF8StringEncoding],
                     @"softwareVersion" : [NSNumber numberWithUnsignedLong:softwareVersion],
                     @"updateToken" : [NSData dataWithBytes:updateToken.data() length:updateToken.size()],
                     @"userConsentNeeded" : [NSNumber numberWithBool:userConsentNeeded],
@@ -2351,7 +2379,9 @@ public:
                 callback->mHandler(nil, @ {
                     @"StatusCode" : [NSNumber numberWithUnsignedChar:StatusCode],
                     @"FabricIndex" : [NSNumber numberWithUnsignedChar:FabricIndex],
-                    @"DebugText" : [NSData dataWithBytes:DebugText.data() length:DebugText.size()],
+                    @"DebugText" : [[NSString alloc] initWithBytes:DebugText.data()
+                                                            length:DebugText.size()
+                                                          encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2579,7 +2609,7 @@ public:
     ~CHIPScenesClusterViewSceneResponseCallbackBridge() {};
 
     static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-        uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+        chip::ByteSpan sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
         CHIPScenesClusterViewSceneResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterViewSceneResponseCallbackBridge *>(context);
@@ -2590,7 +2620,9 @@ public:
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
                     @"transitionTime" : [NSNumber numberWithUnsignedShort:transitionTime],
-                    @"sceneName" : [NSString stringWithFormat:@"%s", sceneName],
+                    @"sceneName" : [[NSString alloc] initWithBytes:sceneName.data()
+                                                            length:sceneName.size()
+                                                          encoding:NSUTF8StringEncoding],
                     // extensionFieldSets: /* TYPE WARNING: array array defaults to */ uint8_t *
                     // Conversion from this type to Objc is not properly implemented yet
                 });
@@ -2651,7 +2683,7 @@ public:
 
     ~CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, chip::ByteSpan data)
     {
         CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge * callback
             = reinterpret_cast<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge *>(context);
@@ -2659,7 +2691,7 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"status" : [NSNumber numberWithUnsignedChar:status],
-                    @"data" : [NSString stringWithFormat:@"%s", data],
+                    @"data" : [[NSString alloc] initWithBytes:data.data() length:data.size() encoding:NSUTF8StringEncoding],
                 });
                 callback->Cancel();
                 delete callback;
@@ -2793,7 +2825,9 @@ public:
             for (uint16_t i = 0; i < count; i++) {
                 values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedChar:entries[i].index],
                                                   @"index", [NSNumber numberWithUnsignedChar:entries[i].outputType], @"outputType",
-                                                  [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()],
+                                                  [[NSString alloc] initWithBytes:entries[i].name.data()
+                                                                           length:entries[i].name.size()
+                                                                         encoding:NSUTF8StringEncoding],
                                                   @"name", nil];
             }
 
@@ -3042,9 +3076,14 @@ public:
         if (callback && callback->mQueue) {
             id values[count];
             for (uint16_t i = 0; i < count; i++) {
-                values[i] = [[NSDictionary alloc]
-                    initWithObjectsAndKeys:[NSData dataWithBytes:entries[i].label.data() length:entries[i].label.size()], @"label",
-                    [NSData dataWithBytes:entries[i].value.data() length:entries[i].value.size()], @"value", nil];
+                values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[[NSString alloc] initWithBytes:entries[i].label.data()
+                                                                                                  length:entries[i].label.size()
+                                                                                                encoding:NSUTF8StringEncoding],
+                                                  @"label",
+                                                  [[NSString alloc] initWithBytes:entries[i].value.data()
+                                                                           length:entries[i].value.size()
+                                                                         encoding:NSUTF8StringEncoding],
+                                                  @"value", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -3081,8 +3120,10 @@ public:
             id values[count];
             for (uint16_t i = 0; i < count; i++) {
                 values[i] = [[NSDictionary alloc]
-                    initWithObjectsAndKeys:[NSData dataWithBytes:entries[i].Name.data() length:entries[i].Name.size()], @"Name",
-                    [NSNumber numberWithBool:entries[i].FabricConnected], @"FabricConnected",
+                    initWithObjectsAndKeys:[[NSString alloc] initWithBytes:entries[i].Name.data()
+                                                                    length:entries[i].Name.size()
+                                                                  encoding:NSUTF8StringEncoding],
+                    @"Name", [NSNumber numberWithBool:entries[i].FabricConnected], @"FabricConnected",
                     [NSNumber numberWithBool:entries[i].OffPremiseServicesReachableIPv4], @"OffPremiseServicesReachableIPv4",
                     [NSNumber numberWithBool:entries[i].OffPremiseServicesReachableIPv6], @"OffPremiseServicesReachableIPv6",
                     [NSData dataWithBytes:entries[i].HardwareAddress.data() length:entries[i].HardwareAddress.size()],
@@ -3202,11 +3243,16 @@ public:
         if (callback && callback->mQueue) {
             id values[count];
             for (uint16_t i = 0; i < count; i++) {
-                values[i] = [[NSDictionary alloc]
-                    initWithObjectsAndKeys:[NSNumber numberWithUnsignedChar:entries[i].index], @"index",
-                    [NSNumber numberWithUnsignedChar:entries[i].inputType], @"inputType",
-                    [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()], @"name",
-                    [NSData dataWithBytes:entries[i].description.data() length:entries[i].description.size()], @"description", nil];
+                values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedChar:entries[i].index],
+                                                  @"index", [NSNumber numberWithUnsignedChar:entries[i].inputType], @"inputType",
+                                                  [[NSString alloc] initWithBytes:entries[i].name.data()
+                                                                           length:entries[i].name.size()
+                                                                         encoding:NSUTF8StringEncoding],
+                                                  @"name",
+                                                  [[NSString alloc] initWithBytes:entries[i].description.data()
+                                                                           length:entries[i].description.size()
+                                                                         encoding:NSUTF8StringEncoding],
+                                                  @"description", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -3245,7 +3291,9 @@ public:
                 values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                                   @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
                                                   [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId",
-                                                  [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()],
+                                                  [[NSString alloc] initWithBytes:entries[i].Label.data()
+                                                                           length:entries[i].Label.size()
+                                                                         encoding:NSUTF8StringEncoding],
                                                   @"Label", nil];
             }
 
@@ -3281,13 +3329,21 @@ public:
         if (callback && callback->mQueue) {
             id values[count];
             for (uint16_t i = 0; i < count; i++) {
-                values[i] = [[NSDictionary alloc]
-                    initWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:entries[i].majorNumber], @"majorNumber",
-                    [NSNumber numberWithUnsignedShort:entries[i].minorNumber], @"minorNumber",
-                    [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()], @"name",
-                    [NSData dataWithBytes:entries[i].callSign.data() length:entries[i].callSign.size()], @"callSign",
-                    [NSData dataWithBytes:entries[i].affiliateCallSign.data() length:entries[i].affiliateCallSign.size()],
-                    @"affiliateCallSign", nil];
+                values[i] =
+                    [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:entries[i].majorNumber],
+                                          @"majorNumber", [NSNumber numberWithUnsignedShort:entries[i].minorNumber], @"minorNumber",
+                                          [[NSString alloc] initWithBytes:entries[i].name.data()
+                                                                   length:entries[i].name.size()
+                                                                 encoding:NSUTF8StringEncoding],
+                                          @"name",
+                                          [[NSString alloc] initWithBytes:entries[i].callSign.data()
+                                                                   length:entries[i].callSign.size()
+                                                                 encoding:NSUTF8StringEncoding],
+                                          @"callSign",
+                                          [[NSString alloc] initWithBytes:entries[i].affiliateCallSign.data()
+                                                                   length:entries[i].affiliateCallSign.size()
+                                                                 encoding:NSUTF8StringEncoding],
+                                          @"affiliateCallSign", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -3323,9 +3379,12 @@ public:
         if (callback && callback->mQueue) {
             id values[count];
             for (uint16_t i = 0; i < count; i++) {
-                values[i] = [[NSDictionary alloc]
-                    initWithObjectsAndKeys:[NSNumber numberWithUnsignedChar:entries[i].identifier], @"identifier",
-                    [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()], @"name", nil];
+                values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedChar:entries[i].identifier],
+                                                  @"identifier",
+                                                  [[NSString alloc] initWithBytes:entries[i].name.data()
+                                                                           length:entries[i].name.size()
+                                                                         encoding:NSUTF8StringEncoding],
+                                                  @"name", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -15340,8 +15399,8 @@ private:
 
 - (void)readAttributeTvChannelLineupWithResponseHandler:(ResponseHandler)responseHandler
 {
-    CHIPOctetStringAttributeCallbackBridge * onSuccess
-        = new CHIPOctetStringAttributeCallbackBridge(responseHandler, [self callbackQueue]);
+    CHIPCharStringAttributeCallbackBridge * onSuccess
+        = new CHIPCharStringAttributeCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
         responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
         return;
@@ -15368,8 +15427,8 @@ private:
 
 - (void)readAttributeCurrentTvChannelWithResponseHandler:(ResponseHandler)responseHandler
 {
-    CHIPOctetStringAttributeCallbackBridge * onSuccess
-        = new CHIPOctetStringAttributeCallbackBridge(responseHandler, [self callbackQueue]);
+    CHIPCharStringAttributeCallbackBridge * onSuccess
+        = new CHIPCharStringAttributeCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
         responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
         return;

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -53,7 +53,7 @@ public:
                   {{else if (isOctetString type)}}
                   @"{{asSymbol label}}": [NSData dataWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size()],
                   {{else if (isCharString type)}}
-                  @"{{asSymbol label}}": [NSString stringWithFormat:@"%s", {{asSymbol label}}],
+                  @"{{asSymbol label}}": [[NSString alloc] initWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size() encoding:NSUTF8StringEncoding],
                   {{else}}
                   @"{{asSymbol label}}": [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
                   {{/if}}
@@ -98,7 +98,7 @@ public:
                     {{#if (isOctetString type)}}
                     [NSData dataWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size()],
                     {{else}}
-                    [[NSString alloc] initWithBytes:entries[i].{{name}}+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i].{{name}}) encoding:NSUTF8StringEncoding],
+                    [[NSString alloc] initWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size() encoding:NSUTF8StringEncoding],
                     {{/if}}
                     {{else}}
                     [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i].{{name}}],
@@ -111,7 +111,7 @@ public:
                 {{#if (isOctetString type)}}
                 values[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
                 {{else}}
-                values[i] = [[NSString alloc] initWithBytes:entries[i]+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i]) encoding:NSUTF8StringEncoding];
+                values[i] = [[NSString alloc] initWithBytes:entries[i].data() length:entries[i].size() encoding:NSUTF8StringEncoding];
                 {{/if}}
                 {{else}}
                 values[i] = [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i]];
@@ -220,7 +220,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asLowerCamelCase label}}.bytes, {{asLowerCamelCase label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asLowerCamelCase label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asLowerCamelCase label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
+        err = self.cppCluster.{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{#if (isOctetString type)}}{{asLowerCamelCase label}}.bytes, {{asLowerCamelCase label}}.length{{else}}[{{asLowerCamelCase label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asLowerCamelCase label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]{{/if}}){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -282,10 +282,10 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         {{#if (isOctetString type)}}
-        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)value.bytes, value.length));
+        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), {{asUnderlyingZclType type}}((const uint8_t*)value.bytes, value.length));
         {{else if (isCharString type)}}
         NSData * data = [value dataUsingEncoding:NSUTF8StringEncoding];
-        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)data.bytes, data.length));
+        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), {{asUnderlyingZclType type}}((const uint8_t*)data.bytes, data.length));
         {{else}}
         err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), value);
         {{/if}}

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -81,8 +81,7 @@ public:
     // Returns a pointer to a null terminated char array
     const uint8_t * GetFabricLabel() const { return Uint8::from_const_char(mFabricLabel); };
 
-    // Expects a pointer to a null terminated char array
-    CHIP_ERROR SetFabricLabel(const uint8_t * fabricLabel);
+    CHIP_ERROR SetFabricLabel(chip::ByteSpan label);
 
     ~FabricInfo()
     {


### PR DESCRIPTION
#### Problem

This PR uses `chip::ByteSpan` for `OCTET_STRING`, `CHAR_STRING`, `LONG_OCTET_STRING` and `LONG_CHAR_STRING`.

I'm keeping it as a draft at the moment since there are various codepaths that I have not tested locally...

#fixes  #7112, #7655, #6112

#### Change overview
 * Use `chip::ByteSpan` under the hood for `OCTET_STRING`, `CHAR_STRING`, `LONG_OCTET_STRING` and `LONG_CHAR_STRING`.
 * Update XML definitions for structs that were using `OCTET_STRING` instead of `CHAR_STRING`
 * Update various callbacks that were expecting a `uint8_t *`

#### Testing
 * It was tested locally but I still need to do various checks before removing it from the draft state. Particularly because I have updated the code of some clusters that does not have any tests...
