### PR TITLE
Update Darwin framework API to get connected device

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -85,10 +85,7 @@ BOOL CHIPGetConnectedDevice(CHIPDeviceConnectionCallback completionHandler)
         // Let's use the last device that was paired
         deviceId--;
         NSError * error;
-        return [controller getConnectedDevice:deviceId
-                            completionHandler:completionHandler
-                                        queue:dispatch_get_main_queue()
-                                        error:&error];
+        return [controller getConnectedDevice:deviceId queue:dispatch_get_main_queue() completionHandler:completionHandler];
     }
 
     return NO;
@@ -99,10 +96,7 @@ BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallbac
     CHIPDeviceController * controller = InitializeCHIP();
 
     NSError * error;
-    return [controller getConnectedDevice:deviceId
-                        completionHandler:completionHandler
-                                    queue:dispatch_get_main_queue()
-                                    error:&error];
+    return [controller getConnectedDevice:deviceId queue:dispatch_get_main_queue() completionHandler:completionHandler];
 }
 
 BOOL CHIPIsDevicePaired(uint64_t deviceId)

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -65,9 +65,8 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 
 - (BOOL)isDevicePaired:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
-         completionHandler:(CHIPDeviceConnectionCallback)completionHandler
                      queue:(dispatch_queue_t)queue
-                     error:(NSError * __autoreleasing *)error;
+         completionHandler:(CHIPDeviceConnectionCallback)completionHandler;
 - (nullable CHIPDevice *)getPairedDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -374,21 +374,24 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 }
 
 - (BOOL)getConnectedDevice:(uint64_t)deviceID
-         completionHandler:(CHIPDeviceConnectionCallback)completionHandler
                      queue:(dispatch_queue_t)queue
-                     error:(NSError * __autoreleasing *)error
+         completionHandler:(CHIPDeviceConnectionCallback)completionHandler
 {
-    __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
     if (![self isRunning]) {
-        [self checkForError:errorCode logMsg:kErrorNotRunning error:error];
+        NSError * error;
+        [self checkForError:CHIP_ERROR_INCORRECT_STATE logMsg:kErrorNotRunning error:&error];
+        dispatch_async(queue, ^{
+            completionHandler(nil, error);
+        });
         return NO;
     }
 
     dispatch_async(_chipWorkQueue, ^{
         CHIPDeviceConnectionBridge * connectionBridge = new CHIPDeviceConnectionBridge(completionHandler, queue);
-        errorCode = connectionBridge->connect(self->_cppCommissioner, deviceID);
+        CHIP_ERROR errorCode = connectionBridge->connect(self->_cppCommissioner, deviceID);
 
-        if ([self checkForError:errorCode logMsg:kErrorGetPairedDevice error:error]) {
+        NSError * error;
+        if ([self checkForError:errorCode logMsg:kErrorGetPairedDevice error:&error]) {
             // Errors are propagated to the caller thru completionHandler.
             // No extra error handling is needed here.
             return;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -392,7 +392,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 
         NSError * error;
         if ([self checkForError:errorCode logMsg:kErrorGetPairedDevice error:&error]) {
-            // Errors are propagated to the caller thru completionHandler.
+            // Errors are propagated to the caller through completionHandler.
             // No extra error handling is needed here.
             return;
         }

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -66,8 +66,8 @@
     XCTAssertFalse([controller getConnectedDevice:1234
                                             queue:dispatch_get_main_queue()
                                 completionHandler:^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
+                                    XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
                                 }]);
-    XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
     XCTAssertFalse([controller unpairDevice:1 error:&error]);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
 }

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -64,10 +64,9 @@
     NSError * error;
     XCTAssertFalse([controller isRunning]);
     XCTAssertFalse([controller getConnectedDevice:1234
-                                completionHandler:^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
-                                }
                                             queue:dispatch_get_main_queue()
-                                            error:&error]);
+                                completionHandler:^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
+                                }]);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);
     XCTAssertFalse([controller unpairDevice:1 error:&error]);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidState);


### PR DESCRIPTION
#### Problem
Darwin framework's `getConnectedDevice` is not idiomatic. The error should not be provided as an out parameter, and should be returned via completion handler. Also, the completion handler should be the last argument.

#### Change overview
Updated the API and it's usage.

#### Testing
Ran iOS CHIPTool app to test the updated API.