### PR TITLE
[nrfconnect] Minor shell improvements

### DIFF
--- a/src/lib/shell/BUILD.gn
+++ b/src/lib/shell/BUILD.gn
@@ -59,13 +59,13 @@ static_library("shell") {
       "streamer_k32w.cpp",
     ]
   } else if (current_os == "zephyr") {
-    sources += [ "MainLoopZephyr.cpp" ]
+    sources += [
+      "MainLoopZephyr.cpp",
+      "streamer_zephyr.cpp",
+      "streamer_zephyr.h"
+    ]
   } else {
     sources += [ "MainLoopDefault.cpp" ]
-  }
-
-  if (current_os == "zephyr") {
-    sources += [ "streamer_zephyr.cpp" ]
   }
 
   if (current_os == "mbed") {

--- a/src/lib/shell/BUILD.gn
+++ b/src/lib/shell/BUILD.gn
@@ -62,7 +62,7 @@ static_library("shell") {
     sources += [
       "MainLoopZephyr.cpp",
       "streamer_zephyr.cpp",
-      "streamer_zephyr.h"
+      "streamer_zephyr.h",
     ]
   } else {
     sources += [ "MainLoopDefault.cpp" ]

--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -19,11 +19,13 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Engine.h>
+#include <lib/shell/streamer_zephyr.h>
 
 using chip::Shell::Engine;
 
 static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
 {
+    chip::Shell::streamer_set_shell(shell);
     return (Engine::Root().ExecCommand(argc - 1, argv + 1) == CHIP_NO_ERROR) ? 0 : -ENOEXEC;
 }
 

--- a/src/lib/shell/commands/Config.cpp
+++ b/src/lib/shell/commands/Config.cpp
@@ -35,11 +35,11 @@ static CHIP_ERROR ConfigGetVendorId(bool printHeader)
     streamer_t * sout = streamer_get();
     uint16_t value16;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetVendorId(value16));
     if (printHeader)
     {
         streamer_printf(sout, "VendorId:        ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetVendorId(value16));
     streamer_printf(sout, "%" PRIu16 " (0x%" PRIX16 ")\r\n", value16, value16);
     return CHIP_NO_ERROR;
 }
@@ -49,11 +49,11 @@ static CHIP_ERROR ConfigGetProductId(bool printHeader)
     streamer_t * sout = streamer_get();
     uint16_t value16;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetProductId(value16));
     if (printHeader)
     {
         streamer_printf(sout, "ProductId:       ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetProductId(value16));
     streamer_printf(sout, "%" PRIu16 " (0x%" PRIX16 ")\r\n", value16, value16);
     return CHIP_NO_ERROR;
 }
@@ -63,11 +63,11 @@ static CHIP_ERROR ConfigGetProductRevision(bool printHeader)
     streamer_t * sout = streamer_get();
     uint16_t value16;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetProductRevision(value16));
     if (printHeader)
     {
         streamer_printf(sout, "ProductRevision: ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetProductRevision(value16));
     streamer_printf(sout, "%" PRIu16 " (0x%" PRIX16 ")\r\n", value16, value16);
     return CHIP_NO_ERROR;
 }
@@ -77,11 +77,11 @@ static CHIP_ERROR ConfigGetDeviceId(bool printHeader)
     streamer_t * sout = streamer_get();
     uint64_t value64;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetDeviceId(value64));
     if (printHeader)
     {
         streamer_printf(sout, "DeviceId:        ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetDeviceId(value64));
     streamer_printf(sout, "%" PRIu64 " (0x" ChipLogFormatX64 ")\r\n", value64, ChipLogValueX64(value64));
     return CHIP_NO_ERROR;
 }
@@ -91,11 +91,11 @@ static CHIP_ERROR ConfigGetSetupPinCode(bool printHeader)
     streamer_t * sout = streamer_get();
     uint32_t setupPinCode;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetSetupPinCode(setupPinCode));
     if (printHeader)
     {
         streamer_printf(sout, "PinCode:         ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetSetupPinCode(setupPinCode));
     streamer_printf(sout, "%09u\r\n", setupPinCode);
     return CHIP_NO_ERROR;
 }
@@ -105,11 +105,11 @@ static CHIP_ERROR ConfigGetSetupDiscriminator(bool printHeader)
     streamer_t * sout = streamer_get();
     uint16_t setupDiscriminator;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetSetupDiscriminator(setupDiscriminator));
     if (printHeader)
     {
         streamer_printf(sout, "Discriminator:   ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetSetupDiscriminator(setupDiscriminator));
     streamer_printf(sout, "%03x\r\n", setupDiscriminator & 0xFFF);
     return CHIP_NO_ERROR;
 }
@@ -119,11 +119,11 @@ static CHIP_ERROR ConfigGetFabricId(bool printHeader)
     streamer_t * sout = streamer_get();
     uint64_t value64;
 
+    ReturnErrorOnFailure(ConfigurationMgr().GetFabricId(value64));
     if (printHeader)
     {
         streamer_printf(sout, "FabricId:        ");
     }
-    ReturnErrorOnFailure(ConfigurationMgr().GetFabricId(value64));
     streamer_printf(sout, "%" PRIu64 " (0x" ChipLogFormatX64 ")\r\n", value64, ChipLogValueX64(value64));
     return CHIP_NO_ERROR;
 }

--- a/src/lib/shell/streamer_zephyr.cpp
+++ b/src/lib/shell/streamer_zephyr.cpp
@@ -30,6 +30,7 @@
 namespace chip {
 namespace Shell {
 namespace {
+const shell* sShellInstance;
 
 int streamer_zephyr_init(streamer_t * streamer)
 {
@@ -46,13 +47,14 @@ ssize_t streamer_zephyr_read(streamer_t * streamer, char * buffer, size_t length
 ssize_t streamer_zephyr_write(streamer_t * streamer, const char * buffer, size_t length)
 {
     ARG_UNUSED(streamer);
-    for (size_t i = 0; i < length; ++i)
-        // TODO: Don't assume that UART backend is used.
-        shell_fprintf(shell_backend_uart_get_ptr(), SHELL_NORMAL, "%c", buffer[i]);
+
+    if (sShellInstance)
+        shell_fprintf(sShellInstance, SHELL_NORMAL, "%.*s", length, buffer);
+
     return length;
 }
 
-static streamer_t streamer_zephyr = {
+streamer_t sStreamer = {
     .init_cb  = streamer_zephyr_init,
     .read_cb  = streamer_zephyr_read,
     .write_cb = streamer_zephyr_write,
@@ -61,7 +63,12 @@ static streamer_t streamer_zephyr = {
 
 streamer_t * streamer_get(void)
 {
-    return &streamer_zephyr;
+    return &sStreamer;
+}
+
+void streamer_set_shell(const shell* shellInstance)
+{
+    sShellInstance = shellInstance;
 }
 
 } // namespace Shell

--- a/src/lib/shell/streamer_zephyr.cpp
+++ b/src/lib/shell/streamer_zephyr.cpp
@@ -30,7 +30,7 @@
 namespace chip {
 namespace Shell {
 namespace {
-const shell* sShellInstance;
+const shell * sShellInstance;
 
 int streamer_zephyr_init(streamer_t * streamer)
 {
@@ -66,7 +66,7 @@ streamer_t * streamer_get(void)
     return &sStreamer;
 }
 
-void streamer_set_shell(const shell* shellInstance)
+void streamer_set_shell(const shell * shellInstance)
 {
     sShellInstance = shellInstance;
 }

--- a/src/lib/shell/streamer_zephyr.h
+++ b/src/lib/shell/streamer_zephyr.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+struct shell;
+
+namespace chip {
+namespace Shell {
+
+void streamer_set_shell(const shell * shellInstance);
+
+} // namespace Shell
+} // namespace chip


### PR DESCRIPTION
#### Problem
Matter commands on nRF Connect platform work correctly with UART console only. Moreover, their output is printed inefficiently, one character at a time, which may cause that the output is interwoven with logs and other console output.

#### Change overview
* Support Matter commands in shells other than UART-based.
* Write whole line at once instead of one character at a time.
* Fix "config" command output when some configuration values are unknown.

#### Testing
Tested with "config" command on nRF52840 DK
