### PR TITLE
[workflows] Use shallow git clone in workflows

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -42,9 +42,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 #             - name: Initialize CodeQL
 #               uses: github/codeql-action/init@v1

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -43,9 +43,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 #             - name: Initialize CodeQL
 #               uses: github/codeql-action/init@v1

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -41,9 +41,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 #            - name: Initialize CodeQL
 #              uses: github/codeql-action/init@v1

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -42,9 +42,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 #             - name: Initialize CodeQL
 #               uses: github/codeql-action/init@v1

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -47,9 +47,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 
             - name: Build example

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -42,9 +42,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
             - name: Bootstrap
               timeout-minutes: 25

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -41,9 +41,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-              # Fetch depth 0 to get all history and be able to check mergepoint for bloat report
               with:
-                  fetch-depth: 0
                   submodules: true
 #             - name: Initialize CodeQL
 #               uses: github/codeql-action/init@v1


### PR DESCRIPTION
#### Problem
Some our github workflows fetch the entire commit history, allegedly to make bloat reports work, but after examining the bloat check script it appears that the requirement may be no longer valid. The bloat check script used to be run as part of the PR workflows, but now there's a separate workflow for the bloat report. Let's try if we can safely switch to the shallow cloning.

#### Change overview
* Use shallow cloning for workflows that build the examples.

#### Testing
CI only change - no testing needed.