### PR TITLE
WindowCovering: Add Target Positions support to scenes

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -943,9 +943,9 @@ typedef struct
     uint8_t currentPositionLiftPercentageValue;
     bool hasCurrentPositionTiltPercentageValue;
     uint8_t currentPositionTiltPercentageValue;
-    bool  hasTargetPositionLiftPercent100thsValue;
+    bool hasTargetPositionLiftPercent100thsValue;
     uint16_t targetPositionLiftPercent100thsValue;
-    bool  hasTargetPositionTiltPercent100thsValue;
+    bool hasTargetPositionTiltPercent100thsValue;
     uint16_t targetPositionTiltPercent100thsValue;
 #endif
 } EmberAfSceneTableEntry;

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -943,6 +943,10 @@ typedef struct
     uint8_t currentPositionLiftPercentageValue;
     bool hasCurrentPositionTiltPercentageValue;
     uint8_t currentPositionTiltPercentageValue;
+    bool  hasTargetPositionLiftPercent100thsValue;
+    uint16_t targetPositionLiftPercent100thsValue;
+    bool  hasTargetPositionTiltPercent100thsValue;
+    uint16_t targetPositionTiltPercent100thsValue;
 #endif
 } EmberAfSceneTableEntry;
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

WindowCovering Cluster is outdated and date from ZCL
Define New Attributes and Commands required for Test Event
Rename Attributes and Commands accordingly with the Specs

#### Change overview
What's in this PR

This is the 3rd part of a multiple series of PRs to update the examples for Window Covering in order to simplify code reviews:

* Update Scenes for Window Covering cluster with Target Positions

#### Testing
How was this tested? (at least one bullet point required)
* Not tested: since SCENES features aren't completely supported yet and we need other dependencies in this cluster

