### PR TITLE
Don't wait for CASE connection if resolve fails in chip-device-ctrl

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -110,10 +110,14 @@ class ChipDeviceController(object):
         def HandleAddressUpdateComplete(nodeid, err):
             if err != 0:
                 print("Failed to update node address: {}".format(err))
+                # Failed update address, don't wait for HandleCommissioningComplete
+                self.state = DCState.IDLEHandleCommissioningComplete
+                self._ChipStack.callbackRes = err
+                self._ChipStack.completeEvent.set()
             else:
                 print("Node address has been updated")
-            # Wait for HandleCommissioningComplete before setting
-            # self._ChipStack.callbackRes; we're not done until that happens.
+                # Wait for HandleCommissioningComplete before setting
+                # self._ChipStack.callbackRes; we're not done until that happens.
 
         def HandleCommissioningComplete(nodeid, err):
             if err != 0:


### PR DESCRIPTION
#### Problem
`chip-device-ctrl` would wait forever for CASE connection callback if name resolution fails (regression from #8012)

#### Change overview
Don't wait for `HandleCommissioningComplete` callback if `HandleAddressUpdateComplete` was passed an error

#### Testing
How was this tested? (at least one bullet point required)
* Manually tested with chip-device-ctrl
