### PR TITLE
Add test for sending a command to an unsupported endpoint

### DIFF
--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -3581,6 +3581,9 @@ public:
         case 100:
             err = TestSendClusterTestClusterCommandWriteAttribute_100();
             break;
+        case 101:
+            err = TestSendClusterTestClusterCommandTest_101();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -3592,7 +3595,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 101;
+    const uint16_t mTestCount = 102;
 
     //
     // Tests methods
@@ -11056,6 +11059,75 @@ private:
         delete runner->mOnSuccessCallback_100;
 
         if (runner->mIsFailureExpected_100 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Send Test Command to unsupported endpoint
+    typedef void (*SuccessCallback_101)(void * context);
+    chip::Callback::Callback<SuccessCallback_101> * mOnSuccessCallback_101    = nullptr;
+    chip::Callback::Callback<DefaultFailureCallback> * mOnFailureCallback_101 = nullptr;
+    bool mIsFailureExpected_101                                               = 1;
+
+    CHIP_ERROR TestSendClusterTestClusterCommandTest_101()
+    {
+        ChipLogProgress(chipTool, "Test Cluster - Send Test Command to unsupported endpoint: Sending command...");
+
+        mOnFailureCallback_101 =
+            new chip::Callback::Callback<DefaultFailureCallback>(OnTestSendClusterTestClusterCommandTest_101_FailureResponse, this);
+        mOnSuccessCallback_101 =
+            new chip::Callback::Callback<SuccessCallback_101>(OnTestSendClusterTestClusterCommandTest_101_SuccessResponse, this);
+
+        chip::Controller::TestClusterCluster cluster;
+        cluster.Associate(mDevice, 200);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        err = cluster.Test(mOnSuccessCallback_101->Cancel(), mOnFailureCallback_101->Cancel());
+
+        if (CHIP_NO_ERROR != err)
+        {
+            delete mOnFailureCallback_101;
+            delete mOnSuccessCallback_101;
+        }
+
+        return err;
+    }
+
+    static void OnTestSendClusterTestClusterCommandTest_101_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Test Cluster - Send Test Command to unsupported endpoint: Failure Response");
+
+        TestCluster * runner = reinterpret_cast<TestCluster *>(context);
+
+        delete runner->mOnFailureCallback_101;
+        delete runner->mOnSuccessCallback_101;
+
+        if (runner->mIsFailureExpected_101 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterTestClusterCommandTest_101_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Test Cluster - Send Test Command to unsupported endpoint: Success Response");
+
+        TestCluster * runner = reinterpret_cast<TestCluster *>(context);
+
+        delete runner->mOnFailureCallback_101;
+        delete runner->mOnSuccessCallback_101;
+
+        if (runner->mIsFailureExpected_101 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -112,7 +112,7 @@ for j in "${iter_array[@]}"; do
         # Prevent cleanup trying to kill a process we already killed.
         temp_background_pid=$background_pid
         background_pid=0
-        kill -9 "$temp_background_pid" || true
+        kill -9 "$temp_background_pid"
         echo "  ===== Test complete: $i"
     done
     echo " ===== Iteration $j completed"

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -671,3 +671,10 @@ tests:
       optional: true
       arguments:
           value: 0
+
+    - label: "Send Test Command to unsupported endpoint"
+      command: "test"
+      endpoint: 200
+      response:
+          # No cluster on that endpoint, so expect an error.
+          error: 1

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -2042,6 +2042,23 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
+- (void)testSendClusterTestCluster_000101_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command to unsupported endpoint"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:200 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    [cluster test:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Send Test Command to unsupported endpoint Error: %@", err);
+
+        XCTAssertEqual(err.code, 1);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
 
 - (void)testSendClusterTest_TC_OO_1_1_000000_ReadAttribute
 {


### PR DESCRIPTION
#### Problem
We have no test coverage for sending a command to an unsupported endpoint.

#### Change overview
Add a test.

#### Testing
Ran Darwin tests and `test_suites.sh` manually, verified the test fails.  And will keep failing until https://github.com/project-chip/connectedhomeip/pull/8054 merges.