### PR TITLE
Followup #7873 - Replace emberAfPutInt8uInResp(ZCL_DEFAULT_RESPONSE_C…

### DIFF
--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -845,7 +845,7 @@ EmberStatus emberAfSendDefaultResponseWithCallback(const EmberAfClusterCommand *
         emberAfPutInt16uInResp(cmd->mfgCode);
     }
     emberAfPutInt8uInResp(cmd->seqNum);
-    emberAfPutInt8uInResp(ZCL_DEFAULT_RESPONSE_COMMAND_ID);
+    emberAfPutInt32uInResp(ZCL_DEFAULT_RESPONSE_COMMAND_ID);
     emberAfPutInt32uInResp(cmd->commandId);
     emberAfPutStatusInResp(status);
 


### PR DESCRIPTION
…OMMAND_ID) by emberAfPutInt32uInResp(ZCL_DEFAULT_RESPONSE_COMMAND_ID) in src/app/util/util.cpp

#### Problem

This is a followup for #7873 where command id has been converted from `uint8_t` to `uint32_t`. This line has been forgotten.

#### Change overview
 * Change the forgotten line.
 
#### Testing
It was tested running `./scripts/tests/test_suites.sh` on Mac. That said, it does not mean much since this has not been found by running the same tests suite in #7873...