### PR TITLE
Revert "Mark UDP socket as ready for write in send msg. (#7927)"

### DIFF
--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -649,10 +649,6 @@ INET_ERROR UDPEndPoint::SendMsg(const IPPacketInfo * pktInfo, System::PacketBuff
     SuccessOrExit(res);
 
     res = IPEndPointBasis::SendMsg(pktInfo, std::move(msg), sendFlags);
-
-    // Wait for ability to write on this endpoint.
-    mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
-    mSocket.OnRequestCallbackOnPendingWrite();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK


### PR DESCRIPTION
#### Problem
Turns out the code causes that subsequent select()-s never wait so another solution for the original issue must be prepared.

#### Change overview
This reverts commit 8c555239212ca31160df633fa1e68c5a3c46852b. Discussed this offline with @pan-.

#### Testing
Tested using nRF Connect Lock example and Python CHIP Controller (both commissioning and ZCL messages)
