### PR TITLE
[ChipTool] Add pairing qrcode/manualcode option

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -32,6 +32,18 @@ public:
     PairBypass() : PairingCommand("bypass", PairingMode::Bypass, PairingNetworkType::None) {}
 };
 
+class PairQRCode : public PairingCommand
+{
+public:
+    PairQRCode() : PairingCommand("qrcode", PairingMode::QRCode, PairingNetworkType::None) {}
+};
+
+class PairManualCode : public PairingCommand
+{
+public:
+    PairManualCode() : PairingCommand("manualcode", PairingMode::ManualCode, PairingNetworkType::None) {}
+};
+
 class PairOnNetwork : public PairingCommand
 {
 public:
@@ -67,8 +79,9 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),     make_unique<PairBypass>(), make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
-        make_unique<PairSoftAP>(), make_unique<Ethernet>(),   make_unique<PairOnNetwork>(),
+        make_unique<Unpair>(),         make_unique<PairBypass>(),  make_unique<PairQRCode>(),
+        make_unique<PairManualCode>(), make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),
+        make_unique<PairSoftAP>(),     make_unique<Ethernet>(),    make_unique<PairOnNetwork>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -20,6 +20,9 @@
 #include "platform/PlatformManager.h"
 #include <lib/core/CHIPSafeCasts.h>
 
+#include <setup_payload/ManualSetupPayloadParser.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
+
 using namespace ::chip;
 
 constexpr uint64_t kBreadcrumb                = 0;
@@ -56,6 +59,12 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::Bypass:
         err = PairWithoutSecurity(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;
+    case PairingMode::QRCode:
+        err = PairWithQRCode(remoteId);
+        break;
+    case PairingMode::ManualCode:
+        err = PairWithManualCode(remoteId);
+        break;
     case PairingMode::Ble:
         err = Pair(remoteId, PeerAddress::BLE());
         break;
@@ -69,6 +78,33 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     }
 
     return err;
+}
+
+CHIP_ERROR PairingCommand::PairWithQRCode(NodeId remoteId)
+{
+    SetupPayload payload;
+    ReturnErrorOnFailure(QRCodeSetupPayloadParser(mOnboardingPayload).populatePayload(payload));
+    return PairWithCode(remoteId, payload);
+}
+
+CHIP_ERROR PairingCommand::PairWithManualCode(NodeId remoteId)
+{
+    SetupPayload payload;
+    ReturnErrorOnFailure(ManualSetupPayloadParser(mOnboardingPayload).populatePayload(payload));
+    return PairWithCode(remoteId, payload);
+}
+
+CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId, SetupPayload payload)
+{
+    chip::RendezvousInformationFlags rendezvousInformation = payload.rendezvousInformation;
+    ReturnErrorCodeIf(rendezvousInformation != RendezvousInformationFlag::kBLE, CHIP_ERROR_INVALID_ARGUMENT);
+
+    RendezvousParameters params = RendezvousParameters()
+                                      .SetSetupPINCode(payload.setUpPINCode)
+                                      .SetDiscriminator(payload.discriminator)
+                                      .SetPeerAddress(PeerAddress::BLE());
+
+    return GetExecContext()->commissioner->PairDevice(remoteId, params);
 }
 
 CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -24,12 +24,15 @@
 #include "gen/CHIPClusters.h"
 
 #include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <setup_payload/SetupPayload.h>
 #include <support/Span.h>
 
 enum class PairingMode
 {
     None,
     Bypass,
+    QRCode,
+    ManualCode,
     Ble,
     SoftAP,
     Ethernet,
@@ -73,6 +76,11 @@ public:
         case PairingMode::Bypass:
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            break;
+        case PairingMode::QRCode:
+        case PairingMode::ManualCode:
+            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
+            AddArgument("payload", &mOnboardingPayload);
             break;
         case PairingMode::Ble:
             AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
@@ -118,6 +126,9 @@ public:
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);
     CHIP_ERROR Pair(NodeId remoteId, PeerAddress address);
+    CHIP_ERROR PairWithQRCode(NodeId remoteId);
+    CHIP_ERROR PairWithManualCode(NodeId remoteId);
+    CHIP_ERROR PairWithCode(NodeId remoteId, chip::SetupPayload payload);
     CHIP_ERROR PairWithoutSecurity(NodeId remoteId, PeerAddress address);
     CHIP_ERROR Unpair(NodeId remoteId);
 
@@ -140,6 +151,7 @@ private:
     chip::ByteSpan mOperationalDataset;
     chip::ByteSpan mSSID;
     chip::ByteSpan mPassword;
+    char * mOnboardingPayload;
 
     chip::Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> * mOnAddThreadNetworkCallback = nullptr;
     chip::Callback::Callback<NetworkCommissioningClusterAddWiFiNetworkResponseCallback> * mOnAddWiFiNetworkCallback     = nullptr;


### PR DESCRIPTION
#### Problem

`chip-tool` does not accepts manual code or qrcode for the `pairing` command.

#fixes #8042

#### Change overview
 * Add `chip-tool pairing qrcode` command
 * Add `chip-tool pairing manualcode` command

#### Testing
 @cjandhyala Can you confirm that it works as you expect ?