### PR TITLE
Remove unused or redundant helpers from src/app/zap-templates/templat…

### DIFF
--- a/src/app/zap-templates/common/ChipTypesHelper.js
+++ b/src/app/zap-templates/common/ChipTypesHelper.js
@@ -44,14 +44,7 @@ function asBasicType(type)
   }
 }
 
-const signedTypes = [ 'INT8S', 'INT16S', 'INT32S', 'INT64S' ];
-function isSigned(type)
-{
-  return signedTypes.includes(type);
-}
-
 //
 // Module exports
 //
 exports.asBasicType = asBasicType;
-exports.isSigned    = isSigned;

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -16,64 +16,14 @@
  */
 
 // Import helpers from zap core
-const zapPath       = '../../../../../third_party/zap/repo/src-electron/';
-const templateUtil  = require(zapPath + 'generator/template-util.js')
-const queryEndpoint = require(zapPath + 'db/query-endpoint.js')
-const zclHelper     = require(zapPath + 'generator/helper-zcl.js')
-const zclQuery      = require(zapPath + 'db/query-zcl.js')
-const cHelper       = require(zapPath + 'generator/helper-c.js')
+const zapPath      = '../../../../../third_party/zap/repo/src-electron/';
+const templateUtil = require(zapPath + 'generator/template-util.js')
+const zclHelper    = require(zapPath + 'generator/helper-zcl.js')
+const zclQuery     = require(zapPath + 'db/query-zcl.js')
+const cHelper      = require(zapPath + 'generator/helper-c.js')
 
 const StringHelper    = require('../../common/StringHelper.js');
 const ChipTypesHelper = require('../../common/ChipTypesHelper.js');
-
-/**
- * Check if the cluster (name) has any enabled manufacturer commands. This works only inside
- * cluster block helpers.
- *
- * @param {*} name : Cluster name
- * @param {*} side : Cluster side
- * @param {*} options
- * @returns True if cluster has enabled commands otherwise false
- */
-function user_cluster_has_enabled_manufacturer_command(name, side, options)
-{
-  return queryEndpoint.selectEndPointTypeIds(this.global.db, this.global.sessionId)
-      .then((endpointTypes) => zclQuery.exportClustersAndEndpointDetailsFromEndpointTypes(this.global.db, endpointTypes))
-      .then((endpointsAndClusters) => zclQuery.exportCommandDetailsFromAllEndpointTypesAndClusters(
-                this.global.db, endpointsAndClusters))
-      .then((endpointCommands) => {
-        return !!endpointCommands.find(cmd => cmd.mfgCode && zclHelper.isStrEqual(name, cmd.clusterName)
-                && zclHelper.isCommandAvailable(side, cmd.incoming, cmd.outgoing, cmd.commandSource, cmd.name));
-      })
-}
-
-function asValueIfNotPresent(type, isArray)
-{
-  if (StringHelper.isString(type) || isArray) {
-    return 'NULL';
-  }
-
-  function fn(pkgId)
-  {
-    const options = { 'hash' : {} };
-    return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
-      switch (zclType) {
-      case 'uint8_t':
-        return 'UINT8_MAX';
-      case 'uint16_t':
-        return 'UINT16_MAX';
-      case 'uint32_t':
-        return 'UINT32_MAX';
-      default:
-        error = 'Unhandled underlying type ' + zclType + ' for original type ' + type;
-        throw error;
-      }
-    })
-  }
-
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
-  return templateUtil.templatePromise(this.global, promise)
-}
 
 // TODO Expose the readTypeLength as an additional member field of {{asUnderlyingZclType}} instead
 //      of having to call this method separately.
@@ -324,16 +274,6 @@ function asPrintFormat(type)
   return templateUtil.templatePromise(this.global, promise)
 }
 
-function isFirstElement(index)
-{
-  return index == 0;
-}
-
-function isStrEndsWith(str, substr)
-{
-  return str.endsWith(substr);
-}
-
 function asTypeLiteralSuffix(type)
 {
   switch (type) {
@@ -355,14 +295,9 @@ function asTypeLiteralSuffix(type)
 //
 // Module exports
 //
-exports.asPrintFormat                                 = asPrintFormat;
-exports.asReadType                                    = asReadType;
-exports.asReadTypeLength                              = asReadTypeLength;
-exports.asValueIfNotPresent                           = asValueIfNotPresent;
-exports.isFirstElement                                = isFirstElement;
-exports.user_cluster_has_enabled_manufacturer_command = user_cluster_has_enabled_manufacturer_command;
-exports.chip_endpoint_generated_functions             = chip_endpoint_generated_functions
-exports.chip_endpoint_cluster_list                    = chip_endpoint_cluster_list
-exports.isSigned                                      = ChipTypesHelper.isSigned;
-exports.isStrEndsWith                                 = isStrEndsWith;
-exports.asTypeLiteralSuffix                           = asTypeLiteralSuffix;
+exports.asPrintFormat                     = asPrintFormat;
+exports.asReadType                        = asReadType;
+exports.asReadTypeLength                  = asReadTypeLength;
+exports.chip_endpoint_generated_functions = chip_endpoint_generated_functions
+exports.chip_endpoint_cluster_list        = chip_endpoint_cluster_list
+exports.asTypeLiteralSuffix               = asTypeLiteralSuffix;

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -37,9 +37,6 @@ void Dispatch{{asCamelCased side false}}Command(app::Command * apCommandObj, Com
     uint32_t expectArgumentCount = 0;
     uint32_t currentDecodeTagId = 0;
     bool wasHandled = false;
-    {{#if (user_cluster_has_enabled_manufacturer_command name side)}}
-    {{else}}
-    {{/if}}
     {
         switch (aCommandId)
         {

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -584,7 +584,7 @@ private:
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if (isFirstElement index)}}{{else}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
+- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
 - (void){{asCamelCased name}}:(ResponseHandler)responseHandler
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if (isFirstElement index)}}{{else}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
+- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
 {{else}}
 - (void){{asCamelCased name}}:(ResponseHandler)responseHandler;
 {{/if}}


### PR DESCRIPTION
…es/app/helper.js

#### Problem
Some `js` helpers has not been removed when the templates that was making use of them as been removed or some others are just redundant or used without any results.


#### Change overview
 * Remove the `js` helpers that does not makes sense anymore

#### Testing
 * The code has been regenerated and nothing has changed, so there is effectively no code changes...
