### PR TITLE
Fix python compile.

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -512,8 +512,8 @@ exit:
 
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
-    NodeId peerNodeId = state.GetPeerNodeId();
-    ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired", ChipLogValueX64(peerNodeId));
+    ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired",
+                  ChipLogValueX64(state.GetPeerNodeId()));
 
     if (mCB != nullptr)
     {


### PR DESCRIPTION
#### Problem
Looks like ChipLogDetail is off for the controller so it throws
an unused variable exception. 

#### Change overview
Just moving the var into the log.

#### Testing
compiled chip-device-ctrl.
