### PR TITLE
Remove dead code: SecureSessionMgr::GetTransportType(NodeId peerNodeId)

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -110,18 +110,6 @@ void SecureSessionMgr::Shutdown()
     mCB           = nullptr;
 }
 
-Transport::Type SecureSessionMgr::GetTransportType(NodeId peerNodeId)
-{
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
-
-    if (state)
-    {
-        return state->GetPeerAddress().GetTransportType();
-    }
-
-    return Transport::Type::kUndefined;
-}
-
 CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SecureSessionHandle session, PayloadHeader & payloadHeader,
                                                           System::PacketBufferHandle && msgBuf,
                                                           EncryptedPacketBufferHandle & encryptedMessage)

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -262,14 +262,6 @@ public:
 
     NodeId GetLocalNodeId() { return mLocalNodeId; }
 
-    /**
-     * @brief
-     *   Return the transport type of current connection to the node with id peerNodeId.
-     *   'Transport::Type::kUndefined' will be returned if the connection to the specified
-     *   peer node does not exist.
-     */
-    Transport::Type GetTransportType(NodeId peerNodeId);
-
     TransportMgrBase * GetTransportManager() const { return mTransportMgr; }
 
     /**


### PR DESCRIPTION
#### Problem
`SecureSessionMgr::GetTransportType(NodeId peerNodeId)`

This function is not used anymore. and it is confusing, that only `NodeId` is not able to identify a connection.

#### Change overview
Remove function `SecureSessionMgr::GetTransportType(NodeId peerNodeId)`

#### Testing
Manually verified using unit-tests