### PR TITLE
Clean up temporary error code macros added in PR#7916

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -164,7 +164,7 @@ exit:
     return;
 }
 
-void IdentifyTimerHandler(Layer * systemLayer, void * appState, Error error)
+void IdentifyTimerHandler(Layer * systemLayer, void * appState, CHIP_ERROR error)
 {
     statusLED1.Animate();
 

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -413,7 +413,7 @@ void Command::WaitForResponse(uint16_t seconds)
 
 #else // CONFIG_USE_SEPARATE_EVENTLOOP
 
-static void OnResponseTimeout(chip::System::Layer *, void *, chip::System::Error)
+static void OnResponseTimeout(chip::System::Layer *, void *, CHIP_ERROR)
 {
     ChipLogError(chipTool, "No response from device");
 

--- a/src/ble/BleError.h
+++ b/src/ble/BleError.h
@@ -310,20 +310,6 @@
  *  @}
  */
 
-// !!!!! IMPORTANT !!!!!
-// These definitions are present temporarily in order to reduce breakage for PRs in flight.
-// TODO: remove compatibility definitions
-#define BLE_ERROR                               CHIP_ERROR
-#define BLE_NO_ERROR                            CHIP_NO_ERROR
-#define BLE_ERROR_BAD_ARGS                      CHIP_ERROR_INVALID_ARGUMENT
-#define BLE_ERROR_INCORRECT_STATE               CHIP_ERROR_INCORRECT_STATE
-#define BLE_ERROR_MESSAGE_INCOMPLETE            CHIP_ERROR_MESSAGE_INCOMPLETE
-#define BLE_ERROR_NOT_IMPLEMENTED               CHIP_ERROR_NOT_IMPLEMENTED
-#define BLE_ERROR_NO_ENDPOINTS                  CHIP_ERROR_ENDPOINT_POOL_FULL
-#define BLE_ERROR_NO_MEMORY                     CHIP_ERROR_NO_MEMORY
-#define BLE_ERROR_OUTBOUND_MESSAGE_TOO_BIG      CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG
-#define BLE_ERROR_RECEIVED_MESSAGE_TOO_BIG      CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG
-
 // clang-format on
 
 namespace chip {

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -1424,7 +1424,7 @@ CHIP_ERROR IPEndPointBasis::StartListener()
         case nw_listener_state_cancelled:
             ChipLogDetail(Inet, "Listener: Cancelled");
             if (res == CHIP_NO_ERROR)
-                res = INET_ERROR_CONNECTION_ABORTED;
+                res = CHIP_ERROR_CONNECTION_ABORTED;
 
             dispatch_semaphore_signal(mListenerSemaphore);
             break;
@@ -1480,7 +1480,7 @@ CHIP_ERROR IPEndPointBasis::StartConnection(nw_connection_t & aConnection)
         case nw_connection_state_cancelled:
             ChipLogDetail(Inet, "Connection: Cancelled");
             if (res == CHIP_NO_ERROR)
-                res = INET_ERROR_CONNECTION_ABORTED;
+                res = CHIP_ERROR_CONNECTION_ABORTED;
 
             dispatch_semaphore_signal(mConnectionSemaphore);
             break;

--- a/src/inet/InetError.h
+++ b/src/inet/InetError.h
@@ -236,22 +236,6 @@
  *  @}
  */
 
-// !!!!! IMPORTANT !!!!!
-// These definitions are present temporarily in order to reduce breakage for PRs in flight.
-// TODO: remove compatibility definitions
-#define INET_ERROR                              CHIP_ERROR
-#define INET_NO_ERROR                           CHIP_NO_ERROR
-#define INET_ERROR_BAD_ARGS                     CHIP_ERROR_INVALID_ARGUMENT
-#define INET_ERROR_INBOUND_MESSAGE_TOO_BIG      CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG
-#define INET_ERROR_INCORRECT_STATE              CHIP_ERROR_INCORRECT_STATE
-#define INET_ERROR_MESSAGE_TOO_LONG             CHIP_ERROR_MESSAGE_TOO_LONG
-#define INET_ERROR_NO_CONNECTION_HANDLER        CHIP_ERROR_NO_CONNECTION_HANDLER
-#define INET_ERROR_NO_ENDPOINTS                 CHIP_ERROR_ENDPOINT_POOL_FULL
-#define INET_ERROR_NOT_IMPLEMENTED              CHIP_ERROR_NOT_IMPLEMENTED
-#define INET_ERROR_NOT_SUPPORTED                CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
-#define INET_ERROR_NO_MEMORY                    CHIP_ERROR_NO_MEMORY
-#define INET_ERROR_CONNECTION_ABORTED           CHIP_ERROR_CONNECTION_ABORTED
-
 // clang-format on
 
 namespace chip {

--- a/src/lib/asn1/ASN1Error.h
+++ b/src/lib/asn1/ASN1Error.h
@@ -194,12 +194,6 @@ namespace ASN1 {
  *  @}
  */
 
-// !!!!! IMPORTANT !!!!!
-// These definitions are present temporarily in order to reduce breakage for PRs in flight.
-// TODO: remove compatibility definitions
-#define ASN1_ERROR                              CHIP_ERROR
-#define ASN1_NO_ERROR                           CHIP_NO_ERROR
-
 // clang-format on
 
 bool FormatASN1Error(char * buf, uint16_t bufSize, int32_t err);

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -709,7 +709,7 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_SYSTEM_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -38,12 +38,6 @@
 // Show BLE status with LEDs
 #define _BLEMGRIMPL_USE_LEDS 0
 
-/* Undefine the BLE_ERROR_NOT_IMPLEMENTED macro provided by CHIP's
- * src/ble/BleError.h to avoid a name conflict with Mbed-OS ble_error_t
- * enum value. For the enum values, see:
- * mbed-os/connectivity/FEATURE_BLE/include/ble/common/blecommon.h
- */
-#undef BLE_ERROR_NOT_IMPLEMENTED
 // mbed-os headers
 #include "ble/BLE.h"
 #include "ble/Gap.h"

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -61,7 +61,7 @@ uint64_t GetClock_MonotonicHiRes()
 // Platform-specific function for getting the current real (civil) time in microsecond Unix time format,
 // where |curTime| argument is the current time, expressed as Unix time scaled to microseconds.
 // Returns CHIP_NO_ERROR if the method succeeded.
-Error GetClock_RealTime(uint64_t & curTime)
+CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
@@ -80,7 +80,7 @@ Error GetClock_RealTime(uint64_t & curTime)
 // Platform-specific function for getting the current real (civil) time in millisecond Unix time
 // where |curTimeMS| is the current time, expressed as Unix time scaled to milliseconds.
 // Returns CHIP_NO_ERROR if the method succeeded.
-Error GetClock_RealTimeMS(uint64_t & curTimeMS)
+CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
@@ -99,7 +99,7 @@ Error GetClock_RealTimeMS(uint64_t & curTimeMS)
 // Platform-specific function for setting the current real (civil) time
 // where |newCurTime| is the  new current time, expressed as Unix time scaled to microseconds.
 // Returns CHIP_NO_ERROR if the method succeeded.
-Error SetClock_RealTime(uint64_t newCurTime)
+CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(newCurTime / UINT64_C(1000000));

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -60,45 +60,45 @@ uint64_t GetClock_MonotonicHiRes()
 
 // Platform-specific function for getting the current real (civil) time in microsecond Unix time format,
 // where |curTime| argument is the current time, expressed as Unix time scaled to microseconds.
-// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
+// Returns CHIP_NO_ERROR if the method succeeded.
 Error GetClock_RealTime(uint64_t & curTime)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
     if (res != 0)
     {
-        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+        return CHIP_ERROR_INCORRECT_STATE;
     }
     if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
     {
-        return CHIP_SYSTEM_ERROR_REAL_TIME_NOT_SYNCED;
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     curTime = (tv.tv_sec * UINT64_C(1000000)) + tv.tv_usec;
-    return CHIP_SYSTEM_NO_ERROR;
+    return CHIP_NO_ERROR;
 }
 
 // Platform-specific function for getting the current real (civil) time in millisecond Unix time
 // where |curTimeMS| is the current time, expressed as Unix time scaled to milliseconds.
-// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
+// Returns CHIP_NO_ERROR if the method succeeded.
 Error GetClock_RealTimeMS(uint64_t & curTimeMS)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
     if (res != 0)
     {
-        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+        return CHIP_ERROR_INCORRECT_STATE;
     }
     if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
     {
-        return CHIP_SYSTEM_ERROR_REAL_TIME_NOT_SYNCED;
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     curTimeMS = (tv.tv_sec * UINT64_C(1000)) + (tv.tv_usec / 1000);
-    return CHIP_SYSTEM_NO_ERROR;
+    return CHIP_NO_ERROR;
 }
 
 // Platform-specific function for setting the current real (civil) time
 // where |newCurTime| is the  new current time, expressed as Unix time scaled to microseconds.
-// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
+// Returns CHIP_NO_ERROR if the method succeeded.
 Error SetClock_RealTime(uint64_t newCurTime)
 {
     struct timeval tv;
@@ -107,7 +107,7 @@ Error SetClock_RealTime(uint64_t newCurTime)
     int res    = settimeofday(&tv, NULL);
     if (res != 0)
     {
-        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+        return CHIP_ERROR_INCORRECT_STATE;
     }
 #if CHIP_PROGRESS_LOGGING
     {
@@ -120,7 +120,7 @@ Error SetClock_RealTime(uint64_t newCurTime)
                         tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
     }
 #endif // CHIP_PROGRESS_LOGGING
-    return CHIP_SYSTEM_NO_ERROR;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Layer

--- a/src/system/SystemError.h
+++ b/src/system/SystemError.h
@@ -66,21 +66,6 @@ extern bool FormatLwIPError(char * buf, uint16_t bufSize, CHIP_ERROR err);
 
 // clang-format off
 
-// !!!!! IMPORTANT !!!!!
-// These definitions are present temporarily in order to reduce breakage for PRs in flight.
-// TODO: remove compatibility definitions
-using Error = CHIP_ERROR;
-#define CHIP_SYSTEM_NO_ERROR                    CHIP_NO_ERROR
-#define CHIP_SYSTEM_ERROR_ACCESS_DENIED         CHIP_ERROR_ACCESS_DENIED
-#define CHIP_SYSTEM_ERROR_BAD_ARGS              CHIP_ERROR_INVALID_ARGUMENT
-#define CHIP_SYSTEM_ERROR_NOT_SUPPORTED         CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
-#define CHIP_SYSTEM_ERROR_NO_MEMORY             CHIP_ERROR_NO_MEMORY
-#define CHIP_SYSTEM_ERROR_REAL_TIME_NOT_SYNCED  CHIP_ERROR_REAL_TIME_NOT_SYNCED
-#define CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT      CHIP_ERROR_UNEXPECTED_EVENT
-#define CHIP_SYSTEM_ERROR_UNEXPECTED_STATE      CHIP_ERROR_INCORRECT_STATE
-
-// clang-format on
-
 } // namespace System
 } // namespace chip
 

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -128,7 +128,7 @@ inline Error Mutex::Init(Mutex & aMutex)
 {
     // The mutex is initialized when constructed and generates
     // a runtime error in case of failure.
-    return CHIP_SYSTEM_NO_ERROR;
+    return CHIP_NO_ERROR;
 }
 
 inline void Mutex::Lock()

--- a/src/system/SystemMutex.h
+++ b/src/system/SystemMutex.h
@@ -124,7 +124,7 @@ inline void Mutex::Unlock(void)
 #endif // CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING
 
 #if CHIP_SYSTEM_CONFIG_MBED_LOCKING
-inline Error Mutex::Init(Mutex & aMutex)
+inline CHIP_ERROR Mutex::Init(Mutex & aMutex)
 {
     // The mutex is initialized when constructed and generates
     // a runtime error in case of failure.


### PR DESCRIPTION
#### Problem

PR #7916 _Consolidate error types_ included some temporary
definitions to avoid breaking any PRs in flight.

#### Change overview

- Removed the temporary definitions.
- Updated names in recent PRs.

#### Testing

No changes to functionality.
