### PR TITLE
[Android] Separate KeyValueStoreManager.java into interface and impl

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -26,6 +26,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import chip.devicecontroller.ChipDeviceController
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
 import com.google.chip.chiptool.attestation.AttestationTestFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
@@ -36,7 +37,7 @@ import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
 import com.google.chip.chiptool.setuppayloadscanner.QrCodeInfo
-import chip.devicecontroller.KeyValueStoreManager
+import chip.devicecontroller.PreferencesKeyValueStoreManager
 import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
 
@@ -52,9 +53,8 @@ class CHIPToolActivity :
     super.onCreate(savedInstanceState)
     setContentView(R.layout.top_activity)
 
-    KeyValueStoreManager.initialize(this);
-
     if (savedInstanceState == null) {
+      ChipDeviceController.setKeyValueStoreManager(PreferencesKeyValueStoreManager(this))
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
           .beginTransaction()

--- a/src/controller/java/AndroidKeyValueStoreManagerImpl.h
+++ b/src/controller/java/AndroidKeyValueStoreManagerImpl.h
@@ -18,24 +18,31 @@
 
 #pragma once
 
+#include "JniReferences.h"
+
 #include <jni.h>
 
 namespace chip {
 namespace DeviceLayer {
 namespace PersistedStorage {
 
+using namespace chip::Controller;
+
 class KeyValueStoreManagerImpl : public KeyValueStoreManager
 {
 public:
+    ~KeyValueStoreManagerImpl()
+    {
+        JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mKeyValueStoreManagerObject);
+    }
     CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0);
     CHIP_ERROR _Delete(const char * key);
     CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);
 
-    void InitializeMethodForward(JavaVM * vm, JNIEnv * env);
+    void InitializeWithObject(jobject managerObject);
 
 private:
-    JavaVM * mJvm                     = nullptr;
-    jclass mKeyValueStoreManagerClass = nullptr;
+    jobject mKeyValueStoreManagerObject = nullptr;
 
     jmethodID mSetMethod    = nullptr;
     jmethodID mGetMethod    = nullptr;

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -67,6 +67,7 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceController.java",
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/KeyValueStoreManager.java",
+    "src/chip/devicecontroller/PreferencesKeyValueStoreManager.java",
   ]
 
   javac_flags = [ "-Xlint:deprecation" ]

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -140,8 +140,6 @@ jint JNI_OnLoad(JavaVM * jvm, void * reserved)
     env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrExit(env != NULL, err = CHIP_JNI_ERROR_NO_ENV);
 
-    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeMethodForward(sJVM, env);
-
     ChipLogProgress(Controller, "Loading Java class references.");
 
     // Get various class references need by the API.
@@ -257,6 +255,12 @@ exit:
     return result;
 }
 
+JNI_METHOD(void, setKeyValueStoreManager)(JNIEnv * env, jclass self, jobject manager)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(manager);
+}
+
 JNI_METHOD(void, pairDevice)
 (JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint connObj, jlong pinCode, jbyteArray csrNonce)
 {
@@ -275,7 +279,7 @@ JNI_METHOD(void, pairDevice)
     if (csrNonce != nullptr)
     {
         JniByteArray jniCsrNonce(env, csrNonce);
-        params = params.SetCSRNonce(jniCsrNonce.byteSpan());
+        params.SetCSRNonce(jniCsrNonce.byteSpan());
     }
     err = wrapper->Controller()->PairDevice(deviceId, params);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -240,6 +240,8 @@ public class ChipDeviceController {
 
   private native boolean isActive(long deviceControllerPtr, long deviceId);
 
+  public static native void setKeyValueStoreManager(KeyValueStoreManager manager);
+
   static {
     System.loadLibrary("CHIPController");
   }

--- a/src/controller/java/src/chip/devicecontroller/KeyValueStoreManager.java
+++ b/src/controller/java/src/chip/devicecontroller/KeyValueStoreManager.java
@@ -17,38 +17,15 @@
  */
 package chip.devicecontroller;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.util.Log;
-
 /**
- * Java implementation of a key/value store.
+ * Java interface for a key/value store.
  *
  * <p>Exposes get/set/delete methods to be used by the native C++ JNI Layer.
  */
-public class KeyValueStoreManager {
-  private static final String TAG = KeyValueStoreManager.class.getSimpleName();
-  private static SharedPreferences preferences;
-  private static final String PREFERENCE_FILE_KEY = "com.google.chip.KeyValueStore";
+public interface KeyValueStoreManager {
+  public String get(String key);
 
-  public static String get(String key) {
-    String value = preferences.getString(key, null);
-    if (value == null) {
-      Log.d(TAG, "Key '" + key + "' not found in shared preferences");
-    }
-    return value;
-  }
+  public void set(String key, String value);
 
-  public static void set(String key, String value) {
-    preferences.edit().putString(key, value).apply();
-  }
-
-  public static void delete(String key) {
-    preferences.edit().remove(key).apply();
-  }
-
-  /** Initialization MUST be done before any of get/set/delete work. */
-  public static void initialize(Context context) {
-    preferences = context.getSharedPreferences(PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
-  }
+  public void delete(String key);
 }

--- a/src/controller/java/src/chip/devicecontroller/PreferencesKeyValueStoreManager.java
+++ b/src/controller/java/src/chip/devicecontroller/PreferencesKeyValueStoreManager.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+/** Android implementation of a key/value store using SharedPreferences. */
+public class PreferencesKeyValueStoreManager implements KeyValueStoreManager {
+  private final String TAG = KeyValueStoreManager.class.getSimpleName();
+  private final String PREFERENCE_FILE_KEY = "com.google.chip.KeyValueStore";
+  private SharedPreferences preferences;
+
+  public PreferencesKeyValueStoreManager(Context context) {
+    preferences = context.getSharedPreferences(PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
+  }
+
+  @Override
+  public String get(String key) {
+    String value = preferences.getString(key, null);
+    if (value == null) {
+      Log.d(TAG, "Key '" + key + "' not found in shared preferences");
+    }
+    return value;
+  }
+
+  @Override
+  public void set(String key, String value) {
+    preferences.edit().putString(key, value).apply();
+  }
+
+  @Override
+  public void delete(String key) {
+    preferences.edit().remove(key).apply();
+  }
+}


### PR DESCRIPTION
#### Problem
* `KeyValueStoreManager.java` is hard-coded to use Android preferences, no way to swap implementation

#### Change overview
* Make `KeyValueStoreManager` an interface, with `PreferencesKeyValueStoreManager` implementing
* Add static JNI setter for the desired `KeyValueStoreManager` - CHIPTool calls this in `CHIPToolActivity`
* Convert static KVS methods to instance methods, and call them in `AndroidKeyValueStoreManagerImpl.cpp`

#### Testing
* Ran through commissioning and control flow
* No functionality change expected
