### PR TITLE
[Test] Add Test_TC_DM_3_1

### DIFF
--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -11786,13 +11786,53 @@ private:
     }
 };
 
+class Test_TC_DM_3_1 : public TestCommand
+{
+public:
+    Test_TC_DM_3_1() : TestCommand("Test_TC_DM_3_1"), mTestIndex(0) {}
+
+    /////////// TestCommand Interface /////////
+    void NextTest() override
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        if (mTestCount == mTestIndex)
+        {
+            ChipLogProgress(chipTool, "Test_TC_DM_3_1: Test complete");
+            SetCommandExitStatus(CHIP_NO_ERROR);
+        }
+
+        // Ensure we increment mTestIndex before we start running the relevant
+        // command.  That way if we lose the timeslice after we send the message
+        // but before our function call returns, we won't end up with an
+        // incorrect mTestIndex value observed when we get the response.
+        switch (mTestIndex++)
+        {
+        }
+
+        if (CHIP_NO_ERROR != err)
+        {
+            ChipLogProgress(chipTool, "Test_TC_DM_3_1: %s", chip::ErrorStr(err));
+            SetCommandExitStatus(err);
+        }
+    }
+
+private:
+    std::atomic_uint16_t mTestIndex;
+    const uint16_t mTestCount = 0;
+
+    //
+    // Tests methods
+    //
+};
+
 void registerCommandsTests(Commands & commands)
 {
     const char * clusterName = "Tests";
 
     commands_list clusterCommands = {
         make_unique<TestCluster>(), make_unique<Test_3_1_1>(),  make_unique<Test_3_2_1>(),
-        make_unique<Test_3_2_2>(),  make_unique<Test_10_1_1>(),
+        make_unique<Test_3_2_2>(),  make_unique<Test_10_1_1>(), make_unique<Test_TC_DM_3_1>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/templates/tests-commands.zapt
+++ b/examples/chip-tool/templates/tests-commands.zapt
@@ -4,7 +4,7 @@
 
 #include "TestCommand.h"
 
-{{>test_cluster tests="TestCluster, Test_3_1_1, Test_3_2_1, Test_3_2_2, Test_10_1_1"}}
+{{>test_cluster tests="TestCluster, Test_3_1_1, Test_3_2_1, Test_3_2_2, Test_10_1_1, Test_TC_DM_3_1"}}
 
 void registerCommandsTests(Commands & commands)
 {
@@ -16,6 +16,7 @@ void registerCommandsTests(Commands & commands)
         make_unique<Test_3_2_1>(),
         make_unique<Test_3_2_2>(),
         make_unique<Test_10_1_1>(),
+        make_unique<Test_TC_DM_3_1>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/tests/suites/Test_TC_DM_3_1.yaml
+++ b/src/app/tests/suites/Test_TC_DM_3_1.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 10.3.1. [TC-DM-3.1] Network Commissioning Attributes
+
+config:
+    cluster: "Network Commissioning"
+    endpoint: 0
+
+tests:
+    - label: "Query MaxNetworks"
+      command: "readAttribute"
+      attribute: "MaxNetworks"
+      disabled: true
+      optional: true
+      response:
+          constraints:
+              type: uint8
+
+    - label: "Query Networks"
+      command: "readAttribute"
+      attribute: "Networks"
+      disabled: true
+      optional: true
+      response:
+          constraints:
+              type: list

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -137,7 +137,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-{{>test_cluster tests="TestCluster, Test_3_1_1, Test_3_2_1, Test_3_2_2, Test_10_1_1"}}
+{{>test_cluster tests="TestCluster, Test_3_1_1, Test_3_2_1, Test_3_2_2, Test_10_1_1, Test_TC_DM_3_1"}}
 
 {{#chip_client_clusters}}
 {{#unless (isStrEqual "Test Cluster" name)}}


### PR DESCRIPTION
#### Problem

This PR is adding `Test_TC_DM_3_1` with everything disabled since the `Network Commissioning` cluster does not implemented those into the XML definition.

#### Change overview
 * Add more disabled tests to the tree

#### Testing
 * This is just tests, but disabled...
