### PR TITLE
Use synchronizable keys for Darwin credentials issuer

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -44,10 +44,12 @@ public:
 
 private:
     CHIP_ERROR GenerateKeys();
+    CHIP_ERROR StoreKeysInKeyChain(NSData * keypairData);
     CHIP_ERROR LoadKeysFromKeyChain();
+    CHIP_ERROR LoadDeprecatedKeysFromKeyChain();
     CHIP_ERROR DeleteKeys();
 
-    CHIP_ERROR ConvertToP256Keypair(SecKeyRef privateKey);
+    CHIP_ERROR ConvertToP256Keypair(NSData * keypairData);
 
     CHIP_ERROR SetIssuerID(CHIPPersistentStorageDelegateBridge * storage);
 
@@ -57,8 +59,10 @@ private:
     uint32_t mIssuerId = 1234;
 
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
-    const NSString * kCHIPCAKeyLabel = @"chip.nodeopcerts.CA:0";
-    const NSData * kCHIPCAKeyTag = [@"com.zigbee.chip.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
+    const NSString * kCHIPCADeprecatedKeyLabel = @"chip.nodeopcerts.CA:0";
+    const NSData * kCHIPCADeprecatedKeyTag = [@"com.zigbee.chip.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
+    const NSString * kCHIPCAKeyLabel = @"matter.nodeopcerts.CA:0";
+    const NSData * kCHIPCAKeyTag = [@"com.zigbee.matter.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
 
     id mKeyType = (id) kSecAttrKeyTypeECSECPrimeRandom;
     id mKeySize = @256;


### PR DESCRIPTION
#### Problem
The credentials issuer keypair in Darwin platform is not synchronized. This can lead to generation of different keys and credentials for the same user.

#### Change overview
Set `kSecAttrSynchronizable` to true when the keys are being stored.
Also, the keystone labels and structure is different for these keys. The PR adds the code to migrate old keys to the new storage, so that the users won't have to delete and reinstall the apps.

#### Testing
Tested pairing and CASE session using iOS CHIPTool app, Python controller and chip-tool. Also, tested the migration of old key to the new storage.