### PR TITLE
Decouple PairingState from PeerConnectionState

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -141,9 +141,9 @@ void RendezvousServer::OnSessionEstablishmentError(CHIP_ERROR err)
 
 void RendezvousServer::OnSessionEstablished()
 {
-    CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
-        mPairingSession.GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kResponder, 0);
+    CHIP_ERROR err =
+        mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                mPairingSession.GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kResponder, 0);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -142,8 +142,8 @@ void RendezvousServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void RendezvousServer::OnSessionEstablished()
 {
     CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kResponder, 0);
+        Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+        mPairingSession.GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kResponder, 0);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
@@ -159,7 +159,7 @@ void RendezvousServer::OnSessionEstablished()
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 
-    if (mPairingSession.PeerConnection().GetPeerAddress().GetTransportType() == Transport::Type::kBle)
+    if (mPairingSession.GetPeerAddress().GetTransportType() == Transport::Type::kBle)
     {
         Cleanup();
     }

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -579,6 +579,7 @@ void Device::OnSessionEstablishmentError(CHIP_ERROR error)
 
 void Device::OnSessionEstablished()
 {
+    // TODO: the session should know which peer we are trying to connect to when started
     mCASESession.SetPeerNodeId(mDeviceId);
 
     CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mCASESession,

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -579,7 +579,7 @@ void Device::OnSessionEstablishmentError(CHIP_ERROR error)
 
 void Device::OnSessionEstablished()
 {
-    mCASESession.PeerConnection().SetPeerNodeId(mDeviceId);
+    mCASESession.SetPeerNodeId(mDeviceId);
 
     CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mCASESession,
                                                  SecureSession::SessionRole::kInitiator, mFabricIndex);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1112,11 +1112,11 @@ void DeviceCommissioner::OnSessionEstablished()
 
     Device * device = &mActiveDevices[mDeviceBeingPaired];
 
-    mPairingSession.PeerConnection().SetPeerNodeId(device->GetDeviceId());
+    mPairingSession.SetPeerNodeId(device->GetDeviceId());
 
-    CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kInitiator, mFabricIndex);
+    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
+                                             SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1112,6 +1112,7 @@ void DeviceCommissioner::OnSessionEstablished()
 
     Device * device = &mActiveDevices[mDeviceBeingPaired];
 
+    // TODO: the session should know which peer we are trying to connect to when started
     mPairingSession.SetPeerNodeId(device->GetDeviceId());
 
     CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -127,11 +127,11 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    mSessionMgr->ExpireAllPairings(mPairingSession.GetPeerNodeId(), mFabricIndex);
+    mSessionMgr->ExpireAllPairings(GetSession().GetPeerNodeId(), mFabricIndex);
 
-    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
-                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
-                                             SecureSession::SessionRole::kResponder, mFabricIndex);
+    CHIP_ERROR err =
+        mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(GetSession().GetPeerAddress()),
+                                GetSession().GetPeerNodeId(), &GetSession(), SecureSession::SessionRole::kResponder, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -127,11 +127,11 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    mSessionMgr->ExpireAllPairings(GetSession().PeerConnection().GetPeerNodeId(), mFabricIndex);
+    mSessionMgr->ExpireAllPairings(mPairingSession.GetPeerNodeId(), mFabricIndex);
 
-    CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(GetSession().PeerConnection().GetPeerAddress()),
-        GetSession().PeerConnection().GetPeerNodeId(), &GetSession(), SecureSession::SessionRole::kResponder, mFabricIndex);
+    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
+                                             SecureSession::SessionRole::kResponder, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -545,7 +545,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         tlvWriter.Init(std::move(msg_R2));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), &msg_rand[0], sizeof(msg_rand)));
-        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyID(), true));
+        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(),
                                                static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(4), msg_R2_Encrypted.Get(),

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -39,7 +39,6 @@
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/PairingSession.h>
-#include <transport/PeerConnectionState.h>
 #include <transport/SecureSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -134,35 +133,9 @@ public:
      */
     virtual CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
-    /**
-     * @brief
-     *  Return the associated secure session peer NodeId
-     *
-     * @return NodeId The associated peer NodeId
-     */
-    NodeId GetPeerNodeId() const { return mConnectionState.GetPeerNodeId(); }
-
-    /**
-     * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    uint16_t GetPeerKeyId() override { return mConnectionState.GetPeerKeyID(); }
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The assocated local key id
-     */
-    uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
-
     const char * GetI2RSessionInfo() const override { return "Sigma I2R Key"; }
 
     const char * GetR2ISessionInfo() const override { return "Sigma R2I Key"; }
-
-    Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /**
      * @brief Serialize the Pairing Session to a string.
@@ -285,8 +258,6 @@ private:
 
 protected:
     bool mPairingComplete = false;
-
-    Transport::PeerConnectionState mConnectionState;
 
     virtual ByteSpan * GetIPKList() const
     {

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -169,6 +169,7 @@ public:
         return &mMessageDispatch;
     }
 
+    // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.
      **/
     void Clear();

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -39,7 +39,6 @@
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/PairingSession.h>
-#include <transport/PeerConnectionState.h>
 #include <transport/SecureSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -167,27 +166,9 @@ public:
      */
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
-    /**
-     * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    uint16_t GetPeerKeyId() override { return mConnectionState.GetPeerKeyID(); }
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The assocated local key id
-     */
-    uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
-
     const char * GetI2RSessionInfo() const override { return kSpake2pI2RSessionInfo; }
 
     const char * GetR2ISessionInfo() const override { return kSpake2pR2ISessionInfo; }
-
-    Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /** @brief Serialize the Pairing Session to a string.
      *
@@ -326,8 +307,6 @@ protected:
     size_t mKeLen = sizeof(mKe);
 
     bool mPairingComplete = false;
-
-    Transport::PeerConnectionState mConnectionState;
 };
 
 /*
@@ -347,9 +326,17 @@ constexpr chip::NodeId kTestDeviceNodeId     = 12344321;
 class SecurePairingUsingTestSecret : public PairingSession
 {
 public:
-    SecurePairingUsingTestSecret() {}
+    SecurePairingUsingTestSecret()
+    {
+        SetLocalKeyId(0);
+        SetPeerKeyId(0);
+    }
 
-    SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId) : mPeerKeyID(peerKeyId), mLocalKeyID(localKeyId) {}
+    SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId)
+    {
+        SetLocalKeyId(localKeyId);
+        SetPeerKeyId(peerKeyId);
+    }
 
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override
     {
@@ -365,16 +352,12 @@ public:
         memset(&serializable, 0, sizeof(serializable));
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
-        serializable.mLocalKeyId      = mLocalKeyID;
-        serializable.mPeerKeyId       = mPeerKeyID;
+        serializable.mLocalKeyId      = GetLocalKeyId();
+        serializable.mPeerKeyId       = GetPeerKeyId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);
         return CHIP_NO_ERROR;
     }
-
-    uint16_t GetPeerKeyId() override { return mPeerKeyID; }
-
-    uint16_t GetLocalKeyId() override { return mLocalKeyID; }
 
     const char * GetI2RSessionInfo() const override { return "i2r"; }
 
@@ -382,9 +365,6 @@ public:
 
 private:
     const char * kTestSecret = "Test secret for key derivation";
-
-    uint16_t mPeerKeyID  = 0;
-    uint16_t mLocalKeyID = 0;
 };
 
 typedef struct PASESessionSerialized

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -194,6 +194,7 @@ public:
      **/
     CHIP_ERROR FromSerializable(const PASESessionSerializable & output);
 
+    // TODO: remove Clear, we should create a new instance instead reset the old instance.
     /** @brief This function zeroes out and resets the memory used by the object.
      **/
     void Clear();

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -36,6 +36,28 @@ public:
     PairingSession() {}
     virtual ~PairingSession() {}
 
+    NodeId GetPeerNodeId() const { return mPeerNodeId; }
+    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
+
+    uint16_t GetPeerKeyId() const { return mPeerKeyId; }
+    void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
+    bool IsValidPeerKeyId() const { return mPeerKeyId != kInvalidKeyId; }
+
+    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
+    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
+    bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
+
+    const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
+    Transport::PeerAddress & GetPeerAddress() { return mPeerAddress; }
+    void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
+
+    void Clear()
+    {
+        mPeerAddress = Transport::PeerAddress::Uninitialized();
+        mPeerKeyId   = kInvalidKeyId;
+        mLocalKeyId  = kInvalidKeyId;
+    }
+
     /**
      * @brief
      *   Derive a secure session from the paired session. The API will return error
@@ -50,22 +72,6 @@ public:
 
     /**
      * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    virtual uint16_t GetPeerKeyId() = 0;
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The associated local key id
-     */
-    virtual uint16_t GetLocalKeyId() = 0;
-
-    /**
-     * @brief
      *   Get the value of peer session counter which is synced during session establishment
      */
     virtual uint32_t GetPeerCounter()
@@ -77,6 +83,14 @@ public:
     virtual const char * GetI2RSessionInfo() const = 0;
 
     virtual const char * GetR2ISessionInfo() const = 0;
+
+private:
+    NodeId mPeerNodeId = kUndefinedNodeId;
+    // TODO(#8206): Remove address and use peer cache instead.
+    Transport::PeerAddress mPeerAddress     = Transport::PeerAddress::Uninitialized();
+    static constexpr uint16_t kInvalidKeyId = UINT16_MAX;
+    uint16_t mPeerKeyId                     = kInvalidKeyId;
+    uint16_t mLocalKeyId                    = kInvalidKeyId;
 };
 
 } // namespace chip

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -36,26 +36,39 @@ public:
     PairingSession() {}
     virtual ~PairingSession() {}
 
+    // TODO: the session should know which peer we are trying to connect to at start
+    // mPeerNodeId should be const and assigned at the construction, such that GetPeerNodeId will never return kUndefinedNodeId, and
+    // SetPeerNodeId is not necessary.
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
 
-    uint16_t GetPeerKeyId() const { return mPeerKeyId; }
-    void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
-    bool IsValidPeerKeyId() const { return mPeerKeyId != kInvalidKeyId; }
-
+    // TODO: the local key id should be allocateed at start
+    // mLocalKeyId should be const and assigned at the construction, such that GetLocalKeyId will always return a valid key id , and
+    // SetLocalKeyId is not necessary.
     uint16_t GetLocalKeyId() const { return mLocalKeyId; }
     void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
     bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
 
+    uint16_t GetPeerKeyId() const
+    {
+        VerifyOrDie(mPeerKeyId.HasValue());
+        return mPeerKeyId.Value();
+    }
+    void SetPeerKeyId(uint16_t id) { mPeerKeyId.SetValue(id); }
+    bool IsValidPeerKeyId() const { return mPeerKeyId.HasValue(); }
+
+    // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     Transport::PeerAddress & GetPeerAddress() { return mPeerAddress; }
     void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
 
+    // TODO: remove Clear, we should create a new instance instead reset the old instance.
     void Clear()
     {
+        mPeerNodeId  = kUndefinedNodeId;
         mPeerAddress = Transport::PeerAddress::Uninitialized();
-        mPeerKeyId   = kInvalidKeyId;
-        mLocalKeyId  = kInvalidKeyId;
+        mPeerKeyId.ClearValue();
+        mLocalKeyId = kInvalidKeyId;
     }
 
     /**
@@ -86,11 +99,16 @@ public:
 
 private:
     NodeId mPeerNodeId = kUndefinedNodeId;
-    // TODO(#8206): Remove address and use peer cache instead.
-    Transport::PeerAddress mPeerAddress     = Transport::PeerAddress::Uninitialized();
+
+    // TODO: the local key id should be allocateed at start
+    // then we can remove kInvalidKeyId
     static constexpr uint16_t kInvalidKeyId = UINT16_MAX;
-    uint16_t mPeerKeyId                     = kInvalidKeyId;
     uint16_t mLocalKeyId                    = kInvalidKeyId;
+
+    // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
+    Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();
+
+    Optional<uint16_t> mPeerKeyId;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
PASESession and CASESession are reusing `PeerConnectionState` to store pairing states, but actually they are different things.

I'm going to make `SecureSessionManager` also handle unsecure message, where `PeerConnectionState` must be extended to handle unsecure connections. So I need to decouple `PairingState` from `PeerConnectionState`.

#### Change overview
Create a new class `PairingState` and switch `mConnection` in  PASESession and CASESession to that class.

#### Testing
Verified using unit-tests