### PR TITLE
Fix mbedtls version in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "mbedtls"]
 	path = third_party/mbedtls/repo
 	url = https://github.com/ARMmbed/mbedtls.git
-	branch = mbedtls-2.18
+	branch = mbedtls-2.25
 [submodule "qrcode"]
 	path = examples/common/QRCode/repo
 	url = https://github.com/nayuki/QR-Code-generator.git


### PR DESCRIPTION
#### Problem
The mbedtls version was updated from 2.18 to 2.25, but the .gitmodules file was not updated.

#### Change overview
Updated the .gitmodules file to match the required version. 

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
It's a config change to the source tree. 
