### PR TITLE
Re-enable MRP for reads and writes

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -158,10 +158,8 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdmin
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
-    // TODO (#7909): Disable CRMP temporary for duplicate ACK issues, should be enabled later.
-    err = mpExchangeCtx->SendMessage(
-        Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
-        Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse).Set(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
     SuccessOrExit(err);
     MoveToState(ClientState::AwaitingResponse);
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -268,9 +268,8 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, Transport::AdminId aAdm
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
-    err = mpExchangeCtx->SendMessage(
-        Protocols::InteractionModel::MsgType::WriteRequest, std::move(packet),
-        Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse).Set(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::WriteRequest, std::move(packet),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
     SuccessOrExit(err);
     MoveToState(State::AwaitingResponse);
 


### PR DESCRIPTION
With https://github.com/project-chip/connectedhomeip/pull/7958 merged,
this should not be a problem.

#### Problem
MRP is disabled for reads and writes

#### Change overview
Re-enable it.

#### Testing
Ran CI locally and it passes.

We really need to stand up some CI that checks that IM is using MRP across the board, but I haven't quite figured out a good way to do it yet.