### PR TITLE
Log string attribute value into CHIPClientCallbacks.cpp

### DIFF
--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -29,6 +29,7 @@
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPEncoding.h>
+#include <support/BytesToHex.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -380,25 +381,19 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     }
 }
 
-void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+void LogStringAttribute(const uint8_t * string, const uint32_t length, const bool isHumanReadable)
 {
-    if (isAscii)
+    if (isHumanReadable)
     {
         ChipLogProgress(Zcl, "  value: %.*s", length, string);
         return;
     }
 
-    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
-    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
-    char * bufferPos                              = buffer + strlen(buffer);
-    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
-
-    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR == Encoding::BytesToUppercaseHexString(&string[0], length, &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
     {
-        snprintf(bufferPos, static_cast<size_t>(bufferEnd - bufferPos), "%02X ", string[i]);
+        ChipLogProgress(Zcl, "  value: %s", buffer);
     }
-
-    ChipLogProgress(Zcl, "%s", buffer);
 }
 
 // Singleton instance of the callbacks manager
@@ -471,6 +466,8 @@ void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data, 
 
     if (CHIP_NO_ERROR == err)
     {
+        LogStringAttribute(val, len, data->GetType() == chip::TLV::kTLVType_UTF8String);
+
         chip::Callback::Callback<StringAttributeCallback> * cb =
             chip::Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccess);
         cb->mCall(cb->mContext, chip::ByteSpan(val, len));

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -29,6 +29,7 @@
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPEncoding.h>
+#include <support/BytesToHex.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -380,25 +381,19 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     }
 }
 
-void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+void LogStringAttribute(const uint8_t * string, const uint32_t length, const bool isHumanReadable)
 {
-    if (isAscii)
+    if (isHumanReadable)
     {
         ChipLogProgress(Zcl, "  value: %.*s", length, string);
         return;
     }
 
-    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
-    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
-    char * bufferPos                              = buffer + strlen(buffer);
-    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
-
-    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR == Encoding::BytesToUppercaseHexString(&string[0], length, &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
     {
-        snprintf(bufferPos, static_cast<size_t>(bufferEnd - bufferPos), "%02X ", string[i]);
+        ChipLogProgress(Zcl, "  value: %s", buffer);
     }
-
-    ChipLogProgress(Zcl, "%s", buffer);
 }
 
 // Singleton instance of the callbacks manager
@@ -471,6 +466,8 @@ void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data, 
 
     if (CHIP_NO_ERROR == err)
     {
+        LogStringAttribute(val, len, data->GetType() == chip::TLV::kTLVType_UTF8String);
+
         chip::Callback::Callback<StringAttributeCallback> * cb =
             chip::Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccess);
         cb->mCall(cb->mContext, chip::ByteSpan(val, len));

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -118,12 +118,6 @@ EmberAfAttributeType BaseType(EmberAfAttributeType type)
                       "chip::NodeId is expected to be uint64_t, change this when necessary");
         return ZCL_INT64U_ATTRIBUTE_TYPE;
 
-    case ZCL_CHAR_STRING_ATTRIBUTE_TYPE: // Character string
-        return ZCL_OCTET_STRING_ATTRIBUTE_TYPE;
-
-    case ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE:
-        return ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE;
-
     default:
         return type;
     }
@@ -276,6 +270,28 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         int64_t int64_data;
         memcpy(&int64_data, data, sizeof(int64_data));
         ReturnErrorOnFailure(apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), int64_data));
+        break;
+    }
+    case ZCL_CHAR_STRING_ATTRIBUTE_TYPE: // Char string
+    {
+        char * actualData  = reinterpret_cast<char *>(data + 1);
+        uint8_t dataLength = data[0];
+        if (dataLength == 0xFF /* invalid data, put empty value instead */)
+        {
+            dataLength = 0;
+        }
+        ReturnErrorOnFailure(apWriter->PutString(TLV::ContextTag(AttributeDataElement::kCsTag_Data), actualData, dataLength));
+        break;
+    }
+    case ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE: {
+        char * actualData = reinterpret_cast<char *>(data + 2); // The pascal string contains 2 bytes length
+        uint16_t dataLength;
+        memcpy(&dataLength, data, sizeof(dataLength));
+        if (dataLength == 0xFFFF /* invalid data, put empty value instead */)
+        {
+            dataLength = 0;
+        }
+        ReturnErrorOnFailure(apWriter->PutString(TLV::ContextTag(AttributeDataElement::kCsTag_Data), actualData, dataLength));
         break;
     }
     case ZCL_OCTET_STRING_ATTRIBUTE_TYPE: // Octet string

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -13,6 +13,7 @@
 #include <app/util/basic-types.h>
 #include <app/util/CHIPDeviceCallbacksMgr.h>
 #include <core/CHIPEncoding.h>
+#include <support/BytesToHex.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -365,25 +366,19 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     }
 }
 
-void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+void LogStringAttribute(const uint8_t * string, const uint32_t length, const bool isHumanReadable)
 {
-    if (isAscii)
+    if (isHumanReadable)
     {
         ChipLogProgress(Zcl, "  value: %.*s", length, string);
         return;
     }
 
-    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
-    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
-    char * bufferPos                              = buffer + strlen(buffer);
-    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
-
-    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR == Encoding::BytesToUppercaseHexString(&string[0], length, &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
     {
-        snprintf(bufferPos, static_cast<size_t>(bufferEnd - bufferPos), "%02X ", string[i]);
+        ChipLogProgress(Zcl, "  value: %s", buffer);
     }
-
-    ChipLogProgress(Zcl, "%s", buffer);
 }
 
 // Singleton instance of the callbacks manager
@@ -453,6 +448,8 @@ void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data,
 
     if (CHIP_NO_ERROR == err)
     {
+        LogStringAttribute(val, len, data->GetType() == chip::TLV::kTLVType_UTF8String);
+
         chip::Callback::Callback<StringAttributeCallback> * cb =
             chip::Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccess);
         cb->mCall(cb->mContext, chip::ByteSpan(val, len));

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -29,6 +29,7 @@
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
 #include <core/CHIPEncoding.h>
+#include <support/BytesToHex.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -380,25 +381,19 @@ static void LogIMStatus(Protocols::InteractionModel::ProtocolCode status)
     }
 }
 
-void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+void LogStringAttribute(const uint8_t * string, const uint32_t length, const bool isHumanReadable)
 {
-    if (isAscii)
+    if (isHumanReadable)
     {
         ChipLogProgress(Zcl, "  value: %.*s", length, string);
         return;
     }
 
-    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
-    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
-    char * bufferPos                              = buffer + strlen(buffer);
-    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
-
-    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+    if (CHIP_NO_ERROR == Encoding::BytesToUppercaseHexString(&string[0], length, &buffer[0], CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
     {
-        snprintf(bufferPos, static_cast<size_t>(bufferEnd - bufferPos), "%02X ", string[i]);
+        ChipLogProgress(Zcl, "  value: %s", buffer);
     }
-
-    ChipLogProgress(Zcl, "%s", buffer);
 }
 
 // Singleton instance of the callbacks manager
@@ -471,6 +466,8 @@ void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data, 
 
     if (CHIP_NO_ERROR == err)
     {
+        LogStringAttribute(val, len, data->GetType() == chip::TLV::kTLVType_UTF8String);
+
         chip::Callback::Callback<StringAttributeCallback> * cb =
             chip::Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccess);
         cb->mCall(cb->mContext, chip::ByteSpan(val, len));


### PR DESCRIPTION
#### Problem

For TE4, it will be useful to see the value of attributes that are read. This PR add such thing into `CHIPClientCallbacks.cpp`

#### Change overview
 * Uses `LogStringAttribute`

#### Testing
* It was tested locally with `chip-tool`, `read` and `write` command against the `Basic` cluster and `Test Cluster`