### PR TITLE
Add CI for disabling detail logging.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,12 @@ jobs:
 
         strategy:
             matrix:
-                type: [gcc_debug, gcc_release, clang, mbedtls, clang_experimental]
+                type: [gcc_debug, gcc_release, clang, mbedtls, clang_experimental, no_detail_logging]
+                # Disabling progress logging does not compile yet.  Once it does, we can add the no_progress_logging type.
         env:
             BUILD_TYPE: ${{ matrix.type }}
+            DETAIL_LOGGING: ${{ matrix.type != 'no_detail_logging' && matrix.type != 'no_progress_logging' }}
+            PROGRESS_LOGGING: ${{ matrix.type != 'no_progress_logging' }}
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -85,7 +88,7 @@ jobs:
                      *) ;;
                   esac
 
-                  scripts/build/gn_gen.sh --args="$GN_ARGS"
+                  scripts/build/gn_gen.sh --args="$GN_ARGS chip_detail_logging=${DETAIL_LOGGING} chip_progress_logging=${PROGRESS_LOGGING}"
             - name: Run Build
               timeout-minutes: 10
               run: scripts/build/gn_build.sh


### PR DESCRIPTION
This way we won't have to worry about problems popping up if/when
someone tries to do that.

For now assuming no one really plans to disable error logging.

#### Problem
#8135 had to happen because we have no CI for the "detail logging disabled" configuration that is used by `scripts/build_python.sh` by default.

#### Change overview
Add basic CI for a build in this configuration.

#### Testing
Verified that this CI fails without the change from #8135 and passes on tip.