### PR TITLE
[QPG] Fix CASE session setup flow.  Add missing ECDH support through HW crypto engine

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -559,8 +559,7 @@ exit:
 
 CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
 {
-// TODO: Enable ECDH_derive_secret for Qorvo when their mbedTLS static libraries are updated
-#if defined(MBEDTLS_ECDH_C) && !defined(QORVO_CRYPTO_ENGINE)
+#if defined(MBEDTLS_ECDH_C)
     CHIP_ERROR error     = CHIP_NO_ERROR;
     int result           = 0;
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();


### PR DESCRIPTION
#### Problem
ECDH support was enabled in #7948, but was not yet available in our HW engine.
The full CASE session flow could not complete without this functionality.

TODO's
* Fixes #7957 
* Fixes #7956

#### Change overview
* Remove TODO and #ifdef guard to activated ECDH Derive Secret function.
* Update QPG SDK and mbedtls config to support ECDH through an HW accelerated ALT version.

#### Testing
* Commissioning flow tested with python chip-device-ctrl (ToT and test_event_4 branch)
* CASE session is established correctly after resolve.
