### PR TITLE
Fix crash when doing onnetwork pairing with chip-device-ctrl.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1588,14 +1588,6 @@ void BasicFailure(void * context, uint8_t status)
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 void DeviceCommissioner::OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData)
 {
-    if (mDeviceBeingPaired < kNumMaxActiveDevices)
-    {
-        Device * device = &mActiveDevices[mDeviceBeingPaired];
-        if (device->GetDeviceId() == nodeData.mPeerId.GetNodeId() && mCommissioningStage == CommissioningStage::kFindOperational)
-        {
-            AdvanceCommissioningStage(CHIP_NO_ERROR);
-        }
-    }
     DeviceController::OnNodeIdResolved(nodeData);
     OperationalDiscoveryComplete(nodeData.mPeerId.GetNodeId());
 }
@@ -1619,6 +1611,16 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, Device * device)
 {
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
     VerifyOrReturn(commissioner != nullptr, ChipLogProgress(Controller, "Device connected callback with null context. Ignoring"));
+
+    if (commissioner->mDeviceBeingPaired < kNumMaxActiveDevices)
+    {
+        Device * deviceBeingPaired = &commissioner->mActiveDevices[commissioner->mDeviceBeingPaired];
+        if (device == deviceBeingPaired && commissioner->mCommissioningStage == CommissioningStage::kFindOperational)
+        {
+            commissioner->AdvanceCommissioningStage(CHIP_NO_ERROR);
+        }
+    }
+
     VerifyOrReturn(commissioner->mPairingDelegate != nullptr,
                    ChipLogProgress(Controller, "Device connected callback with null pairing delegate. Ignoring"));
     commissioner->mPairingDelegate->OnCommissioningComplete(device->GetDeviceId(), CHIP_NO_ERROR);


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/7982

#### Problem
Python controller crashes when doing `connect -ip ::1 20202021 12344321`

#### Change overview
Move the sending of the "commissioning complete" command in the rendezvous flow python controller uses by default in this case (the "use clusters for ip commissioning" one) to _after_ we tear down the PASE connection and set up the CASE one, both to comply better with spec and to avoid having that command execution be aborted by the PASE teardown.

#### Testing
Manual testing:
1. Compiled chip-device-ctrl with `./scripts/build_python.sh -c true` and tested:
   1. BLE pairing to an m5stack running all-clusters-app.
   2. On-network pairing to all-clusters-app on localhost.
1. Compiled chip-device-ctrl with `./scripts/build_python.sh -c false` and tested:
   1. BLE pairing to an m5stack running all-clusters-app.
   2. On-network pairing to all-clusters-app on localhost.
1. Compiled chip-tool and tested:
   1. BLE pairing to an m5stack running all-clusters-app.
   2. On-network pairing to all-clusters-app on localhost.
