### PR TITLE
[util] Introduce `to_underlying` for casting enum classes to underlying values.

### DIFF
--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -31,6 +31,7 @@
 #include <core/CHIPEncoding.h>
 #include <support/BytesToHex.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace ::chip;
@@ -253,130 +254,130 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     switch (status)
     {
     case Protocols::InteractionModel::ProtocolCode::Success:
-        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Failure:
-        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidSubscription:
-        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAccess:
-        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedEndpoint:
-        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidAction:
-        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
-        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated82:
-        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated83:
-        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated84:
-        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
-        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute:
-        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidValue:
-        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedWrite:
-        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
-        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
-        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
-        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnreportableAttribute:
-        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
-        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
-        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
-        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated90:
-        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated91:
-        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
-        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated93:
-        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
-        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved95:
-        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved96:
-        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved97:
-        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved98:
-        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved99:
-        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved9a:
-        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ConstraintError:
-        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Busy:
-        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
-        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
-        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
-        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
-        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
-        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
-        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidArgument:
-        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     default:
-        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, Protocols::InteractionModel::ToUint16(status));
+        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, chip::to_underlying(status));
         break;
     }
 }
@@ -528,7 +529,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         Callback::Callback<DefaultFailureCallback> * cb =
             Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
         // TODO: Should change failure callbacks to accept uint16 status code.
-        cb->mCall(cb->mContext, static_cast<uint8_t>(Protocols::InteractionModel::ToUint16(status)));
+        cb->mCall(cb->mContext, static_cast<uint8_t>(chip::to_underlying(status)));
     }
 
     return true;

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -31,6 +31,7 @@
 #include <core/CHIPEncoding.h>
 #include <support/BytesToHex.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace ::chip;
@@ -253,130 +254,130 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     switch (status)
     {
     case Protocols::InteractionModel::ProtocolCode::Success:
-        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Failure:
-        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidSubscription:
-        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAccess:
-        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedEndpoint:
-        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidAction:
-        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
-        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated82:
-        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated83:
-        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated84:
-        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
-        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute:
-        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidValue:
-        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedWrite:
-        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
-        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
-        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
-        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnreportableAttribute:
-        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
-        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
-        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
-        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated90:
-        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated91:
-        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
-        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated93:
-        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
-        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved95:
-        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved96:
-        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved97:
-        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved98:
-        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved99:
-        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved9a:
-        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ConstraintError:
-        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Busy:
-        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
-        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
-        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
-        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
-        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
-        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
-        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidArgument:
-        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     default:
-        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, Protocols::InteractionModel::ToUint16(status));
+        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, chip::to_underlying(status));
         break;
     }
 }
@@ -528,7 +529,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         Callback::Callback<DefaultFailureCallback> * cb =
             Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
         // TODO: Should change failure callbacks to accept uint16 status code.
-        cb->mCall(cb->mContext, static_cast<uint8_t>(Protocols::InteractionModel::ToUint16(status)));
+        cb->mCall(cb->mContext, static_cast<uint8_t>(chip::to_underlying(status)));
     }
 
     return true;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -28,6 +28,7 @@
 #include "InteractionModelEngine.h"
 
 #include <protocols/secure_channel/Constants.h>
+#include <support/TypeTraits.h>
 
 using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 
@@ -146,8 +147,7 @@ CHIP_ERROR CommandHandler::AddStatusCode(const CommandPathParams & aCommandPathP
     statusElementBuilder =
         mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder().CreateStatusElementBuilder();
     statusElementBuilder
-        .EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(),
-                             Protocols::InteractionModel::ToUint16(aProtocolCode))
+        .EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), chip::to_underlying(aProtocolCode))
         .EndOfStatusElement();
     err = statusElementBuilder.GetError();
     SuccessOrExit(err);

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -21,6 +21,7 @@
 #include <app/MessageDef/EventPath.h>
 #include <app/WriteHandler.h>
 #include <app/reporting/Engine.h>
+#include <support/TypeTraits.h>
 
 namespace chip {
 namespace app {
@@ -257,8 +258,7 @@ CHIP_ERROR WriteHandler::AddAttributeStatusCode(const AttributePathParams & aAtt
 
     statusElementBuilder = attributeStatusElement.CreateStatusElementBuilder();
     statusElementBuilder
-        .EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(),
-                             Protocols::InteractionModel::ToUint16(aProtocolCode))
+        .EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), chip::to_underlying(aProtocolCode))
         .EndOfStatusElement();
     err = statusElementBuilder.GetError();
     SuccessOrExit(err);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -35,6 +35,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <support/ErrorStr.h>
+#include <support/TypeTraits.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/UDP.h>
@@ -394,7 +395,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     // We do not really care about the value, just return a not found status code.
     VerifyOrReturnError(apWriter != nullptr, CHIP_NO_ERROR);
     return apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_Status),
-                         Protocols::InteractionModel::ToUint16(Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute));
+                         chip::to_underlying(Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute));
 }
 
 CHIP_ERROR WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -31,6 +31,7 @@
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPTLV.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TypeTraits.h>
 #include <protocols/interaction_model/Constants.h>
 
 #include <app/common/gen/att-storage.h>
@@ -207,7 +208,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         return apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_Status),
-                             Protocols::InteractionModel::ToUint16(ToInteractionModelProtocolCode(status)));
+                             chip::to_underlying(ToInteractionModelProtocolCode(status)));
     }
 
     // TODO: ZCL_STRUCT_ATTRIBUTE_TYPE is not included in this switch case currently, should add support for structures.
@@ -331,7 +332,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     default:
         ChipLogError(DataManagement, "Attribute type 0x%x not handled", static_cast<int>(attributeType));
         return apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_Status),
-                             Protocols::InteractionModel::ToUint16(Protocols::InteractionModel::ProtocolCode::UnsupportedRead));
+                             chip::to_underlying(Protocols::InteractionModel::ProtocolCode::UnsupportedRead));
     }
 
     // TODO: Add DataVersion support

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -15,6 +15,7 @@
 #include <core/CHIPEncoding.h>
 #include <support/BytesToHex.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace ::chip;
@@ -238,130 +239,130 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     switch (status)
     {
     case Protocols::InteractionModel::ProtocolCode::Success:
-        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Failure:
-        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidSubscription:
-        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAccess:
-        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedEndpoint:
-        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidAction:
-        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
-        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated82:
-        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated83:
-        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated84:
-        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
-        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute:
-        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidValue:
-        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedWrite:
-        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
-        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
-        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
-        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnreportableAttribute:
-        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
-        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
-        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
-        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated90:
-        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated91:
-        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
-        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated93:
-        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
-        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved95:
-        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved96:
-        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved97:
-        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved98:
-        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved99:
-        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved9a:
-        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ConstraintError:
-        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Busy:
-        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
-        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
-        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
-        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
-        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
-        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
-        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidArgument:
-        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     default:
-        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, Protocols::InteractionModel::ToUint16(status));
+        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, chip::to_underlying(status));
         break;
     }
 }
@@ -510,7 +511,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         Callback::Callback<DefaultFailureCallback> * cb =
             Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
         // TODO: Should change failure callbacks to accept uint16 status code.
-        cb->mCall(cb->mContext, static_cast<uint8_t>(Protocols::InteractionModel::ToUint16(status)));
+        cb->mCall(cb->mContext, static_cast<uint8_t>(chip::to_underlying(status)));
     }
 
     return true;

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -31,6 +31,7 @@
 #include <core/CHIPEncoding.h>
 #include <support/BytesToHex.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace ::chip;
@@ -253,130 +254,130 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     switch (status)
     {
     case Protocols::InteractionModel::ProtocolCode::Success:
-        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Success                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Failure:
-        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Failure                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidSubscription:
-        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidSubscription    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAccess:
-        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAccess      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedEndpoint:
-        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedEndpoint    (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidAction:
-        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidAction          (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
-        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated82:
-        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated83:
-        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated84:
-        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
-        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute:
-        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedAttribute   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidValue:
-        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidValue           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedWrite:
-        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedWrite       (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
-        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
-        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
-        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnreportableAttribute:
-        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnreportableAttribute  (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
-        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
-        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
-        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated90:
-        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated91:
-        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
-        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecated93:
-        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
-        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved95:
-        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved95             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved96:
-        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved96             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved97:
-        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved97             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved98:
-        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved98             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved99:
-        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved99             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved9a:
-        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Reserved9a             (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::ConstraintError:
-        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: ConstraintError        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Busy:
-        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
-        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
-        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
-        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
-        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
-        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
-        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidArgument:
-        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+        ChipLogProgress(Zcl, "  status: InvalidArgument        (0x%04" PRIx16 ")", chip::to_underlying(status));
         break;
     default:
-        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, Protocols::InteractionModel::ToUint16(status));
+        ChipLogError(Zcl, "Unknown status: 0x%04" PRIx16, chip::to_underlying(status));
         break;
     }
 }
@@ -528,7 +529,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         Callback::Callback<DefaultFailureCallback> * cb =
             Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
         // TODO: Should change failure callbacks to accept uint16 status code.
-        cb->mCall(cb->mContext, static_cast<uint8_t>(Protocols::InteractionModel::ToUint16(status)));
+        cb->mCall(cb->mContext, static_cast<uint8_t>(chip::to_underlying(status)));
     }
 
     return true;

--- a/src/lib/support/TypeTraits.h
+++ b/src/lib/support/TypeTraits.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines and implements a number of miscellaneous
+ *      templates for simplify code with handling types.
+ *
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace chip {
+
+/**
+ * @brief Implemented std::to_underlying introduced in C++23.
+ */
+template <class T>
+constexpr std::underlying_type_t<T> to_underlying(T e)
+{
+    static_assert(std::is_enum<T>::value, "to_underlying called to non-enum values.");
+    return static_cast<std::underlying_type_t<T>>(e);
+}
+
+} // namespace chip

--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -109,12 +109,6 @@ enum class ProtocolCode : uint16_t
     NoUpstreamSubscription = 0xc5,
     InvalidArgument        = 0xc6,
 };
-
-inline uint16_t ToUint16(ProtocolCode aProtocolCode)
-{
-    static_assert(std::is_same<uint16_t, std::underlying_type_t<ProtocolCode>>::value, "Cast might not be right");
-    return static_cast<uint16_t>(aProtocolCode);
-}
 } // namespace InteractionModel
 
 template <>


### PR DESCRIPTION
#### Problem
- We have functions like `Protocols::InteractionModel::ToUint16` for casting enum to uint16. C++23 introduces `std::to_underlying`, which is useful for this case.

#### Change overview
- Introduce `to_underlying`
- This functions takes exactly the same name and parameter as C++23 standard, so it can be replaced by STL implementation in the future.

#### Testing
- This code is used during compile time,, the code compiles.
