### PR TITLE
Mbed: Add 'cortex-debug' vscode extension to devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,8 @@
         "redhat.vscode-yaml",
         "christian-kohler.path-intellisense",
         "knisterpeter.vscode-github",
-        "npclaudiu.vscode-gn"
+        "npclaudiu.vscode-gn",
+        "marus25.cortex-debug"
     ],
     // Use 'settings' to set *default* container specific settings.json values on container create.
     // You can edit these settings after create using File > Preferences > Settings > Remote.


### PR DESCRIPTION
#### Problem
The 'cortex-debug' vscode extension is used by mbed-os launch
tasks during debug/flash processes.
https://github.com/project-chip/connectedhomeip/blob/2202b9474e38d5766974e5ca2f66cc4f1e600820/.vscode/launch.json#L89-L91

However, it looks like it is not installed automatically when opening
vscode inside the container.

To fix this, the 'cortex debug' has to be added to devcontainer.json file.

#### Change overview
Add 'cortex debug' extension to devcontainer.json 

#### Testing
Tested manually (debug/flash within mbed-os launch tasks)
