### PR TITLE
Added Command Line Tool to Generate Attestation Certificates

### DIFF
--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -23,6 +23,7 @@ executable("chip-cert") {
     "CertUtils.cpp",
     "Cmd_ConvertCert.cpp",
     "Cmd_ConvertKey.cpp",
+    "Cmd_GenAttCert.cpp",
     "Cmd_GenCert.cpp",
     "Cmd_PrintCert.cpp",
     "Cmd_ResignCert.cpp",

--- a/src/tools/chip-cert/Cmd_GenAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenAttCert.cpp
@@ -1,0 +1,389 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that generates attestation certificates.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include "chip-cert.h"
+
+#include <support/SafeInt.h>
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert gen-att-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "type",             kArgumentRequired, 't' },
+    { "subject-cn",       kArgumentRequired, 'c' },
+    { "subject-vid",      kArgumentRequired, 'V' },
+    { "subject-pid",      kArgumentRequired, 'P' },
+    { "key",              kArgumentRequired, 'k' },
+    { "ca-cert",          kArgumentRequired, 'C' },
+    { "ca-key",           kArgumentRequired, 'K' },
+    { "out",              kArgumentRequired, 'o' },
+    { "out-key",          kArgumentRequired, 'O' },
+    { "valid-from",       kArgumentRequired, 'f' },
+    { "lifetime",         kArgumentRequired, 'l' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "   -t, --type <att-cert-type>\n"
+    "\n"
+    "       Attestation certificate type to be generated. Valid certificate type values are:\n"
+    "           a - product attestation authority certificate\n"
+    "           i - product attestation intermediate certificate\n"
+    "           d - device attestation certificate\n"
+    "\n"
+    "   -c, --subject-cn <string>\n"
+    "\n"
+    "       Subject DN Common Name attribute encoded as UTF8String.\n"
+    "\n"
+    "   -V, --subject-vid <hex-digits>\n"
+    "\n"
+    "       Subject DN CHIP VID attribute (in hex).\n"
+    "\n"
+    "   -P, --subject-pid <hex-digits>\n"
+    "\n"
+    "       Subject DN CHIP PID attribute (in hex).\n"
+    "\n"
+    "   -C, --ca-cert <file>\n"
+    "\n"
+    "       File containing CA certificate to be used to sign the new certificate.\n"
+    "\n"
+    "   -K, --ca-key <file>\n"
+    "\n"
+    "       File containing CA private key to be used to sign the new certificate.\n"
+    "\n"
+    "   -k, --key <file>\n"
+    "\n"
+    "       File containing the public and private keys for the new certificate (in an X.509 PEM format).\n"
+    "       If not specified, a new key pair will be generated.\n"
+    "\n"
+    "   -o, --out <file>\n"
+    "\n"
+    "       File to contain the new certificate (in an X.509 PEM format).\n"
+    "\n"
+    "   -O, --out-key <file>\n"
+    "\n"
+    "       File to contain the public/private key for the new certificate (in an X.509 PEM format).\n"
+    "       This option must be specified if the --key option is not.\n"
+    "\n"
+    "   -f, --valid-from <YYYY>-<MM>-<DD> [ <HH>:<MM>:<SS> ]\n"
+    "\n"
+    "       The start date for the certificate's validity period. If not specified,\n"
+    "       the validity period starts on the current day.\n"
+    "\n"
+    "   -l, --lifetime <days>\n"
+    "\n"
+    "       The lifetime for the new certificate, in whole days.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ]\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Generate a CHIP certificate"
+);
+
+OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+AttCertType gAttCertType      = kAttCertType_NotSpecified;
+const char * gSubjectCN       = nullptr;
+uint16_t gSubjectVID          = 0;
+uint16_t gSubjectPID          = 0;
+const char * gCACertFileName  = nullptr;
+const char * gCAKeyFileName   = nullptr;
+const char * gInKeyFileName   = nullptr;
+const char * gOutCertFileName = nullptr;
+const char * gOutKeyFileName  = nullptr;
+uint32_t gValidDays           = 0;
+struct tm gValidFrom;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    uint64_t chip64bitAttr;
+
+    switch (id)
+    {
+    case 't':
+        if (strlen(arg) == 1)
+        {
+            if (*arg == 'd')
+            {
+                gAttCertType = kAttCertType_DAC;
+            }
+            else if (*arg == 'i')
+            {
+                gAttCertType = kAttCertType_PAI;
+            }
+            else if (*arg == 'a')
+            {
+                gAttCertType = kAttCertType_PAA;
+            }
+        }
+
+        if (gAttCertType == kAttCertType_NotSpecified)
+        {
+            PrintArgError("%s: Invalid value specified for the attestation certificate type: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case 'c':
+        gSubjectCN = arg;
+        break;
+    case 'V':
+        if (!ParseChip64bitAttr(arg, chip64bitAttr) || !chip::CanCastTo<uint16_t>(chip64bitAttr))
+        {
+            PrintArgError("%s: Invalid value specified for the subject VID attribute: %s\n", progName, arg);
+            return false;
+        }
+        gSubjectVID = static_cast<uint16_t>(chip64bitAttr);
+        break;
+    case 'P':
+        if (!ParseChip64bitAttr(arg, chip64bitAttr) || !chip::CanCastTo<uint16_t>(chip64bitAttr))
+        {
+            PrintArgError("%s: Invalid value specified for the subject PID attribute: %s\n", progName, arg);
+            return false;
+        }
+        gSubjectPID = static_cast<uint16_t>(chip64bitAttr);
+        break;
+    case 'k':
+        gInKeyFileName = arg;
+        break;
+    case 'C':
+        gCACertFileName = arg;
+        break;
+    case 'K':
+        gCAKeyFileName = arg;
+        break;
+    case 'o':
+        gOutCertFileName = arg;
+        break;
+    case 'O':
+        gOutKeyFileName = arg;
+        break;
+    case 'f':
+        if (!ParseDateTime(arg, gValidFrom))
+        {
+            PrintArgError("%s: Invalid value specified for certificate validity date: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case 'l':
+        if (!ParseInt(arg, gValidDays))
+        {
+            PrintArgError("%s: Invalid value specified for certificate lifetime: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_GenAttCert(int argc, char * argv[])
+{
+    bool res = true;
+    std::unique_ptr<X509, void (*)(X509 *)> newCert(X509_new(), &X509_free);
+    std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> newKey(EVP_PKEY_new(), &EVP_PKEY_free);
+
+    {
+        time_t now         = time(nullptr);
+        gValidFrom         = *gmtime(&now);
+        gValidFrom.tm_hour = 0;
+        gValidFrom.tm_min  = 0;
+        gValidFrom.tm_sec  = 0;
+    }
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        return true;
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets);
+    VerifyTrueOrExit(res);
+
+    if (gAttCertType == kAttCertType_NotSpecified)
+    {
+        fprintf(stderr, "Please specify attestation certificate type.\n");
+        return false;
+    }
+    else if (gAttCertType == kAttCertType_DAC)
+    {
+        if (gSubjectVID == 0 || gSubjectPID == 0)
+        {
+            fprintf(stderr, "Please specify VID and PID subject DN attributes.\n");
+            return false;
+        }
+    }
+    else if (gAttCertType == kAttCertType_PAI)
+    {
+        if (gSubjectVID == 0)
+        {
+            fprintf(stderr, "Please specify VID subject DN attributes.\n");
+            return false;
+        }
+    }
+    else if (gAttCertType == kAttCertType_PAA)
+    {
+        if (gSubjectVID != 0 || gSubjectPID != 0)
+        {
+            fprintf(stderr, "VID & PID SHALL NOT specify subject DN attributes.\n");
+            return false;
+        }
+    }
+
+    if (gCACertFileName == nullptr && gAttCertType != kAttCertType_PAA)
+    {
+        fprintf(stderr, "Please specify the CA certificate file name using the --ca-cert option.\n");
+        return false;
+    }
+    else if (gCACertFileName != nullptr && gAttCertType == kAttCertType_PAA)
+    {
+        fprintf(stderr, "Please don't specify --ca-cert option for the self signed certificate. \n");
+        return false;
+    }
+
+    if (gCACertFileName != nullptr && gCAKeyFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the CA key file name using the --ca-key option.\n");
+        return false;
+    }
+
+    if (gOutCertFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the file name for the new certificate using the --out option.\n");
+        return false;
+    }
+
+    if (gInKeyFileName == nullptr && gOutKeyFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the file name for the new public/private key using the --out-key option.\n");
+        return false;
+    }
+
+    if (gValidDays == 0)
+    {
+        fprintf(stderr, "Please specify the lifetime (in dys) for the new certificate using the --lifetime option.\n");
+        return false;
+    }
+
+    if (access(gOutCertFileName, R_OK) == 0)
+    {
+        fprintf(stderr,
+                "Output certificate file already exists (%s)\n"
+                "To replace the file, please remove it and re-run the command.\n",
+                gOutCertFileName);
+        return false;
+    }
+
+    if (gOutKeyFileName != nullptr && access(gOutKeyFileName, R_OK) == 0)
+    {
+        fprintf(stderr,
+                "Output key file already exists (%s)\n"
+                "To replace the file, please remove it and re-run the command.\n",
+                gOutKeyFileName);
+        return false;
+    }
+
+    res = InitOpenSSL();
+    VerifyTrueOrExit(res);
+
+    if (gInKeyFileName != nullptr)
+    {
+        res = ReadKey(gInKeyFileName, newKey.get());
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        res = GenerateKeyPair(newKey.get());
+        VerifyTrueOrExit(res);
+    }
+
+    if (gAttCertType == kAttCertType_PAA)
+    {
+        res = MakeAttCert(gAttCertType, gSubjectCN, gSubjectVID, gSubjectPID, newCert.get(), newKey.get(), gValidFrom, gValidDays,
+                          newCert.get(), newKey.get());
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        std::unique_ptr<X509, void (*)(X509 *)> caCert(X509_new(), &X509_free);
+        std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> caKey(EVP_PKEY_new(), &EVP_PKEY_free);
+
+        res = ReadCert(gCACertFileName, caCert.get());
+        VerifyTrueOrExit(res);
+
+        res = ReadKey(gCAKeyFileName, caKey.get());
+        VerifyTrueOrExit(res);
+
+        res = MakeAttCert(gAttCertType, gSubjectCN, gSubjectVID, gSubjectPID, caCert.get(), caKey.get(), gValidFrom, gValidDays,
+                          newCert.get(), newKey.get());
+        VerifyTrueOrExit(res);
+    }
+
+    res = WriteCert(gOutCertFileName, newCert.get(), kCertFormat_X509_PEM);
+    VerifyTrueOrExit(res);
+
+    if (gOutKeyFileName != nullptr)
+    {
+        res = WritePrivateKey(gOutKeyFileName, newKey.get(), kKeyFormat_X509_PEM);
+        VerifyTrueOrExit(res);
+    }
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -20,12 +20,14 @@
 /**
  *    @file
  *      This file implements utility functions for OpenSSL, base-64
- *      encoding and decoding, date and time parsing, EUI64 parsing,
+ *      encoding and decoding, date and time parsing, integer parsing,
  *      OID translation, and file reading.
  *
  */
 
 #include "chip-cert.h"
+
+#include <support/SafeInt.h>
 
 using namespace chip;
 using namespace chip::Credentials;
@@ -38,6 +40,8 @@ int gNIDChipRootId;
 int gNIDChipFabricId;
 int gNIDChipAuthTag1;
 int gNIDChipAuthTag2;
+int gNIDChipAttAttrVID;
+int gNIDChipAttAttrPID;
 int gNIDChipCurveP256 = EC_curve_nist2nid("P-256");
 
 bool InitOpenSSL()
@@ -91,6 +95,18 @@ bool InitOpenSSL()
         ReportOpenSSLErrorAndExit("OBJ_create", res = false);
     }
 
+    gNIDChipAttAttrVID = OBJ_create("1.3.6.1.4.1.37244.2.1", "ChipAttestationAttrVID", "ChipAttestationAttrVID");
+    if (gNIDChipAttAttrVID == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipAttAttrPID = OBJ_create("1.3.6.1.4.1.37244.2.2", "ChipAttestationAttrPID", "ChipAttestationAttrPID");
+    if (gNIDChipAttAttrPID == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
     ASN1_STRING_TABLE_add(gNIDChipNodeId, 16, 16, B_ASN1_UTF8STRING, 0);
     ASN1_STRING_TABLE_add(gNIDChipFirmwareSigningId, 16, 16, B_ASN1_UTF8STRING, 0);
     ASN1_STRING_TABLE_add(gNIDChipICAId, 16, 16, B_ASN1_UTF8STRING, 0);
@@ -98,6 +114,8 @@ bool InitOpenSSL()
     ASN1_STRING_TABLE_add(gNIDChipFabricId, 16, 16, B_ASN1_UTF8STRING, 0);
     ASN1_STRING_TABLE_add(gNIDChipAuthTag1, 8, 8, B_ASN1_UTF8STRING, 0);
     ASN1_STRING_TABLE_add(gNIDChipAuthTag2, 8, 8, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipAttAttrVID, 4, 4, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipAttAttrPID, 4, 4, B_ASN1_UTF8STRING, 0);
 
 exit:
     return res;

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -18,6 +18,7 @@ This directory contains various command handler for the 'chip-cert' tool that:
 -   validate CHIP certificate chain
 -   resign CHIP certificate
 -   print CHIP certificate
+-   generate CHIP attestation certificates
 
 ## Usage Examples
 
@@ -32,6 +33,8 @@ Specify '--help' option for detail instructions on usage of each command:
 ```
 ./chip-cert gen-cert --help
 ```
+
+## Operational Certificates Usage Examples
 
 Example command that can be used to generate CHIP root certificate and private
 key:
@@ -77,4 +80,34 @@ human friendly/readable form:
 
 ```
 ./chip-cert print-cert Chip-ICA-Cert.chip
+```
+
+### Attestation Certificates Usage Examples
+
+Example command that can be used to generate Product Attestation Authority (PAA)
+certificate and private key:
+
+```
+./chip-cert gen-att-cert --type a --subject-cn "Matter Development PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key Chip-PAA-Key.pem --out Chip-PAA-Cert.pem
+```
+
+The PAA certificate/key output of last command can then be used to generate the
+Product Attestation Intermediate (PAI) certificate and private key:
+
+```
+./chip-cert gen-att-cert --type i --subject-cn "Matter Development PAI 01" --subject-vid FFF1 --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key Chip-PAA-Key.pem --ca-cert Chip-PAA-Cert.pem --out-key Chip-PAI-Key.pem --out Chip-PAI-Cert.pem
+```
+
+The generated PAI certificate/key can then be used to sign multiple Device
+Attestation Certificates (DAC):
+
+```
+./chip-cert gen-att-cert --type d --subject-cn "Matter Development DAC 01" --subject-vid FFF1 --subject-pid 0123 --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key Chip-PAI-Key.pem --ca-cert Chip-PAI-Cert.pem --out-key Chip-DAC-Key.pem --out Chip-DAC-Cert.pem
+```
+
+The standard openssl command line tool can be used to verify the attestation
+certificate chain that was just created:
+
+```
+openssl verify -CAfile Chip-PAA-Cert.pem -untrusted Chip-PAI-Cert.pem Chip-DAC-Cert.pem
 ```

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -119,6 +119,10 @@ extern "C" int main(int argc, char * argv[])
     {
         res = Cmd_PrintCert(argc - 1, argv + 1);
     }
+    else if (strcasecmp(argv[1], "gen-att-cert") == 0 || strcasecmp(argv[1], "genattcert") == 0)
+    {
+        res = Cmd_GenAttCert(argc - 1, argv + 1);
+    }
     else
     {
         fprintf(stderr, "Unrecognized command: %s\n", argv[1]);

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -89,6 +89,14 @@ enum KeyFormat
     kKeyFormat_Chip_Base64
 };
 
+enum AttCertType
+{
+    kAttCertType_NotSpecified = 0, /**< The attestation certificate type has not been specified. */
+    kAttCertType_PAA,              /**< Product Attestation Authority (PAA) Certificate. */
+    kAttCertType_PAI,              /**< Product Attestation Intermediate (PAI) Certificate. */
+    kAttCertType_DAC,              /**< Device Attestation Certificate (DAC). */
+};
+
 struct FutureExtension
 {
     int nid;
@@ -109,6 +117,7 @@ extern bool Cmd_ConvertKey(int argc, char * argv[]);
 extern bool Cmd_ResignCert(int argc, char * argv[]);
 extern bool Cmd_ValidateCert(int argc, char * argv[]);
 extern bool Cmd_PrintCert(int argc, char * argv[]);
+extern bool Cmd_GenAttCert(int argc, char * argv[]);
 
 extern bool ReadCert(const char * fileName, X509 * cert);
 extern bool ReadCert(const char * fileName, X509 * cert, CertFormat & origCertFmt);
@@ -120,6 +129,9 @@ extern bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCe
                      uint32_t validDays, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert,
                      EVP_PKEY * newKey);
 extern bool ResignCert(X509 * cert, X509 * caCert, EVP_PKEY * caKey);
+
+extern bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subjectVID, uint16_t subjectPID, X509 * caCert,
+                        EVP_PKEY * caKey, const struct tm & validFrom, uint32_t validDays, X509 * newCert, EVP_PKEY * newKey);
 
 extern bool GenerateKeyPair(EVP_PKEY * key);
 extern bool ReadKey(const char * fileName, EVP_PKEY * key);
@@ -146,6 +158,8 @@ extern int gNIDChipFabricId;
 extern int gNIDChipAuthTag1;
 extern int gNIDChipAuthTag2;
 extern int gNIDChipCurveP256;
+extern int gNIDChipAttAttrVID;
+extern int gNIDChipAttAttrPID;
 
 /**
  *  @def VerifyTrueOrExit(aStatus)


### PR DESCRIPTION
#### Problem
CHIP SDK is missing command line tool to generate attestation certificate for testing or could be for real use purposes. 

#### Change overview
Tool is added

#### Testing
Validated tool outputs using openssl commands.