### PR TITLE
Move IM standalone test run on a single event loop

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -296,12 +296,6 @@ void HandleWriteComplete()
            static_cast<double>(gWriteRespCount) * 100 / gWriteCount, static_cast<double>(transitTime) / 1000);
 }
 
-void Shutdown()
-{
-    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
-    ShutdownChip();
-}
-
 void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -335,7 +329,7 @@ void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appSta
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 }
 
@@ -355,7 +349,7 @@ void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * app
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 }
 
@@ -388,7 +382,7 @@ void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState,
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 }
 
@@ -419,13 +413,13 @@ void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState
     else
     {
         // Complete all tests.
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 }
 
@@ -595,6 +589,9 @@ int main(int argc, char * argv[])
     SuccessOrExit(err);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+    ShutdownChip();
 exit:
     if (err != CHIP_NO_ERROR || (gCommandRespCount != kMaxCommandMessageCount + kTotalFailureCommandMessageCount))
     {

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -58,7 +58,6 @@ exit:
 
 void ShutdownChip(void)
 {
-    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* This PR is to fix the remaining race issues happens in IM test by running everything within a single event loop.
* Currently, Platform Layer provides both API RunEventLoop to run Matter on the app main thread and StartEventLoopTask/StopEventLoopTask to run Matter on a separate thread.  For internal testing, we plan to make all test apps single threaded to prevent any race issue occurs.

* Fixes #7939 

#### Change overview
Move IM standalone test run on a single event loop

#### Testing
How was this tested? (at least one bullet point required)
Setting up cirque environment
git submodule update --init
./scripts/tests/cirque_tests.sh bootstrap

Run IM test for 10 times and confirmed no race issue occurs
./scripts/tests/cirque_tests.sh run_test InteractionModelTest
