### PR TITLE
Make exchanges handle closing on message receipt more automatically.

### DIFF
--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -110,7 +110,6 @@ public:
         streamer_printf(sout, "Response received: len=%u time=%.3fms\n", buffer->DataLength(),
                         static_cast<double>(transitTime) / 1000);
 
-        gExchangeCtx->Close();
         gExchangeCtx = nullptr;
         return CHIP_NO_ERROR;
     }

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -71,6 +71,8 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
     MoveToState(CommandState::Sending);
 
 exit:
+    // Keep Shutdown() from double-closing our exchange.
+    mpExchangeCtx = nullptr;
     Shutdown();
     ChipLogFunctError(err);
     return err;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -92,9 +92,8 @@ CHIP_ERROR CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExcha
 exit:
     ChipLogFunctError(err);
 
-    // Close the exchange cleanly so that the ExchangeManager will send an ack for the message we just received.
-    // This needs to be done before the Reset() call, because Reset() aborts mpExchangeCtx if its not null.
-    mpExchangeCtx->Close();
+    // Null out mpExchangeCtx, so our Shutdown() call below won't try to abort
+    // it and fail to send an ack for the message we just received.
     mpExchangeCtx = nullptr;
 
     if (mpDelegate != nullptr)

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -190,7 +190,6 @@ CHIP_ERROR InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext *
     // err = SendStatusReport(ec, kChipProfile_Common, kStatus_UnsupportedMessage);
     // SuccessOrExit(err);
 
-    apExchangeContext->Close();
     apExchangeContext = nullptr;
 
     ChipLogFunctError(err);

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -229,8 +229,8 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
 exit:
     ChipLogFunctError(err);
 
-    // Close the exchange cleanly so that the ExchangeManager will send an ack for the message we just received.
-    mpExchangeCtx->Close();
+    // Null out mpExchangeCtx, so our Shutdown() call below won't try to abort
+    // it and fail to send an ack for the message we just received.
     mpExchangeCtx = nullptr;
     MoveToState(ClientState::Initialized);
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -294,19 +294,15 @@ CHIP_ERROR WriteClient::OnMessageReceived(Messaging::ExchangeContext * apExchang
 
     VerifyOrDie(apExchangeContext == mpExchangeCtx);
 
+    // We are done with this exchange, and it will be closing itself.
+    mpExchangeCtx = nullptr;
+
     // Verify that the message is an Write Response.
     // If not, close the exchange and free the payload.
     if (!aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::WriteResponse))
     {
-        apExchangeContext->Close();
-        mpExchangeCtx = nullptr;
         ExitNow();
     }
-
-    // Close the current exchange after receiving the response since the response message marks the
-    // end of conversation represented by the exchange. We should create an new exchange for a new
-    // conversation defined in Interaction Model protocol.
-    ClearExistingExchangeContext();
 
     err = ProcessWriteResponseMessage(std::move(aPayload));
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -74,6 +74,8 @@ CHIP_ERROR WriteHandler::OnWriteRequest(Messaging::ExchangeContext * apExchangeC
 
 exit:
     ChipLogFunctError(err);
+    // Keep Shutdown() from double-closing our exchange.
+    mpExchangeCtx = nullptr;
     Shutdown();
     return err;
 }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -387,7 +387,6 @@ public:
         }
 
     exit:
-        exchangeContext->Close();
         return err;
     }
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -337,7 +337,6 @@ CHIP_ERROR Device::OnMessageReceived(Messaging::ExchangeContext * exchange, cons
             HandleDataModelMessage(exchange, std::move(msgBuf));
         }
     }
-    exchange->Close();
     return CHIP_NO_ERROR;
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -572,7 +572,6 @@ CHIP_ERROR DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, 
                                                const PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf)
 {
     uint16_t index;
-    bool needClose = true;
 
     VerifyOrExit(mState == State::Initialized, ChipLogError(Controller, "OnMessageReceived was called in incorrect state"));
 
@@ -582,14 +581,9 @@ CHIP_ERROR DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, 
     index = FindDeviceIndex(packetHeader.GetSourceNodeId().Value());
     VerifyOrExit(index < kNumMaxActiveDevices, ChipLogError(Controller, "OnMessageReceived was called for unknown device object"));
 
-    needClose = false; // Device will handle it
     mActiveDevices[index].OnMessageReceived(ec, packetHeader, payloadHeader, std::move(msgBuf));
 
 exit:
-    if (needClose)
-    {
-        ec->Close();
-    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -110,6 +110,12 @@ public:
     }
 
     /**
+     * A notification that we will have SendMessage called on us in the future
+     * (and should stay open until that happens).
+     */
+    void WillSendMessage() { mFlags.Set(Flags::kFlagWillSendMessage); }
+
+    /**
      *  Handle a received CHIP message on this exchange.
      *
      *  @param[in]    packetHeader  A reference to the PacketHeader object.

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -49,7 +49,18 @@ public:
 
     /**
      * @brief
-     *   This function is the protocol callback for handling a received CHIP message.
+     *   This function is the protocol callback for handling a received CHIP
+     *   message.
+     *
+     *   After calling this method an exchange will close itself unless one of
+     *   two things happens:
+     *
+     *   1) A call to SendMessage on the exchange with the kExpectResponse flag
+     *      set.
+     *   2) A call to WillSendMessage on the exchange.
+     *
+     *   Consumers that don't do one of those things MUST NOT retain a pointer
+     *   to the exchange.
      *
      *  @param[in]    ec            A pointer to the ExchangeContext object.
      *  @param[in]    packetHeader  A reference to the PacketHeader object.

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -202,6 +202,14 @@ protected:
 
         /// When set, signifies that at least one message has been received from peer on this exchange context.
         kFlagMsgRcvdFromPeer = 0x0040,
+
+        /// When set, signifies that this exchange is waiting for a call to SendMessage.
+        kFlagWillSendMessage = 0x0080,
+
+        /// When set, signifies that we are currently in the middle of HandleMessage.
+        kFlagHandlingMessage = 0x0100,
+        /// When set, we have had Close() or Abort() called on us already.
+        kFlagClosed = 0x0200,
     };
 
     BitFlags<Flags> mFlags; // Internal state flags

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -67,7 +67,6 @@ public:
                                  System::PacketBufferHandle && buffer) override
     {
         IsOnMessageReceivedCalled = true;
-        ec->Close();
         return CHIP_NO_ERROR;
     }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -88,8 +88,11 @@ public:
 
         if (!mRetainExchange)
         {
-            ec->Close();
             ec = nullptr;
+        }
+        else
+        {
+            ec->WillSendMessage();
         }
         mExchange = ec;
 
@@ -154,7 +157,6 @@ public:
                                  System::PacketBufferHandle && buffer) override
     {
         IsOnMessageReceivedCalled = true;
-        ec->Close();
         if (mTestSuite != nullptr)
         {
             NL_TEST_ASSERT(mTestSuite, buffer->TotalLength() == sizeof(PAYLOAD));
@@ -943,6 +945,56 @@ void CheckNoPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
+void CheckSendUnsolicitedStandaloneAckMessage(nlTestSuite * inSuite, void * inContext)
+{
+    /**
+     * Tests sending a standalone ack message that is:
+     * 1) Unsolicited.
+     * 2) Requests an ack.
+     *
+     * This is not a thing that would normally happen, but a malicious entity
+     * could absolutely do this.
+     */
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData("", 0);
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    MockAppDelegate mockSender;
+    ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockSender);
+    NL_TEST_ASSERT(inSuite, exchange != nullptr);
+
+    mockSender.mTestSuite = inSuite;
+
+    ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    NL_TEST_ASSERT(inSuite, rm != nullptr);
+
+    // Ensure the retransmit table is empty right now
+    NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
+
+    // We send a message, have it get received by the peer, expect an ack from
+    // the peer.
+    gLoopback.mSentMessageCount    = 0;
+    gLoopback.mNumMessagesToDrop   = 0;
+    gLoopback.mDroppedMessageCount = 0;
+
+    // Purposefully sending a standalone ack that requests an ack!
+    err = exchange->SendMessage(SecureChannel::MsgType::StandaloneAck, std::move(buffer));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    exchange->Close();
+
+    // Ensure the message and its ack were sent.
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+
+    // And that nothing is waiting for acks.
+    NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
+}
+
 void CheckSendStandaloneAckMessage(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
@@ -1106,6 +1158,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test ReliableMessageMgr::CheckDuplicateMessageClosedExchange", CheckDuplicateMessageClosedExchange),
     NL_TEST_DEF("Test that a reply after a standalone ack comes through correctly", CheckReceiveAfterStandaloneAck),
     NL_TEST_DEF("Test that a reply to a non-MRP message does not piggyback an ack even if there were MRP things happening on the context before", CheckNoPiggybackAfterPiggyback),
+    NL_TEST_DEF("Test sending an unsolicited ack-soliciting 'standalone ack' message", CheckSendUnsolicitedStandaloneAckMessage),
     NL_TEST_DEF("Test ReliableMessageMgr::CheckSendStandaloneAckMessage", CheckSendStandaloneAckMessage),
     NL_TEST_DEF("Test command, response, default response, with receiver closing exchange after sending response", CheckMessageAfterClosed),
 

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -95,21 +95,13 @@ CHIP_ERROR EchoClient::OnMessageReceived(Messaging::ExchangeContext * ec, const 
     // which clears the OnMessageReceived callback.
     VerifyOrDie(ec == mExchangeCtx);
 
+    mExchangeCtx = nullptr;
+
     // Verify that the message is an Echo Response.
-    // If not, close the exchange and free the payload.
     if (!payloadHeader.HasMessageType(MsgType::EchoResponse))
     {
-        ec->Close();
-        mExchangeCtx = nullptr;
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-
-    // Remove the EC from the app state now. OnEchoResponseReceived can call
-    // SendEchoRequest and install a new one. We abort rather than close
-    // because we no longer care whether the echo request message has been
-    // acknowledged at the transport layer.
-    mExchangeCtx->Abort();
-    mExchangeCtx = nullptr;
 
     // Call the registered OnEchoResponseReceived handler, if any.
     if (OnEchoResponseReceived != nullptr)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -929,8 +929,8 @@ CHIP_ERROR CASESession::SendSigmaR3()
 
     mPairingComplete = true;
 
-    // Close the exchange, as no additional messages are expected from the peer
-    CloseExchange();
+    // Forget our exchange, as no additional messages are expected from the peer
+    mExchangeCtxt = nullptr;
 
     // Call delegate to indicate pairing completion
     mDelegate->OnSessionEstablished();
@@ -1073,8 +1073,8 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
 
     mPairingComplete = true;
 
-    // Close the exchange, as no additional messages are expected from the peer
-    CloseExchange();
+    // Forget our exchange, as no additional messages are expected from the peer
+    mExchangeCtxt = nullptr;
 
     // Call delegate to indicate pairing completion
     mDelegate->OnSessionEstablished();
@@ -1326,8 +1326,6 @@ CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const Pack
     {
         if (mExchangeCtxt != ec)
         {
-            // Close the incoming exchange explicitly, as the cleanup code only closes mExchangeCtxt
-            ec->Close();
             ReturnErrorOnFailure(CHIP_ERROR_INVALID_ARGUMENT);
         }
     }
@@ -1395,6 +1393,9 @@ exit:
     // Call delegate to indicate session establishment failure.
     if (err != CHIP_NO_ERROR)
     {
+        // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
+        // exchange will handle that.
+        mExchangeCtxt = nullptr;
         Clear();
         mDelegate->OnSessionEstablishmentError(err);
     }

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -277,7 +277,6 @@ exit:
         ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncReq message with error:%s", ErrorStr(err));
     }
 
-    exchangeContext->Close();
     return err;
 }
 
@@ -324,7 +323,6 @@ exit:
         ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncResp message with error:%s", ErrorStr(err));
     }
 
-    exchangeContext->Close();
     return err;
 }
 

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -63,7 +63,6 @@ public:
                                  System::PacketBufferHandle && msgBuf) override
     {
         ++ReceiveHandlerCallCount;
-        ec->Close();
         return CHIP_NO_ERROR;
     }
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -99,7 +99,6 @@ public:
     CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                                  System::PacketBufferHandle && buffer) override
     {
-        ec->Close();
         return CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
The idea is that the cases that want to keep the exchange open should
do so explicitly and in all other cases the exchange should close.
This helps avoid exchange leaks and makes it much clearer when an
exchange is being kept open.

#### Problem
Closing exchanges manually is very fragile.  This is step 1 of having it be a lot more automatic, with app-level context being used to decide whether to close.

#### Change overview
Exchanges auto-close on message receipt unless the app either sends a message expecting a response or indicates it plans to do so.

#### Testing
No behavior change (ideally) if all of our consumers are handling this correctly.  This code is exercised by a variety of unit tests, so I have decent confidence in it.