### PR TITLE
Remove asChipUnderlyingType helper

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -111,7 +111,7 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
 {{#if (isStrEqual clusterName parent.name)}}
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
 {{#if (isStrEndsWith name "Response")}}
-static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
 {
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
 

--- a/src/app/common/gen/client-command-macro.h
+++ b/src/app/common/gen/client-command-macro.h
@@ -23,7 +23,7 @@
 /** @brief Command description for ReadAttributes
  *
  * Command: ReadAttributes
- * @param attributeIds ATTRIBUTE_ID []
+ * @param attributeIds ATTRIB_ID []
  * @param attributeIdsLen int
  */
 #define emberAfFillCommandGlobalReadAttributes(clusterId, attributeIds, attributeIdsLen)                                           \
@@ -144,7 +144,7 @@
 /** @brief Command description for DiscoverAttributes
  *
  * Command: DiscoverAttributes
- * @param startId ATTRIBUTE_ID
+ * @param startId ATTRIB_ID
  * @param maxAttributeIds INT8U
  */
 #define emberAfFillCommandGlobalDiscoverAttributes(clusterId, startId, maxAttributeIds)                                            \
@@ -238,7 +238,7 @@
 /** @brief Command description for DiscoverAttributesExtended
  *
  * Command: DiscoverAttributesExtended
- * @param startId ATTRIBUTE_ID
+ * @param startId ATTRIB_ID
  * @param maxAttributeIds INT8U
  */
 #define emberAfFillCommandGlobalDiscoverAttributesExtended(clusterId, startId, maxAttributeIds)                                    \

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -43,6 +43,9 @@ function atomicType(arg)
     return 'chip::FabricIndex';
   case 'status':
     return 'chip::StatusCode';
+  case 'octet_string':
+  case 'long_octet_string':
+    return 'chip::ByteSpan';
   default:
     throw 'not overriding';
   }

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -1,9 +1,7 @@
 {{#if (zcl_command_arguments_count this.id)}}
 expectArgumentCount = {{ zcl_command_arguments_count this.id }};
 {{#zcl_command_arguments}}
-{{#if (isOctetString type)}}
-chip::ByteSpan {{asSymbol label}};
-{{else if (isString type)}}
+{{#if (isCharString type)}}
 const uint8_t * {{asSymbol label}};
 {{else}}
 {{asUnderlyingZclType type}} {{asSymbol label}};
@@ -44,7 +42,7 @@ while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
     {
         const uint8_t * data = nullptr;
         TLVUnpackError = aDataTlv.GetDataPtr(data);
-        {{asSymbol label}} = chip::ByteSpan(data, aDataTlv.GetLength());
+        {{asSymbol label}} = {{asUnderlyingZclType type}}(data, aDataTlv.GetLength());
     }
 {{else if (isString type)}}
       // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -811,7 +811,7 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
 {{#if (isStrEqual clusterName parent.name)}}
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
 {{#if (isStrEndsWith name "Response")}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/zcl_command_arguments}})
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/zcl_command_arguments}})
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
     {{#zcl_command_arguments}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -72,7 +72,7 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16
 {{#all_user_cluster_commands}}
 {{#if (isStrEqual clusterName parent.name)}}
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
-typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}});
+typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}});
 {{/if}}
 {{/if}}
 {{/all_user_cluster_commands}}

--- a/src/app/zap-templates/templates/app/af-structs.zapt
+++ b/src/app/zap-templates/templates/app/af-structs.zapt
@@ -14,7 +14,7 @@
 // Struct for {{label}}
 typedef struct _{{asType label}} {
 {{#zcl_struct_items}}
-{{ident}}{{asChipUnderlyingType label type}} {{asSymbol label}};
+{{ident}}{{asUnderlyingZclType type}} {{asSymbol label}};
 {{/zcl_struct_items}}
 } {{asUnderlyingType label}};
 {{else}}

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -115,7 +115,7 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}TickCal
 * @brief {{parent.name}} Cluster {{name}} Command callback
 */
 
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/zcl_command_arguments}});
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/zcl_command_arguments}});
 
 {{/if}}
 {{/if}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -162,38 +162,6 @@ function asReadType(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
-/**
- * Returns CHIP specific type for ZCL framework
- * This function is flawed since it relies on the
- * type label for CHIP type conversion. CHIP specific XML should have the
- * correct type directly embedded inside.
- *
- * @param {*} label : The xml label of the type.
- * @param {*} type : The xml type to be converted
- */
-function asChipUnderlyingType(label, type)
-{
-
-  if (zclHelper.isStrEqual(label, "endpoint")) {
-    return 'chip::EndpointId';
-  } else if (zclHelper.isStrEqual(label, "endpointId")) {
-    return 'chip::EndpointId';
-  } else if (zclHelper.isStrEqual(type, "CLUSTER_ID")) {
-    return 'chip::ClusterId';
-  } else if (zclHelper.isStrEqual(type, "ATTRIBUTE_ID")) {
-    return 'chip::AttributeId';
-  } else if (zclHelper.isStrEqual(label, "groupId")) {
-    return 'chip::GroupId';
-  } else if (zclHelper.isStrEqual(label, "commandId")) {
-    return 'chip::CommandId';
-  } else if (type == 'OCTET_STRING') {
-    return 'chip::ByteSpan';
-  } else {
-    const options = { 'hash' : {} };
-    return zclHelper.asUnderlyingZclType.call(this, type, options);
-  }
-}
-
 //  Endpoint-config specific helpers
 // these helpers are a Hot fix for the "GENERATED_FUNCTIONS" problem
 // They should be removed or replace once issue #4369 is resolved
@@ -391,7 +359,6 @@ exports.asPrintFormat                                 = asPrintFormat;
 exports.asReadType                                    = asReadType;
 exports.asReadTypeLength                              = asReadTypeLength;
 exports.asValueIfNotPresent                           = asValueIfNotPresent;
-exports.asChipUnderlyingType                          = asChipUnderlyingType;
 exports.isFirstElement                                = isFirstElement;
 exports.user_cluster_has_enabled_manufacturer_command = user_cluster_has_enabled_manufacturer_command;
 exports.chip_endpoint_generated_functions             = chip_endpoint_generated_functions

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -31,7 +31,7 @@ limitations under the License.
       <description>
         Command description for ReadAttributes
       </description>
-      <arg name="attributeIds" type="ATTRIBUTE_ID" array="true"/>
+      <arg name="attributeIds" type="ATTRIB_ID" array="true"/>
     </command>
     <command code="0x01" name="ReadAttributesResponse" source="either" disableDefaultResponse="true">
       <description>
@@ -104,7 +104,7 @@ limitations under the License.
       <description>
         Command description for DiscoverAttributes
       </description>
-      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="startId" type="ATTRIB_ID"/>
       <arg name="maxAttributeIds" type="INT8U"/>
     </command>
     <command code="0x0D" name="DiscoverAttributesResponse" source="either" disableDefaultResponse="true">
@@ -154,7 +154,7 @@ limitations under the License.
     </command>
     <command code="0x15" name="DiscoverAttributesExtended" source="either">
       <description>This command is similar to the discover attributes command, but also includes a field to indicate whether the attribute is readable, writeable or reportable.</description>
-      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="startId" type="ATTRIB_ID"/>
       <arg name="maxAttributeIds" type="INT8U"/>
     </command>
     <command code="0x16" name="DiscoverAttributesExtendedResponse" source="either" disableDefaultResponse="true">

--- a/src/app/zap-templates/zcl/data-model/silabs/types.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types.xml
@@ -436,23 +436,23 @@ limitations under the License.
     <item name="InvalidDataType" value="0x8D"/>
   </enum>
   <struct name="ReadAttributeStatusRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="status" type="Status"/>
     <item name="attributeType" type="INT8U"/>
     <item name="attributeLocation" type="NO_DATA"/>
   </struct>
   <struct name="WriteAttributeRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
     <item name="attributeLocation" type="NO_DATA"/>
   </struct>
   <struct name="WriteAttributeStatusRecord">
     <item name="status" type="Status"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
   </struct>
   <struct name="ConfigureReportingRecord">
     <item name="direction" type="INT8U"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
     <item name="minimumReportingInterval" type="INT16U"/>
     <item name="maximumReportingInterval" type="INT16U"/>
@@ -462,12 +462,12 @@ limitations under the License.
   <struct name="ConfigureReportingStatusRecord">
     <item name="status" type="Status"/>
     <item name="direction" type="INT8U"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
   </struct>
   <struct name="ReadReportingConfigurationRecord">
     <item name="status" type="Status"/>
     <item name="direction" type="INT8U"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
     <item name="minimumReportingInterval" type="INT16U"/>
     <item name="maximumReportingInterval" type="INT16U"/>
@@ -480,29 +480,29 @@ limitations under the License.
   </enum>
   <struct name="ReadReportingConfigurationAttributeRecord">
     <item name="direction" type="INT8U"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
   </struct>
   <struct name="ReportAttributeRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
     <item name="attributeLocation" type="NO_DATA"/>
   </struct>
   <struct name="DiscoverAttributesInfoRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
   </struct>
   <struct name="ExtendedDiscoverAttributesInfoRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="attributeType" type="INT8U"/>
     <item name="attributeAccessControl" type="INT8U"/>
   </struct>
   <struct name="ReadStructuredAttributeRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="indicator" type="INT8U"/>
     <item name="indicies" type="INT16U" array="true"/>
   </struct>
   <struct name="WriteStructuredAttributeRecord">
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="indicator" type="INT8U"/>
     <item name="indicies" type="INT16U" array="true"/>
     <item name="attributeType" type="INT8U"/>
@@ -510,7 +510,7 @@ limitations under the License.
   </struct>
   <struct name="WriteStructuredAttributeStatusRecord">
     <item name="status" type="Status"/>
-    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeId" type="ATTRIB_ID"/>
     <item name="indicator" type="INT8U"/>
     <item name="indicies" type="INT16U" array="true"/>
   </struct>

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -225,7 +225,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             env->DeleteGlobalRef(javaCallbackRef);
         };
 
-        static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+        static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
         {
             StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -271,7 +271,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
                 {{#zcl_command_arguments}}
                 {{#unless (isStrEqual label "status")}}
                 {{#if isArray}}
-                // {{asSymbol label}}: {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}}
+                // {{asSymbol label}}: {{asUnderlyingZclType type}}
                 // Conversion from this type to Java is not properly implemented yet
                 {{else if (isOctetString type)}}
                 , {{asSymbol label}}Arr
@@ -368,7 +368,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(J
     onFailure = new CHIPDefaultFailureCallback(callback);
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}Arr.data(), {{asCamelCased label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}, strlen({{asCamelCased label}}Str.c_str())){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
+    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asCamelCased label}}Arr.data(), {{asCamelCased label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}, strlen({{asCamelCased label}}Str.c_str())){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
     SuccessOrExit(err);
 
 exit: 

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -429,7 +429,7 @@ public:
 
     ~CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge() {};
 
-    static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
+    static void CallbackFn(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
     {
         CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge * callback = reinterpret_cast<CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge *>(context);
         if (callback && callback->mQueue)
@@ -439,7 +439,7 @@ public:
                   {{#zcl_command_arguments}}
                   {{#unless (isStrEqual label "status")}}
                   {{#if isArray}}
-                  // {{asSymbol label}}: {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}}
+                  // {{asSymbol label}}: {{asUnderlyingZclType type}}
                   // Conversion from this type to Objc is not properly implemented yet
                   {{else if (isOctetString type)}}
                   @"{{asSymbol label}}": [NSData dataWithBytes:{{asSymbol label}}.data() length:{{asSymbol label}}.size()],
@@ -616,7 +616,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}chip::ByteSpan((const uint8_t*){{asCamelCased label}}.bytes, {{asCamelCased label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asCamelCased label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asCamelCased label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        err = self.cppCluster.{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asCamelCased label}}.bytes, {{asCamelCased label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asCamelCased label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asCamelCased label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
     });
 
     if (err != CHIP_NO_ERROR) {


### PR DESCRIPTION
#### Problem

In many places into our templates `{{asUnderlyingZclType type}}` is used to retrieve which types should be used for the signature of methods. But it does not return the proper type for `octet_string` nor `long_octet_string` at the moment so there in many places the code has been written such as:
```
{{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}}
```

This PR adds `octet_string` and `long_octet_string` to `override.js` so the code can be rewritten such as:
```
{{asUnderlyingZclType type}}
```

And in a few other places, the code assume that `octet_string` means the `chip::ByteSpan` class which is not very convenient if at some point this type needs to be updated...
 
#### Change overview
* Return the expected type into `override.js`
* Clean up the places where `{{#if (isOctetString type)}}` is useless now

#### Testing
 The only code changes that is generated is `ATTRIBUTE_ID` -> `ATTRIB_ID` into a comment. So nothing has really changed.