### PR TITLE
[hotfix] Fix regression / crash caused by #7873

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -884,7 +884,7 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
 
     if (emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, manufacturerCode) == NULL)
     {
-        return 0xFF;
+        return 0xFFFF;
     }
 
     for (i = 0; i < emberAfEndpointCount(); i++)
@@ -914,7 +914,7 @@ static uint16_t findIndexFromEndpoint(EndpointId endpoint, bool ignoreDisabledEn
             return epi;
         }
     }
-    return 0xFF;
+    return 0xFFFF;
 }
 
 bool emberAfEndpointIsEnabled(EndpointId endpoint)

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -35,7 +35,7 @@ struct __attribute__((packed)) CommandStatus
     uint8_t CommandIndex;
 };
 
-static_assert(sizeof(CommandStatus) == 4 + 2 + 1 + 2 + 1 + 1, "");
+static_assert(sizeof(CommandStatus) == 4 + 2 + 2 + 4 + 4 + 1, "CommandStatus has padding");
 
 extern "C" {
 typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <app/InteractionModelDelegate.h>
 #include <controller/CHIPDeviceController.h>
 
@@ -35,7 +37,10 @@ struct __attribute__((packed)) CommandStatus
     uint8_t CommandIndex;
 };
 
-static_assert(sizeof(CommandStatus) == 4 + 2 + 2 + 4 + 4 + 1, "CommandStatus has padding");
+static_assert(std::is_same<chip::EndpointId, uint16_t>::value && std::is_same<chip::ClusterId, uint32_t>::value &&
+                  std::is_same<chip::CommandId, uint32_t>::value,
+              "Members in CommandStatus does not match interaction_model/delegate.py");
+static_assert(sizeof(CommandStatus) == 4 + 2 + 2 + 4 + 4 + 1, "Size of CommandStatus might contains padding");
 
 extern "C" {
 typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -35,6 +35,8 @@ struct __attribute__((packed)) CommandStatus
     uint8_t CommandIndex;
 };
 
+static_assert(sizeof(CommandStatus) == 4 + 2 + 1 + 2 + 1 + 1, "");
+
 extern "C" {
 typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,
                                                                                         void * commandStatusBuf,

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -40,7 +40,7 @@ struct __attribute__((packed)) CommandStatus
 static_assert(std::is_same<chip::EndpointId, uint16_t>::value && std::is_same<chip::ClusterId, uint32_t>::value &&
                   std::is_same<chip::CommandId, uint32_t>::value,
               "Members in CommandStatus does not match interaction_model/delegate.py");
-static_assert(sizeof(CommandStatus) == 4 + 2 + 2 + 4 + 4 + 1, "Size of CommandStatus might contains padding");
+static_assert(sizeof(CommandStatus) == 4 + 2 + 2 + 4 + 4 + 1, "Size of CommandStatus might contain padding");
 
 extern "C" {
 typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -21,6 +21,8 @@ import chip.native
 import threading
 import chip.exceptions
 
+# The type should match CommandStatus in interaction_model/Delegate.h
+# CommandStatus should not contain padding
 IMCommandStatus = Struct(
     "ProtocolId" /  Int32ul,
     "ProtocolCode" / Int16ul,

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -24,9 +24,9 @@ import chip.exceptions
 IMCommandStatus = Struct(
     "ProtocolId" /  Int32ul,
     "ProtocolCode" / Int16ul,
-    "EndpointId" / Int8ul,
-    "ClusterId" / Int16ul,
-    "CommandId" / Int8ul,
+    "EndpointId" / Int16ul,
+    "ClusterId" / Int32ul,
+    "CommandId" / Int32ul,
     "CommandIndex" / Int8ul,
 )
 


### PR DESCRIPTION
#### Problem
there are some regressions caused by #7873
- Sending command to unexist endpoint causes crash
- Python device controller cannot receive response due to mismatch type
- Fixes ##7983

#### Change overview
- Fix type in src/controller/python/chip/interaction_model/delegate.py
- Add static assert to guard this.
- Fix `findClusterEndpointIndex`

#### Testing
- Manaully tested with `src/controller/python/test/test_scripts/mobile-device-test.py` (network commissioning not included for #7913
