### PR TITLE
Update build timeouts from 15/20 minutes to 25/30 minutes.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -153,7 +153,7 @@ jobs:
               run: |
                   scripts/build/gn_gen.sh --args='is_clang=true target_os="all"'
             - name: Run Build
-              timeout-minutes: 20
+              timeout-minutes: 30
               run: scripts/build/gn_build.sh
             - name: Run Tests
               timeout-minutes: 10

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -78,7 +78,7 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Run Tests
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: |
                   integrations/docker/images/chip-build-cirque/run.sh \
                      --env LOG_DIR=/tmp/cirque_test_output \

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -47,7 +47,7 @@ jobs:
                 OPEN_SSL_VERSION=`ls -la /usr/local/Cellar/openssl@1.1 | cat | tail -n1 | awk '{print $NF}'`
                 ln -s /usr/local/Cellar/openssl@1.1/$OPEN_SSL_VERSION/lib/pkgconfig/* .
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
@@ -58,11 +58,11 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Run iOS Build Debug
-              timeout-minutes: 20
+              timeout-minutes: 30
               working-directory: src/darwin/Framework
               run: xcodebuild -target "CHIP" -sdk iphoneos
             - name: Run iOS Build Release
-              timeout-minutes: 20
+              timeout-minutes: 30
               working-directory: src/darwin/Framework
               run: xcodebuild -target "CHIP" -sdk iphoneos -configuration Release
             - name: Clean Build
@@ -72,7 +72,7 @@ jobs:
               run: defaults delete com.apple.dt.xctest.tool
               continue-on-error: true
             - name: Run macOS Build
-              timeout-minutes: 20
+              timeout-minutes: 30
               # Enable -Werror by hand here, because the Xcode config can't
               # enable it for various reasons.  Keep whatever Xcode settings
               # for OTHER_CFLAGS exist by using ${inherited}.

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -51,7 +51,7 @@ jobs:
 #               with:
 #                   languages: "cpp, python"
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -52,7 +52,7 @@ jobs:
 #               with:
 #                   languages: "cpp, python"
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
@@ -63,7 +63,7 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Build example All Clusters App
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/examples/esp_example.sh all-clusters-app
             - name: Copy aside build products
               run: |
@@ -103,7 +103,7 @@ jobs:
                   cp examples/shell/esp32/build/chip-shell.elf \
                      example_binaries/$BUILD_TYPE-build/chip-shell.elf
             - name: Build example Temperature Measurement App
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/examples/esp_example.sh temperature-measurement-app
             - name: Copy aside build products
               run: |

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -51,7 +51,7 @@ jobs:
 #                  languages: "cpp"
 #                  queries: +security-and-quality
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -47,7 +47,7 @@ jobs:
                   fetch-depth: 0
                   submodules: true
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -50,7 +50,7 @@ jobs:
 #               with:
 #                   languages: "cpp"
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -44,7 +44,7 @@ jobs:
               with:
                   submodules: true
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
@@ -55,10 +55,10 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Build example All Clusters App
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/examples/esp_example.sh all-clusters-app
             - name: Build ESP32 QEMU and Run Tests
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/tests/esp32_qemu_tests.sh /tmp/test_logs
             - name: Uploading Logs
               uses: actions/upload-artifact@v1

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -38,7 +38,7 @@ jobs:
                   submodules: true
                   ref: "${{ github.event.inputs.releaseTag }}"
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
@@ -78,7 +78,7 @@ jobs:
                   submodules: true
                   ref: "${{ github.event.inputs.releaseTag }}"
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -137,7 +137,7 @@ jobs:
                   OPEN_SSL_VERSION=`ls -la /usr/local/Cellar/openssl@1.1 | cat | tail -n1 | awk '{print $NF}'`
                   ln -s /usr/local/Cellar/openssl@1.1/$OPEN_SSL_VERSION/lib/pkgconfig/* .
             - name: Bootstrap
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
@@ -161,7 +161,7 @@ jobs:
                   # actually succeeded, because that just wastes space.
                   rsync -a out/debug/standalone/ objdir-clone || true
             - name: Run Test Suites
-              timeout-minutes: 15
+              timeout-minutes: 25
               run: |
                   scripts/tests/test_suites.sh
             - name: Uploading core files


### PR DESCRIPTION
#### Problem
We are seeing build timeouts more frequently now, seeminglu on the 20min timeouts
It is unclear as to why - actual build times seem the same outside gihub, with some repo clones potentially being slow and maybe github infra being busy.

#### Change overview
Bump larger timeouts by 10 minutes. Kept old timeouts for smaller ones (2/4/10 minutes) which will keep bootstrap and some compiles considered fast.

This is considered a temporary measure to unblock requirement to click 'try again' since that button is restricted after we locked down branches. 

#### Testing
Not directly tested as this is infra timeouts. Will be visible in build operation.