### PR TITLE
[im] Land IM AttributeWriting protocol

### DIFF
--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -128,6 +128,8 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
         return true;                                                                                                               \
     }
 
+#define GET_ATTRIBUTE_RESPONSE_CALLBACKS(name)
+
 #define GET_REPORT_CALLBACK(name)                                                                                                  \
     Callback::Cancelable * onReportCallback = nullptr;                                                                             \
     CHIP_ERROR err = gCallbacks.GetReportCallback(sourceId, endpointId, clusterId, attributeId, &onReportCallback);                \
@@ -141,6 +143,9 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
                                                                                                                                    \
         return true;                                                                                                               \
     }
+
+// TODO: These IM related callbacks contains small or no generated code, should be put into seperate file to reduce the size of
+// template.
 
 void LogStatus(uint8_t status)
 {
@@ -415,6 +420,48 @@ bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfSta
     LogStatus(status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
+    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    {
+        Callback::Callback<DefaultSuccessCallback> * cb =
+            Callback::Callback<DefaultSuccessCallback>::FromCancelable(onSuccessCallback);
+        cb->mCall(cb->mContext);
+    }
+    else
+    {
+        Callback::Callback<DefaultFailureCallback> * cb =
+            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
+        cb->mCall(cb->mContext, static_cast<uint8_t>(status));
+    }
+
+    return true;
+}
+
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status)
+{
+    ChipLogProgress(Zcl, "WriteResponse:");
+    LogStatus(status);
+
+    Callback::Cancelable * onSuccessCallback = nullptr;
+    Callback::Cancelable * onFailureCallback = nullptr;
+    NodeId sourceNodeId                      = writeClient->GetSourceNodeId();
+    uint8_t seq                              = static_cast<uint8_t>(writeClient->GetAppIdentifier());
+    CHIP_ERROR err = gCallbacks.GetResponseCallback(sourceNodeId, seq, &onSuccessCallback, &onFailureCallback);
+
+    if (CHIP_NO_ERROR != err)
+    {
+        if (onSuccessCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing success callback", __FUNCTION__);
+        }
+
+        if (onFailureCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing failure callback", __FUNCTION__);
+        }
+
+        return true;
+    }
+
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
         Callback::Callback<DefaultSuccessCallback> * cb =

--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.h
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.h
@@ -33,6 +33,7 @@
 bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
 bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
                                             chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status);
 
 // Global Response Callbacks
 typedef void (*DefaultSuccessCallback)(void * context);

--- a/examples/pump-app/pump-common/gen/CHIPClusters.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClusters.cpp
@@ -30,7 +30,10 @@
 #include <app/common/gen/ids/Attributes.h>
 #include <app/util/basic-types.h>
 
+#include <app/InteractionModelEngine.h>
 #include <gen/CHIPClientCallbacks.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -128,6 +128,8 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
         return true;                                                                                                               \
     }
 
+#define GET_ATTRIBUTE_RESPONSE_CALLBACKS(name)
+
 #define GET_REPORT_CALLBACK(name)                                                                                                  \
     Callback::Cancelable * onReportCallback = nullptr;                                                                             \
     CHIP_ERROR err = gCallbacks.GetReportCallback(sourceId, endpointId, clusterId, attributeId, &onReportCallback);                \
@@ -141,6 +143,9 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
                                                                                                                                    \
         return true;                                                                                                               \
     }
+
+// TODO: These IM related callbacks contains small or no generated code, should be put into seperate file to reduce the size of
+// template.
 
 void LogStatus(uint8_t status)
 {
@@ -415,6 +420,48 @@ bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfSta
     LogStatus(status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
+    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    {
+        Callback::Callback<DefaultSuccessCallback> * cb =
+            Callback::Callback<DefaultSuccessCallback>::FromCancelable(onSuccessCallback);
+        cb->mCall(cb->mContext);
+    }
+    else
+    {
+        Callback::Callback<DefaultFailureCallback> * cb =
+            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
+        cb->mCall(cb->mContext, static_cast<uint8_t>(status));
+    }
+
+    return true;
+}
+
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status)
+{
+    ChipLogProgress(Zcl, "WriteResponse:");
+    LogStatus(status);
+
+    Callback::Cancelable * onSuccessCallback = nullptr;
+    Callback::Cancelable * onFailureCallback = nullptr;
+    NodeId sourceNodeId                      = writeClient->GetSourceNodeId();
+    uint8_t seq                              = static_cast<uint8_t>(writeClient->GetAppIdentifier());
+    CHIP_ERROR err = gCallbacks.GetResponseCallback(sourceNodeId, seq, &onSuccessCallback, &onFailureCallback);
+
+    if (CHIP_NO_ERROR != err)
+    {
+        if (onSuccessCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing success callback", __FUNCTION__);
+        }
+
+        if (onFailureCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing failure callback", __FUNCTION__);
+        }
+
+        return true;
+    }
+
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
         Callback::Callback<DefaultSuccessCallback> * cb =

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.h
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.h
@@ -33,6 +33,7 @@
 bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
 bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
                                             chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status);
 
 // Global Response Callbacks
 typedef void (*DefaultSuccessCallback)(void * context);

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -115,18 +115,22 @@ public:
     CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
-                               EventNumber aEventNumber, intptr_t aAppIdentifier = 0);
+                               EventNumber aEventNumber, uint64_t aAppIdentifier = 0);
 
     /**
      *  Retrieve a WriteClient that the SDK consumer can use to send a write.  If the call succeeds,
      *  see WriteClient documentation for lifetime handling.
+     *
+     *  The Write interaction is more like Invoke interaction (cluster specific commands) since it will include cluster specific
+     * payload, and may have the need to encode non-scalar values (like structs and arrays). Thus we use WriteClientHandle to
+     * prevent user's code from leaking WriteClients.
      *
      *  @param[out]    apWriteClient    A pointer to the WriteClient object.
      *
      *  @retval #CHIP_ERROR_NO_MEMORY If there is no WriteClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR NewWriteClient(WriteClient ** const apWriteClient);
+    CHIP_ERROR NewWriteClient(WriteClientHandle & apWriteClient, uint64_t aApplicationIdentifier = 0);
 
     /**
      *  Get read client index in mReadClients
@@ -177,7 +181,7 @@ private:
      *  @retval #CHIP_ERROR_INCORRECT_STATE If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, intptr_t aAppIdentifier);
+    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, uint64_t aAppIdentifier);
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -30,7 +30,7 @@ namespace chip {
 namespace app {
 
 CHIP_ERROR ReadClient::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
-                            intptr_t aAppIdentifier)
+                            uint64_t aAppIdentifier)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Error if already initialized.

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -77,7 +77,7 @@ public:
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                EventNumber aEventNumber);
 
-    intptr_t GetAppIdentifier() const { return mAppIdentifier; }
+    uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
 
 private:
@@ -105,7 +105,7 @@ private:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate, intptr_t aAppIdentifier);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate, uint64_t aAppIdentifier);
 
     virtual ~ReadClient() = default;
 
@@ -140,7 +140,7 @@ private:
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
     ClientState mState                         = ClientState::Uninitialized;
-    intptr_t mAppIdentifier                    = 0;
+    uint64_t mAppIdentifier                    = 0;
 };
 
 }; // namespace app

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -29,7 +29,8 @@
 namespace chip {
 namespace app {
 
-CHIP_ERROR WriteClient::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate)
+CHIP_ERROR WriteClient::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                             uint64_t aApplicationIdentifier)
 {
     VerifyOrReturnError(apExchangeMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mpExchangeMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -50,6 +51,7 @@ CHIP_ERROR WriteClient::Init(Messaging::ExchangeManager * apExchangeMgr, Interac
     mpExchangeMgr         = apExchangeMgr;
     mpDelegate            = apDelegate;
     mAttributeStatusIndex = 0;
+    mAppIdentifier        = aApplicationIdentifier;
     MoveToState(State::Initialized);
 
     return CHIP_NO_ERROR;
@@ -392,6 +394,23 @@ exit:
     if (err != CHIP_NO_ERROR && mpDelegate != nullptr)
     {
         mpDelegate->WriteResponseProtocolError(this, mAttributeStatusIndex);
+    }
+    return err;
+}
+
+CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession)
+{
+    CHIP_ERROR err = mpWriteClient->SendWriteRequest(aNodeId, aFabricIndex, apSecureSession);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        // On success, the InteractionModelEngine will be responible to take care of the lifecycle of the WriteClient, so we release
+        // the WriteClient without closing it.
+        mpWriteClient = nullptr;
+    }
+    else
+    {
+        SetWriteClient(nullptr);
     }
     return err;
 }

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -36,6 +36,10 @@
 
 namespace chip {
 namespace app {
+
+class WriteClientHandle;
+class InteractionModelEngine;
+
 /**
  *  @brief The read client represents the initiator side of a Write Interaction, and is responsible
  *  for generating one Write Request for a particular set of attributes, and handling the Write response.
@@ -52,22 +56,21 @@ public:
      */
     void Shutdown();
 
-    /**
-     *  Once SendWriteRequest returns successfully, the WriteClient will
-     *  handle calling Shutdown on itself once it decides it's done with waiting
-     *  for a response (i.e. times out or gets a response).
-     *  If SendWriteRequest is never called, or the call fails, the API
-     *  consumer is responsible for calling Shutdown on the WriteClient.
-     */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
-
     CHIP_ERROR PrepareAttribute(const AttributePathParams & attributePathParams);
     CHIP_ERROR FinishAttribute();
     TLV::TLVWriter * GetAttributeDataElementTLVWriter();
 
+    uint64_t GetAppIdentifier() const { return mAppIdentifier; }
+    void SetAppIdentifier(uint64_t aAppIdentifier) { mAppIdentifier = aAppIdentifier; }
+    NodeId GetSourceNodeId() const
+    {
+        return mpExchangeCtx != nullptr ? mpExchangeCtx->GetSecureSession().GetPeerNodeId() : kUndefinedNodeId;
+    }
+
 private:
     friend class TestWriteInteraction;
     friend class InteractionModelEngine;
+    friend class WriteClientHandle;
 
     enum class State
     {
@@ -76,6 +79,20 @@ private:
         AddAttribute,      // The client has added attribute and ready for a SendWriteRequest
         AwaitingResponse,  // The client has sent out the write request message
     };
+
+    /**
+     * Finalize Write Request Message TLV Builder and retrieve final data from tlv builder for later sending
+     */
+    CHIP_ERROR FinalizeMessage(System::PacketBufferHandle & aPacket);
+
+    /**
+     *  Once SendWriteRequest returns successfully, the WriteClient will
+     *  handle calling Shutdown on itself once it decides it's done with waiting
+     *  for a response (i.e. times out or gets a response).
+     *  If SendWriteRequest is never called, or the call fails, the API
+     *  consumer is responsible for calling Shutdown on the WriteClient.
+     */
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
 
     /**
      *  Initialize the client object. Within the lifetime
@@ -88,7 +105,8 @@ private:
      *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                    uint64_t aApplicationIdentifier);
 
     virtual ~WriteClient() = default;
 
@@ -100,11 +118,6 @@ private:
      *  Check if current write client is being used
      */
     bool IsFree() const { return mState == State::Uninitialized; };
-
-    /**
-     * Finalize Write Request Message TLV Builder and retrieve final data from tlv builder for later sending
-     */
-    CHIP_ERROR FinalizeMessage(System::PacketBufferHandle & aPacket);
 
     void MoveToState(const State aTargetState);
     CHIP_ERROR ProcessWriteResponseMessage(System::PacketBufferHandle && payload);
@@ -128,7 +141,78 @@ private:
     System::PacketBufferTLVWriter mMessageWriter;
     WriteRequest::Builder mWriteRequestBuilder;
     uint8_t mAttributeStatusIndex = 0;
-    intptr_t mAppIdentifier       = 0;
+    uint64_t mAppIdentifier       = 0;
+};
+
+class WriteClientHandle
+{
+public:
+    /**
+     * Construct an empty WriteClientHandle.
+     */
+    WriteClientHandle() : mpWriteClient(nullptr) {}
+    WriteClientHandle(decltype(nullptr)) : mpWriteClient(nullptr) {}
+
+    /**
+     * Construct a WriteClientHandle that takes ownership of a WriteClient from another.
+     */
+    WriteClientHandle(WriteClientHandle && aOther)
+    {
+        mpWriteClient        = aOther.mpWriteClient;
+        aOther.mpWriteClient = nullptr;
+    }
+
+    ~WriteClientHandle() { SetWriteClient(nullptr); }
+
+    /**
+     * Access a WriteClientHandle's public methods.
+     */
+    WriteClient * operator->() const { return mpWriteClient; }
+
+    /**
+     *  Finalize the message and send it to the desired node. The underlying write object will always be released, and the user
+     * should not use this object after calling this function.
+     */
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
+
+    /**
+     *  Encode an attribute value that can be directly encoded using TLVWriter::Put
+     */
+    template <class T>
+    CHIP_ERROR EncodeScalarAttributeWritePayload(const chip::app::AttributePathParams & attributePath, T value)
+    {
+        chip::TLV::TLVWriter * writer = nullptr;
+
+        VerifyOrReturnError(mpWriteClient != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        ReturnErrorOnFailure(mpWriteClient->PrepareAttribute(attributePath));
+        VerifyOrReturnError((writer = mpWriteClient->GetAttributeDataElementTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        ReturnErrorOnFailure(writer->Put(chip::TLV::ContextTag(chip::app::AttributeDataElement::kCsTag_Data), value));
+        ReturnErrorOnFailure(mpWriteClient->FinishAttribute());
+
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     *  Set the internal WriteClient of the Handler, expected to be called by InteractionModelEngline only since the user
+     * application does not have direct access to apWriteClient.
+     */
+    void SetWriteClient(WriteClient * apWriteClient)
+    {
+        if (mpWriteClient != nullptr)
+        {
+            mpWriteClient->Shutdown();
+        }
+        mpWriteClient = apWriteClient;
+    }
+
+private:
+    friend class TestWriteInteraction;
+
+    WriteClientHandle(const WriteClientHandle &) = delete;
+    WriteClientHandle & operator=(const WriteClientHandle &) = delete;
+    WriteClientHandle & operator=(const WriteClientHandle &&) = delete;
+
+    WriteClient * mpWriteClient = nullptr;
 };
 
 } // namespace app

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -27,17 +27,17 @@ namespace chip {
 namespace app {
 CHIP_ERROR WriteHandler::Init(InteractionModelDelegate * apDelegate)
 {
-    VerifyOrReturnError(apDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    IgnoreUnusedVariable(apDelegate);
+    VerifyOrReturnLogError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     System::PacketBufferHandle packet = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
-    VerifyOrReturnError(!packet.IsNull(), CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnLogError(!packet.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     mMessageWriter.Init(std::move(packet));
-    ReturnErrorOnFailure(mWriteResponseBuilder.Init(&mMessageWriter));
+    ReturnLogErrorOnFailure(mWriteResponseBuilder.Init(&mMessageWriter));
 
     AttributeStatusList::Builder attributeStatusListBuilder = mWriteResponseBuilder.CreateAttributeStatusListBuilder();
-    ReturnErrorOnFailure(attributeStatusListBuilder.GetError());
+    ReturnLogErrorOnFailure(attributeStatusListBuilder.GetError());
 
     MoveToState(State::Initialized);
 

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -56,7 +56,7 @@ public:
     static void TestWriteRoundtrip(nlTestSuite * apSuite, void * apContext);
 
 private:
-    static void AddAttributeDataElement(nlTestSuite * apSuite, void * apContext, WriteClient & aWriteClient);
+    static void AddAttributeDataElement(nlTestSuite * apSuite, void * apContext, WriteClientHandle & aWriteClient);
     static void AddAttributeStatus(nlTestSuite * apSuite, void * apContext, WriteHandler & aWriteHandler);
     static void GenerateWriteRequest(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload);
     static void GenerateWriteResponse(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload);
@@ -73,7 +73,7 @@ class TestExchangeDelegate : public Messaging::ExchangeDelegate
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
 };
 
-void TestWriteInteraction::AddAttributeDataElement(nlTestSuite * apSuite, void * apContext, WriteClient & aWriteClient)
+void TestWriteInteraction::AddAttributeDataElement(nlTestSuite * apSuite, void * apContext, WriteClientHandle & aWriteClient)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     AttributePathParams attributePathParams;
@@ -84,15 +84,15 @@ void TestWriteInteraction::AddAttributeDataElement(nlTestSuite * apSuite, void *
     attributePathParams.mListIndex  = 5;
     attributePathParams.mFlags.Set(AttributePathParams::Flags::kFieldIdValid);
 
-    err = aWriteClient.PrepareAttribute(attributePathParams);
+    err = aWriteClient->PrepareAttribute(attributePathParams);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    chip::TLV::TLVWriter * writer = aWriteClient.GetAttributeDataElementTLVWriter();
+    chip::TLV::TLVWriter * writer = aWriteClient->GetAttributeDataElementTLVWriter();
 
     err = writer->PutBoolean(chip::TLV::ContextTag(chip::app::AttributeDataElement::kCsTag_Data), true);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = aWriteClient.FinishAttribute();
+    err = aWriteClient->FinishAttribute();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 
@@ -206,16 +206,20 @@ void TestWriteInteraction::TestWriteClient(nlTestSuite * apSuite, void * apConte
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     app::WriteClient writeClient;
+    app::WriteClientHandle writeClientHandle;
+    writeClientHandle.SetWriteClient(&writeClient);
 
     chip::app::InteractionModelDelegate delegate;
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                            = writeClient.Init(&ctx.GetExchangeManager(), &delegate);
+    err                            = writeClient.Init(&ctx.GetExchangeManager(), &delegate, 0);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    AddAttributeDataElement(apSuite, apContext, writeClient);
+    AddAttributeDataElement(apSuite, apContext, writeClientHandle);
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err                         = writeClient.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
+    err                         = writeClientHandle.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    // The internal WriteClient should be nullptr once we SendWriteRequest.
+    NL_TEST_ASSERT(apSuite, nullptr == writeClientHandle.mpWriteClient);
 
     GenerateWriteResponse(apSuite, apContext, buf);
 
@@ -290,17 +294,18 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
     err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    app::WriteClient * writeClient;
-    err = engine->NewWriteClient(&writeClient);
+    app::WriteClientHandle writeClient;
+    err = engine->NewWriteClient(writeClient);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    AddAttributeDataElement(apSuite, apContext, *writeClient);
+    AddAttributeDataElement(apSuite, apContext, writeClient);
 
     NL_TEST_ASSERT(apSuite, !delegate.mGotResponse);
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err                         = writeClient->SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
+
+    err = writeClient.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(apSuite, delegate.mGotResponse);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -213,7 +213,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SendWriteRequest(chip::app::WriteClient * apWriteClient)
+CHIP_ERROR SendWriteRequest(chip::app::WriteClientHandle & apWriteClient)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::TLV::TLVWriter * writer;
@@ -235,7 +235,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClient * apWriteClient)
 
     SuccessOrExit(err = writer->PutBoolean(chip::TLV::ContextTag(chip::app::AttributeDataElement::kCsTag_Data), true));
     SuccessOrExit(err = apWriteClient->FinishAttribute());
-    SuccessOrExit(err = apWriteClient->SendWriteRequest(chip::kTestDeviceNodeId, gFabricIndex, nullptr));
+    SuccessOrExit(err = apWriteClient.SendWriteRequest(chip::kTestDeviceNodeId, gFabricIndex, nullptr));
 
     gWriteCount++;
 
@@ -400,8 +400,8 @@ void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState
 
     if (gWriteRespCount < kMaxWriteMessageCount)
     {
-        chip::app::WriteClient * writeClient;
-        err = chip::app::InteractionModelEngine::GetInstance()->NewWriteClient(&writeClient);
+        chip::app::WriteClientHandle writeClient;
+        err = chip::app::InteractionModelEngine::GetInstance()->NewWriteClient(writeClient);
         SuccessOrExit(err);
 
         err = SendWriteRequest(writeClient);
@@ -528,7 +528,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
                          chip::to_underlying(Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute));
 }
 
-CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader)
+CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader, WriteHandler *)
 {
     if (aClusterInfo.mClusterId != kTestClusterId || aClusterInfo.mEndpointId != kTestEndpointId)
     {

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -25,12 +25,14 @@
 #include <app/InteractionModelEngine.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/attribute-table.h>
 #include <app/util/ember-compatibility-functions.h>
 #include <app/util/error-mapping.h>
 #include <app/util/util.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 #include <lib/support/TypeTraits.h>
 #include <protocols/interaction_model/Constants.h>
 
@@ -177,6 +179,11 @@ void ResetEmberAfObjects()
 
 } // namespace Compatibility
 
+namespace {
+// Common buffer for ReadSingleClusterData & WriteSingleClusterData
+uint8_t attributeData[kAttributeReadBufferSize];
+} // namespace
+
 bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)
 {
     // TODO: Currently, we are using cluster catalog from the ember library, this should be modified or replaced after several
@@ -186,8 +193,6 @@ bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCom
 
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * apWriter, bool * apDataExists)
 {
-    static uint8_t data[kAttributeReadBufferSize];
-
     ChipLogDetail(DataManagement,
                   "Received Cluster Command: Cluster=" ChipLogFormatMEI " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx16
                   " FieldId=%" PRIx32 " ListIndex=%" PRIx16,
@@ -197,7 +202,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     EmberAfAttributeType attributeType;
     EmberAfStatus status;
     status = emberAfReadAttribute(aClusterInfo.mEndpointId, aClusterInfo.mClusterId, aClusterInfo.mFieldId, CLUSTER_MASK_SERVER,
-                                  data, sizeof(data), &attributeType);
+                                  attributeData, sizeof(attributeData), &attributeType);
 
     if (apDataExists != nullptr)
     {
@@ -218,64 +223,64 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         ReturnErrorOnFailure(apWriter->PutNull(TLV::ContextTag(AttributeDataElement::kCsTag_Data)));
         break;
     case ZCL_BOOLEAN_ATTRIBUTE_TYPE: // Boolean
-        ReturnErrorOnFailure(apWriter->PutBoolean(TLV::ContextTag(AttributeDataElement::kCsTag_Data), !!data[0]));
+        ReturnErrorOnFailure(apWriter->PutBoolean(TLV::ContextTag(AttributeDataElement::kCsTag_Data), !!attributeData[0]));
         break;
     case ZCL_INT8U_ATTRIBUTE_TYPE: // Unsigned 8-bit integer
-        ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), data[0]));
+        ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), attributeData[0]));
         break;
     case ZCL_INT16U_ATTRIBUTE_TYPE: // Unsigned 16-bit integer
     {
         uint16_t uint16_data;
-        memcpy(&uint16_data, data, sizeof(uint16_data));
+        memcpy(&uint16_data, attributeData, sizeof(uint16_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), uint16_data));
         break;
     }
     case ZCL_INT32U_ATTRIBUTE_TYPE: // Unsigned 32-bit integer
     {
         uint32_t uint32_data;
-        memcpy(&uint32_data, data, sizeof(uint32_data));
+        memcpy(&uint32_data, attributeData, sizeof(uint32_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), uint32_data));
         break;
     }
     case ZCL_INT64U_ATTRIBUTE_TYPE: // Unsigned 64-bit integer
     {
         uint64_t uint64_data;
-        memcpy(&uint64_data, data, sizeof(uint64_data));
+        memcpy(&uint64_data, attributeData, sizeof(uint64_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), uint64_data));
         break;
     }
     case ZCL_INT8S_ATTRIBUTE_TYPE: // Signed 8-bit integer
     {
         int8_t int8_data;
-        memcpy(&int8_data, data, sizeof(int8_data));
+        memcpy(&int8_data, attributeData, sizeof(int8_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), int8_data));
         break;
     }
     case ZCL_INT16S_ATTRIBUTE_TYPE: // Signed 16-bit integer
     {
         int16_t int16_data;
-        memcpy(&int16_data, data, sizeof(int16_data));
+        memcpy(&int16_data, attributeData, sizeof(int16_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), int16_data));
         break;
     }
     case ZCL_INT32S_ATTRIBUTE_TYPE: // Signed 32-bit integer
     {
         int32_t int32_data;
-        memcpy(&int32_data, data, sizeof(int32_data));
+        memcpy(&int32_data, attributeData, sizeof(int32_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), int32_data));
         break;
     }
     case ZCL_INT64S_ATTRIBUTE_TYPE: // Signed 64-bit integer
     {
         int64_t int64_data;
-        memcpy(&int64_data, data, sizeof(int64_data));
+        memcpy(&int64_data, attributeData, sizeof(int64_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), int64_data));
         break;
     }
     case ZCL_CHAR_STRING_ATTRIBUTE_TYPE: // Char string
     {
-        char * actualData  = reinterpret_cast<char *>(data + 1);
-        uint8_t dataLength = data[0];
+        char * actualData  = reinterpret_cast<char *>(attributeData + 1);
+        uint8_t dataLength = attributeData[0];
         if (dataLength == 0xFF /* invalid data, put empty value instead */)
         {
             dataLength = 0;
@@ -284,9 +289,9 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         break;
     }
     case ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE: {
-        char * actualData = reinterpret_cast<char *>(data + 2); // The pascal string contains 2 bytes length
+        char * actualData = reinterpret_cast<char *>(attributeData + 2); // The pascal string contains 2 bytes length
         uint16_t dataLength;
-        memcpy(&dataLength, data, sizeof(dataLength));
+        memcpy(&dataLength, attributeData, sizeof(dataLength));
         if (dataLength == 0xFFFF /* invalid data, put empty value instead */)
         {
             dataLength = 0;
@@ -296,8 +301,8 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     }
     case ZCL_OCTET_STRING_ATTRIBUTE_TYPE: // Octet string
     {
-        uint8_t * actualData = data + 1;
-        uint8_t dataLength   = data[0];
+        uint8_t * actualData = attributeData + 1;
+        uint8_t dataLength   = attributeData[0];
         if (dataLength == 0xFF /* invalid data, put empty value instead */)
         {
             dataLength = 0;
@@ -307,9 +312,9 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         break;
     }
     case ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE: {
-        uint8_t * actualData = data + 2; // The pascal string contains 2 bytes length
+        uint8_t * actualData = attributeData + 2; // The pascal string contains 2 bytes length
         uint16_t dataLength;
-        memcpy(&dataLength, data, sizeof(dataLength));
+        memcpy(&dataLength, attributeData, sizeof(dataLength));
         if (dataLength == 0xFFFF /* invalid data, put empty value instead */)
         {
             dataLength = 0;
@@ -323,9 +328,9 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         ReturnErrorOnFailure(
             apWriter->StartContainer(TLV::ContextTag(AttributeDataElement::kCsTag_Data), TLV::kTLVType_List, containerType));
         // TODO: Encode data in TLV, now raw buffers
-        ReturnErrorOnFailure(
-            apWriter->PutBytes(TLV::AnonymousTag, data,
-                               emberAfAttributeValueSize(aClusterInfo.mClusterId, aClusterInfo.mFieldId, attributeType, data)));
+        ReturnErrorOnFailure(apWriter->PutBytes(
+            TLV::AnonymousTag, attributeData,
+            emberAfAttributeValueSize(aClusterInfo.mClusterId, aClusterInfo.mFieldId, attributeType, attributeData)));
         ReturnErrorOnFailure(apWriter->EndContainer(containerType));
         break;
     }
@@ -338,6 +343,118 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     // TODO: Add DataVersion support
     ReturnErrorOnFailure(apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_DataVersion), kTemporaryDataVersion));
     return CHIP_NO_ERROR;
+}
+
+namespace {
+template <typename T>
+CHIP_ERROR numericTlvDataToAttributeBuffer(TLV::TLVReader & aReader, uint16_t & dataLen)
+{
+    T value;
+    static_assert(sizeof(value) <= sizeof(attributeData), "Value cannot fit into attribute data");
+    ReturnErrorOnFailure(aReader.Get(value));
+    dataLen = sizeof(value);
+    memcpy(attributeData, &value, sizeof(value));
+    return CHIP_NO_ERROR;
+}
+template <typename T>
+CHIP_ERROR stringTlvDataToAttributeBuffer(TLV::TLVReader & aReader, uint16_t & dataLen)
+{
+    const uint8_t * data = nullptr;
+    T len;
+    VerifyOrReturnError(aReader.GetType() == TLV::TLVType::kTLVType_ByteString ||
+                            aReader.GetType() == TLV::TLVType::kTLVType_UTF8String,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<T>(aReader.GetLength()), CHIP_ERROR_MESSAGE_TOO_LONG);
+    ReturnErrorOnFailure(aReader.GetDataPtr(data));
+    len = static_cast<T>(aReader.GetLength());
+    VerifyOrReturnError(len + sizeof(len) /* length at the beginning of data */ <= sizeof(attributeData),
+                        CHIP_ERROR_MESSAGE_TOO_LONG);
+    memcpy(&attributeData[0], &len, sizeof(len));
+    memcpy(&attributeData[sizeof(len)], data, len);
+    dataLen = static_cast<uint16_t>(len + sizeof(len));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR prepareWriteData(EmberAfAttributeType expectedType, TLV::TLVReader & aReader, uint16_t & dataLen)
+{
+    switch (BaseType(expectedType))
+    {
+    case ZCL_BOOLEAN_ATTRIBUTE_TYPE: // Boolean
+        return numericTlvDataToAttributeBuffer<bool>(aReader, dataLen);
+    case ZCL_INT8U_ATTRIBUTE_TYPE: // Unsigned 8-bit integer
+        return numericTlvDataToAttributeBuffer<uint8_t>(aReader, dataLen);
+    case ZCL_INT16U_ATTRIBUTE_TYPE: // Unsigned 16-bit integer
+        return numericTlvDataToAttributeBuffer<uint16_t>(aReader, dataLen);
+    case ZCL_INT32U_ATTRIBUTE_TYPE: // Unsigned 32-bit integer
+        return numericTlvDataToAttributeBuffer<uint32_t>(aReader, dataLen);
+    case ZCL_INT64U_ATTRIBUTE_TYPE: // Unsigned 64-bit integer
+        return numericTlvDataToAttributeBuffer<uint64_t>(aReader, dataLen);
+    case ZCL_INT8S_ATTRIBUTE_TYPE: // Signed 8-bit integer
+        return numericTlvDataToAttributeBuffer<int8_t>(aReader, dataLen);
+    case ZCL_INT16S_ATTRIBUTE_TYPE: // Signed 16-bit integer
+        return numericTlvDataToAttributeBuffer<int16_t>(aReader, dataLen);
+    case ZCL_INT32S_ATTRIBUTE_TYPE: // Signed 32-bit integer
+        return numericTlvDataToAttributeBuffer<int32_t>(aReader, dataLen);
+    case ZCL_INT64S_ATTRIBUTE_TYPE: // Signed 64-bit integer
+        return numericTlvDataToAttributeBuffer<int64_t>(aReader, dataLen);
+    case ZCL_OCTET_STRING_ATTRIBUTE_TYPE: // Octet string
+    case ZCL_CHAR_STRING_ATTRIBUTE_TYPE:  // Char string
+        return stringTlvDataToAttributeBuffer<uint8_t>(aReader, dataLen);
+    case ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE: // Long octet string
+    case ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE:  // Long char string
+        return stringTlvDataToAttributeBuffer<uint16_t>(aReader, dataLen);
+    default:
+        ChipLogError(DataManagement, "Attribute type %x not handled", static_cast<int>(expectedType));
+        return CHIP_ERROR_INVALID_DATA_LIST;
+    }
+}
+} // namespace
+
+CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader, WriteHandler * apWriteHandler)
+{
+    AttributePathParams attributePathParams;
+    attributePathParams.mNodeId     = aClusterInfo.mNodeId;
+    attributePathParams.mEndpointId = aClusterInfo.mEndpointId;
+    attributePathParams.mClusterId  = aClusterInfo.mClusterId;
+    attributePathParams.mFieldId    = aClusterInfo.mFieldId;
+    attributePathParams.mFlags.Set(AttributePathParams::Flags::kFieldIdValid);
+
+    EmberAfAttributeType attributeType = ZCL_UNKNOWN_ATTRIBUTE_TYPE;
+
+    // Passing nullptr as buf to emberAfReadAttribute means we only need attribute type here, and ember will not do data read &
+    // copy in this case.
+    EmberAfStatus status = emberAfReadAttribute(aClusterInfo.mEndpointId, aClusterInfo.mClusterId, aClusterInfo.mFieldId,
+                                                CLUSTER_MASK_SERVER, nullptr, 0, &attributeType);
+    Protocols::InteractionModel::ProtocolCode imCode = Protocols::InteractionModel::ProtocolCode::Success;
+
+    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    {
+        return apWriteHandler->AddAttributeStatusCode(attributePathParams, Protocols::SecureChannel::GeneralStatusCode::kFailure,
+                                                      Protocols::SecureChannel::Id,
+                                                      Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute);
+    }
+
+    CHIP_ERROR preparationError = CHIP_NO_ERROR;
+    uint16_t dataLen            = 0;
+    if ((preparationError = prepareWriteData(attributeType, aReader, dataLen)) == CHIP_NO_ERROR)
+    {
+        // TODO (#8442): emberAfWriteAttributeExternal is doing additional ACL check, however true ACL support is missing in ember /
+        // IM. Should invesgate this function and integrate ACL support with related interactions.
+        imCode = ToInteractionModelProtocolCode(emberAfWriteAttributeExternal(aClusterInfo.mEndpointId, aClusterInfo.mClusterId,
+                                                                              aClusterInfo.mFieldId, CLUSTER_MASK_SERVER, 0,
+                                                                              attributeData, attributeType));
+    }
+    else
+    {
+        ChipLogError(Zcl, "Failed to preapre data to write: %s", ErrorStr(preparationError));
+        imCode = Protocols::InteractionModel::ProtocolCode::InvalidValue;
+    }
+
+    return apWriteHandler->AddAttributeStatusCode(attributePathParams,
+                                                  imCode == Protocols::InteractionModel::ProtocolCode::Success
+                                                      ? Protocols::SecureChannel::GeneralStatusCode::kSuccess
+                                                      : Protocols::SecureChannel::GeneralStatusCode::kFailure,
+                                                  Protocols::SecureChannel::Id, imCode);
 }
 
 } // namespace app

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -99,7 +99,6 @@ static void printDiscoverCommandsResponse(bool generated, ClusterId clusterId, b
 
 bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
 {
-    AttributeId attrId;
     uint8_t frameControl;
     // This is a little clumsy but easier to read and port
     // from earlier implementation.
@@ -112,9 +111,12 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
 
     // If we are disabled then we can only respond to read or write commands
     // or identify cluster (see device enabled attr of basic cluster)
-    if (!emberAfIsDeviceEnabled(cmd->apsFrame->destinationEndpoint) && zclCmd != ZCL_READ_ATTRIBUTES_COMMAND_ID &&
+    // Since read and write is handled by interaction model, we only need to handle identify command.
+    if (!emberAfIsDeviceEnabled(cmd->apsFrame->destinationEndpoint) &&
+        /* zclCmd != ZCL_READ_ATTRIBUTES_COMMAND_ID &&
         zclCmd != ZCL_WRITE_ATTRIBUTES_COMMAND_ID && zclCmd != ZCL_WRITE_ATTRIBUTES_UNDIVIDED_COMMAND_ID &&
-        zclCmd != ZCL_WRITE_ATTRIBUTES_NO_RESPONSE_COMMAND_ID && clusterId != ZCL_IDENTIFY_CLUSTER_ID)
+        zclCmd != ZCL_WRITE_ATTRIBUTES_NO_RESPONSE_COMMAND_ID && */
+        clusterId != ZCL_IDENTIFY_CLUSTER_ID)
     {
         emberAfCorePrintln("disabled");
         emberAfDebugPrintln("%pd, dropping global cmd:%x", "disable", zclCmd);
@@ -154,203 +156,8 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
 
     switch (zclCmd)
     {
-    // Write undivided means all attributes must be written in order to write
-    // any of them. So first do a check. If the check fails, send back a fail
-    // response. If it works, fall through to the normal write attr code.
-    // write attr responses are the same for undivided and normal writes.
-    case ZCL_WRITE_ATTRIBUTES_UNDIVIDED_COMMAND_ID: {
-        uint8_t numFailures = 0;
-        uint8_t dataType;
-        uint16_t dataSize;
-        EmberAfStatus status;
-
-        emberAfPutInt32uInResp(ZCL_WRITE_ATTRIBUTES_RESPONSE_COMMAND_ID);
-
-        // Go through the message until there are no more attrID/type/data
-        while (msgIndex < msgLen - 5)
-        {
-            attrId   = emberAfGetInt32u(message, msgIndex, msgLen);
-            dataType = emberAfGetInt8u(message, msgIndex + 4, msgLen);
-
-            dataSize = emberAfAttributeValueSize(clusterId, attrId, dataType, message + msgIndex + 5);
-
-            // Check to see if there are dataSize bytes left in the message if it is a string
-            if (emberAfIsThisDataTypeAStringType(dataType) && (dataSize < msgLen - (msgIndex + 5)))
-            {
-                // This command is malformed
-                status = EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            else
-            {
-                status = emberAfVerifyAttributeWrite(cmd->apsFrame->destinationEndpoint, clusterId, attrId, clientServerMask,
-                                                     cmd->mfgCode, &(message[msgIndex + 5]), dataType);
-            }
-
-            if (status != EMBER_ZCL_STATUS_SUCCESS)
-            {
-                numFailures++;
-                // Write to the response buffer - status and then attrID
-                emberAfPutStatusInResp(status);
-                emberAfPutInt32uInResp(attrId);
-
-                emberAfAttributesPrintln("WRITE: clus %2x attr %2x ", clusterId, attrId);
-                emberAfAttributesPrintln("FAIL %x", status);
-                emberAfCoreFlush();
-                if (status == EMBER_ZCL_STATUS_MALFORMED_COMMAND)
-                {
-                    // this attribute is malformed, terminate attribute processing.
-                    break;
-                }
-            }
-
-            // Increment past the attribute id (four bytes), the type (one byte), and
-            // the data (N bytes, including the length byte for strings).
-            msgIndex = static_cast<uint16_t>(msgIndex + 5 + dataSize);
-        }
-        // If there are any failures, send the response and exit
-        if (numFailures > 0)
-        {
-            emberAfSendResponse();
-            return true;
-        }
-    }
-        // Reset message back to start
-        msgIndex          = cmd->payloadStartIndex;
-        appResponseLength = (cmd->mfgSpecific ? 4 : 2);
-        FALLTHROUGH;
-        /* fall through */
-    // DO NOT BREAK from this case
-
-    // the format of the write attributes cmd is:
-    // ([attr ID:4] [data type:1] [data:N]) * N
-    // the format of the write attributes response is:
-    // ([status 1] [attr ID 2]) * n
-    // ONLY errors are reported unless all are successful then a single success
-    // is sent. write attr no response is handled by just executing the same
-    // code but not setting the flag that sends the response at the end.
-    case ZCL_WRITE_ATTRIBUTES_NO_RESPONSE_COMMAND_ID:
-    case ZCL_WRITE_ATTRIBUTES_COMMAND_ID: {
-        uint8_t numFailures = 0;
-        uint8_t numSuccess  = 0;
-        uint8_t dataType;
-        uint16_t dataSize;
-#if (BIGENDIAN_CPU)
-        uint8_t writeData[ATTRIBUTE_LARGEST];
-#endif //(BIGENDIAN_CPU)
-        EmberAfStatus status;
-
-        // set the cmd byte - this is byte 3 index 2, but since we have
-        // already incremented past the 3 byte ZCL header (our index is at 3),
-        // this gets written to "-1" since 3 - 1 = 2.
-        emberAfPutInt32uInResp(ZCL_WRITE_ATTRIBUTES_RESPONSE_COMMAND_ID);
-
-        // go through the message until there are no more attrID/type/data
-        while (msgLen > msgIndex + 5)
-        {
-            attrId   = emberAfGetInt32u(message, msgIndex, msgLen);
-            dataType = emberAfGetInt8u(message, msgIndex + 4, msgLen);
-
-            dataSize = emberAfAttributeValueSize(clusterId, attrId, dataType, message + msgIndex + 5);
-
-            // the data is sent little endian over-the-air, it needs to be
-            // inserted into the table big endian for the EM250 and little
-            // endian for the EZSP hosts. This means for the EM250 the data
-            // needs to be reversed before sending to writeAttributes
-#if (BIGENDIAN_CPU)
-            if (dataSize <= msgLen - (msgIndex + 5) && dataSize <= ATTRIBUTE_LARGEST)
-            {
-                // strings go over the air as length byte and then in human
-                // readable format. These should not be flipped.
-                if (emberAfIsThisDataTypeAStringType(dataType))
-                {
-                    memmove(writeData, message + msgIndex + 5, dataSize);
-                }
-                else
-                {
-                    // the data is sent little endian over-the-air, it needs to be
-                    // inserted into the table big endian
-                    uint16_t i;
-                    for (i = 0; i < dataSize; i++)
-                    {
-                        writeData[i] = message[msgIndex + 5 + dataSize - i - 1];
-                    }
-                }
-#else  //(BIGENDIAN_CPU)
-            if (dataSize <= msgLen - (msgIndex + 5))
-            {
-#endif //(BIGENDIAN_CPU)
-
-                status = emberAfWriteAttributeExternal(cmd->apsFrame->destinationEndpoint, clusterId, attrId, clientServerMask,
-                                                       cmd->mfgCode,
-#if (BIGENDIAN_CPU)
-                                                       writeData,
-#else  //(BIGENDIAN_CPU)
-                                                       &(message[msgIndex + 5]),
-#endif //(BIGENDIAN_CPU)
-                                                       dataType);
-                emberAfAttributesPrint("WRITE: clus %2x attr %2x ", clusterId, attrId);
-                if (status == EMBER_ZCL_STATUS_SUCCESS)
-                {
-                    numSuccess++;
-                    emberAfAttributesPrintln("OK");
-                }
-                else
-                {
-                    numFailures++;
-                    // write to the response buffer - status and then attrID
-                    emberAfPutStatusInResp(status);
-                    emberAfPutInt32uInResp(attrId);
-                    emberAfAttributesPrintln("FAIL %x", status);
-                }
-                emberAfCoreFlush();
-
-                // Increment past the attribute id (four bytes), the type (one byte), and
-                // the data (N bytes, including the length byte for strings).
-                msgIndex = static_cast<uint16_t>(msgIndex + 5 + dataSize);
-            }
-            else
-            {
-                numFailures++;
-                status = EMBER_ZCL_STATUS_INVALID_VALUE;
-                // write to the response buffer - status and then attrID
-                emberAfPutStatusInResp(status);
-                emberAfPutInt32uInResp(attrId);
-                emberAfAttributesPrintln("FAIL %x", status);
-                // size exceeds buffer, terminate loop
-                break;
-            }
-        }
-
-        // always send a response unless the cmd requested no response
-        if (zclCmd == ZCL_WRITE_ATTRIBUTES_NO_RESPONSE_COMMAND_ID)
-        {
-            return true;
-        }
-
-        if (numFailures == 0)
-        {
-            // if no failures and no success this means the packet was too short
-            // print an error message but still return true as we consumed the
-            // message
-            if (numSuccess == 0)
-            {
-                emberAfAttributesPrintln("WRITE: too short");
-                emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_MALFORMED_COMMAND);
-                return true;
-            }
-            // if no failures and at least one success, write a success status
-            // that means everything worked
-            else
-            {
-                emberAfPutInt8uInResp(EMBER_ZCL_STATUS_SUCCESS);
-            }
-        }
-        emberAfSendResponse();
-        return true;
-    }
-
-    // the format of discover is: [start attr ID:4] [max attr IDs:1]
-    // the format of the response is: [done:1] ([attrID:4] [type:1]) * N
+    // the format of discover is: [start attr ID:2] [max attr IDs:1]
+    // the format of the response is: [done:1] ([attrID:2] [type:1]) * N
     case ZCL_DISCOVER_ATTRIBUTES_COMMAND_ID:
     case ZCL_DISCOVER_ATTRIBUTES_EXTENDED_COMMAND_ID: {
         AttributeId startingAttributeId;
@@ -413,87 +220,6 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         }
         break;
 
-    // ([attribute id:4] [status:1] [type:0/1] [value:0/V])+
-    case ZCL_READ_ATTRIBUTES_RESPONSE_COMMAND_ID:
-        // The "timesync" command in the CLI sends a Read Attributes command for the
-        // Time attribute on another device and then sets a flag.  If that flag is
-        // set and a Read Attributes Response command for the time comes in, we set
-        // the time to the value in the message.
-        if (clusterId == ZCL_TIME_CLUSTER_ID)
-        {
-            if (emAfSyncingTime && !cmd->mfgSpecific && msgLen - msgIndex == 10 // attr:4 status:1 type:1 data:4
-                && (emberAfGetInt32u(message, msgIndex, msgLen) == ZCL_TIME_ATTRIBUTE_ID) &&
-                (emberAfGetInt8u(message, msgIndex + 4, msgLen) == EMBER_ZCL_STATUS_SUCCESS) &&
-                (emberAfGetInt8u(message, msgIndex + 5, msgLen) == ZCL_UTC_ATTRIBUTE_TYPE))
-            {
-                // emberAfSetTime(emberAfGetInt32u(message, msgIndex + 4, msgLen));
-                // emberAfDebugPrintln("time sync ok, time: %4x", emberAfGetCurrentTime());
-                emAfSyncingTime = false;
-            }
-#ifdef EMBER_AF_PLUGIN_SMART_ENERGY_REGISTRATION_TIME_SOURCE_REQUIRED
-            emAfPluginSmartEnergyRegistrationReadAttributesResponseCallback(message + msgIndex, msgLen - msgIndex);
-#endif // EMBER_AF_PLUGIN_SMART_ENERGY_REGISTRATION_TIME_SOURCE_REQUIRED
-#ifdef EMBER_AF_PLUGIN_WWAH_SERVER_SILABS
-            emAfPluginSlWwahReadAttributesResponseCallback(clusterId, message, msgLen);
-#endif
-        }
-
-#ifdef EMBER_AF_PLUGIN_TRUST_CENTER_KEEPALIVE
-        if (clusterId == ZCL_KEEPALIVE_CLUSTER_ID && !cmd->mfgSpecific)
-        {
-            emAfPluginTrustCenterKeepaliveReadAttributesResponseCallback(message + msgIndex, msgLen - msgIndex);
-        }
-#endif // EMBER_AF_PLUGIN_TRUST_CENTER_KEEPALIVE
-
-#if defined(EMBER_AF_PLUGIN_KEY_ESTABLISHMENT)
-        if (clusterId == ZCL_KEY_ESTABLISHMENT_CLUSTER_ID && !cmd->mfgSpecific &&
-            msgLen - msgIndex == 8 // attr:4 status:1 type:1 data:2
-            && (emberAfGetInt32u(message, msgIndex, msgLen) == ZCL_KEY_ESTABLISHMENT_SUITE_CLIENT_ATTRIBUTE_ID) &&
-            (emberAfGetInt8u(message, msgIndex + 4, msgLen) == EMBER_ZCL_STATUS_SUCCESS) &&
-            ((emberAfGetInt8u(message, msgIndex + 5, msgLen) == ZCL_ENUM16_ATTRIBUTE_TYPE) ||
-             (emberAfGetInt8u(message, msgIndex + 5, msgLen) == ZCL_BITMAP16_ATTRIBUTE_TYPE)))
-        {
-            uint16_t suite = emberAfGetInt16u(message, msgIndex + 6, msgLen);
-            emberAfPluginKeyEstablishmentReadAttributesCallback(suite);
-        }
-#endif
-
-#if defined(EMBER_AF_PLUGIN_TEST_HARNESS)
-        emberAfPluginTestHarnessReadAttributesResponseCallback(clusterId, message + msgIndex, msgLen - msgIndex);
-#endif
-
-#if defined(EMBER_AF_PLUGIN_IAS_ZONE_CLIENT)
-        emberAfPluginIasZoneClientReadAttributesResponseCallback(clusterId, message + msgIndex,
-                                                                 static_cast<uint16_t>(msgLen - msgIndex));
-#endif
-
-#if defined(EMBER_AF_PLUGIN_SIMPLE_METERING_SERVER)
-        emberAfPluginSimpleMeteringClusterReadAttributesResponseCallback(clusterId, message + msgIndex,
-                                                                         static_cast<uint16_t>(msgLen - msgIndex));
-#endif
-
-        return true;
-
-    // ([status:1] [attribute id:4])+
-    case ZCL_WRITE_ATTRIBUTES_RESPONSE_COMMAND_ID:
-
-#if defined(EMBER_AF_PLUGIN_TEST_HARNESS)
-        emberAfPluginTestHarnessWriteAttributesResponseCallback(clusterId, message + msgIndex,
-                                                                static_cast<uint16_t>(msgLen - msgIndex));
-#endif
-
-#if defined(EMBER_AF_PLUGIN_IAS_ZONE_CLIENT)
-        emberAfPluginIasZoneClientWriteAttributesResponseCallback(clusterId, message + msgIndex,
-                                                                  static_cast<uint16_t>(msgLen - msgIndex));
-#endif
-
-        if (!emberAfWriteAttributesResponseCallback(clusterId, message + msgIndex, static_cast<uint16_t>(msgLen - msgIndex)))
-        {
-            emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_SUCCESS);
-        }
-        return true;
-
-    // ([status:1] [direction:1] [attribute id:4])+
     case ZCL_CONFIGURE_REPORTING_RESPONSE_COMMAND_ID:
         if (!emberAfConfigureReportingResponseCallback(clusterId, message + msgIndex, static_cast<uint16_t>(msgLen - msgIndex)))
         {

--- a/src/app/zap-templates/app-templates.json
+++ b/src/app/zap-templates/app-templates.json
@@ -5,6 +5,7 @@
         "partials/helper.js",
         "common/ListHelper.js",
         "common/StringHelper.js",
+        "common/ChipTypesHelper.js",
         "templates/app/helper.js",
         "templates/chip/helper.js"
     ],

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -113,6 +113,9 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
         return true;                                                                                                               \
     }
 
+#define GET_ATTRIBUTE_RESPONSE_CALLBACKS(name)                                                                                     \
+
+
 #define GET_REPORT_CALLBACK(name)                                                                                                  \
     Callback::Cancelable * onReportCallback = nullptr;                                                                             \
     CHIP_ERROR err = gCallbacks.GetReportCallback(sourceId, endpointId, clusterId, attributeId, &onReportCallback);                \
@@ -126,6 +129,8 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
                                                                                                                                    \
         return true;                                                                                                               \
     }
+
+// TODO: These IM related callbacks contains small or no generated code, should be put into seperate file to reduce the size of template.
 
 void LogStatus(uint8_t status)
 {
@@ -406,6 +411,48 @@ bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfSta
     else
     {
         Callback::Callback<DefaultFailureCallback> * cb = Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
+        cb->mCall(cb->mContext, static_cast<uint8_t>(status));
+    }
+
+    return true;
+}
+
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status)
+{
+    ChipLogProgress(Zcl, "WriteResponse:");
+    LogStatus(status);
+
+    Callback::Cancelable * onSuccessCallback = nullptr;                                                                            \
+    Callback::Cancelable * onFailureCallback = nullptr;                                                                            \
+    NodeId sourceNodeId                      = writeClient->GetSourceNodeId();                                                     \
+    uint8_t seq                              = static_cast<uint8_t>(writeClient->GetAppIdentifier());                      \
+    CHIP_ERROR err = gCallbacks.GetResponseCallback(sourceNodeId, seq, &onSuccessCallback, &onFailureCallback);                    \
+                                                                                                                                   \
+    if (CHIP_NO_ERROR != err)                                                                                                      \
+    {                                                                                                                              \
+        if (onSuccessCallback == nullptr)                                                                                          \
+        {                                                                                                                          \
+            ChipLogDetail(Zcl, "%s: Missing success callback", __FUNCTION__);                                                              \
+        }                                                                                                                          \
+                                                                                                                                   \
+        if (onFailureCallback == nullptr)                                                                                          \
+        {                                                                                                                          \
+            ChipLogDetail(Zcl, "%s: Missing failure callback", __FUNCTION__);                                                              \
+        }                                                                                                                          \
+                                                                                                                                   \
+        return true;                                                                                                               \
+    }
+
+    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    {
+        Callback::Callback<DefaultSuccessCallback> * cb =
+            Callback::Callback<DefaultSuccessCallback>::FromCancelable(onSuccessCallback);
+        cb->mCall(cb->mContext);
+    }
+    else
+    {
+        Callback::Callback<DefaultFailureCallback> * cb =
+            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
         cb->mCall(cb->mContext, static_cast<uint8_t>(status));
     }
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -17,6 +17,7 @@
 bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
 bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
                                             chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status);
 
 // Global Response Callbacks
 typedef void (*DefaultSuccessCallback)(void * context);

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -15,6 +15,9 @@
 #include <app/util/basic-types.h>
 
 #include <gen/CHIPClientCallbacks.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/CodeUtils.h>
+#include <app/InteractionModelEngine.h>
 
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
@@ -140,31 +143,20 @@ CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ReadAttribute{{asUpperCamelC
 }
 
 {{#if isWritableAttribute}}
-CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::WriteAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, {{chipType}} {{asLowerCamelCase name}})
+CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::WriteAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, {{chipType}} value)
 {
-    COMMAND_HEADER("Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}", {{asUpperCamelCase parent.name}}::Id);
-    {{#if (isString type)}}
-    size_t {{asLowerCamelCase name}}StrLen = {{asLowerCamelCase name}}.size();
-    if (!CanCastTo<{{#if (isShortString type)}}uint8_t{{else}}uint16_t{{/if}}>({{asLowerCamelCase name}}StrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, {{asLowerCamelCase name}}StrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId         = mDevice->GetDeviceId();
+    attributePath.mEndpointId     = mEndpoint;
+    attributePath.mClusterId      = mClusterId;
+    attributePath.mFieldId        = {{ asHex code 8 }};
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    {{/if}}
-    buf.Put8(kFrameControlGlobalCommand)
-       .Put8(seqNum)
-       .Put32(Globals::Commands::Ids::WriteAttributes)
-       .Put32({{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::Ids::{{asUpperCamelCase name}})
-       .Put8({{atomicTypeId}})
-    {{#if (isString type)}}
-       .Put{{#if (isLongString type)}}16{{/if}}(static_cast<{{#if (isShortString type)}}uint8_t{{else}}uint16_t{{/if}}>({{asLowerCamelCase name}}StrLen))
-       .Put({{asLowerCamelCase name}}.data(), {{asLowerCamelCase name}}StrLen)
-    {{else}}
-       .Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>({{asLowerCamelCase name}}))
-    {{/if}}
-       ;
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 {{/if}}

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -697,6 +697,27 @@ CHIP_ERROR Device::SendReadAttributeRequest(app::AttributePathParams aPath, Call
     return err;
 }
 
+CHIP_ERROR Device::SendWriteAttributeRequest(app::WriteClientHandle aHandle, Callback::Cancelable * onSuccessCallback,
+                                             Callback::Cancelable * onFailureCallback)
+{
+    bool loadedSecureSession = false;
+    uint8_t seqNum           = GetNextSequenceNumber();
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+
+    aHandle->SetAppIdentifier(seqNum);
+    ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
+
+    if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
+    {
+        AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback);
+    }
+    if ((err = aHandle.SendWriteRequest(GetDeviceId(), 0, &mSecureSession)) != CHIP_NO_ERROR)
+    {
+        CancelResponseHandler(seqNum);
+    }
+    return err;
+}
+
 Device::~Device()
 {
     if (mExchangeMgr)

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -151,6 +151,9 @@ public:
     CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
                                         Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter);
 
+    CHIP_ERROR SendWriteAttributeRequest(app::WriteClientHandle aHandle, Callback::Cancelable * onSuccessCallback,
+                                         Callback::Cancelable * onFailureCallback);
+
     /**
      * @brief
      *   Send the command in internal command sender.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -45,6 +45,7 @@
 
 #include <app/InteractionModelEngine.h>
 #include <app/util/DataModelHandler.h>
+#include <app/util/error-mapping.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
@@ -1669,6 +1670,36 @@ CHIP_ERROR DeviceControllerInteractionModelDelegate::ReportError(const app::Read
 #if !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE // temporary - until example app clusters are updated (Issue 8347)
     IMReadReportAttributesResponseCallback(apReadClient, path, nullptr, Protocols::InteractionModel::ProtocolCode::Failure);
 #endif // !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceControllerInteractionModelDelegate::WriteResponseStatus(
+    const app::WriteClient * apWriteClient, const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
+    const uint32_t aProtocolId, const uint16_t aProtocolCode, app::AttributePathParams & aAttributePathParams,
+    uint8_t aCommandIndex)
+{
+#if !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE // temporary - until example app clusters are updated (Issue 8347)
+    IMWriteResponseCallback(apWriteClient, chip::app::ToEmberAfStatus(Protocols::InteractionModel::ProtocolCode(aProtocolCode)));
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceControllerInteractionModelDelegate::WriteResponseProtocolError(const app::WriteClient * apWriteClient,
+                                                                                uint8_t aAttributeIndex)
+{
+#if !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE // temporary - until example app clusters are updated (Issue 8347)
+    // When WriteResponseProtocolError occurred, it means server returned an invalid packet.
+    IMWriteResponseCallback(apWriteClient, EMBER_ZCL_STATUS_FAILURE);
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceControllerInteractionModelDelegate::WriteResponseError(const app::WriteClient * apWriteClient, CHIP_ERROR aError)
+{
+#if !CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE // temporary - until example app clusters are updated (Issue 8347)
+    // When WriteResponseError occurred, it means we failed to receive the response from server.
+    IMWriteResponseCallback(apWriteClient, EMBER_ZCL_STATUS_FAILURE);
+#endif
     return CHIP_NO_ERROR;
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -180,6 +180,15 @@ public:
     void OnReportData(const app::ReadClient * apReadClient, const app::ClusterInfo & aPath, TLV::TLVReader * apData,
                       Protocols::InteractionModel::ProtocolCode status) override;
     CHIP_ERROR ReportError(const app::ReadClient * apReadClient, CHIP_ERROR aError) override;
+
+    CHIP_ERROR WriteResponseStatus(const app::WriteClient * apWriteClient,
+                                   const Protocols::SecureChannel::GeneralStatusCode aGeneralCode, const uint32_t aProtocolId,
+                                   const uint16_t aProtocolCode, app::AttributePathParams & aAttributePathParams,
+                                   uint8_t aCommandIndex) override;
+
+    CHIP_ERROR WriteResponseProtocolError(const app::WriteClient * apWriteClient, uint8_t aAttributeIndex) override;
+
+    CHIP_ERROR WriteResponseError(const app::WriteClient * apWriteClient, CHIP_ERROR aError) override;
 };
 
 /**

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -128,6 +128,8 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
         return true;                                                                                                               \
     }
 
+#define GET_ATTRIBUTE_RESPONSE_CALLBACKS(name)
+
 #define GET_REPORT_CALLBACK(name)                                                                                                  \
     Callback::Cancelable * onReportCallback = nullptr;                                                                             \
     CHIP_ERROR err = gCallbacks.GetReportCallback(sourceId, endpointId, clusterId, attributeId, &onReportCallback);                \
@@ -141,6 +143,9 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
                                                                                                                                    \
         return true;                                                                                                               \
     }
+
+// TODO: These IM related callbacks contains small or no generated code, should be put into seperate file to reduce the size of
+// template.
 
 void LogStatus(uint8_t status)
 {
@@ -415,6 +420,48 @@ bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfSta
     LogStatus(status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
+    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    {
+        Callback::Callback<DefaultSuccessCallback> * cb =
+            Callback::Callback<DefaultSuccessCallback>::FromCancelable(onSuccessCallback);
+        cb->mCall(cb->mContext);
+    }
+    else
+    {
+        Callback::Callback<DefaultFailureCallback> * cb =
+            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
+        cb->mCall(cb->mContext, static_cast<uint8_t>(status));
+    }
+
+    return true;
+}
+
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status)
+{
+    ChipLogProgress(Zcl, "WriteResponse:");
+    LogStatus(status);
+
+    Callback::Cancelable * onSuccessCallback = nullptr;
+    Callback::Cancelable * onFailureCallback = nullptr;
+    NodeId sourceNodeId                      = writeClient->GetSourceNodeId();
+    uint8_t seq                              = static_cast<uint8_t>(writeClient->GetAppIdentifier());
+    CHIP_ERROR err = gCallbacks.GetResponseCallback(sourceNodeId, seq, &onSuccessCallback, &onFailureCallback);
+
+    if (CHIP_NO_ERROR != err)
+    {
+        if (onSuccessCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing success callback", __FUNCTION__);
+        }
+
+        if (onFailureCallback == nullptr)
+        {
+            ChipLogDetail(Zcl, "%s: Missing failure callback", __FUNCTION__);
+        }
+
+        return true;
+    }
+
     if (status == EMBER_ZCL_STATUS_SUCCESS)
     {
         Callback::Callback<DefaultSuccessCallback> * cb =

--- a/src/controller/data_model/gen/CHIPClientCallbacks.h
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.h
@@ -33,6 +33,7 @@
 bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
 bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
                                             chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
+bool IMWriteResponseCallback(const chip::app::WriteClient * writeClient, EmberAfStatus status);
 
 // Global Response Callbacks
 typedef void (*DefaultSuccessCallback)(void * context);

--- a/src/controller/data_model/gen/CHIPClusters.cpp
+++ b/src/controller/data_model/gen/CHIPClusters.cpp
@@ -30,7 +30,10 @@
 #include <app/common/gen/ids/Attributes.h>
 #include <app/util/basic-types.h>
 
+#include <app/InteractionModelEngine.h>
 #include <gen/CHIPClientCallbacks.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
@@ -994,24 +997,20 @@ CHIP_ERROR BasicCluster::ReadAttributeUserLabel(Callback::Cancelable * onSuccess
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 chip::ByteSpan userLabel)
+                                                 chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteBasicUserLabel", Basic::Id);
-    size_t userLabelStrLen = userLabel.size();
-    if (!CanCastTo<uint8_t>(userLabelStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, userLabelStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000005;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Basic::Attributes::Ids::UserLabel)
-        .Put8(66)
-        .Put(static_cast<uint8_t>(userLabelStrLen))
-        .Put(userLabel.data(), userLabelStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BasicCluster::ReadAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
@@ -1026,24 +1025,20 @@ CHIP_ERROR BasicCluster::ReadAttributeLocation(Callback::Cancelable * onSuccessC
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                chip::ByteSpan location)
+                                                chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteBasicLocation", Basic::Id);
-    size_t locationStrLen = location.size();
-    if (!CanCastTo<uint8_t>(locationStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, locationStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000006;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Basic::Attributes::Ids::Location)
-        .Put8(66)
-        .Put(static_cast<uint8_t>(locationStrLen))
-        .Put(location.data(), locationStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BasicCluster::ReadAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback,
@@ -1165,16 +1160,20 @@ CHIP_ERROR BasicCluster::ReadAttributeLocalConfigDisabled(Callback::Cancelable *
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, bool localConfigDisabled)
+                                                           Callback::Cancelable * onFailureCallback, bool value)
 {
-    COMMAND_HEADER("WriteBasicLocalConfigDisabled", Basic::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Basic::Attributes::Ids::LocalConfigDisabled)
-        .Put8(16)
-        .Put8(static_cast<uint8_t>(localConfigDisabled));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000010;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BasicCluster::ReadAttributeReachable(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
@@ -1223,16 +1222,20 @@ CHIP_ERROR BinaryInputBasicCluster::ReadAttributeOutOfService(Callback::Cancelab
 }
 
 CHIP_ERROR BinaryInputBasicCluster::WriteAttributeOutOfService(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, bool outOfService)
+                                                               Callback::Cancelable * onFailureCallback, bool value)
 {
-    COMMAND_HEADER("WriteBinaryInputBasicOutOfService", BinaryInputBasic::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(BinaryInputBasic::Attributes::Ids::OutOfService)
-        .Put8(16)
-        .Put8(static_cast<uint8_t>(outOfService));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000051;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ReadAttributePresentValue(Callback::Cancelable * onSuccessCallback,
@@ -1248,16 +1251,20 @@ CHIP_ERROR BinaryInputBasicCluster::ReadAttributePresentValue(Callback::Cancelab
 }
 
 CHIP_ERROR BinaryInputBasicCluster::WriteAttributePresentValue(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, bool presentValue)
+                                                               Callback::Cancelable * onFailureCallback, bool value)
 {
-    COMMAND_HEADER("WriteBinaryInputBasicPresentValue", BinaryInputBasic::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(BinaryInputBasic::Attributes::Ids::PresentValue)
-        .Put8(16)
-        .Put8(static_cast<uint8_t>(presentValue));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000055;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ConfigureAttributePresentValue(Callback::Cancelable * onSuccessCallback,
@@ -1501,24 +1508,20 @@ CHIP_ERROR BridgedDeviceBasicCluster::ReadAttributeUserLabel(Callback::Cancelabl
 }
 
 CHIP_ERROR BridgedDeviceBasicCluster::WriteAttributeUserLabel(Callback::Cancelable * onSuccessCallback,
-                                                              Callback::Cancelable * onFailureCallback, chip::ByteSpan userLabel)
+                                                              Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteBridgedDeviceBasicUserLabel", BridgedDeviceBasic::Id);
-    size_t userLabelStrLen = userLabel.size();
-    if (!CanCastTo<uint8_t>(userLabelStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, userLabelStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000005;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(BridgedDeviceBasic::Attributes::Ids::UserLabel)
-        .Put8(66)
-        .Put(static_cast<uint8_t>(userLabelStrLen))
-        .Put(userLabel.data(), userLabelStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BridgedDeviceBasicCluster::ReadAttributeHardwareVersion(Callback::Cancelable * onSuccessCallback,
@@ -2837,17 +2840,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorControlOptions(Callback::Cance
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback,
-                                                                  uint8_t colorControlOptions)
+                                                                  Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorControlOptions", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorControlOptions)
-        .Put8(24)
-        .Put8(static_cast<uint8_t>(colorControlOptions));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000000F;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback,
@@ -3091,16 +3097,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointX(Callback::Cancelable * 
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeWhitePointX(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback, uint16_t whitePointX)
+                                                          Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlWhitePointX", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::WhitePointX)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(whitePointX));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000030;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
@@ -3116,16 +3126,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointY(Callback::Cancelable * 
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
-                                                          Callback::Cancelable * onFailureCallback, uint16_t whitePointY)
+                                                          Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlWhitePointY", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::WhitePointY)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(whitePointY));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000031;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
@@ -3141,16 +3155,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRX(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointRX)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointRX", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointRX)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointRX));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000032;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
@@ -3166,16 +3184,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRY(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointRY)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointRY", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointRY)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointRY));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000033;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
@@ -3191,17 +3213,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRIntensity(Callback::Canc
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback,
-                                                                   uint8_t colorPointRIntensity)
+                                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointRIntensity", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointRIntensity)
-        .Put8(32)
-        .Put8(static_cast<uint8_t>(colorPointRIntensity));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000034;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
@@ -3217,16 +3242,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGX(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointGX)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointGX", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointGX)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointGX));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000036;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
@@ -3242,16 +3271,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGY(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointGY)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointGY", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointGY)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointGY));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000037;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
@@ -3267,17 +3300,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGIntensity(Callback::Canc
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback,
-                                                                   uint8_t colorPointGIntensity)
+                                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointGIntensity", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointGIntensity)
-        .Put8(32)
-        .Put8(static_cast<uint8_t>(colorPointGIntensity));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000038;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
@@ -3293,16 +3329,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBX(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointBX)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointBX", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointBX)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointBX));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000003A;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
@@ -3318,16 +3358,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBY(Callback::Cancelable *
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t colorPointBY)
+                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointBY", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointBY)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(colorPointBY));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000003B;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
@@ -3343,17 +3387,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBIntensity(Callback::Canc
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback,
-                                                                   uint8_t colorPointBIntensity)
+                                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteColorControlColorPointBIntensity", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::ColorPointBIntensity)
-        .Put8(32)
-        .Put8(static_cast<uint8_t>(colorPointBIntensity));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000003C;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback,
@@ -3478,16 +3525,20 @@ CHIP_ERROR ColorControlCluster::ReadAttributeStartUpColorTemperatureMireds(Callb
 
 CHIP_ERROR ColorControlCluster::WriteAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
                                                                             Callback::Cancelable * onFailureCallback,
-                                                                            uint16_t startUpColorTemperatureMireds)
+                                                                            uint16_t value)
 {
-    COMMAND_HEADER("WriteColorControlStartUpColorTemperatureMireds", ColorControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ColorControl::Attributes::Ids::StartUpColorTemperatureMireds)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(startUpColorTemperatureMireds));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00004010;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -5362,16 +5413,20 @@ CHIP_ERROR GeneralCommissioningCluster::ReadAttributeBreadcrumb(Callback::Cancel
 }
 
 CHIP_ERROR GeneralCommissioningCluster::WriteAttributeBreadcrumb(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback, uint64_t breadcrumb)
+                                                                 Callback::Cancelable * onFailureCallback, uint64_t value)
 {
-    COMMAND_HEADER("WriteGeneralCommissioningBreadcrumb", GeneralCommissioning::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(GeneralCommissioning::Attributes::Ids::Breadcrumb)
-        .Put8(39)
-        .Put64(static_cast<uint64_t>(breadcrumb));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000001;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -5861,16 +5916,20 @@ CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyTime(Callback::Cancelable * onS
 }
 
 CHIP_ERROR IdentifyCluster::WriteAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback, uint16_t identifyTime)
+                                                       Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteIdentifyIdentifyTime", Identify::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Identify::Attributes::Ids::IdentifyTime)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(identifyTime));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000000;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IdentifyCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -8089,16 +8148,20 @@ CHIP_ERROR OnOffCluster::ReadAttributeOnTime(Callback::Cancelable * onSuccessCal
 }
 
 CHIP_ERROR OnOffCluster::WriteAttributeOnTime(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              uint16_t onTime)
+                                              uint16_t value)
 {
-    COMMAND_HEADER("WriteOnOffOnTime", OnOff::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(OnOff::Attributes::Ids::OnTime)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(onTime));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00004001;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ReadAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
@@ -8114,16 +8177,20 @@ CHIP_ERROR OnOffCluster::ReadAttributeOffWaitTime(Callback::Cancelable * onSucce
 }
 
 CHIP_ERROR OnOffCluster::WriteAttributeOffWaitTime(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, uint16_t offWaitTime)
+                                                   Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteOnOffOffWaitTime", OnOff::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(OnOff::Attributes::Ids::OffWaitTime)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(offWaitTime));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00004002;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ReadAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
@@ -8139,16 +8206,20 @@ CHIP_ERROR OnOffCluster::ReadAttributeStartUpOnOff(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR OnOffCluster::WriteAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, uint8_t startUpOnOff)
+                                                    Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteOnOffStartUpOnOff", OnOff::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(OnOff::Attributes::Ids::StartUpOnOff)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(startUpOnOff));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00004003;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ReadAttributeFeatureMap(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
@@ -8776,17 +8847,20 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeOperationMode(Callba
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::WriteAttributeOperationMode(Callback::Cancelable * onSuccessCallback,
-                                                                           Callback::Cancelable * onFailureCallback,
-                                                                           uint8_t operationMode)
+                                                                           Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WritePumpConfigurationAndControlOperationMode", PumpConfigurationAndControl::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(PumpConfigurationAndControl::Attributes::Ids::OperationMode)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(operationMode));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000020;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -9974,16 +10048,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBoolean(Callback::Cancelable * onSuc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBoolean(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback, bool boolean)
+                                                     Callback::Cancelable * onFailureCallback, bool value)
 {
-    COMMAND_HEADER("WriteTestClusterBoolean", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Boolean)
-        .Put8(16)
-        .Put8(static_cast<uint8_t>(boolean));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000000;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeBitmap8(Callback::Cancelable * onSuccessCallback,
@@ -9999,16 +10077,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBitmap8(Callback::Cancelable * onSuc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBitmap8(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback, uint8_t bitmap8)
+                                                     Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteTestClusterBitmap8", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Bitmap8)
-        .Put8(24)
-        .Put8(static_cast<uint8_t>(bitmap8));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000001;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeBitmap16(Callback::Cancelable * onSuccessCallback,
@@ -10024,16 +10106,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBitmap16(Callback::Cancelable * onSu
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBitmap16(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, uint16_t bitmap16)
+                                                      Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteTestClusterBitmap16", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Bitmap16)
-        .Put8(25)
-        .Put16(static_cast<uint16_t>(bitmap16));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000002;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeBitmap32(Callback::Cancelable * onSuccessCallback,
@@ -10049,16 +10135,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBitmap32(Callback::Cancelable * onSu
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBitmap32(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, uint32_t bitmap32)
+                                                      Callback::Cancelable * onFailureCallback, uint32_t value)
 {
-    COMMAND_HEADER("WriteTestClusterBitmap32", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Bitmap32)
-        .Put8(27)
-        .Put32(static_cast<uint32_t>(bitmap32));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000003;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeBitmap64(Callback::Cancelable * onSuccessCallback,
@@ -10074,16 +10164,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBitmap64(Callback::Cancelable * onSu
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBitmap64(Callback::Cancelable * onSuccessCallback,
-                                                      Callback::Cancelable * onFailureCallback, uint64_t bitmap64)
+                                                      Callback::Cancelable * onFailureCallback, uint64_t value)
 {
-    COMMAND_HEADER("WriteTestClusterBitmap64", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Bitmap64)
-        .Put8(31)
-        .Put64(static_cast<uint64_t>(bitmap64));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000004;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt8u(Callback::Cancelable * onSuccessCallback,
@@ -10099,16 +10193,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt8u(Callback::Cancelable * onSucce
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt8u(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, uint8_t int8u)
+                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt8u", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int8u)
-        .Put8(32)
-        .Put8(static_cast<uint8_t>(int8u));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000005;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt16u(Callback::Cancelable * onSuccessCallback,
@@ -10124,16 +10222,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt16u(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt16u(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, uint16_t int16u)
+                                                    Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt16u", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int16u)
-        .Put8(33)
-        .Put16(static_cast<uint16_t>(int16u));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000006;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt32u(Callback::Cancelable * onSuccessCallback,
@@ -10149,16 +10251,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt32u(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt32u(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, uint32_t int32u)
+                                                    Callback::Cancelable * onFailureCallback, uint32_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt32u", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int32u)
-        .Put8(35)
-        .Put32(static_cast<uint32_t>(int32u));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000008;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt64u(Callback::Cancelable * onSuccessCallback,
@@ -10174,16 +10280,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt64u(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt64u(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, uint64_t int64u)
+                                                    Callback::Cancelable * onFailureCallback, uint64_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt64u", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int64u)
-        .Put8(39)
-        .Put64(static_cast<uint64_t>(int64u));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000000C;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt8s(Callback::Cancelable * onSuccessCallback,
@@ -10199,16 +10309,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt8s(Callback::Cancelable * onSucce
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt8s(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, int8_t int8s)
+                                                   Callback::Cancelable * onFailureCallback, int8_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt8s", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int8s)
-        .Put8(40)
-        .Put8(static_cast<uint8_t>(int8s));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000000D;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt16s(Callback::Cancelable * onSuccessCallback,
@@ -10224,16 +10338,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt16s(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt16s(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, int16_t int16s)
+                                                    Callback::Cancelable * onFailureCallback, int16_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt16s", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int16s)
-        .Put8(41)
-        .Put16(static_cast<uint16_t>(int16s));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000000E;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt32s(Callback::Cancelable * onSuccessCallback,
@@ -10249,16 +10367,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt32s(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt32s(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, int32_t int32s)
+                                                    Callback::Cancelable * onFailureCallback, int32_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt32s", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int32s)
-        .Put8(43)
-        .Put32(static_cast<uint32_t>(int32s));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000010;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeInt64s(Callback::Cancelable * onSuccessCallback,
@@ -10274,16 +10396,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeInt64s(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeInt64s(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, int64_t int64s)
+                                                    Callback::Cancelable * onFailureCallback, int64_t value)
 {
-    COMMAND_HEADER("WriteTestClusterInt64s", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Int64s)
-        .Put8(47)
-        .Put64(static_cast<uint64_t>(int64s));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000014;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeEnum8(Callback::Cancelable * onSuccessCallback,
@@ -10299,16 +10425,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeEnum8(Callback::Cancelable * onSucce
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeEnum8(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, uint8_t enum8)
+                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteTestClusterEnum8", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Enum8)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(enum8));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000015;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeEnum16(Callback::Cancelable * onSuccessCallback,
@@ -10324,16 +10454,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeEnum16(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeEnum16(Callback::Cancelable * onSuccessCallback,
-                                                    Callback::Cancelable * onFailureCallback, uint16_t enum16)
+                                                    Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    COMMAND_HEADER("WriteTestClusterEnum16", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Enum16)
-        .Put8(49)
-        .Put16(static_cast<uint16_t>(enum16));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000016;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeOctetString(Callback::Cancelable * onSuccessCallback,
@@ -10349,24 +10483,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeOctetString(Callback::Cancelable * o
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeOctetString(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback, chip::ByteSpan octetString)
+                                                         Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteTestClusterOctetString", TestCluster::Id);
-    size_t octetStringStrLen = octetString.size();
-    if (!CanCastTo<uint8_t>(octetStringStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, octetStringStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000019;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::OctetString)
-        .Put8(65)
-        .Put(static_cast<uint8_t>(octetStringStrLen))
-        .Put(octetString.data(), octetStringStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeListInt8u(Callback::Cancelable * onSuccessCallback,
@@ -10418,25 +10548,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeLongOctetString(Callback::Cancelable
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeLongOctetString(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback,
-                                                             chip::ByteSpan longOctetString)
+                                                             Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteTestClusterLongOctetString", TestCluster::Id);
-    size_t longOctetStringStrLen = longOctetString.size();
-    if (!CanCastTo<uint16_t>(longOctetStringStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, longOctetStringStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000001D;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::LongOctetString)
-        .Put8(67)
-        .Put16(static_cast<uint16_t>(longOctetStringStrLen))
-        .Put(longOctetString.data(), longOctetStringStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeCharString(Callback::Cancelable * onSuccessCallback,
@@ -10452,24 +10577,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeCharString(Callback::Cancelable * on
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeCharString(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback, chip::ByteSpan charString)
+                                                        Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteTestClusterCharString", TestCluster::Id);
-    size_t charStringStrLen = charString.size();
-    if (!CanCastTo<uint8_t>(charStringStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, charStringStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000001E;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::CharString)
-        .Put8(66)
-        .Put(static_cast<uint8_t>(charStringStrLen))
-        .Put(charString.data(), charStringStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeLongCharString(Callback::Cancelable * onSuccessCallback,
@@ -10485,24 +10606,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeLongCharString(Callback::Cancelable 
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeLongCharString(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback, chip::ByteSpan longCharString)
+                                                            Callback::Cancelable * onFailureCallback, chip::ByteSpan value)
 {
-    COMMAND_HEADER("WriteTestClusterLongCharString", TestCluster::Id);
-    size_t longCharStringStrLen = longCharString.size();
-    if (!CanCastTo<uint16_t>(longCharStringStrLen))
-    {
-        ChipLogError(Zcl, "Error encoding %s command. String too long: %zu", kName, longCharStringStrLen);
-        return CHIP_ERROR_INTERNAL;
-    }
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000001F;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::LongCharString)
-        .Put8(68)
-        .Put16(static_cast<uint16_t>(longCharStringStrLen))
-        .Put(longCharString.data(), longCharStringStrLen);
-    COMMAND_FOOTER();
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeUnsupported(Callback::Cancelable * onSuccessCallback,
@@ -10518,16 +10635,20 @@ CHIP_ERROR TestClusterCluster::ReadAttributeUnsupported(Callback::Cancelable * o
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeUnsupported(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback, bool unsupported)
+                                                         Callback::Cancelable * onFailureCallback, bool value)
 {
-    COMMAND_HEADER("WriteTestClusterUnsupported", TestCluster::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(TestCluster::Attributes::Ids::Unsupported)
-        .Put8(16)
-        .Put8(static_cast<uint8_t>(unsupported));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x000000FF;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TestClusterCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -10809,17 +10930,20 @@ CHIP_ERROR ThermostatCluster::ReadAttributeOccupiedCoolingSetpoint(Callback::Can
 }
 
 CHIP_ERROR ThermostatCluster::WriteAttributeOccupiedCoolingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback,
-                                                                    int16_t occupiedCoolingSetpoint)
+                                                                    Callback::Cancelable * onFailureCallback, int16_t value)
 {
-    COMMAND_HEADER("WriteThermostatOccupiedCoolingSetpoint", Thermostat::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Thermostat::Attributes::Ids::OccupiedCoolingSetpoint)
-        .Put8(41)
-        .Put16(static_cast<uint16_t>(occupiedCoolingSetpoint));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000011;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatCluster::ReadAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
@@ -10835,17 +10959,20 @@ CHIP_ERROR ThermostatCluster::ReadAttributeOccupiedHeatingSetpoint(Callback::Can
 }
 
 CHIP_ERROR ThermostatCluster::WriteAttributeOccupiedHeatingSetpoint(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback,
-                                                                    int16_t occupiedHeatingSetpoint)
+                                                                    Callback::Cancelable * onFailureCallback, int16_t value)
 {
-    COMMAND_HEADER("WriteThermostatOccupiedHeatingSetpoint", Thermostat::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Thermostat::Attributes::Ids::OccupiedHeatingSetpoint)
-        .Put8(41)
-        .Put16(static_cast<uint16_t>(occupiedHeatingSetpoint));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000012;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatCluster::ReadAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
@@ -10861,17 +10988,20 @@ CHIP_ERROR ThermostatCluster::ReadAttributeControlSequenceOfOperation(Callback::
 }
 
 CHIP_ERROR ThermostatCluster::WriteAttributeControlSequenceOfOperation(Callback::Cancelable * onSuccessCallback,
-                                                                       Callback::Cancelable * onFailureCallback,
-                                                                       uint8_t controlSequenceOfOperation)
+                                                                       Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteThermostatControlSequenceOfOperation", Thermostat::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Thermostat::Attributes::Ids::ControlSequenceOfOperation)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(controlSequenceOfOperation));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000001B;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatCluster::ReadAttributeSystemMode(Callback::Cancelable * onSuccessCallback,
@@ -10887,16 +11017,20 @@ CHIP_ERROR ThermostatCluster::ReadAttributeSystemMode(Callback::Cancelable * onS
 }
 
 CHIP_ERROR ThermostatCluster::WriteAttributeSystemMode(Callback::Cancelable * onSuccessCallback,
-                                                       Callback::Cancelable * onFailureCallback, uint8_t systemMode)
+                                                       Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteThermostatSystemMode", Thermostat::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(Thermostat::Attributes::Ids::SystemMode)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(systemMode));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x0000001C;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatCluster::ReadAttributeStartOfWeek(Callback::Cancelable * onSuccessCallback,
@@ -10983,16 +11117,20 @@ ThermostatUserInterfaceConfigurationCluster::ReadAttributeTemperatureDisplayMode
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::WriteAttributeTemperatureDisplayMode(
-    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t temperatureDisplayMode)
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteThermostatUserInterfaceConfigurationTemperatureDisplayMode", ThermostatUserInterfaceConfiguration::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ThermostatUserInterfaceConfiguration::Attributes::Ids::TemperatureDisplayMode)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(temperatureDisplayMode));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000000;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReadAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback,
@@ -11009,16 +11147,20 @@ CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReadAttributeKeypadLocko
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::WriteAttributeKeypadLockout(Callback::Cancelable * onSuccessCallback,
                                                                                     Callback::Cancelable * onFailureCallback,
-                                                                                    uint8_t keypadLockout)
+                                                                                    uint8_t value)
 {
-    COMMAND_HEADER("WriteThermostatUserInterfaceConfigurationKeypadLockout", ThermostatUserInterfaceConfiguration::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ThermostatUserInterfaceConfiguration::Attributes::Ids::KeypadLockout)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(keypadLockout));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000001;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR
@@ -11035,17 +11177,20 @@ ThermostatUserInterfaceConfigurationCluster::ReadAttributeScheduleProgrammingVis
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::WriteAttributeScheduleProgrammingVisibility(
-    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t scheduleProgrammingVisibility)
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteThermostatUserInterfaceConfigurationScheduleProgrammingVisibility",
-                   ThermostatUserInterfaceConfiguration::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(ThermostatUserInterfaceConfiguration::Attributes::Ids::ScheduleProgrammingVisibility)
-        .Put8(48)
-        .Put8(static_cast<uint8_t>(scheduleProgrammingVisibility));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000002;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ThermostatUserInterfaceConfigurationCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
@@ -12655,16 +12800,20 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeMode(Callback::Cancelable * onSuc
 }
 
 CHIP_ERROR WindowCoveringCluster::WriteAttributeMode(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback, uint8_t mode)
+                                                     Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    COMMAND_HEADER("WriteWindowCoveringMode", WindowCovering::Id);
-    buf.Put8(kFrameControlGlobalCommand)
-        .Put8(seqNum)
-        .Put32(Globals::Commands::Ids::WriteAttributes)
-        .Put32(WindowCovering::Attributes::Ids::Mode)
-        .Put8(24)
-        .Put8(static_cast<uint8_t>(mode));
-    COMMAND_FOOTER();
+    app::WriteClientHandle handle;
+    chip::app::AttributePathParams attributePath;
+    attributePath.mNodeId     = mDevice->GetDeviceId();
+    attributePath.mEndpointId = mEndpoint;
+    attributePath.mClusterId  = mClusterId;
+    attributePath.mFieldId    = 0x00000017;
+    attributePath.mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReturnErrorOnFailure(app::InteractionModelEngine::GetInstance()->NewWriteClient(handle));
+    ReturnErrorOnFailure(handle.EncodeScalarAttributeWritePayload(attributePath, value));
+
+    return mDevice->SendWriteAttributeRequest(std::move(handle), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR WindowCoveringCluster::ReadAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback,

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -1160,6 +1160,18 @@ public:
     CHIP_ERROR PutBoolean(uint64_t tag, bool v);
 
     /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, bool v)
+     */
+    CHIP_ERROR Put(uint64_t tag, bool v)
+    {
+        /*
+         * In TLV, boolean values are encoded as standalone tags without actual values, so we have a seperate
+         * PutBoolean method.
+         */
+        return PutBoolean(tag, v);
+    }
+
+    /**
      * Encodes a TLV byte string value.
      *
      * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the


### PR DESCRIPTION
#### Problem
* Fixes #7661

#### Change overview
- Enables WriteRequest
- Cleanup ember code for handling write request
- WriteClientHandle is introduced for a RAII style object management.
- Currently callbacks still goes through CallbackManager

#### Testing
- The Test is already covered by TestSuite and various other tests.