### PR TITLE
Don't treat a resolve as done in chip-device-ctrl until we have a CASE connection

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -66,6 +66,7 @@ using namespace chip::Controller;
 extern "C" {
 typedef void (*ConstructBytesArrayFunct)(const uint8_t * dataBuf, uint32_t dataLen);
 typedef void (*LogMessageFunct)(uint64_t time, uint64_t timeUS, const char * moduleName, uint8_t category, const char * msg);
+typedef void (*DeviceAvailableFunc)(Device * device, CHIP_ERROR err);
 }
 
 namespace {
@@ -120,6 +121,10 @@ CHIP_ERROR
 pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(chip::Controller::DeviceCommissioner * devCtrl,
                                                           chip::Controller::DevicePairingDelegate_OnPairingCompleteFunct callback);
 
+CHIP_ERROR
+pychip_ScriptDevicePairingDelegate_SetCommissioningCompleteCallback(
+    chip::Controller::DeviceCommissioner * devCtrl, chip::Controller::DevicePairingDelegate_OnCommissioningCompleteFunct callback);
+
 void pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
     chip::Controller::DeviceAddressUpdateDelegate_OnUpdateComplete callback);
 CHIP_ERROR pychip_Resolver_ResolveNode(uint64_t fabricid, chip::NodeId nodeid);
@@ -138,6 +143,8 @@ void pychip_Stack_SetLogFunct(LogMessageFunct logFunct);
 
 CHIP_ERROR pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
                                     chip::Controller::Device ** device);
+CHIP_ERROR pychip_GetConnectedDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
+                                             DeviceAvailableFunc callback);
 uint64_t pychip_GetCommandSenderHandle(chip::Controller::Device * device);
 // CHIP Stack objects
 CHIP_ERROR pychip_BLEMgrImpl_ConfigureBle(uint32_t bluetoothAdapterId);
@@ -355,6 +362,14 @@ pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(chip::Controller::Devi
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR
+pychip_ScriptDevicePairingDelegate_SetCommissioningCompleteCallback(
+    chip::Controller::DeviceCommissioner * devCtrl, chip::Controller::DevicePairingDelegate_OnCommissioningCompleteFunct callback)
+{
+    sPairingDelegate.SetCommissioningCompleteCallback(callback);
+    return CHIP_NO_ERROR;
+}
+
 void pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
     chip::Controller::DeviceAddressUpdateDelegate_OnUpdateComplete callback)
 {
@@ -409,6 +424,41 @@ CHIP_ERROR pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCt
 {
     VerifyOrReturnError(devCtrl != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     return devCtrl->GetDevice(nodeId, device);
+}
+
+namespace {
+struct GetDeviceCallbacks
+{
+    GetDeviceCallbacks(DeviceAvailableFunc callback) :
+        mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnConnectionFailureFn, this), mCallback(callback)
+    {}
+
+    static void OnDeviceConnectedFn(void * context, Device * device)
+    {
+        auto * self = static_cast<GetDeviceCallbacks *>(context);
+        self->mCallback(device, CHIP_NO_ERROR);
+        delete self;
+    }
+
+    static void OnConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error)
+    {
+        auto * self = static_cast<GetDeviceCallbacks *>(context);
+        self->mCallback(nullptr, error);
+        delete self;
+    }
+
+    Callback::Callback<OnDeviceConnected> mOnSuccess;
+    Callback::Callback<OnDeviceConnectionFailure> mOnFailure;
+    DeviceAvailableFunc mCallback;
+};
+} // anonymous namespace
+
+CHIP_ERROR pychip_GetConnectedDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
+                                             DeviceAvailableFunc callback)
+{
+    VerifyOrReturnError(devCtrl != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    auto * callbacks = new GetDeviceCallbacks(callback);
+    return devCtrl->GetConnectedDevice(nodeId, &callbacks->mOnSuccess, &callbacks->mOnFailure);
 }
 
 CHIP_ERROR pychip_DeviceCommissioner_CloseBleConnection(chip::Controller::DeviceCommissioner * devCtrl)

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
@@ -27,11 +27,24 @@ void ScriptDevicePairingDelegate::SetKeyExchangeCallback(DevicePairingDelegate_O
     mOnPairingCompleteCallback = callback;
 }
 
+void ScriptDevicePairingDelegate::SetCommissioningCompleteCallback(DevicePairingDelegate_OnCommissioningCompleteFunct callback)
+{
+    mOnCommissioningCompleteCallback = callback;
+}
+
 void ScriptDevicePairingDelegate::OnPairingComplete(CHIP_ERROR error)
 {
     if (mOnPairingCompleteCallback != nullptr)
     {
         mOnPairingCompleteCallback(error);
+    }
+}
+
+void ScriptDevicePairingDelegate::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR error)
+{
+    if (mOnCommissioningCompleteCallback != nullptr)
+    {
+        mOnCommissioningCompleteCallback(nodeId, error);
     }
 }
 

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
@@ -32,6 +32,7 @@ namespace Controller {
 
 extern "C" {
 typedef void (*DevicePairingDelegate_OnPairingCompleteFunct)(CHIP_ERROR err);
+typedef void (*DevicePairingDelegate_OnCommissioningCompleteFunct)(NodeId nodeId, CHIP_ERROR err);
 }
 
 class ScriptDevicePairingDelegate final : public Controller::DevicePairingDelegate
@@ -39,10 +40,13 @@ class ScriptDevicePairingDelegate final : public Controller::DevicePairingDelega
 public:
     ~ScriptDevicePairingDelegate() = default;
     void SetKeyExchangeCallback(DevicePairingDelegate_OnPairingCompleteFunct callback);
+    void SetCommissioningCompleteCallback(DevicePairingDelegate_OnCommissioningCompleteFunct callback);
     void OnPairingComplete(CHIP_ERROR error) override;
+    void OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err) override;
 
 private:
-    DevicePairingDelegate_OnPairingCompleteFunct mOnPairingCompleteCallback = nullptr;
+    DevicePairingDelegate_OnPairingCompleteFunct mOnPairingCompleteCallback             = nullptr;
+    DevicePairingDelegate_OnCommissioningCompleteFunct mOnCommissioningCompleteCallback = nullptr;
 };
 
 } // namespace Controller


### PR DESCRIPTION
This ensures that following commands will work instead of racing the
CASE connection setup.

#### Problem
Quickly entering (e.g. via copy/paste) the following into chip-device-ctrl:
```
connect -ip ::1 20202021 456
resolve 0 456
zclread OnOff OnOff 456 1 0
```
fails with a "not connected" error for the read, because we don't have a CASE connection going at that point.

#### Change overview
Don't return from `resolve` until we've done our CASE handshake.

#### Testing
Manually tested ip and ble rendezvous for chip-device-ctrl.

When compiling with `chip_use_clusters_for_ip_commissioning=true` and doing IP rendezvous, this does not help, because the state machine in DeviceController tears down the CASE connection in that case after notifying CommissioningComplete.  To fix that, we'd need to fix the comments about `pychip_GetConnectedDeviceByNodeId` in this PR.  I tried, but could not figure out how to get the callbacks and waiting right in the time I had.