### PR TITLE
Minor clean-ups in src/crypto

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -20,8 +20,7 @@
  *      Header that exposes the platform agnostic CHIP crypto primitives
  */
 
-#ifndef _CHIP_CRYPTO_PAL_H_
-#define _CHIP_CRYPTO_PAL_H_
+#pragma once
 
 #if CHIP_HAVE_CONFIG_H
 #include <crypto/CryptoBuildConfig.h>
@@ -946,5 +945,3 @@ CHIP_ERROR ExtractPubkeyFromX509Cert(const ByteSpan & certificate, Crypto::P256P
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1331,31 +1331,8 @@ void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl()
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const uint8_t * key, size_t key_len, const uint8_t * in, size_t in_len, uint8_t * out)
 {
-    CHIP_ERROR error         = CHIP_ERROR_INTERNAL;
-    int error_openssl        = 0;
-    unsigned int mac_out_len = 0;
-
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
-
-    HMAC_CTX * mac_ctx = HMAC_CTX_new();
-    VerifyOrExit(mac_ctx != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(CanCastTo<int>(key_len), error = CHIP_ERROR_INTERNAL);
-    error_openssl = HMAC_Init_ex(mac_ctx, Uint8::to_const_uchar(key), static_cast<int>(key_len), context->md_info, nullptr);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error_openssl = HMAC_Update(mac_ctx, Uint8::to_const_uchar(in), in_len);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(CanCastTo<int>(hash_size), error = CHIP_ERROR_INTERNAL);
-    mac_out_len   = static_cast<unsigned int>(hash_size);
-    error_openssl = HMAC_Final(mac_ctx, Uint8::to_uchar(out), &mac_out_len);
-    VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = CHIP_NO_ERROR;
-exit:
-    HMAC_CTX_free(mac_ctx);
-    return error;
+    HMAC_sha hmac;
+    return hmac.HMAC_SHA256(key, key_len, in, in_len, out, kSHA256_Hash_Length);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::MacVerify(const uint8_t * key, size_t key_len, const uint8_t * mac, size_t mac_len,

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -951,31 +951,8 @@ void Spake2p_P256_SHA256_HKDF_HMAC::FreeImpl(void)
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::Mac(const uint8_t * key, size_t key_len, const uint8_t * in, size_t in_len, uint8_t * out)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
-
-    mbedtls_md_context_t hmac_ctx;
-    mbedtls_md_init(&hmac_ctx);
-
-    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
-
-    result = mbedtls_md_setup(&hmac_ctx, context->md_info, 1);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_md_hmac_starts(&hmac_ctx, Uint8::to_const_uchar(key), key_len);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_md_hmac_update(&hmac_ctx, Uint8::to_const_uchar(in), in_len);
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-    result = mbedtls_md_hmac_finish(&hmac_ctx, Uint8::to_uchar(out));
-    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    _log_mbedTLS_error(result);
-
-    mbedtls_md_free(&hmac_ctx);
-    return error;
+    HMAC_sha hmac;
+    return hmac.HMAC_SHA256(key, key_len, in, in_len, out, kSHA256_Hash_Length);
 }
 
 /**

--- a/src/crypto/hsm/CHIPCryptoPALHsm.h
+++ b/src/crypto/hsm/CHIPCryptoPALHsm.h
@@ -20,8 +20,7 @@
  *      Header that exposes the platform agnostic CHIP crypto primitives
  */
 
-#ifndef _CHIP_CRYPTO_PAL_HSM_H_
-#define _CHIP_CRYPTO_PAL_HSM_H_
+#pragma once
 
 #include "CHIPCryptoPALHsm_config.h"
 
@@ -210,5 +209,3 @@ private:
 
 } // namespace Crypto
 } // namespace chip
-
-#endif //#ifndef _CHIP_CRYPTO_PAL_HSM_H_

--- a/src/crypto/hsm/CHIPCryptoPALHsm_config.h
+++ b/src/crypto/hsm/CHIPCryptoPALHsm_config.h
@@ -20,8 +20,7 @@
  *      Header that exposes the options to enable HSM for required crypto operations.
  */
 
-#ifndef _CHIP_CRYPTO_PAL_HSM_CONFIG_H_
-#define _CHIP_CRYPTO_PAL_HSM_CONFIG_H_
+#pragma once
 
 /*
  * Enable HSM for SPAKE VERIFIER
@@ -74,5 +73,3 @@
 #if ((CHIP_CRYPTO_HSM) && (ENABLE_HSM_HMAC_SHA256))
 #define ENABLE_HSM_HMAC
 #endif
-
-#endif //#ifndef _CHIP_CRYPTO_PAL_HSM_CONFIG_H_

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_utils.h
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_utils.h
@@ -15,8 +15,7 @@
  *    limitations under the License.
  */
 
-#ifndef _CHIP_CRYPTO_PAL_HSM_SE05X_UTILS_
-#define _CHIP_CRYPTO_PAL_HSM_SE05X_UTILS_
+#pragma once
 
 #include <string.h>
 
@@ -98,5 +97,3 @@ void setObjID(SE05x_CryptoObjectID_t objId, uint8_t status);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /*_CHIP_CRYPTO_PAL_HSM_SE05X_UTILS_*/

--- a/src/crypto/tests/AES_CCM_256_test_vectors.h
+++ b/src/crypto/tests/AES_CCM_256_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains AES-CCM test vectors.
  */
 
-#ifndef _AES_CCM_256_TEST_VECTORS_H_
-#define _AES_CCM_256_TEST_VECTORS_H_
+#pragma once
 
 typedef struct ccm_test_vector
 {
@@ -1527,4 +1526,3 @@ static const struct ccm_test_vector chiptest_12cb0ed34854_test_vector_1471 = { .
 
 static const struct ccm_test_vector * ccm_invalid_test_vectors[] = { &chiptest_12cb0ed34854_test_vector_3781,
                                                                      &chiptest_12cb0ed34854_test_vector_1471 };
-#endif

--- a/src/crypto/tests/ECDH_P256_test_vectors.h
+++ b/src/crypto/tests/ECDH_P256_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains ECDH P256 test vectors.
  */
 
-#ifndef _ECDH_P256_TEST_VECTORS_H_
-#define _ECDH_P256_TEST_VECTORS_H_
+#pragma once
 
 typedef struct ECDH_P256_test_vector
 {
@@ -92,4 +91,3 @@ ECDH_P256_test_vector ecdh_v3 = { .local_pvt_key         = local_private_key3,
                                   .shared_secret_length  = sizeof(shared_secret3) };
 
 ECDH_P256_test_vector ecdh_test_vectors[] = { ecdh_v1, ecdh_v2, ecdh_v3 };
-#endif

--- a/src/crypto/tests/HKDF_SHA256_test_vectors.h
+++ b/src/crypto/tests/HKDF_SHA256_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains HKDF SHA256 test vectors. https://tools.ietf.org/html/rfc5869
  */
 
-#ifndef _HKDF_SHA256_TEST_VECTOR
-#define _HKDF_SHA256_TEST_VECTOR
+#pragma once
 
 #include <stddef.h>
 
@@ -121,4 +120,3 @@ hkdf_sha256_vector v3 = { .initial_key_material        = IKM3,
                           .output_key_material_length  = sizeof(expected_OKM3) };
 
 hkdf_sha256_vector hkdf_sha256_test_vectors[] = { v1, v2, v3 };
-#endif

--- a/src/crypto/tests/HMAC_SHA256_test_vectors.h
+++ b/src/crypto/tests/HMAC_SHA256_test_vectors.h
@@ -21,8 +21,7 @@
  * See https://tools.ietf.org/html/rfc4231#section-4.7
  */
 
-#ifndef _HMAC_SHA256_TEST_VECTOR
-#define _HMAC_SHA256_TEST_VECTOR
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -67,4 +66,3 @@ hmac_sha256_vector kHmacSha256TestCase1 = { .key                = kHmacTestCase1
                                             .output_hash_length = sizeof(kHmacTestCase1Expected) };
 
 hmac_sha256_vector hmac_sha256_test_vectors[] = { kHmacSha256TestCase1 };
-#endif

--- a/src/crypto/tests/Hash_SHA256_test_vectors.h
+++ b/src/crypto/tests/Hash_SHA256_test_vectors.h
@@ -21,8 +21,7 @@
  *         http://csrc.nist.gov/groups/STM/cavp/index.html
  */
 
-#ifndef _HASH_SHA256_TEST_VECTOR
-#define _HASH_SHA256_TEST_VECTOR
+#pragma once
 
 #include <stddef.h>
 
@@ -164,4 +163,3 @@ const uint8_t hash11[] = { 0x6c, 0x83, 0xf9, 0xb6, 0x97, 0x54, 0xfa, 0xcc, 0x31,
 hash_sha256_vector v11 = { .data = data11, .data_length = sizeof(data11), .hash = hash11 };
 
 hash_sha256_vector hash_sha256_test_vectors[] = { v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11 };
-#endif

--- a/src/crypto/tests/SPAKE2P_FE_MUL_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_FE_MUL_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains field element multipication test vectors.
  */
 
-#ifndef _SPAKE2P_FE_MUL_TEST_VECTORS_H_
-#define _SPAKE2P_FE_MUL_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -387,5 +386,3 @@ static const struct spake2p_fe_mul_tv * fe_mul_tvs[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_FE_RW_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_FE_RW_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains read / write field element test vectors.
  */
 
-#ifndef _SPAKE2P_FE_RW_TEST_VECTORS_H_
-#define _SPAKE2P_FE_RW_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -120,5 +119,3 @@ static const struct spake2p_fe_rw_tv * fe_rw_tvs[] = { &chiptest_53ea71b7cccd_te
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_HMAC_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_HMAC_test_vectors.h
@@ -16,11 +16,10 @@
  */
 
 /**
- * @file - This file contains hmac test vectors.
+ * @file - This file contains SPAKE2P HMAC test vectors.
  */
 
-#ifndef _SPAKE2P_FE_HMAC_TEST_VECTORS_H_
-#define _SPAKE2P_FE_HMAC_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -131,5 +130,3 @@ static const struct spake2p_hmac_tv * hmac_tvs[] = { &chiptest_be68c22260b3_test
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_POINT_MUL_ADD_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_POINT_MUL_ADD_test_vectors.h
@@ -16,11 +16,10 @@
  */
 
 /**
- * @file - This file contains point multipication & addition test vectors.
+ * @file - This file contains elliptic curve point multiplication & addition test vectors.
  */
 
-#ifndef _SPAKE2P_POINT_MUL_ADD_TEST_VECTORS_H_
-#define _SPAKE2P_POINT_MUL_ADD_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -772,5 +771,3 @@ static const struct spake2p_point_muladd_tv * point_muladd_tvs[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_POINT_MUL_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_POINT_MUL_test_vectors.h
@@ -16,11 +16,10 @@
  */
 
 /**
- * @file - This file contains point multipication test vectors.
+ * @file - This file contains elliptic curve point multipication test vectors.
  */
 
-#ifndef _SPAKE2P_POINT_MUL_TEST_VECTORS_H_
-#define _SPAKE2P_POINT_MUL_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -508,5 +507,3 @@ static const struct spake2p_point_mul_tv * point_mul_tvs[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_POINT_RW_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_POINT_RW_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains point r/w test vectors.
  */
 
-#ifndef _SPAKE2P_POINT_RW_TEST_VECTORS_H_
-#define _SPAKE2P_POINT_RW_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -140,5 +139,3 @@ static const struct spake2p_point_rw_tv * point_rw_tvs[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_POINT_VALID_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_POINT_VALID_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains point validity test vectors.
  */
 
-#ifndef _SPAKE2P_POINT_VALID_TEST_VECTORS_H_
-#define _SPAKE2P_POINT_VALID_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -491,5 +490,3 @@ static const struct spake2p_point_valid_tv * point_valid_tvs[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/SPAKE2P_RFC_test_vectors.h
+++ b/src/crypto/tests/SPAKE2P_RFC_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains Spake2+ RFC test vectors.
  */
 
-#ifndef _SPAKE2P_POINT_RFC_TEST_VECTORS_H_
-#define _SPAKE2P_POINT_RFC_TEST_VECTORS_H_
+#pragma once
 
 namespace chip {
 namespace Crypto {
@@ -441,5 +440,3 @@ static const struct spake2p_rfc_tv * rfc_tvs[] = { &chiptest_e4836c3b50dd_test_v
 
 } // namespace Crypto
 } // namespace chip
-
-#endif

--- a/src/crypto/tests/X509_PKCS7Extraction_test_vectors.h
+++ b/src/crypto/tests/X509_PKCS7Extraction_test_vectors.h
@@ -19,8 +19,7 @@
  * @file - This file contains PKCS7 test vectors.
  */
 
-#ifndef _X509_PKCS7_EXTRACTION_H_
-#define _X509_PKCS7_EXTRACTION_H_
+#pragma once
 
 #include <cstdint>
 
@@ -144,5 +143,3 @@ static const uint8_t certificate_blob_root[] = {
 
 } // namespace Crypto
 } // namespace chip
-
-#endif


### PR DESCRIPTION
#### Problem
* `#pragma once` is not uniformly used, and this was raised in a previous PR.
* Spake2+ uses own impl of HMAC when there is a common one more widely applicable.

#### Change overview
- Replace all header guards with `#pragma once` that
  were not already.
- Replace "specific" implementation of HMAC in SPAKE2P
  impl with the common HMAC method, saving bytes overall
  once HMAC is more frequently used outside of SPAKE2P
- Minor typo fixes and some added context to comments

#### Testing
- Testing done: ran OpenSSL and mbedTLS unit tests and still pass

