### PR TITLE
Split up src/platform/BUILD.gn

### DIFF
--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 
 #include <core/CHIPCore.h>
-#include <platform/internal/DeviceNetworkInfo.h>
 #include <support/Span.h>
 
 namespace chip {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -192,17 +192,18 @@ if (chip_device_platform != "none") {
   }
 }
 
-if (chip_device_platform != "none" && chip_device_platform != "external") {
-  config("platform_config") {
-    if (chip_device_platform == "darwin") {
-      frameworks = [
-        "CoreData.framework",
-        "CoreFoundation.framework",
-        "CoreBluetooth.framework",
-        "Foundation.framework",
-        "IOKit.framework",
-      ]
-    }
+if (chip_device_platform != "none") {
+  group("platform_base") {
+    public_deps = [
+      ":platform_buildconfig",
+      "${chip_root}/src/ble",
+      "${chip_root}/src/inet",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support",
+      "${chip_root}/src/system",
+    ]
+
+    public_configs = [ "${chip_root}/src:includes" ]
   }
 
   static_library("platform") {
@@ -255,454 +256,44 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     cflags = [ "-Wconversion" ]
 
     public_deps = [
-      ":platform_buildconfig",
-      "${chip_root}/src/ble",
-      "${chip_root}/src/inet",
-      "${chip_root}/src/lib/core",
-      "${chip_root}/src/lib/core:chip_config_header",
+      ":platform_base",
       "${chip_root}/src/lib/support",
-      "${chip_root}/src/platform/logging:headers",
-      "${chip_root}/src/setup_payload",
-      "${nlio_root}:nlio",
     ]
-
-    public_configs = [
-      ":platform_config",
-      "${chip_root}/src:includes",
-    ]
-
-    if (chip_mdns != "none") {
-      public_deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
-    }
 
     if (chip_device_platform == "cc13x2_26x2") {
-      sources += [
-        "FreeRTOS/SystemTimeSupport.cpp",
-        "cc13x2_26x2/BlePlatformConfig.h",
-        "cc13x2_26x2/CC13X2_26X2Config.cpp",
-        "cc13x2_26x2/CC13X2_26X2Config.h",
-        "cc13x2_26x2/CHIPDevicePlatformConfig.h",
-        "cc13x2_26x2/CHIPDevicePlatformConfig.h",
-        "cc13x2_26x2/CHIPDevicePlatformEvent.h",
-        "cc13x2_26x2/ConfigurationManagerImpl.cpp",
-        "cc13x2_26x2/ConnectivityManagerImpl.cpp",
-        "cc13x2_26x2/ConnectivityManagerImpl.h",
-        "cc13x2_26x2/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "cc13x2_26x2/DeviceNetworkProvisioningDelegateImpl.h",
-        "cc13x2_26x2/InetPlatformConfig.h",
-        "cc13x2_26x2/KeyValueStoreManagerImpl.cpp",
-        "cc13x2_26x2/KeyValueStoreManagerImpl.h",
-        "cc13x2_26x2/Logging.cpp",
-        "cc13x2_26x2/PlatformManagerImpl.cpp",
-        "cc13x2_26x2/PlatformManagerImpl.h",
-        "cc13x2_26x2/Random.c",
-        "cc13x2_26x2/SystemPlatformConfig.h",
-      ]
-
-      if (chip_enable_ble) {
-        sources += [
-          "cc13x2_26x2/BLEManagerImpl.cpp",
-          "cc13x2_26x2/BLEManagerImpl.h",
-        ]
-      }
-
-      if (chip_enable_openthread) {
-        # needed for MTD/FTD
-        import("//build_overrides/ti_simplelink_sdk.gni")
-        import("${ti_simplelink_sdk_build_root}/ti_simplelink_board.gni")
-        public_deps += [
-          "${chip_root}/third_party/ti_simplelink_sdk:mbedtls",
-          "${chip_root}/third_party/ti_simplelink_sdk:ti_simplelink_sdk",
-          "${chip_root}/third_party/ti_simplelink_sdk:ti_simplelink_sysconfig",
-        ]
-
-        if (ti_simplelink_device_family == "cc13x2_26x2") {
-          public_deps += [ "${openthread_root}:libopenthread-mtd" ]
-        } else if (ti_simplelink_device_family == "cc13x2x7_26x2x7") {
-          public_deps += [ "${openthread_root}:libopenthread-ftd" ]
-        }
-
-        sources += [
-          "OpenThread/OpenThreadUtils.cpp",
-          "cc13x2_26x2/ThreadStackManagerImpl.cpp",
-          "cc13x2_26x2/ThreadStackManagerImpl.h",
-        ]
-      }
+      _platform_target = "cc13x2_26x2"
     } else if (chip_device_platform == "darwin") {
-      cflags += [ "-fobjc-arc" ]
-
-      sources += [
-        "Darwin/BLEManagerImpl.cpp",
-        "Darwin/BLEManagerImpl.h",
-        "Darwin/BlePlatformConfig.h",
-        "Darwin/CHIPDevicePlatformConfig.h",
-        "Darwin/CHIPDevicePlatformEvent.h",
-        "Darwin/CHIPPlatformConfig.h",
-        "Darwin/ConfigurationManagerImpl.cpp",
-        "Darwin/ConfigurationManagerImpl.h",
-        "Darwin/ConnectivityManagerImpl.cpp",
-        "Darwin/ConnectivityManagerImpl.h",
-        "Darwin/InetPlatformConfig.h",
-        "Darwin/KeyValueStoreManagerImpl.h",
-        "Darwin/KeyValueStoreManagerImpl.mm",
-        "Darwin/Logging.cpp",
-        "Darwin/MdnsError.cpp",
-        "Darwin/MdnsError.h",
-        "Darwin/MdnsImpl.cpp",
-        "Darwin/MdnsImpl.h",
-        "Darwin/PlatformManagerImpl.cpp",
-        "Darwin/PlatformManagerImpl.h",
-        "Darwin/PosixConfig.cpp",
-        "Darwin/PosixConfig.h",
-        "Darwin/SystemPlatformConfig.h",
-        "DeviceSafeQueue.cpp",
-        "DeviceSafeQueue.h",
-      ]
-
-      if (chip_enable_ble) {
-        sources += [
-          "Darwin/BleApplicationDelegate.h",
-          "Darwin/BleApplicationDelegateImpl.mm",
-          "Darwin/BleConnectionDelegate.h",
-          "Darwin/BleConnectionDelegateImpl.mm",
-          "Darwin/BlePlatformDelegate.h",
-          "Darwin/BlePlatformDelegateImpl.mm",
-          "Darwin/UUIDHelper.h",
-          "Darwin/UUIDHelperImpl.mm",
-        ]
-      }
+      _platform_target = "Darwin"
     } else if (chip_device_platform == "efr32") {
-      sources += [
-        "EFR32/BLEManagerImpl.cpp",
-        "EFR32/BLEManagerImpl.h",
-        "EFR32/BlePlatformConfig.h",
-        "EFR32/CHIPDevicePlatformConfig.h",
-        "EFR32/CHIPDevicePlatformEvent.h",
-        "EFR32/CHIPMem-Platform.cpp",
-        "EFR32/CHIPPlatformConfig.h",
-        "EFR32/ConfigurationManagerImpl.cpp",
-        "EFR32/ConfigurationManagerImpl.h",
-        "EFR32/ConnectivityManagerImpl.cpp",
-        "EFR32/ConnectivityManagerImpl.h",
-        "EFR32/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "EFR32/DeviceNetworkProvisioningDelegateImpl.h",
-        "EFR32/EFR32Config.cpp",
-        "EFR32/EFR32Config.h",
-        "EFR32/InetPlatformConfig.h",
-        "EFR32/Logging.cpp",
-        "EFR32/PlatformManagerImpl.cpp",
-        "EFR32/PlatformManagerImpl.h",
-        "EFR32/SystemPlatformConfig.h",
-        "EFR32/freertos_bluetooth.c",
-        "EFR32/freertos_bluetooth.h",
-        "EFR32/gatt_db.c",
-        "EFR32/gatt_db.h",
-        "FreeRTOS/SystemTimeSupport.cpp",
-      ]
-
-      # Add pigweed KVS
-      deps = [
-        "$dir_pw_kvs:crc16",
-        "$dir_pw_log",
-      ]
-      public_deps += [
-        "$dir_pw_checksum",
-        "$dir_pw_kvs",
-      ]
-      sources += [
-        "EFR32/KeyValueStoreManagerImpl.cpp",
-        "EFR32/KeyValueStoreManagerImpl.h",
-      ]
-
-      if (chip_enable_openthread) {
-        public_deps += [ "${openthread_root}:libopenthread-ftd" ]
-
-        sources += [
-          "EFR32/ThreadStackManagerImpl.cpp",
-          "EFR32/ThreadStackManagerImpl.h",
-          "OpenThread/OpenThreadUtils.cpp",
-        ]
-      }
+      _platform_target = "EFR32"
     } else if (chip_device_platform == "esp32") {
-      sources += [
-        "ESP32/BLEManagerImpl.h",
-        "ESP32/CHIPDevicePlatformConfig.h",
-        "ESP32/CHIPDevicePlatformEvent.h",
-        "ESP32/ConfigurationManagerImpl.cpp",
-        "ESP32/ConfigurationManagerImpl.h",
-        "ESP32/ConnectivityManagerImpl.cpp",
-        "ESP32/ConnectivityManagerImpl.h",
-        "ESP32/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "ESP32/DeviceNetworkProvisioningDelegateImpl.h",
-        "ESP32/ESP32Config.cpp",
-        "ESP32/ESP32Config.h",
-        "ESP32/ESP32Utils.cpp",
-        "ESP32/ESP32Utils.h",
-        "ESP32/KeyValueStoreManagerImpl.cpp",
-        "ESP32/KeyValueStoreManagerImpl.h",
-        "ESP32/Logging.cpp",
-        "ESP32/LwIPCoreLock.cpp",
-        "ESP32/MdnsImpl.cpp",
-        "ESP32/PlatformManagerImpl.cpp",
-        "ESP32/PlatformManagerImpl.h",
-        "ESP32/ServiceProvisioning.cpp",
-        "ESP32/ServiceProvisioning.h",
-        "ESP32/SoftwareUpdateManagerImpl.h",
-        "ESP32/SystemTimeSupport.cpp",
-        "ESP32/bluedroid/BLEManagerImpl.cpp",
-        "ESP32/nimble/BLEManagerImpl.cpp",
-        "FreeRTOS/SystemTimeSupport.cpp",
-      ]
-
-      public_deps += [ "${chip_root}/src/crypto" ]
+      _platform_target = "ESP32"
     } else if (chip_device_platform == "k32w") {
-      sources += [
-        "FreeRTOS/SystemTimeSupport.cpp",
-        "K32W/BLEManagerImpl.cpp",
-        "K32W/BLEManagerImpl.h",
-        "K32W/CHIPDevicePlatformConfig.h",
-        "K32W/CHIPDevicePlatformEvent.h",
-        "K32W/ConfigurationManagerImpl.cpp",
-        "K32W/ConfigurationManagerImpl.h",
-        "K32W/ConnectivityManagerImpl.cpp",
-        "K32W/ConnectivityManagerImpl.h",
-        "K32W/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "K32W/DeviceNetworkProvisioningDelegateImpl.h",
-        "K32W/K32WConfig.cpp",
-        "K32W/K32WConfig.h",
-        "K32W/KeyValueStoreManagerImpl.cpp",
-        "K32W/KeyValueStoreManagerImpl.h",
-        "K32W/Logging.cpp",
-        "K32W/NFCManagerImpl.cpp",
-        "K32W/NFCManagerImpl.h",
-        "K32W/PlatformManagerImpl.cpp",
-        "K32W/PlatformManagerImpl.h",
-        "K32W/SoftwareUpdateManagerImpl.h",
-        "K32W/ble_function_mux.c",
-      ]
-
-      if (chip_enable_openthread) {
-        public_deps += [ "${openthread_root}:libopenthread-ftd" ]
-
-        sources += [
-          "K32W/ThreadStackManagerImpl.cpp",
-          "K32W/ThreadStackManagerImpl.h",
-          "OpenThread/OpenThreadUtils.cpp",
-        ]
-      }
-
-      public_deps += [ "${chip_root}/src/crypto" ]
+      _platform_target = "K32W"
     } else if (chip_device_platform == "linux") {
-      sources += [
-        "DeviceSafeQueue.cpp",
-        "DeviceSafeQueue.h",
-        "Linux/BLEManagerImpl.cpp",
-        "Linux/BLEManagerImpl.h",
-        "Linux/BlePlatformConfig.h",
-        "Linux/CHIPDevicePlatformConfig.h",
-        "Linux/CHIPDevicePlatformEvent.h",
-        "Linux/CHIPLinuxStorage.cpp",
-        "Linux/CHIPLinuxStorage.h",
-        "Linux/CHIPLinuxStorageIni.cpp",
-        "Linux/CHIPLinuxStorageIni.h",
-        "Linux/CHIPPlatformConfig.h",
-        "Linux/ConfigurationManagerImpl.cpp",
-        "Linux/ConfigurationManagerImpl.h",
-        "Linux/ConnectivityManagerImpl.cpp",
-        "Linux/ConnectivityManagerImpl.h",
-        "Linux/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "Linux/DeviceNetworkProvisioningDelegateImpl.h",
-        "Linux/InetPlatformConfig.h",
-        "Linux/KeyValueStoreManagerImpl.cpp",
-        "Linux/KeyValueStoreManagerImpl.h",
-        "Linux/Logging.cpp",
-        "Linux/PlatformManagerImpl.cpp",
-        "Linux/PlatformManagerImpl.h",
-        "Linux/PosixConfig.cpp",
-        "Linux/PosixConfig.h",
-        "Linux/SystemPlatformConfig.h",
-        "Linux/SystemTimeSupport.cpp",
-        "Linux/bluez/AdapterIterator.cpp",
-        "Linux/bluez/AdapterIterator.h",
-        "Linux/bluez/ChipDeviceScanner.cpp",
-        "Linux/bluez/ChipDeviceScanner.h",
-        "Linux/bluez/Helper.cpp",
-        "Linux/bluez/Helper.h",
-        "Linux/bluez/MainLoop.cpp",
-        "Linux/bluez/MainLoop.h",
-        "Linux/bluez/Types.h",
-      ]
-
-      if (chip_mdns != "none") {
-        sources += [
-          "Linux/MdnsImpl.cpp",
-          "Linux/MdnsImpl.h",
-        ]
-
-        public_configs += [ ":avahi_client_config" ]
-      }
-
-      if (chip_enable_openthread) {
-        sources += [
-          "Linux/GlibTypeDeleter.h",
-          "Linux/ThreadStackManagerImpl.cpp",
-          "Linux/ThreadStackManagerImpl.h",
-        ]
-        public_deps += [ "Linux/dbus/openthread" ]
-      }
-
-      if (chip_enable_wifi) {
-        public_deps += [ "Linux/dbus/wpa" ]
-      }
-
-      if (chip_enable_ble) {
-        public_deps += [ "Linux/dbus/bluez" ]
-      }
-
-      public_deps += [ "${chip_root}/third_party/inipp" ]
+      _platform_target = "Linux"
     } else if (chip_device_platform == "nrfconnect") {
-      sources += [
-        "Zephyr/BLEManagerImpl.cpp",
-        "Zephyr/ConfigurationManagerImpl.cpp",
-        "Zephyr/KeyValueStoreManagerImpl.cpp",
-        "Zephyr/Logging.cpp",
-        "Zephyr/PlatformManagerImpl.cpp",
-        "Zephyr/SystemTimeSupport.cpp",
-        "Zephyr/ZephyrConfig.cpp",
-        "Zephyr/ZephyrConfig.h",
-        "nrfconnect/BLEManagerImpl.h",
-        "nrfconnect/BlePlatformConfig.h",
-        "nrfconnect/CHIPDevicePlatformConfig.h",
-        "nrfconnect/CHIPDevicePlatformEvent.h",
-        "nrfconnect/CHIPPlatformConfig.h",
-        "nrfconnect/ConfigurationManagerImpl.h",
-        "nrfconnect/ConnectivityManagerImpl.cpp",
-        "nrfconnect/ConnectivityManagerImpl.h",
-        "nrfconnect/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "nrfconnect/DeviceNetworkProvisioningDelegateImpl.h",
-        "nrfconnect/InetPlatformConfig.h",
-        "nrfconnect/KeyValueStoreManagerImpl.h",
-        "nrfconnect/PlatformManagerImpl.h",
-        "nrfconnect/SystemPlatformConfig.h",
-      ]
-
-      if (chip_enable_openthread) {
-        sources += [
-          "OpenThread/OpenThreadUtils.cpp",
-          "Zephyr/ThreadStackManagerImpl.cpp",
-          "nrfconnect/ThreadStackManagerImpl.h",
-        ]
-      }
-
-      if (chip_enable_nfc) {
-        sources += [
-          "Zephyr/NFCManagerImpl.cpp",
-          "nrfconnect/NFCManagerImpl.h",
-        ]
-      }
+      _platform_target = "nrfconnect"
     } else if (chip_device_platform == "qpg") {
-      sources += [
-        "FreeRTOS/SystemTimeSupport.cpp",
-        "qpg/BLEManagerImpl.cpp",
-        "qpg/BLEManagerImpl.h",
-        "qpg/BlePlatformConfig.h",
-        "qpg/CHIPDevicePlatformConfig.h",
-        "qpg/CHIPDevicePlatformEvent.h",
-        "qpg/CHIPPlatformConfig.h",
-        "qpg/ConfigurationManagerImpl.cpp",
-        "qpg/ConfigurationManagerImpl.h",
-        "qpg/ConnectivityManagerImpl.cpp",
-        "qpg/ConnectivityManagerImpl.h",
-        "qpg/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "qpg/DeviceNetworkProvisioningDelegateImpl.h",
-        "qpg/InetPlatformConfig.h",
-        "qpg/Logging.cpp",
-        "qpg/PlatformManagerImpl.cpp",
-        "qpg/PlatformManagerImpl.h",
-        "qpg/SystemPlatformConfig.h",
-        "qpg/qpgConfig.cpp",
-        "qpg/qpgConfig.h",
-      ]
-
-      sources += [
-        "qpg/KeyValueStoreManagerImpl.cpp",
-        "qpg/KeyValueStoreManagerImpl.h",
-      ]
-
-      if (chip_enable_openthread) {
-        public_deps += [ "${openthread_root}:libopenthread-mtd" ]
-
-        public_configs += [ "${chip_root}/third_party/openthread/platforms/qpg:openthread_qpg_config" ]
-
-        sources += [
-          "OpenThread/OpenThreadUtils.cpp",
-          "qpg/ThreadStackManagerImpl.cpp",
-          "qpg/ThreadStackManagerImpl.h",
-        ]
-      }
+      _platform_target = "qpg"
     } else if (chip_device_platform == "telink") {
-      sources += [
-        "Zephyr/BLEManagerImpl.cpp",
-        "Zephyr/ConfigurationManagerImpl.cpp",
-        "Zephyr/KeyValueStoreManagerImpl.cpp",
-        "Zephyr/Logging.cpp",
-        "Zephyr/PlatformManagerImpl.cpp",
-        "Zephyr/SystemTimeSupport.cpp",
-        "Zephyr/ZephyrConfig.cpp",
-        "Zephyr/ZephyrConfig.h",
-        "telink/BLEManagerImpl.h",
-        "telink/BlePlatformConfig.h",
-        "telink/CHIPDevicePlatformConfig.h",
-        "telink/CHIPDevicePlatformEvent.h",
-        "telink/CHIPPlatformConfig.h",
-        "telink/ConfigurationManagerImpl.h",
-        "telink/ConnectivityManagerImpl.cpp",
-        "telink/ConnectivityManagerImpl.h",
-        "telink/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "telink/DeviceNetworkProvisioningDelegateImpl.h",
-        "telink/InetPlatformConfig.h",
-        "telink/KeyValueStoreManagerImpl.h",
-        "telink/PlatformManagerImpl.h",
-        "telink/SystemPlatformConfig.h",
-      ]
-
-      if (chip_enable_openthread) {
-        sources += [
-          "OpenThread/OpenThreadUtils.cpp",
-          "Zephyr/ThreadStackManagerImpl.cpp",
-          "telink/ThreadStackManagerImpl.h",
-        ]
-      }
+      _platform_target = "telink"
     } else if (chip_device_platform == "mbed") {
-      sources += [
-        "mbed/BLEManagerImpl.cpp",
-        "mbed/BLEManagerImpl.h",
-        "mbed/ConfigurationManagerImpl.cpp",
-        "mbed/ConnectivityManagerImpl.cpp",
-        "mbed/ConnectivityManagerImpl.h",
-        "mbed/DeviceNetworkProvisioningDelegateImpl.cpp",
-        "mbed/DeviceNetworkProvisioningDelegateImpl.h",
-        "mbed/KeyValueStoreManagerImpl.cpp",
-        "mbed/KeyValueStoreManagerImpl.h",
-        "mbed/Logging.cpp",
-        "mbed/MbedConfig.cpp",
-        "mbed/MbedEventTimeout.cpp",
-        "mbed/PlatformManagerImpl.cpp",
-        "mbed/SystemTimeSupport.cpp",
-        "mbed/arch.c",
-      ]
+      _platform_target = "mbed"
+    } else if (chip_device_platform == "external") {
+      _platform_target = chip_platform_target
+    } else {
+      assert(false, "Unknown chip_device_platform: ${chip_device_platform}")
     }
 
-    if (chip_enable_openthread && chip_mdns == "platform" &&
-        chip_device_platform != "linux") {
-      sources += [ "OpenThread/MdnsImpl.cpp" ]
-    }
+    public_deps += [ _platform_target ]
 
-    allow_circular_includes_from = [ "${chip_root}/src/lib/support" ]
-  }
-} else if (chip_device_platform == "external") {
-  group("platform") {
-    public_deps = [ "${chip_platform_target}" ]
+    # The platform target needs to include the headers, so allow that here.
+    # It should be considered logically part of this target.
+    allow_circular_includes_from = [
+      _platform_target,
+      "${chip_root}/src/lib/support",
+    ]
   }
 } else {
   group("platform") {

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "darwin")
+
+config("darwin_config") {
+  frameworks = [
+    "CoreData.framework",
+    "CoreFoundation.framework",
+    "CoreBluetooth.framework",
+    "Foundation.framework",
+    "IOKit.framework",
+  ]
+
+  cflags = [ "-fobjc-arc" ]
+}
+
+static_library("Darwin") {
+  sources = [
+    "../DeviceSafeQueue.cpp",
+    "../DeviceSafeQueue.h",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "InetPlatformConfig.h",
+    "KeyValueStoreManagerImpl.h",
+    "KeyValueStoreManagerImpl.mm",
+    "Logging.cpp",
+    "MdnsError.cpp",
+    "MdnsError.h",
+    "MdnsImpl.cpp",
+    "MdnsImpl.h",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "PosixConfig.cpp",
+    "PosixConfig.h",
+    "SystemPlatformConfig.h",
+  ]
+
+  deps = [
+    "${chip_root}/src/lib/mdns:platform_header",
+    "${chip_root}/src/setup_payload",
+  ]
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  public_configs = [ ":darwin_config" ]
+
+  if (chip_enable_ble) {
+    sources += [
+      "BleApplicationDelegate.h",
+      "BleApplicationDelegateImpl.mm",
+      "BleConnectionDelegate.h",
+      "BleConnectionDelegateImpl.mm",
+      "BlePlatformDelegate.h",
+      "BlePlatformDelegateImpl.mm",
+      "UUIDHelper.h",
+      "UUIDHelperImpl.mm",
+    ]
+  }
+}

--- a/src/platform/EFR32/BUILD.gn
+++ b/src/platform/EFR32/BUILD.gn
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "efr32")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+}
+
+static_library("EFR32") {
+  sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPMem-Platform.cpp",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "DeviceNetworkProvisioningDelegateImpl.cpp",
+    "DeviceNetworkProvisioningDelegateImpl.h",
+    "EFR32Config.cpp",
+    "EFR32Config.h",
+    "InetPlatformConfig.h",
+    "KeyValueStoreManagerImpl.cpp",
+    "KeyValueStoreManagerImpl.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
+    "freertos_bluetooth.c",
+    "freertos_bluetooth.h",
+    "gatt_db.c",
+    "gatt_db.h",
+  ]
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  # Add pigweed KVS
+  deps = [
+    "$dir_pw_kvs:crc16",
+    "$dir_pw_log",
+  ]
+  public_deps += [
+    "$dir_pw_checksum",
+    "$dir_pw_kvs",
+  ]
+
+  if (chip_enable_openthread) {
+    public_deps += [ "${openthread_root}:libopenthread-ftd" ]
+
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
+  }
+}

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -16,31 +16,43 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
-assert(chip_device_platform == "mbed")
+assert(chip_device_platform == "esp32")
 
-static_library("mbed") {
+static_library("ESP32") {
   sources = [
-    "BLEManagerImpl.cpp",
+    "../FreeRTOS/SystemTimeSupport.cpp",
     "BLEManagerImpl.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
     "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
     "DeviceNetworkProvisioningDelegateImpl.cpp",
     "DeviceNetworkProvisioningDelegateImpl.h",
+    "ESP32Config.cpp",
+    "ESP32Config.h",
+    "ESP32Utils.cpp",
+    "ESP32Utils.h",
     "KeyValueStoreManagerImpl.cpp",
     "KeyValueStoreManagerImpl.h",
     "Logging.cpp",
-    "MbedConfig.cpp",
-    "MbedEventTimeout.cpp",
+    "LwIPCoreLock.cpp",
+    "MdnsImpl.cpp",
     "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "ServiceProvisioning.cpp",
+    "ServiceProvisioning.h",
+    "SoftwareUpdateManagerImpl.h",
     "SystemTimeSupport.cpp",
-    "arch.c",
+    "bluedroid/BLEManagerImpl.cpp",
+    "nimble/BLEManagerImpl.cpp",
   ]
 
-  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  deps = [ "${chip_root}/src/lib/mdns:platform_header" ]
 
-  if (chip_enable_openthread && chip_mdns == "platform") {
-    sources += [ "../OpenThread/MdnsImpl.cpp" ]
-    deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
-  }
+  public_deps = [
+    "${chip_root}/src/crypto",
+    "${chip_root}/src/platform:platform_base",
+  ]
 }

--- a/src/platform/K32W/BUILD.gn
+++ b/src/platform/K32W/BUILD.gn
@@ -16,31 +16,56 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
-assert(chip_device_platform == "mbed")
+assert(chip_device_platform == "k32w")
 
-static_library("mbed") {
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+}
+
+static_library("K32W") {
   sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
     "BLEManagerImpl.cpp",
     "BLEManagerImpl.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
     "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
     "DeviceNetworkProvisioningDelegateImpl.cpp",
     "DeviceNetworkProvisioningDelegateImpl.h",
+    "K32WConfig.cpp",
+    "K32WConfig.h",
     "KeyValueStoreManagerImpl.cpp",
     "KeyValueStoreManagerImpl.h",
     "Logging.cpp",
-    "MbedConfig.cpp",
-    "MbedEventTimeout.cpp",
+    "NFCManagerImpl.cpp",
+    "NFCManagerImpl.h",
     "PlatformManagerImpl.cpp",
-    "SystemTimeSupport.cpp",
-    "arch.c",
+    "PlatformManagerImpl.h",
+    "SoftwareUpdateManagerImpl.h",
+    "ble_function_mux.c",
   ]
+
+  deps = []
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 
-  if (chip_enable_openthread && chip_mdns == "platform") {
-    sources += [ "../OpenThread/MdnsImpl.cpp" ]
-    deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+  if (chip_enable_openthread) {
+    public_deps += [ "${openthread_root}:libopenthread-ftd" ]
+
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
   }
+
+  public_deps += [ "${chip_root}/src/crypto" ]
 }

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -1,0 +1,113 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${build_root}/config/linux/pkg_config.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "linux")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+  import("//build_overrides/ot_br_posix.gni")
+}
+
+if (chip_mdns != "none") {
+  pkg_config("avahi_client_config") {
+    packages = [ "avahi-client" ]
+  }
+}
+
+static_library("Linux") {
+  sources = [
+    "../DeviceSafeQueue.cpp",
+    "../DeviceSafeQueue.h",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPLinuxStorage.cpp",
+    "CHIPLinuxStorage.h",
+    "CHIPLinuxStorageIni.cpp",
+    "CHIPLinuxStorageIni.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "DeviceNetworkProvisioningDelegateImpl.cpp",
+    "DeviceNetworkProvisioningDelegateImpl.h",
+    "InetPlatformConfig.h",
+    "KeyValueStoreManagerImpl.cpp",
+    "KeyValueStoreManagerImpl.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "PosixConfig.cpp",
+    "PosixConfig.h",
+    "SystemPlatformConfig.h",
+    "SystemTimeSupport.cpp",
+    "bluez/AdapterIterator.cpp",
+    "bluez/AdapterIterator.h",
+    "bluez/ChipDeviceScanner.cpp",
+    "bluez/ChipDeviceScanner.h",
+    "bluez/Helper.cpp",
+    "bluez/Helper.h",
+    "bluez/MainLoop.cpp",
+    "bluez/MainLoop.h",
+    "bluez/Types.h",
+  ]
+
+  deps = [ "${chip_root}/src/setup_payload" ]
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${chip_root}/third_party/inipp",
+  ]
+
+  public_configs = []
+
+  if (chip_mdns != "none") {
+    sources += [
+      "MdnsImpl.cpp",
+      "MdnsImpl.h",
+    ]
+
+    deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+
+    public_configs += [ ":avahi_client_config" ]
+  }
+
+  if (chip_enable_openthread) {
+    sources += [
+      "GlibTypeDeleter.h",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    public_deps += [ "dbus/openthread" ]
+  }
+
+  if (chip_enable_wifi) {
+    public_deps += [ "dbus/wpa" ]
+  }
+
+  if (chip_enable_ble) {
+    public_deps += [ "dbus/bluez" ]
+  }
+}

--- a/src/platform/cc13x2_26x2/BUILD.gn
+++ b/src/platform/cc13x2_26x2/BUILD.gn
@@ -1,0 +1,90 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "cc13x2_26x2")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+}
+
+static_library("cc13x2_26x2") {
+  sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
+    "BlePlatformConfig.h",
+    "CC13X2_26X2Config.cpp",
+    "CC13X2_26X2Config.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "DeviceNetworkProvisioningDelegateImpl.cpp",
+    "DeviceNetworkProvisioningDelegateImpl.h",
+    "InetPlatformConfig.h",
+    "KeyValueStoreManagerImpl.cpp",
+    "KeyValueStoreManagerImpl.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "Random.c",
+    "SystemPlatformConfig.h",
+  ]
+
+  deps = []
+
+  public_deps = [
+    "${chip_root}/src/crypto",
+    "${chip_root}/src/platform:platform_base",
+  ]
+
+  if (chip_enable_ble) {
+    sources += [
+      "BLEManagerImpl.cpp",
+      "BLEManagerImpl.h",
+    ]
+  }
+
+  if (chip_enable_openthread) {
+    # needed for MTD/FTD
+    import("//build_overrides/ti_simplelink_sdk.gni")
+    import("${ti_simplelink_sdk_build_root}/ti_simplelink_board.gni")
+    public_deps += [
+      "${chip_root}/third_party/ti_simplelink_sdk:mbedtls",
+      "${chip_root}/third_party/ti_simplelink_sdk:ti_simplelink_sdk",
+      "${chip_root}/third_party/ti_simplelink_sdk:ti_simplelink_sysconfig",
+    ]
+
+    if (ti_simplelink_device_family == "cc13x2_26x2") {
+      public_deps += [ "${openthread_root}:libopenthread-mtd" ]
+    } else if (ti_simplelink_device_family == "cc13x2x7_26x2x7") {
+      public_deps += [ "${openthread_root}:libopenthread-ftd" ]
+    }
+
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
+  }
+}

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "nrfconnect")
+
+static_library("nrfconnect") {
+  sources = [
+    "../Zephyr/BLEManagerImpl.cpp",
+    "../Zephyr/ConfigurationManagerImpl.cpp",
+    "../Zephyr/KeyValueStoreManagerImpl.cpp",
+    "../Zephyr/Logging.cpp",
+    "../Zephyr/PlatformManagerImpl.cpp",
+    "../Zephyr/SystemTimeSupport.cpp",
+    "../Zephyr/ZephyrConfig.cpp",
+    "../Zephyr/ZephyrConfig.h",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "DeviceNetworkProvisioningDelegateImpl.cpp",
+    "DeviceNetworkProvisioningDelegateImpl.h",
+    "InetPlatformConfig.h",
+    "KeyValueStoreManagerImpl.h",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
+  ]
+
+  deps = []
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  if (chip_enable_openthread) {
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "../Zephyr/ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
+  }
+
+  if (chip_enable_nfc) {
+    sources += [
+      "../Zephyr/NFCManagerImpl.cpp",
+      "NFCManagerImpl.h",
+    ]
+  }
+}

--- a/src/platform/qpg/BUILD.gn
+++ b/src/platform/qpg/BUILD.gn
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/src/platform/device.gni")
+
+assert(chip_device_platform == "qpg")
+
+if (chip_enable_openthread) {
+  import("//build_overrides/openthread.gni")
+}
+
+static_library("qpg") {
+  sources = [
+    "../FreeRTOS/SystemTimeSupport.cpp",
+    "BLEManagerImpl.cpp",
+    "BLEManagerImpl.h",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "DeviceNetworkProvisioningDelegateImpl.cpp",
+    "DeviceNetworkProvisioningDelegateImpl.h",
+    "InetPlatformConfig.h",
+    "Logging.cpp",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
+    "qpgConfig.cpp",
+    "qpgConfig.h",
+  ]
+
+  deps = []
+
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+
+  public_configs = []
+
+  sources += [
+    "KeyValueStoreManagerImpl.cpp",
+    "KeyValueStoreManagerImpl.h",
+  ]
+
+  if (chip_enable_openthread) {
+    public_deps += [ "${openthread_root}:libopenthread-mtd" ]
+
+    public_configs += [
+      "${chip_root}/third_party/openthread/platforms/qpg:openthread_qpg_config",
+    ]
+
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
+  }
+}

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -16,31 +16,46 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
-assert(chip_device_platform == "mbed")
+assert(chip_device_platform == "telink")
 
-static_library("mbed") {
+static_library("telink") {
   sources = [
-    "BLEManagerImpl.cpp",
+    "../Zephyr/BLEManagerImpl.cpp",
+    "../Zephyr/ConfigurationManagerImpl.cpp",
+    "../Zephyr/KeyValueStoreManagerImpl.cpp",
+    "../Zephyr/Logging.cpp",
+    "../Zephyr/PlatformManagerImpl.cpp",
+    "../Zephyr/SystemTimeSupport.cpp",
+    "../Zephyr/ZephyrConfig.cpp",
+    "../Zephyr/ZephyrConfig.h",
     "BLEManagerImpl.h",
-    "ConfigurationManagerImpl.cpp",
+    "BlePlatformConfig.h",
+    "CHIPDevicePlatformConfig.h",
+    "CHIPDevicePlatformEvent.h",
+    "CHIPPlatformConfig.h",
+    "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
     "DeviceNetworkProvisioningDelegateImpl.cpp",
     "DeviceNetworkProvisioningDelegateImpl.h",
-    "KeyValueStoreManagerImpl.cpp",
+    "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.h",
-    "Logging.cpp",
-    "MbedConfig.cpp",
-    "MbedEventTimeout.cpp",
-    "PlatformManagerImpl.cpp",
-    "SystemTimeSupport.cpp",
-    "arch.c",
+    "PlatformManagerImpl.h",
+    "SystemPlatformConfig.h",
   ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 
-  if (chip_enable_openthread && chip_mdns == "platform") {
-    sources += [ "../OpenThread/MdnsImpl.cpp" ]
-    deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+  if (chip_enable_openthread) {
+    sources += [
+      "../OpenThread/OpenThreadUtils.cpp",
+      "../Zephyr/ThreadStackManagerImpl.cpp",
+      "ThreadStackManagerImpl.h",
+    ]
+
+    if (chip_mdns == "platform") {
+      sources += [ "../OpenThread/MdnsImpl.cpp" ]
+      deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
+    }
   }
 }

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -32,17 +32,18 @@ if (chip_device_platform != "none") {
       test_sources += [ "TestPlatformMgr.cpp" ]
     }
 
-    if (chip_mdns != "none" && chip_enable_happy_tests &&
-        (chip_device_platform == "linux" || chip_device_platform == "darwin")) {
-      test_sources += [ "TestMdns.cpp" ]
-    }
-
     public_deps = [
       "${chip_root}/src/lib/support",
       "${chip_root}/src/platform",
       "${chip_root}/src/system",
       "${nlunit_test_root}:nlunit-test",
     ]
+
+    if (chip_mdns != "none" && chip_enable_happy_tests &&
+        (chip_device_platform == "linux" || chip_device_platform == "darwin")) {
+      test_sources += [ "TestMdns.cpp" ]
+      public_deps += [ "${chip_root}/src/lib/mdns" ]
+    }
 
     # These tests appear to be broken on Mac.
     if (current_os != "mac") {


### PR DESCRIPTION
#### Problem
All of the implementations in src/platform are defined in a single build file.

#### Change overview
Rather than defining every platform in a giant switch/case, create
separate build files for each one.

This is a lot more manageable and allows dropping conditionals in many
cases as build files aren't loaded unless reachable from the root.

#### Testing

Built all of the platforms.