### PR TITLE
Use {{chip_server_responses}} instead of multiple #ifs for iterating …

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -106,12 +106,8 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
 }
 
 {{#chip_client_clusters}}
-{{#if (user_cluster_has_enabled_command name side)}}
-{{#all_user_cluster_commands}}
-{{#if (isStrEqual clusterName parent.name)}}
-{{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
-{{#if (isStrEndsWith name "Response")}}
-static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+{{#chip_server_cluster_responses}}
+static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
 {
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
 
@@ -119,11 +115,7 @@ static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-{{/if}}
-{{/if}}
-{{/if}}
-{{/all_user_cluster_commands}}
-{{/if}}
+{{/chip_server_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -806,15 +806,11 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
-{{#if (user_cluster_has_enabled_command name side)}}
-{{#all_user_cluster_commands}}
-{{#if (isStrEqual clusterName parent.name)}}
-{{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
-{{#if (isStrEndsWith name "Response")}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/zcl_command_arguments}})
+{{#chip_server_cluster_responses}}
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#chip_server_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_server_cluster_response_arguments}})
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
-    {{#zcl_command_arguments}}
+    {{#chip_server_cluster_response_arguments}}
     {{#if (isStrEqual label "status")}}
     LogStatus(status);
     {{else if (isOctetString type)}}
@@ -825,11 +821,11 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
     {{else}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: {{asPrintFormat type}}", {{asSymbol label}});
     {{/if}}
-    {{/zcl_command_arguments}}
+    {{/chip_server_cluster_response_arguments}}
 
     GET_CLUSTER_RESPONSE_CALLBACKS("{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback");
 
-    {{#zcl_command_arguments}}
+    {{#chip_server_cluster_response_arguments}}
     {{#if (isStrEqual label "status")}}
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -838,18 +834,14 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
         return true;
     }
     {{/if}}
-    {{/zcl_command_arguments}}
+    {{/chip_server_cluster_response_arguments}}
 
     Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback> * cb = Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}});
+    cb->mCall(cb->mContext{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}});
     return true;
 }
 
-{{/if}}
-{{/if}}
-{{/if}}
-{{/all_user_cluster_commands}}
-{{/if}}
+{{/chip_server_cluster_responses}}
 {{/chip_client_clusters}}
 
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -68,15 +68,9 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16
 
 // Cluster Specific Response Callbacks
 {{#chip_client_clusters}}
-{{#if (user_cluster_has_enabled_command name side)}}
-{{#all_user_cluster_commands}}
-{{#if (isStrEqual clusterName parent.name)}}
-{{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
-typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}});
-{{/if}}
-{{/if}}
-{{/all_user_cluster_commands}}
-{{/if}}
+{{#chip_server_cluster_responses}}
+typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}});
+{{/chip_server_cluster_responses}}
 {{/chip_client_clusters}}
 {{/if}}
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -51,11 +51,12 @@ function checkIsInsideClusterBlock(context, name)
 
 function checkIsInsideCommandBlock(context, name)
 {
-  const commandSource = context.commandSource;
-  const commandId     = context.id;
-  const errorMsg      = name + ': Not inside a ({#chip_cluster_commands}} block.';
+  const clusterName = context.clusterName;
+  const clusterSide = context.clusterSide;
+  const commandId   = context.id;
+  const errorMsg    = name + ': Not inside a ({#chip_cluster_commands}} block.';
 
-  throwErrorIfUndefined(context, errorMsg, [ commandId, commandSource ]);
+  throwErrorIfUndefined(context, errorMsg, [ commandId, clusterName, clusterSide ]);
 
   return commandId;
 }
@@ -151,6 +152,21 @@ function chip_server_cluster_commands(options)
 }
 
 /**
+ * Creates block iterator over the server side cluster responses
+ * for a given cluster.
+ *
+ * This function is meant to be used inside a {{#chip_server_clusters}}
+ * block. It will throw otherwise.
+ *
+ * @param {*} options
+ */
+function chip_server_cluster_responses(options)
+{
+  const { clusterName, clusterSide } = checkIsInsideClusterBlock(this, 'chip_server_cluster_response');
+  return asBlocks.call(this, Clusters.getServerResponses(clusterName), options);
+}
+
+/**
  * Creates block iterator over the server side cluster command arguments
  * for a given command.
  *
@@ -161,11 +177,30 @@ function chip_server_cluster_commands(options)
  */
 function chip_server_cluster_command_arguments(options)
 {
-  const commandId                    = checkIsInsideCommandBlock(this, 'isManufacturerSpecificCommand');
-  const { clusterName, clusterSide } = checkIsInsideClusterBlock(this.parent, 'isManufacturerSpecificCommand');
+  const commandId                    = checkIsInsideCommandBlock(this, 'chip_server_cluster_command_arguments');
+  const { clusterName, clusterSide } = checkIsInsideClusterBlock(this.parent, 'chip_server_cluster_command_arguments');
 
   const filter = command => command.id == commandId;
   const promise          = Clusters.getClientCommands(clusterName).then(commands => commands.find(filter).arguments);
+  return asBlocks.call(this, promise, options);
+}
+
+/**
+ * Creates block iterator over the server side cluster response arguments
+ * for a given command.
+ *
+ * This function is meant to be used inside a {{#chip_server_cluster_responses}}
+ * block. It will throw otherwise.
+ *
+ * @param {*} options
+ */
+function chip_server_cluster_response_arguments(options)
+{
+  const commandId                    = checkIsInsideCommandBlock(this, 'chip_server_cluster_response_arguments');
+  const { clusterName, clusterSide } = checkIsInsideClusterBlock(this.parent, 'chip_server_cluster_response_arguments');
+
+  const filter = command => command.id == commandId;
+  const promise          = Clusters.getServerResponses(clusterName).then(commands => commands.find(filter).arguments);
   return asBlocks.call(this, promise, options);
 }
 
@@ -391,25 +426,27 @@ function hasSpecificAttributes(options)
 //
 // Module exports
 //
-exports.chip_clusters                         = chip_clusters;
-exports.chip_has_clusters                     = chip_has_clusters;
-exports.chip_client_clusters                  = chip_client_clusters;
-exports.chip_has_client_clusters              = chip_has_client_clusters;
-exports.chip_server_clusters                  = chip_server_clusters;
-exports.chip_has_server_clusters              = chip_has_server_clusters;
-exports.chip_server_cluster_commands          = chip_server_cluster_commands;
-exports.chip_server_cluster_command_arguments = chip_server_cluster_command_arguments
-exports.chip_attribute_list_entryTypes        = chip_attribute_list_entryTypes;
-exports.asBasicType                           = ChipTypesHelper.asBasicType;
-exports.chip_server_cluster_attributes        = chip_server_cluster_attributes;
-exports.chip_has_list_attributes              = chip_has_list_attributes;
-exports.chip_server_has_list_attributes       = chip_server_has_list_attributes;
-exports.chip_client_has_list_attributes       = chip_client_has_list_attributes;
-exports.isGlobalAttribute                     = isGlobalAttribute;
-exports.isWritableAttribute                   = isWritableAttribute;
-exports.isReportableAttribute                 = isReportableAttribute;
-exports.isManufacturerSpecificCommand         = isManufacturerSpecificCommand;
-exports.asCallbackAttributeType               = asCallbackAttributeType;
-exports.asLowerCamelCase                      = asLowerCamelCase;
-exports.asUpperCamelCase                      = asUpperCamelCase;
-exports.hasSpecificAttributes                 = hasSpecificAttributes;
+exports.chip_clusters                          = chip_clusters;
+exports.chip_has_clusters                      = chip_has_clusters;
+exports.chip_client_clusters                   = chip_client_clusters;
+exports.chip_has_client_clusters               = chip_has_client_clusters;
+exports.chip_server_clusters                   = chip_server_clusters;
+exports.chip_has_server_clusters               = chip_has_server_clusters;
+exports.chip_server_cluster_commands           = chip_server_cluster_commands;
+exports.chip_server_cluster_command_arguments  = chip_server_cluster_command_arguments
+exports.chip_server_cluster_responses          = chip_server_cluster_responses;
+exports.chip_server_cluster_response_arguments = chip_server_cluster_response_arguments
+exports.chip_attribute_list_entryTypes         = chip_attribute_list_entryTypes;
+exports.asBasicType                            = ChipTypesHelper.asBasicType;
+exports.chip_server_cluster_attributes         = chip_server_cluster_attributes;
+exports.chip_has_list_attributes               = chip_has_list_attributes;
+exports.chip_server_has_list_attributes        = chip_server_has_list_attributes;
+exports.chip_client_has_list_attributes        = chip_client_has_list_attributes;
+exports.isGlobalAttribute                      = isGlobalAttribute;
+exports.isWritableAttribute                    = isWritableAttribute;
+exports.isReportableAttribute                  = isReportableAttribute;
+exports.isManufacturerSpecificCommand          = isManufacturerSpecificCommand;
+exports.asCallbackAttributeType                = asCallbackAttributeType;
+exports.asLowerCamelCase                       = asLowerCamelCase;
+exports.asUpperCamelCase                       = asUpperCamelCase;
+exports.hasSpecificAttributes                  = hasSpecificAttributes;

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -193,12 +193,8 @@ class CHIPDefaultFailureCallback : public Callback::Callback<DefaultFailureCallb
 
 // TODO(#7376): add attribute callbacks.
 
-{{#all_user_clusters}}
-{{#if (isClient side) }}
-{{#if (user_cluster_has_enabled_command name side)}}
-{{#all_user_cluster_commands}}
-{{#if (isStrEqual clusterName parent.name)}}
-{{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
+{{#chip_client_clusters}}
+{{#chip_server_cluster_responses}}
 class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback : public Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>
 {
     public:
@@ -225,7 +221,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             env->DeleteGlobalRef(javaCallbackRef);
         };
 
-        static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+        static void CallbackFn(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
         {
             StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -233,7 +229,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             jobject javaCallbackRef;
             jmethodID javaMethod;
             CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback * cppCallback = nullptr;
-            {{#zcl_command_arguments}}
+            {{#chip_server_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
@@ -242,7 +238,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             UtfString {{asSymbol label}}Str(env, "");
             {{/if}}
             {{/unless}}
-            {{/zcl_command_arguments}}
+            {{/chip_server_cluster_response_arguments}}
 
             VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -252,10 +248,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature label type}}{{/if}}{{/unless}}{{/zcl_command_arguments}})V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature label type}}{{/if}}{{/unless}}{{/chip_server_cluster_response_arguments}})V", &javaMethod);
             SuccessOrExit(err);
 
-            {{#zcl_command_arguments}}
+            {{#chip_server_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             {{asSymbol label}}Arr = env->NewByteArray({{asSymbol label}}.size());
@@ -265,10 +261,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
             {{/if}}
             {{/unless}}
-            {{/zcl_command_arguments}}
+            {{/chip_server_cluster_response_arguments}}
 
             env->CallVoidMethod(javaCallbackRef, javaMethod
-                {{#zcl_command_arguments}}
+                {{#chip_server_cluster_response_arguments}}
                 {{#unless (isStrEqual label "status")}}
                 {{#if isArray}}
                 // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -281,16 +277,16 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
                 , static_cast<{{asJniBasicTypeForZclType type}}>({{asSymbol label}})
                 {{/if}}
                 {{/unless}}
-                {{/zcl_command_arguments}}
+                {{/chip_server_cluster_response_arguments}}
             );
 
-            {{#zcl_command_arguments}}
+            {{#chip_server_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             env->DeleteLocalRef({{asSymbol label}}Arr);
             {{/if}}
             {{/unless}}
-            {{/zcl_command_arguments}}
+            {{/chip_server_cluster_response_arguments}}
 
         exit:
             if (err != CHIP_NO_ERROR) {
@@ -306,12 +302,8 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
         jobject javaCallbackRef;
 };
 
-{{/if}}
-{{/if}}
-{{/all_user_cluster_commands}}
-{{/if}}
-{{/if}}
-{{/all_user_clusters}}
+{{/chip_server_cluster_responses}}
+{{/chip_client_clusters}}
 JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlong clusterPtr)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -65,13 +65,10 @@ public class ChipClusters {
   {{/if}}
 
   {{/chip_server_cluster_commands}}
-  {{#if (user_cluster_has_enabled_command name side)}}
-  {{#all_user_cluster_commands}}
-  {{#if (isStrEqual clusterName parent.name)}}
-  {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
+  {{#chip_server_cluster_responses}}
     public interface {{asCamelCased name false}}Callback {
       void onSuccess(
-{{#zcl_command_arguments}}
+{{#chip_server_cluster_response_arguments}}
 {{#unless (isStrEqual label "status")}}
 {{#if isArray}}
       // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -84,16 +81,13 @@ public class ChipClusters {
       {{omitCommaForFirstNonStatusCommand parent.id index}}{{asJavaBasicTypeForZclType type}} {{asSymbol label}}
 {{/if}}
 {{/unless}}
-{{/zcl_command_arguments}}
+{{/chip_server_cluster_response_arguments}}
       );
       
       void onError(Exception error);
     }
 
-  {{/if}}
-  {{/if}}
-  {{/all_user_cluster_commands}}
-  {{/if}}
+  {{/chip_server_cluster_responses}}
   }
   {{#unless (isLastElement index count)}}
 

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -416,12 +416,8 @@ private:
     bool mKeepAlive;
 };
 
-{{#all_user_clusters}}
-{{#if (isClient side) }}
-{{#if (user_cluster_has_enabled_command name side)}}
-{{#all_user_cluster_commands}}
-{{#if (isStrEqual clusterName parent.name)}}
-{{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
+{{#chip_client_clusters}}
+{{#chip_server_cluster_responses}}
 class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge : public Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>
 {
 public:
@@ -429,14 +425,14 @@ public:
 
     ~CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge() {};
 
-    static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+    static void CallbackFn(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
     {
         CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge * callback = reinterpret_cast<CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge *>(context);
         if (callback && callback->mQueue)
         {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @{
-                  {{#zcl_command_arguments}}
+                  {{#chip_server_cluster_response_arguments}}
                   {{#unless (isStrEqual label "status")}}
                   {{#if isArray}}
                   // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -449,7 +445,7 @@ public:
                   @"{{asSymbol label}}": [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
                   {{/if}}
                   {{/unless}}
-                  {{/zcl_command_arguments}}
+                  {{/chip_server_cluster_response_arguments}}
                 });
                 callback->Cancel();
                 delete callback;
@@ -462,12 +458,8 @@ private:
     dispatch_queue_t mQueue;
 };
 
-{{/if}}
-{{/if}}
-{{/all_user_cluster_commands}}
-{{/if}}
-{{/if}}
-{{/all_user_clusters}}
+{{/chip_server_cluster_responses}}
+{{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}


### PR DESCRIPTION
…over the command responses

#### Problem

Various templates generates code by iterating over command responses. The current code is more complex that it can be.
It also makes it harder to update the code to iterate over all commands, enabled or not, instead of having a single place in the code.

#### Change overview
 * Add `chip_server_cluster_responses` iterator and `chip_server_cluster_response_arguments` iterator.
 * Use it into templates

#### Testing
 * I have tested those changes by regenerating the templates and making sure nothing has changed. So the output binary is the same before and after this change.