### PR TITLE
Add -Wformat-type-confusion to catch a wider range of format string errors

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -182,6 +182,7 @@ config("strict_warnings") {
     cflags += [
       "-Wimplicit-fallthrough",
       "-Wheader-hygiene",
+      "-Wformat-type-confusion",
     ]
   }
 

--- a/third_party/lwip/lwip.gni
+++ b/third_party/lwip/lwip.gni
@@ -60,6 +60,7 @@ template("lwip_target") {
       "-Wno-type-limits",
       "-Wno-unused-variable",
       "-Wno-maybe-uninitialized",
+      "-Wno-format-type-confusion",
     ]
   }
 


### PR DESCRIPTION
This is supported by clang, not gcc, hence adding this only to the
clang cflags in the strict warnings config.

lwip triggers this warning a lot, so we disable it there.

Fixes https://github.com/project-chip/connectedhomeip/issues/7935

#### Problem
https://github.com/project-chip/connectedhomeip/issues/7935 (but more broadly, some compiler configurations fail warnings that we don't have enabled by default in the tree).

#### Change overview
Enable stricter warnings.

#### Testing
Made sure all our CI compiles work.