### PR TITLE
Fix for failure in compilation of python device controller

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -512,8 +512,8 @@ exit:
 
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
-    NodeId peerNodeId = state.GetPeerNodeId();
-    ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired", ChipLogValueX64(peerNodeId));
+    ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired",
+                  ChipLogValueX64(state.GetPeerNodeId()));
 
     if (mCB != nullptr)
     {


### PR DESCRIPTION
#### Problem
* The compilation of python device controller fails on this command `./scripts/build_python.sh -m platform`
```
Done. Made 1025 targets from 161 files in 128ms
ninja: Entering directory `./out/python_lib'
[1/6] c++ obj/src/transport/libTransportLayer.SecureSessionMgr.cpp.o
FAILED: obj/src/transport/libTransportLayer.SecureSessionMgr.cpp.o 
g++ -MMD -MF obj/src/transport/libTransportLayer.SecureSessionMgr.cpp.o.d -Wconversion -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Wextra -Wshadow -Wunreachable-code -Werror -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wno-cast-function-type -fdiagnostics-color -fno-strict-aliasing -D_REENTRANT -isystem../../third_party/ot-br-posix/repo/src -isystem../../third_party/ot-br-posix/repo/include -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -I../../src/include -I../../src -Igen/include -I../../src/lib -I../../config/standalone -I../../third_party/nlassert/repo/include -I../../third_party/nlio/repo/include -I../../third_party/nlfaultinjection/repo/include -Igen/include -Igen/include -I../../third_party/inipp/repo/inipp -c ../../src/transport/SecureSessionMgr.cpp -o obj/src/transport/libTransportLayer.SecureSessionMgr.cpp.o
../../src/transport/SecureSessionMgr.cpp: In member function ‘void chip::SecureSessionMgr::HandleConnectionExpired(const chip::Transport::PeerConnectionState&)’:
../../src/transport/SecureSessionMgr.cpp:522:12: error: unused variable ‘peerNodeId’ [-Werror=unused-variable]
  522 |     NodeId peerNodeId = state.GetPeerNodeId();
      |            ^~~~~~~~~~
At global scope:
cc1plus: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```
* Same error occurs with new branch for test event 4 ( test_event_4 ).

#### Change overview
Remove unused variable.

#### Testing
* `./scripts/build_python.sh -m platform` worked successfully.