### PR TITLE
[TE4] Add command to generate setup code, QR code with various parame…

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -52,6 +52,7 @@ shared_library("ChipDeviceCtrl") {
     "chip/internal/CommissionerImpl.cpp",
     "chip/logging/LoggingRedirect.cpp",
     "chip/native/StackInit.cpp",
+    "chip/setup_payload/Generator.cpp",
     "chip/setup_payload/Parser.cpp",
   ]
 

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -383,6 +383,17 @@ address of the node in the device controller:
 chip-device-ctrl > resolve 5544332211 1234
 ```
 
+### `setup-payload generate [-v <Vendor ID>] [-p <Product ID>] [-cf <Custom Flow>] [-dc <Discovery Capabilities>] [-dv <Discriminator Value>] [-ps <Passcode>]`
+
+Print the generated Onboarding Payload Contents in human-readable (Manual
+Pairing Code) and machine-readable (QR Code) format:
+
+```
+chip-device-ctrl > setup-payload generate -v 9050 -p 65279 -cf 0 -dc 2 -dv 2976 -ps 34567890
+Manual pairing code: [26318621095]
+SetupQRCode: [MT:YNJV7VSC00CMVH7SR00]
+```
+
 ### `setup-payload parse-manual <manual-pairing-code>`
 
 Print the commissioning information encoded in the Manual Pairing Code:

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -320,20 +320,42 @@ class DeviceMgrCmd(Cmd):
 
     def do_setuppayload(self, line):
         """
+        setup-payload generate [options]
+
+        Options:
+          -v   Vendor ID
+          -p   Product ID
+          -cf  Custom Flow [Standard = 0, UserActionRequired = 1, Custom = 2]
+          -dc  Discovery Capabilities [SoftAP = 1 | BLE = 2 | OnNetwork = 4]
+          -dv  Discriminator Value
+          -ps  Passcode
+
         setup-payload parse-manual <manual-pairing-code>
         setup-payload parse-qr <qr-code-payload>
         """
         try:
-            args = shlex.split(line)
-            if (len(args) != 2) or (args[0] not in ("parse-manual", "parse-qr")):
+            arglist = shlex.split(line)
+            if arglist[0] not in ("generate", "parse-manual", "parse-qr"):
                 self.do_help("setup-payload")
                 return
 
-            if args[0] == "parse-manual":
-                SetupPayload().ParseManualPairingCode(args[1]).Print()
+            if arglist[0] == "generate":
+                parser = argparse.ArgumentParser()
+                parser.add_argument("-v", type=int, default=0, dest='vendorId')
+                parser.add_argument("-p", type=int, default=0, dest='productId')
+                parser.add_argument('-cf', type=int, default=0, dest='customFlow')
+                parser.add_argument("-dc", type=int, default=0, dest='capabilities')
+                parser.add_argument("-dv", type=int, default=0, dest='discriminator')
+                parser.add_argument("-ps", type=int, dest='passcode')                
+                args = parser.parse_args(arglist[1:])
 
-            if args[0] == "parse-qr":
-                SetupPayload().ParseQrCode(args[1]).Print()
+                SetupPayload().PrintOnboardingCodes(args.passcode, args.vendorId, args.productId, args.discriminator, args.customFlow, args.capabilities)
+
+            if arglist[0] == "parse-manual":
+                SetupPayload().ParseManualPairingCode(arglist[1]).Print()
+
+            if arglist[0] == "parse-qr":
+                SetupPayload().ParseQrCode(arglist[1]).Print()
 
         except exceptions.ChipStackException as ex:
             print(str(ex))

--- a/src/controller/python/chip/setup_payload/Generator.cpp
+++ b/src/controller/python/chip/setup_payload/Generator.cpp
@@ -1,0 +1,64 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <support/CodeUtils.h>
+
+#include <string>
+
+using namespace chip;
+
+extern "C" CHIP_ERROR pychip_SetupPayload_PrintOnboardingCodes(uint32_t passcode, uint16_t vendorId, uint16_t productId,
+                                                               uint16_t discriminator, uint8_t customFlow, uint8_t capabilities)
+{
+    std::string QRCode;
+    std::string manualPairingCode;
+    SetupPayload payload;
+    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kNone;
+
+    payload.version               = 0;
+    payload.setUpPINCode          = passcode;
+    payload.vendorID              = vendorId;
+    payload.productID             = productId;
+    payload.discriminator         = discriminator;
+    payload.rendezvousInformation = rendezvousFlags.SetRaw(capabilities);
+
+    switch (customFlow)
+    {
+    case 0:
+        payload.commissioningFlow = CommissioningFlow::kStandard;
+        break;
+    case 1:
+        payload.commissioningFlow = CommissioningFlow::kUserActionRequired;
+        break;
+    case 2:
+        payload.commissioningFlow = CommissioningFlow::kCustom;
+        break;
+    default:
+        ChipLogError(SetupPayload, "Invalid Custom Flow");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    ReturnErrorOnFailure(ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode));
+    ChipLogProgress(SetupPayload, "Manual pairing code: [%s]", manualPairingCode.c_str());
+
+    ReturnErrorOnFailure(QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode));
+    ChipLogProgress(SetupPayload, "SetupQRCode: [%s]", QRCode.c_str());
+
+    return CHIP_NO_ERROR;
+}

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -62,6 +62,13 @@ class SetupPayload:
 
         return self
 
+    def PrintOnboardingCodes(self, passcode, vendorId, productId, discriminator, customFlow, capabilities):
+        self.Clear()
+        err = self.chipLib.pychip_SetupPayload_PrintOnboardingCodes(passcode, vendorId, productId, discriminator, customFlow, capabilities)
+
+        if err != 0:
+            raise ChipStackError(err)
+
     def Print(self):
         for name, value in self.attributes.items():
             decorated_value = self.__DecorateValue(name, value)
@@ -95,3 +102,6 @@ class SetupPayload:
         setter.Set("pychip_SetupPayload_ParseManualPairingCode",
                    c_int32,
                    [c_char_p, SetupPayload.AttributeVisitor, SetupPayload.VendorAttributeVisitor])
+        setter.Set("pychip_SetupPayload_PrintOnboardingCodes",
+                   c_int32,
+                   [c_uint32, c_uint16, c_uint16, c_uint16, uint8_t, uint8_t])


### PR DESCRIPTION
…ters

#### Problem
What is being fixed?  Examples:
Python controller misses command to generate setup code, QR code, this is needed to generated setupCode/QRcode with various parameters for certification testing of controllers to have them verify all invalid combinations. Right now we are using setup code/QRcode generated in the sample apps. but for certification testing we need to generate different combinations of these codes.

* Fixes #7015
#### Change overview
Add command to generate setup code, QR code with various parameters

#### Testing
How was this tested? (at least one bullet point required)
1. Test generate is added to setup-payload
```
chip-device-ctrl > setup-payload ?

setup-payload generate [options]

Options:
  -v   Vendor ID
  -p   Product ID
  -cf  Custom Flow [Standard = 0, UserActionRequired = 1, Custom = 2]
  -dc  Discovery Capabilities [SoftAP = 1 | BLE = 2 | OnNetwork = 4]
  -dv  Discriminator Value
  -ps  Passcode

setup-payload parse-manual <manual-pairing-code>
setup-payload parse-qr <qr-code-payload>
```
2. Generate Manual and QR code with default values used in chip-all-clusters-app 
```
chip-device-ctrl > setup-payload generate -v 9050 -p 65279 -cf 0 -dc 2 -dv 2976 -ps 34567890
[1624904564.806728][902702] CHIP:SPL: Manual pairing code: [26318621095]
[1624904564.806764][902702] CHIP:SPL: SetupQRCode: [MT:YNJV7VSC00CMVH7SR00]

And confirm the generated codes are same from the codes generated by chip-all-clusters-app by default.
  
[1624898988.117261][825377] CHIP:SVR: SetupQRCode: [MT:YNJV7VSC00CMVH7SR00]
[1624898988.117292][825377] CHIP:SVR: Manual pairing code: [26318621095]
```

3. Input invalid passcode and confirm the CHIP_ERROR_INVALID_ARGUMENT is returned
```
chip-device-ctrl > 
chip-device-ctrl > setup-payload generate -ps 0
[1624904575.396974][902702] CHIP:SPL: Failed encoding invalid payload
Chip Stack Error 4047
chip-device-ctrl > 
```
