### PR TITLE
Zap was not generating the files when calling generate.py

### DIFF
--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -22,6 +22,7 @@ const queryEndpoint = require(zapPath + 'db/query-endpoint.js')
 const templateUtil  = require(zapPath + 'generator/template-util.js')
 const zclHelper     = require(zapPath + 'generator/helper-zcl.js')
 const zclQuery      = require(zapPath + 'db/query-zcl.js')
+const queryCommand  = require(zapPath + 'db/query-command.js')
 
 const { Deferred }    = require('./Deferred.js');
 const ListHelper      = require('./ListHelper.js');
@@ -85,7 +86,7 @@ function loadClusters()
 function loadCommandArguments(command, packageId)
 {
   const { db, sessionId } = this.global;
-  return zclQuery.selectCommandArgumentsByCommandId(db, command.id, packageId).then(commandArguments => {
+  return queryCommand.selectCommandArgumentsByCommandId(db, command.id, packageId).then(commandArguments => {
     command.arguments = commandArguments;
     return command;
   });


### PR DESCRIPTION
#### Problem
What is being fixed?
* Fix ZAP generating files
* Error: TypeError: zclQuery.selectCommandArgumentsByCommandId is not a function

#### Change overview
Updated the call selectCommandArgumentsByCommandId to the correct obj.

#### Testing
How was this tested? (at least one bullet point required)
* Manually ran the following command:
(python_env) vscode@docker-desktop:/workspaces/connectedhomeip_fork/third_party/zap/repo$ ../../../scripts/tools/zap/generate.py /workspaces/connectedhomeip_fork/src/controller/data_model/controller-clusters.zap -t /workspaces/connectedhomeip_fork/src/pybindings/pycontroller/templates/templates.json