### PR TITLE
[im] Add helper for mapping ember error code to im protocol code

### DIFF
--- a/examples/lighting-app/mbed/CMakeLists.txt
+++ b/examples/lighting-app/mbed/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(${APP_TARGET} PRIVATE
                ${CHIP_ROOT}/src/app/util/client-api.cpp
                ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
                ${CHIP_ROOT}/src/app/util/ember-print.cpp
+               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
                ${CHIP_ROOT}/src/app/util/message.cpp
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/util/client-api.cpp
                ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
                ${CHIP_ROOT}/src/app/util/ember-print.cpp
+               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
                ${CHIP_ROOT}/src/app/util/message.cpp
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/util/client-api.cpp
                ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
                ${CHIP_ROOT}/src/app/util/ember-print.cpp
+               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
                ${CHIP_ROOT}/src/app/util/message.cpp
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp

--- a/examples/lock-app/mbed/CMakeLists.txt
+++ b/examples/lock-app/mbed/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(${APP_TARGET} PRIVATE
                ${CHIP_ROOT}/src/app/util/client-api.cpp
                ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
                ${CHIP_ROOT}/src/app/util/ember-print.cpp
+               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
                ${CHIP_ROOT}/src/app/util/message.cpp
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/util/client-api.cpp
                ${CHIP_ROOT}/src/app/util/ember-compatibility-functions.cpp
                ${CHIP_ROOT}/src/app/util/ember-print.cpp
+               ${CHIP_ROOT}/src/app/util/error-mapping.cpp
                ${CHIP_ROOT}/src/app/util/message.cpp
                ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
                ${CHIP_ROOT}/src/app/util/process-global-message.cpp

--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -272,14 +272,14 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
         ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved82:
-        ChipLogProgress(Zcl, "  status: Reserved82             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated82:
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved83:
-        ChipLogProgress(Zcl, "  status: Reserved83             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated83:
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved84:
-        ChipLogProgress(Zcl, "  status: Reserved84             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated84:
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
         ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -296,8 +296,8 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
         ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8a:
-        ChipLogProgress(Zcl, "  status: Reserved8a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
         ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -308,23 +308,23 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
         ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8e:
-        ChipLogProgress(Zcl, "  status: Reserved8e             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
         ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved90:
-        ChipLogProgress(Zcl, "  status: Reserved90             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated90:
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved91:
-        ChipLogProgress(Zcl, "  status: Reserved91             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated91:
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
         ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved93:
-        ChipLogProgress(Zcl, "  status: Reserved93             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated93:
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
         ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -353,20 +353,20 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::Busy:
         ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc0:
-        ChipLogProgress(Zcl, "  status: Reservedc0             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc1:
-        ChipLogProgress(Zcl, "  status: Reservedc1             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc2:
-        ChipLogProgress(Zcl, "  status: Reservedc2             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
         ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc4:
-        ChipLogProgress(Zcl, "  status: Reservedc4             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
         ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -272,14 +272,14 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
         ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved82:
-        ChipLogProgress(Zcl, "  status: Reserved82             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated82:
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved83:
-        ChipLogProgress(Zcl, "  status: Reserved83             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated83:
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved84:
-        ChipLogProgress(Zcl, "  status: Reserved84             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated84:
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
         ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -296,8 +296,8 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
         ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8a:
-        ChipLogProgress(Zcl, "  status: Reserved8a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
         ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -308,23 +308,23 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
         ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8e:
-        ChipLogProgress(Zcl, "  status: Reserved8e             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
         ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved90:
-        ChipLogProgress(Zcl, "  status: Reserved90             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated90:
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved91:
-        ChipLogProgress(Zcl, "  status: Reserved91             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated91:
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
         ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved93:
-        ChipLogProgress(Zcl, "  status: Reserved93             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated93:
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
         ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -353,20 +353,20 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::Busy:
         ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc0:
-        ChipLogProgress(Zcl, "  status: Reservedc0             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc1:
-        ChipLogProgress(Zcl, "  status: Reservedc1             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc2:
-        ChipLogProgress(Zcl, "  status: Reservedc2             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
         ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc4:
-        ChipLogProgress(Zcl, "  status: Reservedc4             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
         ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -110,6 +110,7 @@ template("chip_data_model") {
       "${_app_root}/util/client-api.cpp",
       "${_app_root}/util/ember-compatibility-functions.cpp",
       "${_app_root}/util/ember-print.cpp",
+      "${_app_root}/util/error-mapping.cpp",
       "${_app_root}/util/message.cpp",
       "${_app_root}/util/process-cluster-message.cpp",
       "${_app_root}/util/process-global-message.cpp",

--- a/src/app/util/error-mapping.cpp
+++ b/src/app/util/error-mapping.cpp
@@ -1,0 +1,194 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "error-mapping.h"
+
+namespace chip {
+namespace app {
+
+EmberAfStatus ToEmberAfStatus(Protocols::InteractionModel::ProtocolCode code)
+{
+    using imcode = Protocols::InteractionModel::ProtocolCode;
+    switch (code)
+    {
+    case imcode::Success: // 0x00
+        return EMBER_ZCL_STATUS_SUCCESS;
+    case imcode::Failure: // 0x01
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::InvalidSubscription: // 0x7d
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::UnsupportedAccess: // 0x7e
+        return EMBER_ZCL_STATUS_NOT_AUTHORIZED;
+    case imcode::UnsupportedEndpoint: // 0x7f
+        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
+    case imcode::InvalidAction: // 0x80
+        return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
+    case imcode::UnsupportedCommand: // 0x81
+        return EMBER_ZCL_STATUS_UNSUP_COMMAND;
+    case imcode::Deprecated82: // 0x82
+        return EMBER_ZCL_STATUS_UNSUP_COMMAND;
+    case imcode::Deprecated83: // 0x83
+        return EMBER_ZCL_STATUS_UNSUP_COMMAND;
+    case imcode::Deprecated84: // 0x84
+        return EMBER_ZCL_STATUS_UNSUP_COMMAND;
+    case imcode::InvalidCommand: // 0x85
+        return EMBER_ZCL_STATUS_INVALID_FIELD;
+    case imcode::UnsupportedAttribute: // 0x86
+        return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
+    case imcode::InvalidValue: // 0x87
+        return EMBER_ZCL_STATUS_INVALID_VALUE;
+    case imcode::UnsupportedWrite: // 0x88
+        return EMBER_ZCL_STATUS_READ_ONLY;
+    case imcode::ResourceExhausted: // 0x89
+        return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
+    case imcode::Deprecated8a:
+        return EMBER_ZCL_STATUS_SUCCESS;
+    case imcode::NotFound: // 0x8b
+        return EMBER_ZCL_STATUS_NOT_FOUND;
+    case imcode::UnreportableAttribute: // 0x8c
+        return EMBER_ZCL_STATUS_UNREPORTABLE_ATTRIBUTE;
+    case imcode::InvalidDataType: // 0x8d
+        return EMBER_ZCL_STATUS_INVALID_DATA_TYPE;
+    case imcode::Deprecated8e: // 0x8e
+        return EMBER_ZCL_STATUS_UNREPORTABLE_ATTRIBUTE;
+    case imcode::UnsupportedRead: // 0x8f
+        return EMBER_ZCL_STATUS_WRITE_ONLY;
+    case imcode::Deprecated90: // 0x90
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Deprecated91: // 0x91
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved92: // 0x92
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Deprecated93: // 0x93
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Timeout: // 0x94
+        return EMBER_ZCL_STATUS_TIMEOUT;
+    case imcode::Reserved95: // 0x95
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved96: // 0x96
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved97: // 0x97
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved98: // 0x98
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved99: // 0x99
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Reserved9a: // 0x9a
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::ConstraintError: // 0x9b
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Busy: // 0x9c
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Deprecatedc0: // 0xc0
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Deprecatedc1: // 0xc1
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::Deprecatedc2: // 0xc2
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::UnsupportedCluster: // 0xc3
+        return EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER;
+    case imcode::Deprecatedc4: // 0xc4
+        return EMBER_ZCL_STATUS_SUCCESS;
+    case imcode::NoUpstreamSubscription: // 0xc5
+        return EMBER_ZCL_STATUS_FAILURE;
+    case imcode::InvalidArgument: // 0xc6
+        return EMBER_ZCL_STATUS_INVALID_ARGUMENT;
+        // Default case is omitted intentionally so we can guarantee that we exhaust all of the error codes.
+    }
+    return EMBER_ZCL_STATUS_FAILURE;
+}
+
+Protocols::InteractionModel::ProtocolCode ToInteractionModelProtocolCode(EmberAfStatus code)
+{
+    using imcode = Protocols::InteractionModel::ProtocolCode;
+    switch (code)
+    {
+    case EMBER_ZCL_STATUS_SUCCESS: // 0x00
+        return imcode::Success;
+    case EMBER_ZCL_STATUS_FAILURE: // 0x01
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_NOT_AUTHORIZED: // 0x7E
+        return imcode::UnsupportedAccess;
+    case EMBER_ZCL_STATUS_MALFORMED_COMMAND: // 0x80
+        return imcode::InvalidAction;
+    case EMBER_ZCL_STATUS_UNSUP_COMMAND: // 0x81
+        return imcode::UnsupportedCommand;
+    case EMBER_ZCL_STATUS_UNSUP_GENERAL_COMMAND: // 0x82
+        return imcode::UnsupportedCommand;
+    case EMBER_ZCL_STATUS_UNSUP_MANUF_CLUSTER_COMMAND: // 0x83
+        return imcode::UnsupportedCommand;
+    case EMBER_ZCL_STATUS_UNSUP_MANUF_GENERAL_COMMAND: // 0x84
+        return imcode::UnsupportedCommand;
+    case EMBER_ZCL_STATUS_INVALID_FIELD: // 0x85
+        return imcode::InvalidCommand;
+    case EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE: // 0x86
+        return imcode::UnsupportedAttribute;
+    case EMBER_ZCL_STATUS_INVALID_VALUE: // 0x87
+        return imcode::InvalidValue;
+    case EMBER_ZCL_STATUS_READ_ONLY: // 0x88
+        return imcode::UnsupportedWrite;
+    case EMBER_ZCL_STATUS_INSUFFICIENT_SPACE: // 0x89
+        return imcode::ResourceExhausted;
+    case EMBER_ZCL_STATUS_DUPLICATE_EXISTS: // 0x8A
+        return imcode::Success;
+    case EMBER_ZCL_STATUS_NOT_FOUND: // 0x8B
+        return imcode::NotFound;
+    case EMBER_ZCL_STATUS_UNREPORTABLE_ATTRIBUTE: // 0x8C
+        return imcode::UnreportableAttribute;
+    case EMBER_ZCL_STATUS_INVALID_DATA_TYPE: // 0x8D
+        return imcode::InvalidDataType;
+    case EMBER_ZCL_STATUS_INVALID_SELECTOR: // 0x8E
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_WRITE_ONLY: // 0x8F
+        return imcode::UnsupportedRead;
+    case EMBER_ZCL_STATUS_INCONSISTENT_STARTUP_STATE: // 0x90
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_DEFINED_OUT_OF_BAND: // 0x91
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_ACTION_DENIED: // 0x93
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_TIMEOUT: // 0x94
+        return imcode::Timeout;
+    case EMBER_ZCL_STATUS_ABORT: // 0x95
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_INVALID_IMAGE: // 0x96
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_WAIT_FOR_DATA: // 0x97
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_NO_IMAGE_AVAILABLE: // 0x98
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_REQUIRE_MORE_IMAGE: // 0x99
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_NOTIFICATION_PENDING: // 0x9A
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_HARDWARE_FAILURE: // 0xC0
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_SOFTWARE_FAILURE: // 0xC1
+        return imcode::Failure;
+    case EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER: // 0xC3
+        return imcode::UnsupportedCluster;
+    case EMBER_ZCL_STATUS_LIMIT_REACHED: // 0xC4
+        return imcode::Success;
+    case EMBER_ZCL_STATUS_INVALID_ARGUMENT: // 0xC6
+        return imcode::InvalidArgument;
+    default:
+        return imcode::Failure;
+    }
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/util/error-mapping.h
+++ b/src/app/util/error-mapping.h
@@ -1,0 +1,30 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/af-enums.h>
+#include <protocols/interaction_model/Constants.h>
+
+namespace chip {
+namespace app {
+
+EmberAfStatus ToEmberAfStatus(Protocols::InteractionModel::ProtocolCode code);
+Protocols::InteractionModel::ProtocolCode ToInteractionModelProtocolCode(EmberAfStatus code);
+
+} // namespace app
+} // namespace chip

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -257,14 +257,14 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
         ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved82:
-        ChipLogProgress(Zcl, "  status: Reserved82             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated82:
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved83:
-        ChipLogProgress(Zcl, "  status: Reserved83             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated83:
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved84:
-        ChipLogProgress(Zcl, "  status: Reserved84             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated84:
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
         ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -281,8 +281,8 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
         ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8a:
-        ChipLogProgress(Zcl, "  status: Reserved8a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
         ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -293,23 +293,23 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
         ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8e:
-        ChipLogProgress(Zcl, "  status: Reserved8e             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
         ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved90:
-        ChipLogProgress(Zcl, "  status: Reserved90             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated90:
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved91:
-        ChipLogProgress(Zcl, "  status: Reserved91             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated91:
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
         ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved93:
-        ChipLogProgress(Zcl, "  status: Reserved93             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated93:
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
         ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -338,20 +338,20 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::Busy:
         ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc0:
-        ChipLogProgress(Zcl, "  status: Reservedc0             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc1:
-        ChipLogProgress(Zcl, "  status: Reservedc1             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc2:
-        ChipLogProgress(Zcl, "  status: Reservedc2             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
         ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc4:
-        ChipLogProgress(Zcl, "  status: Reservedc4             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
         ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -272,14 +272,14 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCommand:
         ChipLogProgress(Zcl, "  status: UnsupportedCommand     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved82:
-        ChipLogProgress(Zcl, "  status: Reserved82             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated82:
+        ChipLogProgress(Zcl, "  status: Deprecated82           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved83:
-        ChipLogProgress(Zcl, "  status: Reserved83             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated83:
+        ChipLogProgress(Zcl, "  status: Deprecated83           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved84:
-        ChipLogProgress(Zcl, "  status: Reserved84             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated84:
+        ChipLogProgress(Zcl, "  status: Deprecated84           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::InvalidCommand:
         ChipLogProgress(Zcl, "  status: InvalidCommand         (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -296,8 +296,8 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::ResourceExhausted:
         ChipLogProgress(Zcl, "  status: ResourceExhausted      (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8a:
-        ChipLogProgress(Zcl, "  status: Reserved8a             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8a:
+        ChipLogProgress(Zcl, "  status: Deprecated8a           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NotFound:
         ChipLogProgress(Zcl, "  status: NotFound               (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -308,23 +308,23 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::InvalidDataType:
         ChipLogProgress(Zcl, "  status: InvalidDataType        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved8e:
-        ChipLogProgress(Zcl, "  status: Reserved8e             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated8e:
+        ChipLogProgress(Zcl, "  status: Deprecated8e           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedRead:
         ChipLogProgress(Zcl, "  status: UnsupportedRead        (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved90:
-        ChipLogProgress(Zcl, "  status: Reserved90             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated90:
+        ChipLogProgress(Zcl, "  status: Deprecated90           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved91:
-        ChipLogProgress(Zcl, "  status: Reserved91             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated91:
+        ChipLogProgress(Zcl, "  status: Deprecated91           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Reserved92:
         ChipLogProgress(Zcl, "  status: Reserved92             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reserved93:
-        ChipLogProgress(Zcl, "  status: Reserved93             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecated93:
+        ChipLogProgress(Zcl, "  status: Deprecated93           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::Timeout:
         ChipLogProgress(Zcl, "  status: Timeout                (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
@@ -353,20 +353,20 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     case Protocols::InteractionModel::ProtocolCode::Busy:
         ChipLogProgress(Zcl, "  status: Busy                   (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc0:
-        ChipLogProgress(Zcl, "  status: Reservedc0             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc0:
+        ChipLogProgress(Zcl, "  status: Deprecatedc0           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc1:
-        ChipLogProgress(Zcl, "  status: Reservedc1             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc1:
+        ChipLogProgress(Zcl, "  status: Deprecatedc1           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc2:
-        ChipLogProgress(Zcl, "  status: Reservedc2             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc2:
+        ChipLogProgress(Zcl, "  status: Deprecatedc2           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::UnsupportedCluster:
         ChipLogProgress(Zcl, "  status: UnsupportedCluster     (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
-    case Protocols::InteractionModel::ProtocolCode::Reservedc4:
-        ChipLogProgress(Zcl, "  status: Reservedc4             (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
+    case Protocols::InteractionModel::ProtocolCode::Deprecatedc4:
+        ChipLogProgress(Zcl, "  status: Deprecatedc4           (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));
         break;
     case Protocols::InteractionModel::ProtocolCode::NoUpstreamSubscription:
         ChipLogProgress(Zcl, "  status: NoUpstreamSubscription (0x%04" PRIx16 ")", Protocols::InteractionModel::ToUint16(status));

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		2CB7163B252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */; };
 		2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */; };
 		2CB7163F252F731E0026E2BB /* CHIPDevicePairingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FD775542695557E00FF4B12 /* error-mapping.cpp */; };
 		991DC0842475F45400C13860 /* CHIPDeviceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC0822475F45400C13860 /* CHIPDeviceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
@@ -121,6 +122,7 @@
 		2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevicePairingDelegateBridge.h; sourceTree = "<group>"; };
 		2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDevicePairingDelegateBridge.mm; sourceTree = "<group>"; };
 		2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevicePairingDelegate.h; sourceTree = "<group>"; };
+		2FD775542695557E00FF4B12 /* error-mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "error-mapping.cpp"; path = "../../../app/util/error-mapping.cpp"; sourceTree = "<group>"; };
 		991DC0822475F45400C13860 /* CHIPDeviceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceController.h; sourceTree = "<group>"; };
 		991DC0872475F47D00C13860 /* CHIPDeviceController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceController.mm; sourceTree = "<group>"; };
 		991DC08A247704DC00C13860 /* CHIPLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPLogging.h; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 		1E857311265519DE0050A4D9 /* CHIPApp */ = {
 			isa = PBXGroup;
 			children = (
+				2FD775542695557E00FF4B12 /* error-mapping.cpp */,
 				1E85733326551A700050A4D9 /* reporting-default-configuration.cpp */,
 				1E85733226551A700050A4D9 /* reporting.cpp */,
 				1E85731926551A490050A4D9 /* af-event.cpp */,
@@ -456,6 +459,7 @@
 				1E857310265519AE0050A4D9 /* IMClusterCommandHandler.cpp in Sources */,
 				1E85732D26551A490050A4D9 /* util.cpp in Sources */,
 				1E85732B26551A490050A4D9 /* af-main-common.cpp in Sources */,
+				2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */,
 				1E85732A26551A490050A4D9 /* ember-compatibility-functions.cpp in Sources */,
 				B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */,
 				1E85732F26551A490050A4D9 /* attribute-size-util.cpp in Sources */,

--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <protocols/Protocols.h>
 
 /**
@@ -72,24 +74,24 @@ enum class ProtocolCode : uint16_t
     UnsupportedEndpoint    = 0x7f,
     InvalidAction          = 0x80,
     UnsupportedCommand     = 0x81,
-    Reserved82             = 0x82,
-    Reserved83             = 0x83,
-    Reserved84             = 0x84,
+    Deprecated82           = 0x82,
+    Deprecated83           = 0x83,
+    Deprecated84           = 0x84,
     InvalidCommand         = 0x85,
     UnsupportedAttribute   = 0x86,
     InvalidValue           = 0x87,
     UnsupportedWrite       = 0x88,
     ResourceExhausted      = 0x89,
-    Reserved8a             = 0x8a,
+    Deprecated8a           = 0x8a,
     NotFound               = 0x8b,
     UnreportableAttribute  = 0x8c,
     InvalidDataType        = 0x8d,
-    Reserved8e             = 0x8e,
+    Deprecated8e           = 0x8e,
     UnsupportedRead        = 0x8f,
-    Reserved90             = 0x90,
-    Reserved91             = 0x91,
-    Reserved92             = 0x92,
-    Reserved93             = 0x93,
+    Deprecated90           = 0x90,
+    Deprecated91           = 0x91,
+    Reserved92             = 0x92, // ProtocolCode 0x92 does not have any comments in the spec.
+    Deprecated93           = 0x93,
     Timeout                = 0x94,
     Reserved95             = 0x95,
     Reserved96             = 0x96,
@@ -99,11 +101,11 @@ enum class ProtocolCode : uint16_t
     Reserved9a             = 0x9a,
     ConstraintError        = 0x9b,
     Busy                   = 0x9c,
-    Reservedc0             = 0xc0,
-    Reservedc1             = 0xc1,
-    Reservedc2             = 0xc2,
+    Deprecatedc0           = 0xc0,
+    Deprecatedc1           = 0xc1,
+    Deprecatedc2           = 0xc2,
     UnsupportedCluster     = 0xc3,
-    Reservedc4             = 0xc4,
+    Deprecatedc4           = 0xc4,
     NoUpstreamSubscription = 0xc5,
     InvalidArgument        = 0xc6,
 };


### PR DESCRIPTION
#### Problem
Fixes #7817

#### Change overview
- Add `ToInteractionModelProtocolCode` and `ToEmberAfStatus` for mapping error codes.
- Potential follow up: #8130

#### Testing
- The modified lines are already covered by existing TestSuite.
