### PR TITLE
Darwin BLE: fix length check in advertisement data

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -159,7 +159,7 @@ namespace DeviceLayer {
                 NSData * serviceData = [servicesData objectForKey:serviceUUID];
 
                 NSUInteger length = [serviceData length];
-                if (length == 7) {
+                if (length >= 7) {
                     const uint8_t * bytes = (const uint8_t *) [serviceData bytes];
                     uint8_t opCode = bytes[0];
                     uint16_t discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Darwin BLE implementation was rejecting BLE devices that conform to 5.4.2.8.6. Advertising Data containing 8 bytes or more of service data

#### Change overview
What's in this PR
* allow BLE devices that conform to 5.4.2.8.6. Advertising Data containg service data length of 8 or more
* for backwards compatibility and to avoid disruption in testing also allow service data length of 7 which does not have the additional data flag

#### Testing
How was this tested? (at least one bullet point required)
* Tested manually with 7 and 8 bytes of service data
