### PR TITLE
Update log messages for session expiry

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -257,8 +257,8 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
             state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
     }
 
-    ChipLogDetail(Inet, "New pairing for device 0x%08" PRIx32 "%08" PRIx32 ", key %d!!", static_cast<uint32_t>(peerNodeId >> 32),
-                  static_cast<uint32_t>(peerNodeId), peerKeyId);
+    ChipLogDetail(Inet, "New secure session created for device 0x%08" PRIx32 "%08" PRIx32 ", key %d!!",
+                  static_cast<uint32_t>(peerNodeId >> 32), static_cast<uint32_t>(peerNodeId), peerKeyId);
     state = nullptr;
     ReturnErrorOnFailure(
         mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
@@ -519,10 +519,9 @@ exit:
 
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
-    char addr[Transport::PeerAddress::kMaxToStringSize];
-    state.GetPeerAddress().ToString(addr);
-
-    ChipLogDetail(Inet, "Connection from '%s' expired", addr);
+    NodeId peerNodeId = state.GetPeerNodeId();
+    ChipLogDetail(Inet, "Marking old secure session for device 0x%08" PRIx32 "%08" PRIx32 " as expired",
+                  static_cast<uint32_t>(peerNodeId >> 32), static_cast<uint32_t>(peerNodeId));
 
     if (mCB != nullptr)
     {

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -257,8 +257,8 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
             state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
     }
 
-    ChipLogDetail(Inet, "New secure session created for device 0x%08" PRIx32 "%08" PRIx32 ", key %d!!",
-                  static_cast<uint32_t>(peerNodeId >> 32), static_cast<uint32_t>(peerNodeId), peerKeyId);
+    ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
+                  peerKeyId);
     state = nullptr;
     ReturnErrorOnFailure(
         mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
@@ -520,8 +520,7 @@ exit:
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
     NodeId peerNodeId = state.GetPeerNodeId();
-    ChipLogDetail(Inet, "Marking old secure session for device 0x%08" PRIx32 "%08" PRIx32 " as expired",
-                  static_cast<uint32_t>(peerNodeId >> 32), static_cast<uint32_t>(peerNodeId));
+    ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired", ChipLogValueX64(peerNodeId));
 
     if (mCB != nullptr)
     {


### PR DESCRIPTION
#### Problem
The following log is printed on secure session expiry
```
Connection from 'UDP:<IPAddress>:11097' expired
```

The log could be misinterpreted as an error, specifically in test events. CSG has suggested to reword the log message.

#### Change overview
Updating the log message and aligned it with secure session create log message.
The new output log will be
```
Marking old secure session for device 0x0000000000000001 as expired

< logs about session setup protocol, e.g. Sigma message exchange >

New secure session created for device 0x0000000000000001, key 1
```

#### Testing
Tested the log output using Python controller app.