### PR TITLE
Introduced Separate Constant for Certificate Decode Buffer Length.

### DIFF
--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -48,6 +48,9 @@ static constexpr uint16_t kX509NoWellDefinedExpirationDateYear = 9999;
 static constexpr uint32_t kMaxCHIPCertLength = 400;
 static constexpr uint32_t kMaxDERCertLength  = 600;
 
+// The decode buffer is used to reconstruct TBS section of X.509 certificate, which doesn't include signature.
+static constexpr uint32_t kMaxCHIPCertDecodeBufLength = kMaxDERCertLength - Crypto::kMax_ECDSA_Signature_Length;
+
 /** Data Element Tags for the CHIP Certificate
  */
 enum

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -350,7 +350,7 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
         const ValidationTestCase & testCase = sValidationTestCases[i];
 
         // Initialize the certificate set and load the specified test certificates.
-        certSet.Init(kMaxCertsPerTestCase, kMaxDERCertLength);
+        certSet.Init(kMaxCertsPerTestCase, kMaxCHIPCertDecodeBufLength);
         for (size_t i2 = 0; i2 < kMaxCertsPerTestCase; i2++)
         {
             if (testCase.InputCerts[i2].Type != TestCert::kNone)
@@ -408,7 +408,7 @@ static void TestChipCert_CertValidTime(nlTestSuite * inSuite, void * inContext)
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
-    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
+    certSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength);
 
     err = LoadTestCertSet01(certSet);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -568,7 +568,7 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
     // clang-format on
     size_t sNumUsageTestCases = sizeof(sUsageTestCases) / sizeof(sUsageTestCases[0]);
 
-    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
+    certSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength);
 
     err = LoadTestCertSet01(certSet);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -624,7 +624,7 @@ static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
         uint8_t certType;
 
         // Initialize the certificate set and load the test certificate.
-        certSet.Init(1, kMaxDERCertLength);
+        certSet.Init(1, kMaxCHIPCertDecodeBufLength);
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -671,7 +671,7 @@ static void TestChipCert_CertId(nlTestSuite * inSuite, void * inContext)
         uint64_t chipId;
 
         // Initialize the certificate set and load the test certificate.
-        certSet.Init(1, kMaxDERCertLength);
+        certSet.Init(1, kMaxCHIPCertDecodeBufLength);
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -689,7 +689,7 @@ static void TestChipCert_LoadDuplicateCerts(nlTestSuite * inSuite, void * inCont
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
-    certSet.Init(kStandardCertsCount, kMaxDERCertLength);
+    certSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength);
 
     // Let's load two distinct certificates, and make sure cert count is 2
     err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
@@ -935,7 +935,7 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
                                               sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxCHIPCertDecodeBufLength) == CHIP_NO_ERROR);
 
     static uint8_t rootCertBuf[kMaxCHIPCertLength];
     static uint8_t icaCertBuf[kMaxCHIPCertLength];
@@ -1023,7 +1023,7 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxCHIPCertDecodeBufLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCerts(outCert.data(), static_cast<uint32_t>(outCert.size()),
@@ -1088,7 +1088,7 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxDERCertLength) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, certSet.Init(3, kMaxCHIPCertDecodeBufLength) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
                    certSet.LoadCerts(outCert.data(), static_cast<uint32_t>(outCert.size()),

--- a/src/credentials/tests/TestChipOperationalCredentials.cpp
+++ b/src/credentials/tests/TestChipOperationalCredentials.cpp
@@ -34,12 +34,6 @@
 using namespace chip;
 using namespace chip::TestCerts;
 
-enum
-{
-    kTestCertBufSize = 1024, // Size of buffer needed to hold any of the test certificates
-                             // (in either CHIP or DER form), or to decode the certificates.
-};
-
 namespace {
 static const BitFlags<CertDecodeFlags> sGenTBSHashFlag(CertDecodeFlags::kGenerateTBSHash);
 static const BitFlags<CertDecodeFlags> sTrustAnchorFlag(CertDecodeFlags::kIsTrustAnchor);
@@ -128,7 +122,7 @@ static void TestChipOperationalCredentials_CertValidation(nlTestSuite * inSuite,
         const ValidationTestCase & testCase = sValidationTestCases[i];
 
         // Initialize the certificate set and load the specified test certificates.
-        certSet.Init(kMaxCertsPerTestCase, kTestCertBufSize);
+        certSet.Init(kMaxCertsPerTestCase, kMaxCHIPCertDecodeBufLength);
         for (size_t i2 = 0; i2 < kMaxCertsPerTestCase; i2++)
         {
             if (testCase.InputCerts[i2].Type != TestCerts::kNone)
@@ -199,7 +193,7 @@ static void TestChipOperationalCredentials_Serialization(nlTestSuite * inSuite, 
     };
 
     // Initialize the certificate set and load the specified test certificates.
-    certSet.Init(kMaxCerts, kTestCertBufSize);
+    certSet.Init(kMaxCerts, kMaxCHIPCertDecodeBufLength);
     err = LoadTestCert(certSet, TestCerts::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     err = LoadTestCert(certSet, TestCerts::kICA01, sNullLoadFlag, sGenTBSHashFlag);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1014,7 +1014,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t ** msgIte
 
     ChipCertificateSet certSet;
     // Certificate set can contain up to 3 certs (NOC, ICA cert, and Root CA cert)
-    ReturnErrorOnFailure(certSet.Init(3, kMaxDERCertLength));
+    ReturnErrorOnFailure(certSet.Init(3, kMaxCHIPCertDecodeBufLength));
 
     responderOpCertLen = chip::Encoding::LittleEndian::Read16(*msgIterator);
     *responderOpCert   = *msgIterator;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -91,8 +91,6 @@ P256Keypair accessoryOpKeys;
 enum
 {
     kStandardCertsCount = 4,
-    kTestCertBufSize    = 1024, // Size of buffer needed to hold any of the test certificates
-                                // (in either CHIP or DER form), or to decode the certificates.
 };
 
 class TestCASESecurePairingDelegate : public SessionEstablishmentDelegate
@@ -133,9 +131,9 @@ static CHIP_ERROR InitCredentialSets()
 
     ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
 
-    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
+    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kTestCertBufSize));
+    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength));
 
     // Add the trusted root certificate to the certificate set.
     ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -221,7 +221,7 @@ bool PrintCert(const char * fileName, X509 * cert)
     res = X509ToChipCert(cert, certBuf.get(), kMaxCHIPCertLength, certLen);
     VerifyTrueOrExit(res);
 
-    err = certSet.Init(1, 1024);
+    err = certSet.Init(1, kMaxCHIPCertDecodeBufLength);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -159,7 +159,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
     VerifyTrueOrExit(res);
 
-    err = certSet.Init(kMaxCerts, kMaxDERCertLength);
+    err = certSet.Init(kMaxCerts, kMaxCHIPCertDecodeBufLength);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
In the current implementation a bigger that needed buffer is allocated for certificate decode purposes.  

#### Change overview
 - defined new parameters for required certificate decode buffer length
 - removed some redundant defines 

#### Testing
CHIP Certs and CASE unit tests.