### PR TITLE
Fix bloat check workflow concurrency

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -19,7 +19,9 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}
-    cancel-in-progress: true
+    # Don't cancel an already-running bloat check just because it took more
+    # than 5 minutes to run and our cron job is trying to schedule a new one.
+    cancel-in-progress: false
   
 jobs:
     pull_request_update:


### PR DESCRIPTION
#### Problem
We have not had a completed bloat check in 13 hours; new ones keep canceling old ones.

#### Change overview
Make new bloat checks not cancel old ones, at least if the old ones are running already.

#### Testing
Will see if it helps when it merges... Hard to test otherwise.