### PR TITLE
Deprecated ASN1Writer::Finalize() Method

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -209,9 +209,6 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
         // If requested, generate the hash of the TBS portion of the certificate...
         if (decodeFlags.Has(CertDecodeFlags::kGenerateTBSHash))
         {
-            // Finish writing the ASN.1 DER encoding of the TBS certificate.
-            ReturnErrorOnFailure(writer.Finalize());
-
             // Generate a SHA hash of the encoded TBS certificate.
             chip::Crypto::Hash_SHA256(mDecodeBuf, writer.GetLengthWritten(), cert.mTBSHash);
 
@@ -916,8 +913,6 @@ CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, uint8_t 
     writer.Init(derSig, derSigBufSize);
 
     ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(rawSig, writer));
-
-    ReturnErrorOnFailure(writer.Finalize());
 
     derSigLen = writer.GetLengthWritten();
 

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -848,8 +848,6 @@ DLL_EXPORT CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, uint8_t
 
     ReturnErrorOnFailure(DecodeConvertCert(reader, writer, certData));
 
-    ReturnErrorOnFailure(writer.Finalize());
-
     x509CertLen = writer.GetLengthWritten();
 
     return CHIP_NO_ERROR;

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -410,7 +410,6 @@ CHIP_ERROR NewChipX509Cert(const X509CertRequestParams & requestParams, Certific
     writer.Init(x509CertBuf, x509CertBufSize);
 
     ReturnErrorOnFailure(EncodeTBSCert(requestParams, issuerLevel, subject, subjectPubkey, issuerKeypair.Pubkey(), writer));
-    writer.Finalize();
 
     Crypto::P256ECDSASignature signature;
     ReturnErrorOnFailure(issuerKeypair.ECDSA_sign_msg(x509CertBuf, writer.GetLengthWritten(), signature));
@@ -428,7 +427,6 @@ CHIP_ERROR NewChipX509Cert(const X509CertRequestParams & requestParams, Certific
     }
     ASN1_END_SEQUENCE;
 
-    writer.Finalize();
     x509CertLen = writer.GetLengthWritten();
 
 exit:

--- a/src/lib/asn1/ASN1.h
+++ b/src/lib/asn1/ASN1.h
@@ -165,7 +165,6 @@ class DLL_EXPORT ASN1Writer
 public:
     void Init(uint8_t * buf, uint32_t maxLen);
     void InitNullWriter(void);
-    CHIP_ERROR Finalize(void);
     uint16_t GetLengthWritten(void) const;
 
     CHIP_ERROR PutInteger(int64_t val);

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -68,12 +68,6 @@ void ASN1Writer::InitNullWriter(void)
     mDeferredLengthCount = 0;
 }
 
-CHIP_ERROR ASN1Writer::Finalize()
-{
-    // TODO: This method is not required and can be deprecated.
-    return CHIP_NO_ERROR;
-}
-
 uint16_t ASN1Writer::GetLengthWritten() const
 {
     return (mBuf != nullptr) ? mWritePoint - mBuf : 0;

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -165,9 +165,6 @@ static void TestASN1_Encode(nlTestSuite * inSuite, void * inContext)
     err = EncodeASN1TestData(writer);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Finalize();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     encodedLen = writer.GetLengthWritten();
     NL_TEST_ASSERT(inSuite, encodedLen == sizeof(TestASN1_EncodedData));
     NL_TEST_ASSERT(inSuite, memcmp(buf, TestASN1_EncodedData, sizeof(TestASN1_EncodedData)) == 0);
@@ -299,9 +296,6 @@ static void TestASN1_NullWriter(nlTestSuite * inSuite, void * inContext)
     err = EncodeASN1TestData(writer);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = writer.Finalize();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     encodedLen = writer.GetLengthWritten();
     NL_TEST_ASSERT(inSuite, encodedLen == 0);
 }
@@ -326,9 +320,6 @@ static void TestASN1_ObjectID(nlTestSuite * inSuite, void * inContext)
         ASN1_ENCODE_OBJECT_ID(kOID_KeyPurpose_ServerAuth);
     }
     ASN1_END_SEQUENCE;
-
-    err = writer.Finalize();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     encodedLen = writer.GetLengthWritten();
     NL_TEST_ASSERT(inSuite, encodedLen > 0);


### PR DESCRIPTION
#### Problem
ASN1Writer::Finalize() is not needed after #7832 was merged.

#### Change overview
method is deprecated

#### Testing
ASN1 and CHIP Certs unit testing