### PR TITLE
[im] Seperate dispatch route for CommandSender and CommandHandler

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace BarrierControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -158,7 +159,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Basic {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -211,7 +213,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Binding {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -406,7 +409,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ColorControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1885,7 +1889,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2009,7 +2014,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DoorLock {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3420,7 +3426,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace EthernetNetworkDiagnostics {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3480,7 +3487,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3680,7 +3688,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Groups {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4050,7 +4059,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace IasZone {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4166,7 +4176,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Identify {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4284,7 +4295,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4818,7 +4830,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LowPower {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4877,7 +4890,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5570,7 +5584,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OtaSoftwareUpdateProvider {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5856,7 +5871,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5927,7 +5943,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -6438,7 +6455,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Scenes {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -6943,7 +6961,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TestCluster {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -7015,7 +7034,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -7081,6 +7100,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::TestCluster::Id:
         clusters::TestCluster::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace ColorControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1519,7 +1520,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1643,7 +1645,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace EthernetNetworkDiagnostics {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1703,7 +1706,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1903,7 +1907,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2437,7 +2442,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3130,7 +3136,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3201,7 +3208,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3713,7 +3721,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -3746,6 +3754,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::OperationalCredentials::Id:
         clusters::OperationalCredentials::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -164,7 +165,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -364,7 +366,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1057,7 +1060,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1128,7 +1132,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1640,7 +1645,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -1664,6 +1669,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::OperationalCredentials::Id:
         clusters::OperationalCredentials::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace Basic {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -93,7 +94,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -217,7 +219,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -417,7 +420,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -951,7 +955,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1585,7 +1590,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1656,7 +1662,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2168,7 +2175,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -2198,6 +2205,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::OperationalCredentials::Id:
         clusters::OperationalCredentials::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace Basic {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -93,7 +94,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -217,7 +219,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -417,7 +420,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1110,7 +1114,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1622,7 +1627,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -1646,6 +1651,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::OperationalCredentials::Id:
         clusters::OperationalCredentials::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -164,7 +165,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -364,7 +366,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -915,7 +918,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1427,7 +1431,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -1448,6 +1452,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::OperationalCredentials::Id:
         clusters::OperationalCredentials::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -24,6 +24,7 @@
 #include <app/common/gen/command-id.h>
 
 #include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPSafeCasts.h>
@@ -102,7 +103,8 @@ static void sendResponse(const char * responseName, ContentLaunchResponse launch
     }
 }
 
-bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::Command * command, unsigned char autoplay, unsigned char * data)
+bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::CommandHandler * command, unsigned char autoplay,
+                                                        unsigned char * data)
 {
 
     string dataString(reinterpret_cast<char *>(data));
@@ -112,7 +114,7 @@ bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::Command * com
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::Command * command, unsigned char * contentUrl,
+bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::CommandHandler * command, unsigned char * contentUrl,
                                                     unsigned char * displayString)
 {
     string contentUrlString(reinterpret_cast<char *>(contentUrl));

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace AccountLogin {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -220,7 +221,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ApplicationBasic {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -332,7 +334,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ApplicationLauncher {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -455,7 +458,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace AudioOutput {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -631,7 +635,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Basic {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -684,7 +689,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Binding {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -879,7 +885,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ContentLauncher {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1063,7 +1070,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DiagnosticLogs {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1187,7 +1195,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1387,7 +1396,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace KeypadInput {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1499,7 +1509,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2033,7 +2044,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace LowPower {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2092,7 +2104,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace MediaInput {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2280,7 +2293,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace MediaPlayback {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2558,7 +2572,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3251,7 +3266,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OtaSoftwareUpdateProvider {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3537,7 +3553,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3608,7 +3625,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4119,7 +4137,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TvChannel {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4354,7 +4373,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TargetNavigator {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4472,7 +4492,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -4541,6 +4561,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::TargetNavigator::Id:
         clusters::TargetNavigator::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/window-app/common/gen/IMClusterCommandHandler.cpp
+++ b/examples/window-app/common/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -240,7 +241,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -933,7 +935,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1444,7 +1447,8 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace WindowCovering {
 
-void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1762,7 +1766,7 @@ void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -1783,6 +1787,32 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     case Clusters::WindowCovering::Id:
         clusters::WindowCovering::DispatchServerCommand(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/examples/window-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/window-app/efr32/src/ZclCallbacks.cpp
@@ -23,6 +23,7 @@
 #include <AppConfig.h>
 #include <AppTask.h>
 #include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/util/af-types.h>
@@ -54,7 +55,7 @@ void emberAfWindowCoveringClusterInitCallback(chip::EndpointId endpoint)
  * @brief Window Covering Cluster UpOrOpen Command callback
  */
 
-bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::app::Command *)
+bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::app::CommandHandler *)
 {
     EFR32_LOG("Window UpOrOpen command received");
     AppTask::Instance().Cover().Open();
@@ -67,7 +68,7 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::app::Command *)
  * @brief Window Covering Cluster DownOrClose Command callback
  */
 
-bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::app::Command *)
+bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::app::CommandHandler *)
 {
     EFR32_LOG("Window DownOrClose command received");
     AppTask::Instance().Cover().Close();
@@ -81,7 +82,7 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::app::Command *)
  * @param liftPercentageValue
  */
 
-bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::Command *, uint8_t liftPercentageValue)
+bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::CommandHandler *, uint8_t liftPercentageValue)
 {
     EFR32_LOG("Window GoToLiftPercentage command received");
     AppTask::Instance().Cover().LiftGotoPercent(liftPercentageValue);
@@ -96,7 +97,7 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::Command *
  * @param liftPercent100thsValue
  */
 
-bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::Command *, uint8_t liftPercentageValue,
+bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::CommandHandler *, uint8_t liftPercentageValue,
                                                             uint16_t liftPercent100thsValue)
 {
     EFR32_LOG("Window GoToLiftPercentage w/ Percent100ths command received");
@@ -111,7 +112,7 @@ bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::Command *
  * @param liftValue
  */
 
-bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::app::Command *, uint16_t liftValue)
+bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::app::CommandHandler *, uint16_t liftValue)
 {
     EFR32_LOG("Window GoToLiftValue command received");
     AppTask::Instance().Cover().LiftGotoValue(liftValue);
@@ -125,7 +126,7 @@ bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::app::Command *, uin
  * @param tiltPercentageValue
  */
 
-bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::Command *, uint8_t tiltPercentageValue)
+bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::CommandHandler *, uint8_t tiltPercentageValue)
 {
     EFR32_LOG("Window GoToTiltPercentage command received");
     AppTask::Instance().Cover().TiltGotoPercent(tiltPercentageValue);
@@ -140,7 +141,7 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::Command *
  * @param tiltPercent100thsValue
  */
 
-bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::Command *, uint8_t tiltPercentageValue,
+bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::CommandHandler *, uint8_t tiltPercentageValue,
                                                             uint16_t tiltPercent100thsValue)
 {
     EFR32_LOG("Window GoToTiltPercentage w/ Percent100ths command received");
@@ -155,7 +156,7 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::Command *
  * @param tiltValue
  */
 
-bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::app::Command *, uint16_t tiltValue)
+bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::app::CommandHandler *, uint16_t tiltValue)
 {
     EFR32_LOG("Window GoToTiltValue command received");
     AppTask::Instance().Cover().TiltGotoValue(tiltValue);
@@ -168,7 +169,7 @@ bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::app::Command *, uin
  * @brief Window Covering Cluster StopMotion Command callback
  */
 
-bool emberAfWindowCoveringClusterStopMotionCallback(chip::app::Command *)
+bool emberAfWindowCoveringClusterStopMotionCallback(chip::app::CommandHandler *)
 {
     EFR32_LOG("Window StopMotion command received");
     AppTask::Instance().Cover().Stop();

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -167,7 +167,7 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
         err = aCommandElement.GetData(&commandDataReader);
         SuccessOrExit(err);
         // TODO(#4503): Should call callbacks of cluster that sends the command.
-        DispatchSingleClusterCommand(clusterId, commandId, endpointId, commandDataReader, this);
+        DispatchSingleClusterResponseCommand(clusterId, commandId, endpointId, commandDataReader, this);
     }
 
 exit:

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -203,7 +203,9 @@ private:
 };
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj);
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj);
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj);
 
 /**
  *  Check whether the given cluster exists on the given endpoint and supports the given command.

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -21,7 +21,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/common/gen/command-id.h>
 #include <app/util/af.h>
@@ -30,7 +30,7 @@
 bool accountLoginClusterIsUserLoggedIn(std::string requestTempAccountIdentifier, std::string requestSetupPin);
 std::string accountLoginClusterGetSetupPin(std::string requestTempAccountIdentifier, chip::EndpointId endpoint);
 
-void sendResponse(chip::app::Command * command, const char * responseSetupPin)
+void sendResponse(chip::app::CommandHandler * command, const char * responseSetupPin)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_ACCOUNT_LOGIN_CLUSTER_ID,
@@ -48,7 +48,7 @@ exit:
     }
 }
 
-bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::Command * command, uint8_t * tempAccountIdentifier)
+bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::CommandHandler * command, uint8_t * tempAccountIdentifier)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string tempAccountIdentifierString(reinterpret_cast<char *>(tempAccountIdentifier));
@@ -57,7 +57,8 @@ bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::Command * command,
     return true;
 }
 
-bool emberAfAccountLoginClusterLoginCallback(chip::app::Command * command, uint8_t * tempAccountIdentifier, uint8_t * tempSetupPin)
+bool emberAfAccountLoginClusterLoginCallback(chip::app::CommandHandler * command, uint8_t * tempAccountIdentifier,
+                                             uint8_t * tempSetupPin)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string tempAccountIdentifierString(reinterpret_cast<char *>(tempAccountIdentifier));

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -22,14 +22,14 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 #include <string>
 
 bool applicationBasicClusterChangeApplicationStatus(EmberAfApplicationBasicStatus status, chip::EndpointId endpoint);
 
-bool emberAfApplicationBasicClusterChangeStatusCallback(chip::app::Command * commandObj, uint8_t newApplicationStatus)
+bool emberAfApplicationBasicClusterChangeStatusCallback(chip::app::CommandHandler * commandObj, uint8_t newApplicationStatus)
 {
     bool success = applicationBasicClusterChangeApplicationStatus(static_cast<EmberAfApplicationBasicStatus>(newApplicationStatus),
                                                                   emberAfCurrentEndpoint());

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -22,7 +22,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/clusters/application-launcher-server/application-launcher-server.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/cluster-id.h>
@@ -32,14 +32,14 @@
 
 ApplicationLauncherResponse applicationLauncherClusterLaunchApp(EmberAfApplicationLauncherApp application, std::string data);
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::Command * commandObj, uint8_t *, uint8_t *)
+bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::CommandHandler * commandObj, uint8_t *, uint8_t *)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 
-void sendResponse(chip::app::Command * command, ApplicationLauncherResponse response)
+void sendResponse(chip::app::CommandHandler * command, ApplicationLauncherResponse response)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_APPLICATION_LAUNCHER_CLUSTER_ID,
@@ -66,7 +66,7 @@ EmberAfApplicationLauncherApp getApplicationFromCommand(uint16_t catalogVendorId
     return application;
 }
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::Command * command, uint8_t * requestData,
+bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::CommandHandler * command, uint8_t * requestData,
                                                         uint16_t requestApplicationCatalogVendorId, uint8_t * requestApplicationId)
 {
     EmberAfApplicationLauncherApp application = getApplicationFromCommand(requestApplicationCatalogVendorId, requestApplicationId);

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -22,13 +22,13 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 bool audioOutputClusterSelectOutput(uint8_t index);
 bool audioOutputClusterRenameOutput(uint8_t index, uint8_t * name);
 
-bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::Command * command, uint8_t index, uint8_t * name)
+bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::CommandHandler * command, uint8_t index, uint8_t * name)
 {
     bool success         = audioOutputClusterRenameOutput(index, name);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -36,7 +36,7 @@ bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::Command * command,
     return true;
 }
 
-bool emberAfAudioOutputClusterSelectOutputCallback(chip::app::Command * command, uint8_t index)
+bool emberAfAudioOutputClusterSelectOutputCallback(chip::app::CommandHandler * command, uint8_t index)
 {
     bool success         = audioOutputClusterSelectOutput(index);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -39,7 +39,7 @@
  ******************************************************************************/
 
 #include "barrier-control-server.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/attributes/Accessors.h>
 #include <app/common/gen/ids/Clusters.h>
@@ -296,7 +296,7 @@ static void sendDefaultResponse(EmberAfStatus status)
     }
 }
 
-bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Command * commandObj, uint8_t percentOpen)
+bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::CommandHandler * commandObj, uint8_t percentOpen)
 {
     EndpointId endpoint  = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
@@ -338,7 +338,7 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Co
     return true;
 }
 
-bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::app::Command * commandObj)
+bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::app::CommandHandler * commandObj)
 {
     EndpointId endpoint = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
     emberAfDeactivateServerTick(endpoint, BarrierControl::Id);

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -22,7 +22,7 @@
 
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/binding-table.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -88,8 +88,8 @@ EmberStatus getUnusedBindingIndex(uint8_t * bindingIndex)
     return EMBER_NOT_FOUND;
 }
 
-bool emberAfBindingClusterBindCallback(chip::app::Command * commandObj, NodeId nodeId, GroupId groupId, EndpointId endpointId,
-                                       ClusterId clusterId)
+bool emberAfBindingClusterBindCallback(chip::app::CommandHandler * commandObj, NodeId nodeId, GroupId groupId,
+                                       EndpointId endpointId, ClusterId clusterId)
 {
     ChipLogDetail(Zcl, "RX: BindCallback");
 
@@ -118,8 +118,8 @@ bool emberAfBindingClusterBindCallback(chip::app::Command * commandObj, NodeId n
     return true;
 }
 
-bool emberAfBindingClusterUnbindCallback(chip::app::Command * commandObj, NodeId nodeId, GroupId groupId, EndpointId endpointId,
-                                         ClusterId clusterId)
+bool emberAfBindingClusterUnbindCallback(chip::app::CommandHandler * commandObj, NodeId nodeId, GroupId groupId,
+                                         EndpointId endpointId, ClusterId clusterId)
 {
     ChipLogDetail(Zcl, "RX: UnbindCallback");
 

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -41,7 +41,7 @@
 
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -419,8 +419,9 @@ static bool moveToHueAndSaturation(uint16_t hue, uint8_t saturation, uint16_t tr
  * @param saturation   Ver.: always
  * @param transitionTime   Ver.: always
  */
-bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t saturation,
-                                                              uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t hue,
+                                                              uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
+                                                              uint8_t optionsOverride)
 {
     return moveToHueAndSaturation(static_cast<uint16_t>(hue), saturation, transitionTime, optionsMask, optionsOverride, false);
 }
@@ -517,13 +518,13 @@ static bool moveHue(uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_
     return true;
 }
 
-bool emberAfColorControlClusterMoveHueCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                               uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveHueCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
+                                               uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveHue(moveMode, static_cast<uint16_t>(rate), optionsMask, optionsOverride, false);
 }
 
-bool emberAfColorControlClusterMoveSaturationCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate,
+bool emberAfColorControlClusterMoveSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -688,13 +689,13 @@ static bool moveToHue(uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime
     return true;
 }
 
-bool emberAfColorControlClusterMoveToHueCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t hueMoveMode,
+bool emberAfColorControlClusterMoveToHueCallback(chip::app::CommandHandler * commandObj, uint8_t hue, uint8_t hueMoveMode,
                                                  uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveToHue(static_cast<uint16_t>(hue), hueMoveMode, transitionTime, optionsMask, optionsOverride, false);
 }
 
-bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::Command * commandObj, uint8_t saturation,
+bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t saturation,
                                                         uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -827,14 +828,14 @@ static bool stepHue(uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime
     return true;
 }
 
-bool emberAfColorControlClusterStepHueCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfColorControlClusterStepHueCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     return stepHue(stepMode, static_cast<uint16_t>(stepSize), static_cast<uint16_t>(transitionTime), optionsMask, optionsOverride,
                    false);
 }
 
-bool emberAfColorControlClusterStepSaturationCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfColorControlClusterStepSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                       uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -967,7 +968,7 @@ static uint16_t readEnhancedHue(EndpointId endpoint)
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
 
-bool emberAfColorControlClusterMoveToColorCallback(chip::app::Command * commandObj, uint16_t colorX, uint16_t colorY,
+bool emberAfColorControlClusterMoveToColorCallback(chip::app::CommandHandler * commandObj, uint16_t colorX, uint16_t colorY,
                                                    uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1017,8 +1018,8 @@ bool emberAfColorControlClusterMoveToColorCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfColorControlClusterMoveColorCallback(chip::app::Command * commandObj, int16_t rateX, int16_t rateY, uint8_t optionsMask,
-                                                 uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveColorCallback(chip::app::CommandHandler * commandObj, int16_t rateX, int16_t rateY,
+                                                 uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
 
@@ -1098,7 +1099,7 @@ bool emberAfColorControlClusterMoveColorCallback(chip::app::Command * commandObj
     return true;
 }
 
-bool emberAfColorControlClusterStepColorCallback(chip::app::Command * commandObj, int16_t stepX, int16_t stepY,
+bool emberAfColorControlClusterStepColorCallback(chip::app::CommandHandler * commandObj, int16_t stepX, int16_t stepY,
                                                  uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1236,7 +1237,7 @@ static void moveToColorTemp(EndpointId endpoint, uint16_t colorTemperature, uint
     emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
 }
 
-bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::Command * commandObj, uint16_t colorTemperature,
+bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint16_t colorTemperature,
                                                               uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1253,7 +1254,7 @@ bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::Command
     return true;
 }
 
-bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::Command * commandObj, uint8_t moveMode, uint16_t rate,
+bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint16_t rate,
                                                             uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
                                                             uint8_t optionsMask, uint8_t optionsOverride)
 {
@@ -1337,10 +1338,10 @@ bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::Command * commandObj, uint8_t stepMode, uint16_t stepSize,
-                                                            uint16_t transitionTime, uint16_t colorTemperatureMinimum,
-                                                            uint16_t colorTemperatureMaximum, uint8_t optionsMask,
-                                                            uint8_t optionsOverride)
+bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode,
+                                                            uint16_t stepSize, uint16_t transitionTime,
+                                                            uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
+                                                            uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
 
@@ -1475,7 +1476,8 @@ void emberAfPluginLevelControlCoupledColorTempChangeCallback(EndpointId endpoint
 
 #endif //#ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP
 
-bool emberAfColorControlClusterStopMoveStepCallback(chip::app::Command * commandObj, uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterStopMoveStepCallback(chip::app::CommandHandler * commandObj, uint8_t optionsMask,
+                                                    uint8_t optionsOverride)
 {
     // Received a stop command.  This is all we need to do.
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1489,7 +1491,7 @@ bool emberAfColorControlClusterStopMoveStepCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfColorControlClusterColorLoopSetCallback(chip::app::Command * commandObj, uint8_t updateFlags, uint8_t action,
+bool emberAfColorControlClusterColorLoopSetCallback(chip::app::CommandHandler * commandObj, uint8_t updateFlags, uint8_t action,
                                                     uint8_t direction, uint16_t time, uint16_t startHue, uint8_t optionsMask,
                                                     uint8_t optionsOverride)
 {
@@ -1498,26 +1500,27 @@ bool emberAfColorControlClusterColorLoopSetCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfColorControlClusterEnhancedMoveHueCallback(chip::app::Command * commandObj, uint8_t moveMode, uint16_t rate,
+bool emberAfColorControlClusterEnhancedMoveHueCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint16_t rate,
                                                        uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveHue(moveMode, rate, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedMoveToHueCallback(chip::app::Command * commandObj, uint16_t enhancedHue, uint8_t direction,
-                                                         uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterEnhancedMoveToHueCallback(chip::app::CommandHandler * commandObj, uint16_t enhancedHue,
+                                                         uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
+                                                         uint8_t optionsOverride)
 {
     return moveToHue(enhancedHue, direction, transitionTime, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(chip::app::Command * commandObj, uint16_t enhancedHue,
+bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(chip::app::CommandHandler * commandObj, uint16_t enhancedHue,
                                                                       uint8_t saturation, uint16_t transitionTime,
                                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveToHueAndSaturation(enhancedHue, saturation, transitionTime, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedStepHueCallback(chip::app::Command * commandObj, uint8_t stepMode, uint16_t stepSize,
+bool emberAfColorControlClusterEnhancedStepHueCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint16_t stepSize,
                                                        uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     return stepHue(stepMode, stepSize, transitionTime, optionsMask, optionsOverride, true);

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -38,17 +38,17 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::Command * commandObj)
+bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::Command * commandObj)
+bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -15,10 +15,10 @@
  *    limitations under the License.
  */
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::app::Command * commandObj, uint8_t intent,
+bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::app::CommandHandler * commandObj, uint8_t intent,
                                                              uint8_t requestedProtocol, chip::ByteSpan transferFileDesignator)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;

--- a/src/app/clusters/door-lock-client/door-lock-client.cpp
+++ b/src/app/clusters/door-lock-client/door-lock-client.cpp
@@ -22,19 +22,19 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 using namespace chip;
 
-bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status)
 {
     emberAfDoorLockClusterPrintln("RX: LockDoorResponse 0x%x", status);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status)
 {
     emberAfDoorLockClusterPrintln("RX: UnlockDoorResponse 0x%x", status);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
@@ -46,7 +46,7 @@
 #include <app/util/af.h>
 #include <assert.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <support/CodeUtils.h>
 
 using namespace chip;
@@ -117,7 +117,7 @@ bool emberAfPluginDoorLockServerGetLogEntry(uint16_t * entryId, EmberAfPluginDoo
     return true;
 }
 
-bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::Command * commandObj, uint16_t entryId)
+bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::CommandHandler * commandObj, uint16_t entryId)
 {
     EmberStatus status;
     EmberAfPluginDoorLockServerLogEntry entry;

--- a/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
@@ -43,7 +43,7 @@
 #include <app/common/gen/command-id.h>
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <support/CodeUtils.h>
 
 using namespace chip;
@@ -120,7 +120,7 @@ void emAfPluginDoorLockServerInitSchedule(void)
 #endif
 }
 
-bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
+bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId,
                                                       uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t stopHour,
                                                       uint8_t stopMinute)
 {
@@ -178,7 +178,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId)
 {
     EmberAfStatus zclStatus =
         ((scheduleId > EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE) ? EMBER_ZCL_STATUS_INVALID_FIELD
@@ -217,7 +217,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId)
 {
     EmberAfStatus zclStatus =
         ((scheduleId > EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE) ? EMBER_ZCL_STATUS_INVALID_FIELD
@@ -247,7 +247,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
+bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId,
                                                       uint32_t localStartTime, uint32_t localEndTime)
 {
     uint8_t status;
@@ -283,7 +283,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId)
 {
     EmberAfPluginDoorLockServerYeardayScheduleEntry * entry = &yeardayScheduleTable[0];
     EmberAfStatus zclStatus;
@@ -328,7 +328,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId)
 {
     uint8_t status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -361,7 +361,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t holidayScheduleId,
+bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t holidayScheduleId,
                                                       uint32_t localStartTime, uint32_t localEndTime,
                                                       uint8_t operatingModeDuringHoliday)
 {
@@ -400,7 +400,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t holidayScheduleId)
+bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t holidayScheduleId)
 {
     EmberAfPluginDoorLockServerHolidayScheduleEntry * entry = &holidayScheduleTable[0];
     EmberAfStatus zclStatus;
@@ -444,7 +444,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t holidayScheduleId)
+bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t holidayScheduleId)
 {
     uint8_t status;
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -47,7 +47,7 @@
 #include <app/util/af.h>
 #include <app/util/time-util.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <support/CodeUtils.h>
 
 using namespace chip;
@@ -220,7 +220,7 @@ static uint8_t clearUserPinOrRfid(uint16_t userId, EmberAfPluginDoorLockServerUs
     return (success ? 0x00 : 0x01); // See 7.3.2.17.8 and 7.3.2.17.25).
 }
 
-bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (emAfPluginDoorLockServerCheckForSufficientSpace(userId, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE))
@@ -247,7 +247,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType)
+bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // TODO: Need to validate userType.  https://github.com/project-chip/connectedhomeip/issues/3580
@@ -289,8 +289,8 @@ bool emAfPluginDoorLockServerSetPinUserType(uint16_t userId, EmberAfDoorLockUser
 // ------------------------------------------------------------------------------
 // PIN handling
 
-bool emberAfDoorLockClusterSetPinCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                          uint8_t * pin)
+bool emberAfDoorLockClusterSetPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userStatus,
+                                          uint8_t userType, uint8_t * pin)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // send response
@@ -341,7 +341,7 @@ static bool getSendPinOverTheAir(void)
     return sendPinOverTheAir;
 }
 
-bool emberAfDoorLockClusterGetPinCallback(chip::app::Command * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId)
 {
     EmberAfPluginDoorLockServerUser user;
     EmberStatus status = EMBER_SUCCESS;
@@ -385,7 +385,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearPinCallback(chip::app::Command * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterClearPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status = clearUserPinOrRfid(userId, pinUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE);
@@ -427,7 +427,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllPinsCallback(chip::app::Command * commandObj)
+bool emberAfDoorLockClusterClearAllPinsCallback(chip::app::CommandHandler * commandObj)
 {
     uint8_t i;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -458,8 +458,8 @@ exit:
 // ------------------------------------------------------------------------------
 // RFID handling
 
-bool emberAfDoorLockClusterSetRfidCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                           uint8_t * rfid)
+bool emberAfDoorLockClusterSetRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userStatus,
+                                           uint8_t userType, uint8_t * rfid)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status =
@@ -482,7 +482,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetRfidCallback(chip::app::Command * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId)
 {
     EmberAfPluginDoorLockServerUser user;
     EmberStatus status = EMBER_SUCCESS;
@@ -520,7 +520,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearRfidCallback(chip::app::Command * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterClearRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status = clearUserPinOrRfid(userId, rfidUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE);
@@ -542,7 +542,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::Command * commandObj)
+bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::CommandHandler * commandObj)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     for (uint8_t i = 0; i < EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE; i++)
@@ -624,7 +624,7 @@ static bool verifyPin(uint8_t * pin, uint8_t * userId)
     return false;
 }
 
-bool emberAfDoorLockClusterLockDoorCallback(chip::app::Command * commandObj, uint8_t * PIN)
+bool emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandObj, uint8_t * PIN)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(PIN, &userId);
@@ -688,7 +688,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::Command * commandObj, uint8_t * pin)
+bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::CommandHandler * commandObj, uint8_t * pin)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(pin, &userId);
@@ -877,7 +877,7 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, A
     }
 }
 
-bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::Command * commandObj, uint16_t timeoutS, uint8_t * pin)
+bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::CommandHandler * commandObj, uint16_t timeoutS, uint8_t * pin)
 {
     uint8_t userId;
     uint8_t status;

--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -15,10 +15,10 @@
  *    limitations under the License.
  */
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::app::Command * commandObj)
+bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::app::CommandHandler * commandObj)
 {
     // TODO: Implement the ResetCounts in the platform layer.
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -21,7 +21,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -29,7 +29,7 @@
 
 using namespace chip;
 
-bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
+bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::CommandHandler * commandObj, uint16_t expiryLengthSeconds,
                                                            uint64_t breadcrumb, uint32_t timeoutMs)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().ArmFailSafe(expiryLengthSeconds);
@@ -38,7 +38,7 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * 
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::Command * commandObj)
+bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::CommandHandler * commandObj)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().CommissioningComplete();
     emberAfSendImmediateDefaultResponse(err == CHIP_NO_ERROR ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
@@ -46,7 +46,7 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
+bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::CommandHandler * commandObj, uint8_t location,
                                                                    uint8_t * countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().SetRegulatoryConfig(

--- a/src/app/clusters/groups-client/groups-client.cpp
+++ b/src/app/clusters/groups-client/groups-client.cpp
@@ -45,19 +45,19 @@
 // * Copyright 2010 by Ember Corporation. All rights reserved.              *80*
 // *******************************************************************
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 using namespace chip;
 
-bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId)
+bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: AddGroupResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId,
+bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                    uint8_t * groupName)
 {
     emberAfGroupsClusterPrint("RX: ViewGroupResponse 0x%x, 0x%2x, \"", status, groupId);
@@ -67,8 +67,8 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
-                                                            uint8_t * groupList)
+bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::CommandHandler * commandObj, uint8_t capacity,
+                                                            uint8_t groupCount, uint8_t * groupList)
 {
     uint8_t i;
     emberAfGroupsClusterPrint("RX: GetGroupMembershipResponse 0x%x, 0x%x,", capacity, groupCount);
@@ -81,7 +81,7 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId)
+bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: RemoveGroupResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -46,7 +46,7 @@
 // *******************************************************************
 #include "groups-server.h"
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/att-storage.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -151,7 +151,7 @@ static EmberAfStatus removeEntryFromGroupTable(EndpointId endpoint, GroupId grou
     return EMBER_ZCL_STATUS_NOT_FOUND;
 }
 
-bool emberAfGroupsClusterAddGroupCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t * groupName)
+bool emberAfGroupsClusterAddGroupCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t * groupName)
 {
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -187,7 +187,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, GroupId groupId)
+bool emberAfGroupsClusterViewGroupCallback(chip::app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status                                          = EMBER_ZCL_STATUS_NOT_FOUND;
     CHIP_ERROR err                                                = CHIP_NO_ERROR;
@@ -229,7 +229,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command * commandObj, uint8_t groupCount, uint8_t * groupList)
+bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::CommandHandler * commandObj, uint8_t groupCount, uint8_t * groupList)
 {
     EmberStatus status = EMBER_ZCL_STATUS_FAILURE;
     uint8_t i, j;
@@ -326,7 +326,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, GroupId groupId)
+bool emberAfGroupsClusterRemoveGroupCallback(chip::app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -365,7 +365,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::Command * commandObj)
+bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::CommandHandler * commandObj)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;
     uint8_t i;
@@ -413,7 +413,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::Command * commandObj
     return true;
 }
 
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t * groupName)
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t * groupName)
 {
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;

--- a/src/app/clusters/ias-zone-client/ias-zone-client.cpp
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.cpp
@@ -79,7 +79,7 @@
  ******************************************************************************/
 
 #include "ias-zone-client.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 //-----------------------------------------------------------------------------
@@ -307,7 +307,7 @@ static uint8_t findIasZoneServerByNodeId(EmberNodeId nodeId)
     return i;
 }
 
-bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::Command * commandObj, uint16_t zoneStatus,
+bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::CommandHandler * commandObj, uint16_t zoneStatus,
                                                                uint8_t extendedStatus, uint8_t zoneId, uint16_t delay)
 {
     uint8_t serverIndex = findIasZoneServerByNodeId(emberAfCurrentCommand()->source);
@@ -328,7 +328,8 @@ bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::Comman
     return true;
 }
 
-bool emberAfIasZoneClusterZoneEnrollRequestCallback(chip::app::Command * commandObj, uint16_t zoneType, uint16_t manufacturerCode)
+bool emberAfIasZoneClusterZoneEnrollRequestCallback(chip::app::CommandHandler * commandObj, uint16_t zoneType,
+                                                    uint16_t manufacturerCode)
 {
     EmberAfIasEnrollResponseCode responseCode = EMBER_ZCL_IAS_ENROLL_RESPONSE_CODE_NO_ENROLL_PERMIT;
     uint8_t zoneId                            = UNKNOWN_ZONE_ID;

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -51,7 +51,7 @@
 // *****************************************************************************
 
 #include "ias-zone-server.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/att-storage.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -348,7 +348,8 @@ static void updateEnrollState(EndpointId endpoint, bool enrolled)
     emberAfIasZoneClusterPrintln("IAS Zone Server State: %pEnrolled", (enrolled ? "" : "NOT "));
 }
 
-bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::app::Command * commandObj, uint8_t enrollResponseCode, uint8_t zoneId)
+bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::app::CommandHandler * commandObj, uint8_t enrollResponseCode,
+                                                     uint8_t zoneId)
 {
     EndpointId endpoint;
     uint8_t epZoneId;

--- a/src/app/clusters/identify-client/identify-client.cpp
+++ b/src/app/clusters/identify-client/identify-client.cpp
@@ -22,12 +22,12 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 using namespace chip;
 
-bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout)
+bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::CommandHandler * commandObj, uint16_t timeout)
 {
     emberAfIdentifyClusterPrintln("RX: IdentifyQueryResponse 0x%4x", timeout);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -47,7 +47,7 @@
 #include "identify.h"
 
 // this file contains all the common includes for clusters in the util
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
@@ -103,7 +103,7 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, A
     }
 }
 
-bool emberAfIdentifyClusterIdentifyCallback(chip::app::Command * commandObj, uint16_t time)
+bool emberAfIdentifyClusterIdentifyCallback(chip::app::CommandHandler * commandObj, uint16_t time)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;
     // This Identify callback writes the new attribute, which will trigger the
@@ -120,7 +120,7 @@ bool emberAfIdentifyClusterIdentifyCallback(chip::app::Command * commandObj, uin
     return true;
 }
 
-bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::Command * commandObj)
+bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -21,7 +21,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/common/gen/command-id.h>
 #include <app/common/gen/enums.h>
@@ -29,7 +29,7 @@
 
 EmberAfKeypadInputStatus keypadInputClusterSendKey(EmberAfKeypadInputCecKeyCode keyCode);
 
-static void sendResponse(chip::app::Command * command, EmberAfKeypadInputStatus keypadInputStatus)
+static void sendResponse(chip::app::CommandHandler * command, EmberAfKeypadInputStatus keypadInputStatus)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_KEYPAD_INPUT_CLUSTER_ID,
@@ -49,7 +49,7 @@ exit:
     }
 }
 
-bool emberAfKeypadInputClusterSendKeyCallback(chip::app::Command * command, uint8_t keyCode)
+bool emberAfKeypadInputClusterSendKeyCallback(chip::app::CommandHandler * command, uint8_t keyCode)
 {
     EmberAfKeypadInputStatus status = keypadInputClusterSendKey(static_cast<EmberAfKeypadInputCecKeyCode>(keyCode));
     sendResponse(command, status);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -42,7 +42,7 @@
 #include "level-control.h"
 
 // this file contains all the common includes for clusters in the util
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -406,7 +406,7 @@ static bool shouldExecuteIfOff(EndpointId endpoint, CommandId commandId, uint8_t
 #endif
 }
 
-bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
+bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::CommandHandler * commandObj, uint8_t level, uint16_t transitionTime,
                                                    uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL %x %2x %x %x", "RX level-control:", level, transitionTime, optionMask,
@@ -416,7 +416,8 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime)
+bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t level,
+                                                            uint16_t transitionTime)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL_WITH_ON_OFF %x %2x", "RX level-control:", level, transitionTime);
     moveToLevelHandler(ZCL_MOVE_TO_LEVEL_WITH_ON_OFF_COMMAND_ID, level, transitionTime, 0xFF, 0xFF,
@@ -424,22 +425,22 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
-                                            uint8_t optionOverride)
+bool emberAfLevelControlClusterMoveCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
+                                            uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pMOVE %x %x", "RX level-control:", moveMode, rate);
     moveHandler(ZCL_MOVE_COMMAND_ID, moveMode, rate, optionMask, optionOverride);
     return true;
 }
 
-bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate)
+bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_WITH_ON_OFF %x %x", "RX level-control:", moveMode, rate);
     moveHandler(ZCL_MOVE_WITH_ON_OFF_COMMAND_ID, moveMode, rate, 0xFF, 0xFF);
     return true;
 }
 
-bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfLevelControlClusterStepCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                             uint16_t transitionTime, uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pSTEP %x %x %2x", "RX level-control:", stepMode, stepSize, transitionTime);
@@ -447,7 +448,7 @@ bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uin
     return true;
 }
 
-bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                      uint16_t transitionTime)
 {
     emberAfLevelControlClusterPrintln("%pSTEP_WITH_ON_OFF %x %x %2x", "RX level-control:", stepMode, stepSize, transitionTime);
@@ -455,14 +456,14 @@ bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride)
+bool emberAfLevelControlClusterStopCallback(chip::app::CommandHandler * commandObj, uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pSTOP", "RX level-control:");
     stopHandler(ZCL_STOP_COMMAND_ID, optionMask, optionOverride);
     return true;
 }
 
-bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::Command * commandObj)
+bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::CommandHandler * commandObj)
 {
     emberAfLevelControlClusterPrintln("%pSTOP_WITH_ON_OFF", "RX level-control:");
     stopHandler(ZCL_STOP_WITH_ON_OFF_COMMAND_ID, 0xFF, 0xFF);

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -22,12 +22,12 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 bool lowPowerClusterSleep();
 
-bool emberAfLowPowerClusterSleepCallback(chip::app::Command * command)
+bool emberAfLowPowerClusterSleepCallback(chip::app::CommandHandler * command)
 {
     bool success         = lowPowerClusterSleep();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -21,7 +21,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
@@ -44,7 +44,7 @@ static void storeCurrentInput(chip::EndpointId endpoint, uint8_t currentInput)
     }
 }
 
-bool emberAfMediaInputClusterSelectInputCallback(chip::app::Command * command, uint8_t input)
+bool emberAfMediaInputClusterSelectInputCallback(chip::app::CommandHandler * command, uint8_t input)
 {
     bool success         = mediaInputClusterSelectInput(input);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -56,7 +56,7 @@ bool emberAfMediaInputClusterSelectInputCallback(chip::app::Command * command, u
     return true;
 }
 
-bool emberAfMediaInputClusterShowInputStatusCallback(chip::app::Command * command)
+bool emberAfMediaInputClusterShowInputStatusCallback(chip::app::CommandHandler * command)
 {
     bool success         = mediaInputClusterShowInputStatus();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -64,7 +64,7 @@ bool emberAfMediaInputClusterShowInputStatusCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::Command * command)
+bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::CommandHandler * command)
 {
     bool success         = mediaInputClusterHideInputStatus();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -72,7 +72,7 @@ bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfMediaInputClusterRenameInputCallback(chip::app::Command * command, uint8_t input, uint8_t * name)
+bool emberAfMediaInputClusterRenameInputCallback(chip::app::CommandHandler * command, uint8_t input, uint8_t * name)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string nameString(reinterpret_cast<char *>(name));

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -22,7 +22,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/clusters/media-playback-server/media-playback-server.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -71,7 +71,7 @@ void storeNewPlaybackState(chip::EndpointId endpoint, uint8_t newPlaybackState)
     }
 }
 
-static void sendResponse(chip::app::Command * command, const char * responseName, chip::CommandId commandId,
+static void sendResponse(chip::app::CommandHandler * command, const char * responseName, chip::CommandId commandId,
                          EmberAfMediaPlaybackStatus mediaPlaybackStatus)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
@@ -92,7 +92,7 @@ exit:
     }
 }
 
-bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PLAY, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PLAYING);
@@ -100,7 +100,7 @@ bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::app::Command * command)
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PAUSE, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PAUSED);
@@ -108,7 +108,7 @@ bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::app::Command * command)
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaStopCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaStopCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_STOP, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_NOT_PLAYING);
@@ -116,28 +116,28 @@ bool emberAfMediaPlaybackClusterMediaStopCallback(chip::app::Command * command)
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaFastForwardCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaFastForwardCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_FAST_FORWARD, 0);
     sendResponse(command, "MediaFastForward", ZCL_MEDIA_FAST_FORWARD_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPreviousCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaPreviousCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PREVIOUS, 0);
     sendResponse(command, "MediaPrevious", ZCL_MEDIA_PREVIOUS_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_REWIND, 0);
     sendResponse(command, "MediaRewind", ZCL_MEDIA_REWIND_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::Command * command, uint64_t deltaPositionMilliseconds)
+bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::CommandHandler * command, uint64_t deltaPositionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SKIP_BACKWARD, deltaPositionMilliseconds);
@@ -145,7 +145,7 @@ bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::Command * command, uint64_t deltaPositionMilliseconds)
+bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::CommandHandler * command, uint64_t deltaPositionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SKIP_FORWARD, deltaPositionMilliseconds);
@@ -153,7 +153,7 @@ bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::Command * co
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::app::Command * command, uint64_t positionMilliseconds)
+bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::app::CommandHandler * command, uint64_t positionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SEEK, positionMilliseconds);
@@ -161,13 +161,13 @@ bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::app::Command * command, 
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaNextCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaNextCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_NEXT, 0);
     sendResponse(command, "MediaNext", ZCL_MEDIA_NEXT_RESPONSE_COMMAND_ID, status);
     return true;
 }
-bool emberAfMediaPlaybackClusterMediaStartOverCallback(chip::app::Command * command)
+bool emberAfMediaPlaybackClusterMediaStartOverCallback(chip::app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_START_OVER, 0);
     sendResponse(command, "MediaStartOver", ZCL_MEDIA_START_OVER_RESPONSE_COMMAND_ID, status);

--- a/src/app/clusters/messaging-client/messaging-client.cpp
+++ b/src/app/clusters/messaging-client/messaging-client.cpp
@@ -45,7 +45,7 @@
 #include "../../util/common.h"
 
 #include "app/framework/plugin/esi-management/esi-management.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
 static EmberAfPluginMessagingClientMessage messageTable[EMBER_AF_MESSAGING_CLUSTER_CLIENT_ENDPOINT_COUNT];
 
@@ -121,9 +121,9 @@ void emberAfMessagingClusterClientTickCallback(EndpointId endpoint)
     }
 }
 
-bool emberAfMessagingClusterDisplayMessageCallback(chip::app::Command * commandObj, uint32_t messageId, uint8_t messageControl,
-                                                   uint32_t startTime, uint16_t durationInMinutes, uint8_t * msg,
-                                                   uint8_t optionalExtendedMessageControl)
+bool emberAfMessagingClusterDisplayMessageCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
+                                                   uint8_t messageControl, uint32_t startTime, uint16_t durationInMinutes,
+                                                   uint8_t * msg, uint8_t optionalExtendedMessageControl)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
@@ -242,7 +242,8 @@ kickout:
     return true;
 }
 
-bool emberAfMessagingClusterCancelMessageCallback(chip::app::Command * commandObj, uint32_t messageId, uint8_t messageControl)
+bool emberAfMessagingClusterCancelMessageCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
+                                                  uint8_t messageControl)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);

--- a/src/app/clusters/messaging-server/messaging-server.cpp
+++ b/src/app/clusters/messaging-server/messaging-server.cpp
@@ -41,7 +41,7 @@
 
 #include "messaging-server.h"
 #include "../../include/af.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
 using namespace chip;
 
@@ -86,7 +86,7 @@ void emberAfMessagingClusterServerInitCallback(EndpointId endpoint)
     msgTable[ep].messageStatusControl &= ~VALID;
 }
 
-bool emberAfMessagingClusterGetLastMessageCallback(chip::app::Command * commandObj)
+bool emberAfMessagingClusterGetLastMessageCallback(chip::app::CommandHandler * commandObj)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     EmberAfPluginMessagingServerMessage message;
@@ -109,10 +109,10 @@ bool emberAfMessagingClusterGetLastMessageCallback(chip::app::Command * commandO
 #if defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_0) || defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1B) ||                                   \
     defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_0) || defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1) ||                                    \
     defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1A)
-bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::Command * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
                                                         uint32_t confirmationTime)
 #else
-bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::Command * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
                                                         uint32_t confirmationTime, uint8_t messageConfirmationControl,
                                                         uint8_t * messageResponse)
 #endif

--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -20,7 +20,7 @@
 
 #include <cstring>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/att-storage.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -32,7 +32,7 @@
 
 using namespace chip;
 
-bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, ByteSpan operationalDataset,
+bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan operationalDataset,
                                                                 uint64_t breadcrumb, uint32_t timeoutMs)
 {
     EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
@@ -42,8 +42,8 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, ByteSpan ssid, ByteSpan credentials,
-                                                              uint64_t breadcrumb, uint32_t timeoutMs)
+bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan ssid,
+                                                              ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
         nullptr, emberAfCurrentEndpoint(), ssid, credentials, breadcrumb, timeoutMs);
@@ -52,7 +52,7 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, ByteSpan networkID,
+bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan networkID,
                                                              uint64_t breadcrumb, uint32_t timeoutMs)
 {
     EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
@@ -65,36 +65,37 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 // TODO: The following commands needed to be implemented.
 // These commands are not implemented thus not handled yet, return false so ember will return a error.
 
-bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, ByteSpan networkID,
+bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan networkID,
                                                               uint64_t breadcrumb, uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
+bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::CommandHandler * commandObj,
                                                                                  uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, ByteSpan NetworkID,
+bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan NetworkID,
                                                              uint64_t Breadcrumb, uint32_t TimeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, ByteSpan ssid, uint64_t breadcrumb,
-                                                            uint32_t timeoutMs)
+bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::CommandHandler * commandObj, ByteSpan ssid,
+                                                            uint64_t breadcrumb, uint32_t timeoutMs)
 {
     return false;
 }
-bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj, ByteSpan operationalDataset,
-                                                                   uint64_t breadcrumb, uint32_t timeoutMs)
+bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::CommandHandler * commandObj,
+                                                                   ByteSpan operationalDataset, uint64_t breadcrumb,
+                                                                   uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, ByteSpan ssid,
+bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan ssid,
                                                                  ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     return false;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -106,8 +106,9 @@ namespace {
 NetworkInfo sNetworks[kMaxNetworks];
 } // namespace
 
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset,
-                                                                           uint64_t breadcrumb, uint32_t timeoutMs)
+EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId,
+                                                                           ByteSpan operationalDataset, uint64_t breadcrumb,
+                                                                           uint32_t timeoutMs)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
@@ -154,7 +155,7 @@ exit:
 #endif
 }
 
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid,
+EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan ssid,
                                                                          ByteSpan credentials, uint64_t breadcrumb,
                                                                          uint32_t timeoutMs)
 {
@@ -254,7 +255,7 @@ CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
 }
 } // namespace
 
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID,
+EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan networkID,
                                                                         uint64_t breadcrumb, uint32_t timeoutMs)
 {
     size_t networkSeq;

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/enums.h>
 #include <lib/core/CHIPCore.h>
 #include <platform/internal/DeviceNetworkProvisioning.h>
@@ -27,12 +27,13 @@ namespace chip {
 namespace app {
 namespace clusters {
 namespace NetworkCommissioning {
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset,
-                                                                           uint64_t breadcrumb, uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid,
+EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId,
+                                                                           ByteSpan operationalDataset, uint64_t breadcrumb,
+                                                                           uint32_t timeoutMs);
+EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan ssid,
                                                                          ByteSpan credentials, uint64_t breadcrumb,
                                                                          uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID,
+EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan networkID,
                                                                         uint64_t breadcrumb, uint32_t timeoutMs);
 } // namespace NetworkCommissioning
 

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -47,7 +47,7 @@
 #include <app/common/gen/command-id.h>
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/reporting/reporting.h>
 
 #ifdef EMBER_AF_PLUGIN_SCENES
@@ -165,7 +165,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-bool emberAfOnOffClusterOffCallback(chip::app::Command * commandObj)
+bool emberAfOnOffClusterOffCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_OFF_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
@@ -178,7 +178,7 @@ bool emberAfOnOffClusterOffCallback(chip::app::Command * commandObj)
     return true;
 }
 
-bool emberAfOnOffClusterOnCallback(chip::app::Command * commandObj)
+bool emberAfOnOffClusterOnCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_ON_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
@@ -191,7 +191,7 @@ bool emberAfOnOffClusterOnCallback(chip::app::Command * commandObj)
     return true;
 }
 
-bool emberAfOnOffClusterToggleCallback(chip::app::Command * commandObj)
+bool emberAfOnOffClusterToggleCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_TOGGLE_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -20,7 +20,7 @@
  * @brief Implementation for the Operational Credentials Cluster
  ***************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -212,7 +212,7 @@ void emberAfPluginOperationalCredentialsServerInitCallback(void)
 }
 
 // TODO: Use FabricIndex as a parameter instead of fabricId/nodeId/vendorId once AddOptCert + FabricIndex are implemented
-bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::Command * commandObj, chip::FabricId fabricId,
+bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::CommandHandler * commandObj, chip::FabricId fabricId,
                                                               chip::NodeId nodeId, uint16_t vendorId)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: RemoveFabric"); // TODO: Generate emberAfFabricClusterPrintln
@@ -238,7 +238,7 @@ exit:
 }
 
 // TODO: remove SetFabric once AddOptCert + FabricIndex are implemented
-bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * commandObj, uint16_t VendorId)
+bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::CommandHandler * commandObj, uint16_t VendorId)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: SetFabric with vendorId %" PRIX16, VendorId);
 
@@ -289,7 +289,7 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Command * commandObj, uint8_t * Label)
+bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::CommandHandler * commandObj, uint8_t * Label)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: UpdateFabricLabel");
 
@@ -322,7 +322,7 @@ void DoRemoveAllFabrics(intptr_t)
 } // namespace
 
 // Up for discussion in Multi-Admin TT: chip-spec:#2891
-bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::Command * commandObj)
+bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::CommandHandler * commandObj)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Remove all Fabrics");
     PlatformMgr().ScheduleWork(DoRemoveAllFabrics, 0);
@@ -330,7 +330,7 @@ bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::Com
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::Command * commandObj, chip::ByteSpan NOCArray,
+bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan NOCArray,
                                                            chip::ByteSpan IPKValue, chip::NodeId CaseAdminNode,
                                                            uint16_t AdminVendorId)
 {
@@ -360,7 +360,7 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::Command * commandObj, chip::ByteSpan CSRNonce)
+bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan CSRNonce)
 {
     EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
     EmberStatus sendStatus = EMBER_SUCCESS;
@@ -424,7 +424,7 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterUpdateOpCertCallback(chip::app::Command * commandObj, chip::ByteSpan NOC,
+bool emberAfOperationalCredentialsClusterUpdateOpCertCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan NOC,
                                                               chip::ByteSpan ICACertificate)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
@@ -432,7 +432,7 @@ bool emberAfOperationalCredentialsClusterUpdateOpCertCallback(chip::app::Command
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip::app::Command * commandObj,
+bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip::app::CommandHandler * commandObj,
                                                                            chip::ByteSpan RootCertificate)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
@@ -456,7 +456,7 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(chip::app::Command * commandObj,
+bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(chip::app::CommandHandler * commandObj,
                                                                               chip::ByteSpan TrustedRootIdentifier)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/att-storage.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -67,8 +67,8 @@ bool SendStatusIfDelegateNull(chip::EndpointId endpointId)
  * @param newVersion The SoftwareVersion value of the new Software Image that the client is ready to apply.
  */
 
-bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
-                                                                       uint32_t newVersion)
+bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::app::CommandHandler * commandObj,
+                                                                       chip::ByteSpan updateToken, uint32_t newVersion)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     chip::EndpointId endpointId    = emberAfCurrentEndpoint();
@@ -105,8 +105,8 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::app
  *                       OTA Requestor's Basic Information Cluster.
  */
 
-bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
-                                                                        uint32_t currentVersion)
+bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::app::CommandHandler * commandObj,
+                                                                        chip::ByteSpan updateToken, uint32_t currentVersion)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     chip::EndpointId endpointId    = emberAfCurrentEndpoint();
@@ -152,7 +152,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::ap
  */
 
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(
-    chip::app::Command * commandObj, uint16_t vendorId, uint16_t productId, uint16_t imageType, uint16_t hardwareVersion,
+    chip::app::CommandHandler * commandObj, uint16_t vendorId, uint16_t productId, uint16_t imageType, uint16_t hardwareVersion,
     uint32_t currentVersion,
     /* TYPE WARNING: array array defaults to */ uint8_t * protocolsSupported, uint8_t * location, uint8_t clientCanConsent,
     chip::ByteSpan metadataForProvider)

--- a/src/app/clusters/pump-configuration-and-control-client/pump-configuration-and-control-client.cpp
+++ b/src/app/clusters/pump-configuration-and-control-client/pump-configuration-and-control-client.cpp
@@ -17,7 +17,7 @@
 
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 

--- a/src/app/clusters/scenes-client/scenes-client.cpp
+++ b/src/app/clusters/scenes-client/scenes-client.cpp
@@ -39,19 +39,20 @@
  ******************************************************************************/
 
 #include "scenes-client.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af.h>
 
 #include "gen/command-id.h"
 
 using namespace chip;
 
-bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId, uint8_t sceneId)
+bool emberAfScenesClusterAddSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+                                                  uint8_t sceneId)
 {
     return emberAfPluginScenesClientParseAddSceneResponse(emberAfCurrentCommand(), status, groupId, sceneId);
 }
 
-bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterViewSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                    uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                    uint8_t * extensionFieldSets)
 {
@@ -59,7 +60,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandO
                                                            sceneName, extensionFieldSets);
 }
 
-bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                      uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: RemoveSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
@@ -67,14 +68,14 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId)
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfScenesClusterPrintln("RX: RemoveAllScenesResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                     uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: StoreSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
@@ -82,8 +83,9 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
-                                                            GroupId groupId, uint8_t sceneCount, uint8_t * sceneList)
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status,
+                                                            uint8_t capacity, GroupId groupId, uint8_t sceneCount,
+                                                            uint8_t * sceneList)
 {
     emberAfScenesClusterPrint("RX: GetSceneMembershipResponse 0x%x, 0x%x, 0x%2x", status, capacity, groupId);
 

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -40,7 +40,7 @@
 
 #include "scenes.h"
 #include "app/util/common.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
@@ -216,19 +216,19 @@ void emAfPluginScenesServerPrintInfo(void)
     }
 }
 
-bool emberAfScenesClusterAddSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId,
+bool emberAfScenesClusterAddSceneCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId,
                                           uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets)
 {
     return emberAfPluginScenesServerParseAddScene(commandObj, emberAfCurrentCommand(), groupId, sceneId, transitionTime, sceneName,
                                                   extensionFieldSets);
 }
 
-bool emberAfScenesClusterViewSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId)
+bool emberAfScenesClusterViewSceneCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId)
 {
     return emberAfPluginScenesServerParseViewScene(commandObj, emberAfCurrentCommand(), groupId, sceneId);
 }
 
-bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId)
+bool emberAfScenesClusterRemoveSceneCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
     CHIP_ERROR err       = CHIP_NO_ERROR;
@@ -283,7 +283,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj, GroupId groupId)
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_FIELD;
     CHIP_ERROR err       = CHIP_NO_ERROR;
@@ -332,7 +332,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId)
+bool emberAfScenesClusterStoreSceneCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId)
 {
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -364,7 +364,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, GroupId groupId, uint8_t sceneId,
+bool emberAfScenesClusterRecallSceneCallback(chip::app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId,
                                              uint16_t transitionTime)
 {
     // NOTE: TransitionTime field in the RecallScene command is currently
@@ -398,7 +398,7 @@ bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, Gr
     return true;
 }
 
-bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::Command * commandObj, GroupId groupId)
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::CommandHandler * commandObj, GroupId groupId)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
@@ -718,8 +718,8 @@ EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(EndpointId endpoint, 
     return EMBER_ZCL_STATUS_NOT_FOUND;
 }
 
-bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, const EmberAfClusterCommand * cmd, GroupId groupId,
-                                            uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfPluginScenesServerParseAddScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
+                                            GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                             uint8_t * extensionFieldSets)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1077,8 +1077,8 @@ exit:
     return true;
 }
 
-bool emberAfPluginScenesServerParseViewScene(chip::app::Command * commandObj, const EmberAfClusterCommand * cmd, GroupId groupId,
-                                             uint8_t sceneId)
+bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
+                                             GroupId groupId, uint8_t sceneId)
 {
     CHIP_ERROR err               = CHIP_NO_ERROR;
     EmberAfSceneTableEntry entry = {};

--- a/src/app/clusters/scenes/scenes.h
+++ b/src/app/clusters/scenes/scenes.h
@@ -39,7 +39,7 @@
 
 #pragma once
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/util/af-types.h>
 #include <stdint.h>
 
@@ -80,10 +80,10 @@ extern EmberAfSceneTableEntry emberAfPluginScenesServerSceneTable[];
 #define emberAfPluginScenesServerDecrNumSceneEntriesInUse() (--emberAfPluginScenesServerEntriesInUse)
 #endif // Use tokens
 
-bool emberAfPluginScenesServerParseAddScene(chip::app::Command * commandObj, const EmberAfClusterCommand * cmd,
+bool emberAfPluginScenesServerParseAddScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
                                             chip::GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                             uint8_t * extensionFieldSets);
-bool emberAfPluginScenesServerParseViewScene(chip::app::Command * commandObj, const EmberAfClusterCommand * cmd,
+bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
                                              chip::GroupId groupId, uint8_t sceneId);
 
 /** @brief Scenes Cluster Recall Saved Scene

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -22,7 +22,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/clusters/target-navigator-server/target-navigator-server.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/cluster-id.h>
@@ -32,7 +32,7 @@
 
 TargetNavigatorResponse targetNavigatorClusterNavigateTarget(uint8_t target, std::string data);
 
-void sendResponse(chip::app::Command * command, TargetNavigatorResponse response)
+void sendResponse(chip::app::CommandHandler * command, TargetNavigatorResponse response)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TARGET_NAVIGATOR_CLUSTER_ID,
@@ -51,7 +51,7 @@ exit:
     }
 }
 
-bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::app::Command * command, uint8_t target, uint8_t * data)
+bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::app::CommandHandler * command, uint8_t target, uint8_t * data)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string dataString(reinterpret_cast<char *>(data));

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -20,7 +20,7 @@
  * @brief Implementation for the Test Server Cluster
  ***************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
@@ -146,13 +146,13 @@ void emberAfPluginTestClusterServerInitCallback(void)
     }
 }
 
-bool emberAfTestClusterClusterTestCallback(chip::app::Command *)
+bool emberAfTestClusterClusterTestCallback(chip::app::CommandHandler *)
 {
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfTestClusterClusterTestSpecificCallback(chip::app::Command * apCommandObj)
+bool emberAfTestClusterClusterTestSpecificCallback(chip::app::CommandHandler * apCommandObj)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     uint8_t returnValue = 7;
@@ -176,7 +176,7 @@ exit:
     return true;
 }
 
-bool emberAfTestClusterClusterTestNotHandledCallback(chip::app::Command *)
+bool emberAfTestClusterClusterTestNotHandledCallback(chip::app::CommandHandler *)
 {
     return false;
 }

--- a/src/app/clusters/thermostat-client/thermostat-client.cpp
+++ b/src/app/clusters/thermostat-client/thermostat-client.cpp
@@ -17,7 +17,7 @@
 
 #include <app/util/af.h>
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
@@ -30,13 +30,13 @@ void emberAfThermostatClusterClientInitCallback(void)
 {
     // TODO
 }
-bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(app::Command * commandObj, uint8_t, uint8_t, uint8_t, uint8_t *)
+bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(app::CommandHandler * commandObj, uint8_t, uint8_t, uint8_t, uint8_t *)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterRelayStatusLogCallback(app::Command * commandObj, uint16_t, uint16_t, int16_t, uint8_t, int16_t,
+bool emberAfThermostatClusterRelayStatusLogCallback(app::CommandHandler * commandObj, uint16_t, uint16_t, int16_t, uint8_t, int16_t,
                                                     uint16_t)
 {
     // TODO

--- a/src/app/clusters/tv-channel-server/tv-channel-server.cpp
+++ b/src/app/clusters/tv-channel-server/tv-channel-server.cpp
@@ -38,7 +38,7 @@
  *******************************************************************************
  ******************************************************************************/
 
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 #include <app/common/gen/af-structs.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/common/gen/command-id.h>
@@ -48,7 +48,7 @@ EmberAfTvChannelInfo tvChannelClusterChangeChannel(std::string match);
 bool tvChannelClusterChangeChannelByNumber(uint16_t majorNumer, uint16_t minorNumber);
 bool tvChannelClusterSkipChannel(uint16_t count);
 
-void sendResponse(chip::app::Command * command, EmberAfTvChannelInfo channelInfo)
+void sendResponse(chip::app::CommandHandler * command, EmberAfTvChannelInfo channelInfo)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TV_CHANNEL_CLUSTER_ID,
@@ -69,7 +69,7 @@ exit:
     }
 }
 
-bool emberAfTvChannelClusterChangeChannelCallback(chip::app::Command * command, uint8_t * match)
+bool emberAfTvChannelClusterChangeChannelCallback(chip::app::CommandHandler * command, uint8_t * match)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string matchString(reinterpret_cast<char *>(match));
@@ -80,7 +80,8 @@ bool emberAfTvChannelClusterChangeChannelCallback(chip::app::Command * command, 
     return true;
 }
 
-bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::Command * command, uint16_t majorNumber, uint16_t minorNumber)
+bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::CommandHandler * command, uint16_t majorNumber,
+                                                          uint16_t minorNumber)
 {
     bool success         = tvChannelClusterChangeChannelByNumber(majorNumber, minorNumber);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -88,7 +89,7 @@ bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfTvChannelClusterSkipChannelCallback(chip::app::Command * command, uint16_t count)
+bool emberAfTvChannelClusterSkipChannelCallback(chip::app::CommandHandler * command, uint16_t count)
 {
     bool success         = tvChannelClusterSkipChannel(count);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/zll-identify-server/zll-identify-server.c
+++ b/src/app/clusters/zll-identify-server/zll-identify-server.c
@@ -56,7 +56,7 @@
 // this file contains all the common includes for clusters in the util
 #include "app/framework/include/af.h"
 #include "app/framework/util/common.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
 #ifndef EZSP_HOST
 #include "hal/hal.h"
@@ -149,7 +149,7 @@ void emberAfPluginZllIdentifyServerTriggerEffectEndpointEventHandler(uint8_t end
     }
 }
 
-bool emberAfIdentifyClusterTriggerEffectCallback(chip::app::Command * commandObj, uint8_t effectId, uint8_t effectVariant)
+bool emberAfIdentifyClusterTriggerEffectCallback(chip::app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
 {
     uint8_t endpoint             = emberAfCurrentEndpoint();
     EmAfZllIdentifyState * state = getZllIdentifyState(endpoint);

--- a/src/app/clusters/zll-on-off-server/zll-on-off-server.c
+++ b/src/app/clusters/zll-on-off-server/zll-on-off-server.c
@@ -54,7 +54,7 @@
 
 #include "zll-on-off-server.h"
 #include "../../include/af.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
 #define ZLL_ON_OFF_CLUSTER_ON_OFF_CONTROL_ACCEPT_ONLY_WHEN_ON_MASK EMBER_BIT(0)
 
@@ -167,7 +167,7 @@ void emberAfOnOffClusterServerTickCallback(uint8_t endpoint)
     emberAfScheduleServerTick(endpoint, ZCL_ON_OFF_CLUSTER_ID, MILLISECOND_TICKS_PER_SECOND / 10);
 }
 
-bool emberAfOnOffClusterOffWithEffectCallback(chip::app::Command * commandObj, uint8_t effectId, uint8_t effectVariant)
+bool emberAfOnOffClusterOffWithEffectCallback(chip::app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_VALUE;
     bool globalSceneControl;
@@ -228,7 +228,7 @@ kickout:
     return true;
 }
 
-bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::Command * commandObj)
+bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::CommandHandler * commandObj)
 {
     EmberAfStatus status;
     bool globalSceneControl;
@@ -279,7 +279,7 @@ kickout:
     return true;
 }
 
-bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::Command * commandObj, uint8_t onOffControl, uint16_t onTime,
+bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::CommandHandler * commandObj, uint8_t onOffControl, uint16_t onTime,
                                                uint16_t offWaitTime)
 {
     EmberAfStatus status;

--- a/src/app/clusters/zll-scenes-client/zll-scenes-client.c
+++ b/src/app/clusters/zll-scenes-client/zll-scenes-client.c
@@ -54,15 +54,15 @@
 
 #include "../../include/af.h"
 #include "../scenes-client/scenes-client.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
                                                           uint8_t sceneId)
 {
     return emberAfPluginScenesClientParseAddSceneResponse(emberAfCurrentCommand(), status, groupId, sceneId);
 }
 
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
                                                            uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets)
 {
@@ -70,7 +70,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(chip::app::Command * 
                                                            sceneName, extensionFieldSets);
 }
 
-bool emberAfScenesClusterCopySceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupIdFrom,
+bool emberAfScenesClusterCopySceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupIdFrom,
                                                    uint8_t sceneIdFrom)
 {
     emberAfScenesClusterPrintln("RX: CopySceneResponse 0x%x, 0x%2x, 0x%x", status, groupIdFrom, sceneIdFrom);

--- a/src/app/clusters/zll-scenes-server/zll-scenes-server.c
+++ b/src/app/clusters/zll-scenes-server/zll-scenes-server.c
@@ -54,24 +54,24 @@
 
 #include "../../include/af.h"
 #include "../scenes/scenes.h"
-#include <app/Command.h>
+#include <app/CommandHandler.h>
 
 #define ZCL_SCENES_CLUSTER_MODE_COPY_ALL_SCENES_MASK EMBER_BIT(0)
 
-bool emberAfScenesClusterEnhancedAddSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
                                                   uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets)
 {
     return emberAfPluginScenesServerParseAddScene(emberAfCurrentCommand(), groupId, sceneId, transitionTime, sceneName,
                                                   extensionFieldSets);
 }
 
-bool emberAfScenesClusterEnhancedViewSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId)
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId)
 {
     return emberAfPluginScenesServerParseViewScene(emberAfCurrentCommand(), groupId, sceneId);
 }
 
-bool emberAfScenesClusterCopySceneCallback(chip::app::Command * commandObj, uint8_t mode, uint16_t groupIdFrom, uint8_t sceneIdFrom,
-                                           uint16_t groupIdTo, uint8_t sceneIdTo)
+bool emberAfScenesClusterCopySceneCallback(chip::app::CommandHandler * commandObj, uint8_t mode, uint16_t groupIdFrom,
+                                           uint8_t sceneIdFrom, uint16_t groupIdTo, uint8_t sceneIdTo)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;
     EmberAfStatus status   = EMBER_ZCL_STATUS_INVALID_FIELD;

--- a/src/app/common/gen/callback.h
+++ b/src/app/common/gen/callback.h
@@ -25,6 +25,8 @@
 #include <app/util/basic-types.h>
 
 #include <app/Command.h>
+#include <app/CommandHandler.h>
+#include <app/CommandSender.h>
 #include <lib/support/Span.h>
 
 /** @brief Cluster Init
@@ -15079,1930 +15081,1620 @@ void emberAfSampleMfgSpecificCluster2ClusterClientTickCallback(chip::EndpointId 
 // Cluster Commands Callback
 
 /**
- * @brief  Cluster Identify Command callback
+ * @brief  Cluster Identify Command callback (from client)
  */
-bool emberAfIdentifyClusterIdentifyCallback(chip::app::Command * commandObj, uint16_t identifyTime);
-
+bool emberAfIdentifyClusterIdentifyCallback(chip::app::CommandHandler * commandObj, uint16_t identifyTime);
 /**
- * @brief  Cluster IdentifyQueryResponse Command callback
+ * @brief  Cluster IdentifyQueryResponse Command callback (from server)
  */
-bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout);
-
+bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::CommandSender * commandObj, uint16_t timeout);
 /**
- * @brief  Cluster IdentifyQuery Command callback
+ * @brief  Cluster IdentifyQuery Command callback (from client)
  */
-bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::Command * commandObj);
-
+bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster EZModeInvoke Command callback
+ * @brief  Cluster EZModeInvoke Command callback (from client)
  */
-bool emberAfIdentifyClusterEZModeInvokeCallback(chip::app::Command * commandObj, uint8_t action);
-
+bool emberAfIdentifyClusterEZModeInvokeCallback(chip::app::CommandHandler * commandObj, uint8_t action);
 /**
- * @brief  Cluster UpdateCommissionState Command callback
+ * @brief  Cluster UpdateCommissionState Command callback (from client)
  */
-bool emberAfIdentifyClusterUpdateCommissionStateCallback(chip::app::Command * commandObj, uint8_t action,
+bool emberAfIdentifyClusterUpdateCommissionStateCallback(chip::app::CommandHandler * commandObj, uint8_t action,
                                                          uint8_t commissionStateMask);
-
 /**
- * @brief  Cluster TriggerEffect Command callback
+ * @brief  Cluster TriggerEffect Command callback (from client)
  */
-bool emberAfIdentifyClusterTriggerEffectCallback(chip::app::Command * commandObj, uint8_t effectId, uint8_t effectVariant);
-
+bool emberAfIdentifyClusterTriggerEffectCallback(chip::app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant);
 /**
- * @brief  Cluster AddGroup Command callback
+ * @brief  Cluster AddGroup Command callback (from client)
  */
-bool emberAfGroupsClusterAddGroupCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t * groupName);
-
+bool emberAfGroupsClusterAddGroupCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t * groupName);
 /**
- * @brief  Cluster AddGroupResponse Command callback
+ * @brief  Cluster AddGroupResponse Command callback (from server)
  */
-bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
-
+bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId);
 /**
- * @brief  Cluster ViewGroup Command callback
+ * @brief  Cluster ViewGroup Command callback (from client)
  */
-bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, uint16_t groupId);
-
+bool emberAfGroupsClusterViewGroupCallback(chip::app::CommandHandler * commandObj, uint16_t groupId);
 /**
- * @brief  Cluster ViewGroupResponse Command callback
+ * @brief  Cluster ViewGroupResponse Command callback (from server)
  */
-bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                    uint8_t * groupName);
-
 /**
- * @brief  Cluster GetGroupMembership Command callback
+ * @brief  Cluster GetGroupMembership Command callback (from client)
  */
-bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command * commandObj, uint8_t groupCount,
+bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::CommandHandler * commandObj, uint8_t groupCount,
                                                     /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
-
 /**
- * @brief  Cluster GetGroupMembershipResponse Command callback
+ * @brief  Cluster GetGroupMembershipResponse Command callback (from server)
  */
-bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
+bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::CommandSender * commandObj, uint8_t capacity,
+                                                            uint8_t groupCount,
                                                             /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
-
 /**
- * @brief  Cluster RemoveGroup Command callback
+ * @brief  Cluster RemoveGroup Command callback (from client)
  */
-bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, uint16_t groupId);
-
+bool emberAfGroupsClusterRemoveGroupCallback(chip::app::CommandHandler * commandObj, uint16_t groupId);
 /**
- * @brief  Cluster RemoveGroupResponse Command callback
+ * @brief  Cluster RemoveGroupResponse Command callback (from server)
  */
-bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
-
+bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId);
 /**
- * @brief  Cluster RemoveAllGroups Command callback
+ * @brief  Cluster RemoveAllGroups Command callback (from client)
  */
-bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::Command * commandObj);
-
+bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster AddGroupIfIdentifying Command callback
+ * @brief  Cluster AddGroupIfIdentifying Command callback (from client)
  */
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t * groupName);
-
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::app::CommandHandler * commandObj, uint16_t groupId,
+                                                       uint8_t * groupName);
 /**
- * @brief  Cluster AddScene Command callback
+ * @brief  Cluster AddScene Command callback (from client)
  */
-bool emberAfScenesClusterAddSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterAddSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
                                           uint16_t transitionTime, uint8_t * sceneName,
                                           /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
-
 /**
- * @brief  Cluster AddSceneResponse Command callback
+ * @brief  Cluster AddSceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterAddSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                   uint8_t sceneId);
-
 /**
- * @brief  Cluster ViewScene Command callback
+ * @brief  Cluster ViewScene Command callback (from client)
  */
-bool emberAfScenesClusterViewSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
-
+bool emberAfScenesClusterViewSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId);
 /**
- * @brief  Cluster ViewSceneResponse Command callback
+ * @brief  Cluster ViewSceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterViewSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                    uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
-
 /**
- * @brief  Cluster RemoveScene Command callback
+ * @brief  Cluster RemoveScene Command callback (from client)
  */
-bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
-
+bool emberAfScenesClusterRemoveSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId);
 /**
- * @brief  Cluster RemoveSceneResponse Command callback
+ * @brief  Cluster RemoveSceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                      uint8_t sceneId);
-
 /**
- * @brief  Cluster RemoveAllScenes Command callback
+ * @brief  Cluster RemoveAllScenes Command callback (from client)
  */
-bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj, uint16_t groupId);
-
+bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::CommandHandler * commandObj, uint16_t groupId);
 /**
- * @brief  Cluster RemoveAllScenesResponse Command callback
+ * @brief  Cluster RemoveAllScenesResponse Command callback (from server)
  */
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
-
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId);
 /**
- * @brief  Cluster StoreScene Command callback
+ * @brief  Cluster StoreScene Command callback (from client)
  */
-bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
-
+bool emberAfScenesClusterStoreSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId);
 /**
- * @brief  Cluster StoreSceneResponse Command callback
+ * @brief  Cluster StoreSceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                     uint8_t sceneId);
-
 /**
- * @brief  Cluster RecallScene Command callback
+ * @brief  Cluster RecallScene Command callback (from client)
  */
-bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterRecallSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
                                              uint16_t transitionTime);
-
 /**
- * @brief  Cluster GetSceneMembership Command callback
+ * @brief  Cluster GetSceneMembership Command callback (from client)
  */
-bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::Command * commandObj, uint16_t groupId);
-
+bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::CommandHandler * commandObj, uint16_t groupId);
 /**
- * @brief  Cluster GetSceneMembershipResponse Command callback
+ * @brief  Cluster GetSceneMembershipResponse Command callback (from server)
  */
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint8_t capacity,
                                                             uint16_t groupId, uint8_t sceneCount,
                                                             /* TYPE WARNING: array array defaults to */ uint8_t * sceneList);
-
 /**
- * @brief  Cluster EnhancedAddScene Command callback
+ * @brief  Cluster EnhancedAddScene Command callback (from client)
  */
-bool emberAfScenesClusterEnhancedAddSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedAddSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
                                                   uint16_t transitionTime, uint8_t * sceneName,
                                                   /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
-
 /**
- * @brief  Cluster EnhancedAddSceneResponse Command callback
+ * @brief  Cluster EnhancedAddSceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                           uint8_t sceneId);
-
 /**
- * @brief  Cluster EnhancedViewScene Command callback
+ * @brief  Cluster EnhancedViewScene Command callback (from client)
  */
-bool emberAfScenesClusterEnhancedViewSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
-
+bool emberAfScenesClusterEnhancedViewSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId);
 /**
- * @brief  Cluster EnhancedViewSceneResponse Command callback
+ * @brief  Cluster EnhancedViewSceneResponse Command callback (from server)
  */
 bool emberAfScenesClusterEnhancedViewSceneResponseCallback(
-    chip::app::Command * commandObj, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+    chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
     uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
-
 /**
- * @brief  Cluster CopyScene Command callback
+ * @brief  Cluster CopyScene Command callback (from client)
  */
-bool emberAfScenesClusterCopySceneCallback(chip::app::Command * commandObj, uint8_t mode, uint16_t groupIdFrom, uint8_t sceneIdFrom,
-                                           uint16_t groupIdTo, uint8_t sceneIdTo);
-
+bool emberAfScenesClusterCopySceneCallback(chip::app::CommandHandler * commandObj, uint8_t mode, uint16_t groupIdFrom,
+                                           uint8_t sceneIdFrom, uint16_t groupIdTo, uint8_t sceneIdTo);
 /**
- * @brief  Cluster CopySceneResponse Command callback
+ * @brief  Cluster CopySceneResponse Command callback (from server)
  */
-bool emberAfScenesClusterCopySceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupIdFrom,
+bool emberAfScenesClusterCopySceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupIdFrom,
                                                    uint8_t sceneIdFrom);
-
 /**
- * @brief  Cluster Off Command callback
+ * @brief  Cluster Off Command callback (from client)
  */
-bool emberAfOnOffClusterOffCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterOffCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SampleMfgSpecificOffWithTransition Command callback
+ * @brief  Cluster SampleMfgSpecificOffWithTransition Command callback (from client)
  */
-bool emberAfOnOffClusterSampleMfgSpecificOffWithTransitionCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterSampleMfgSpecificOffWithTransitionCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster On Command callback
+ * @brief  Cluster On Command callback (from client)
  */
-bool emberAfOnOffClusterOnCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterOnCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SampleMfgSpecificOnWithTransition Command callback
+ * @brief  Cluster SampleMfgSpecificOnWithTransition Command callback (from client)
  */
-bool emberAfOnOffClusterSampleMfgSpecificOnWithTransitionCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterSampleMfgSpecificOnWithTransitionCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SampleMfgSpecificOnWithTransition2 Command callback
+ * @brief  Cluster SampleMfgSpecificOnWithTransition2 Command callback (from client)
  */
-bool emberAfOnOffClusterSampleMfgSpecificOnWithTransition2Callback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterSampleMfgSpecificOnWithTransition2Callback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster Toggle Command callback
+ * @brief  Cluster Toggle Command callback (from client)
  */
-bool emberAfOnOffClusterToggleCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterToggleCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SampleMfgSpecificToggleWithTransition Command callback
+ * @brief  Cluster SampleMfgSpecificToggleWithTransition Command callback (from client)
  */
-bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransitionCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SampleMfgSpecificToggleWithTransition2 Command callback
+ * @brief  Cluster SampleMfgSpecificToggleWithTransition2 Command callback (from client)
  */
-bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransition2Callback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransition2Callback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster OffWithEffect Command callback
+ * @brief  Cluster OffWithEffect Command callback (from client)
  */
-bool emberAfOnOffClusterOffWithEffectCallback(chip::app::Command * commandObj, uint8_t EffectId, uint8_t EffectVariant);
-
+bool emberAfOnOffClusterOffWithEffectCallback(chip::app::CommandHandler * commandObj, uint8_t EffectId, uint8_t EffectVariant);
 /**
- * @brief  Cluster OnWithRecallGlobalScene Command callback
+ * @brief  Cluster OnWithRecallGlobalScene Command callback (from client)
  */
-bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::Command * commandObj);
-
+bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster OnWithTimedOff Command callback
+ * @brief  Cluster OnWithTimedOff Command callback (from client)
  */
-bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::Command * commandObj, uint8_t OnOffControl, uint16_t OnTime,
+bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::CommandHandler * commandObj, uint8_t OnOffControl, uint16_t OnTime,
                                                uint16_t OffWaitTime);
-
 /**
- * @brief  Cluster MoveToLevel Command callback
+ * @brief  Cluster MoveToLevel Command callback (from client)
  */
-bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
+bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::CommandHandler * commandObj, uint8_t level, uint16_t transitionTime,
                                                    uint8_t optionMask, uint8_t optionOverride);
-
 /**
- * @brief  Cluster Move Command callback
+ * @brief  Cluster Move Command callback (from client)
  */
-bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
-                                            uint8_t optionOverride);
-
+bool emberAfLevelControlClusterMoveCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
+                                            uint8_t optionMask, uint8_t optionOverride);
 /**
- * @brief  Cluster Step Command callback
+ * @brief  Cluster Step Command callback (from client)
  */
-bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfLevelControlClusterStepCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                             uint16_t transitionTime, uint8_t optionMask, uint8_t optionOverride);
-
 /**
- * @brief  Cluster Stop Command callback
+ * @brief  Cluster Stop Command callback (from client)
  */
-bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride);
-
+bool emberAfLevelControlClusterStopCallback(chip::app::CommandHandler * commandObj, uint8_t optionMask, uint8_t optionOverride);
 /**
- * @brief  Cluster MoveToLevelWithOnOff Command callback
+ * @brief  Cluster MoveToLevelWithOnOff Command callback (from client)
  */
-bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level,
+bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t level,
                                                             uint16_t transitionTime);
-
 /**
- * @brief  Cluster MoveWithOnOff Command callback
+ * @brief  Cluster MoveWithOnOff Command callback (from client)
  */
-bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate);
-
+bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate);
 /**
- * @brief  Cluster StepWithOnOff Command callback
+ * @brief  Cluster StepWithOnOff Command callback (from client)
  */
-bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                      uint16_t transitionTime);
-
 /**
- * @brief  Cluster StopWithOnOff Command callback
+ * @brief  Cluster StopWithOnOff Command callback (from client)
  */
-bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::Command * commandObj);
-
+bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ResetAlarm Command callback
+ * @brief  Cluster ResetAlarm Command callback (from client)
  */
-bool emberAfAlarmsClusterResetAlarmCallback(chip::app::Command * commandObj, uint8_t alarmCode, chip::ClusterId clusterId);
-
+bool emberAfAlarmsClusterResetAlarmCallback(chip::app::CommandHandler * commandObj, uint8_t alarmCode, chip::ClusterId clusterId);
 /**
- * @brief  Cluster Alarm Command callback
+ * @brief  Cluster Alarm Command callback (from server)
  */
-bool emberAfAlarmsClusterAlarmCallback(chip::app::Command * commandObj, uint8_t alarmCode, chip::ClusterId clusterId);
-
+bool emberAfAlarmsClusterAlarmCallback(chip::app::CommandSender * commandObj, uint8_t alarmCode, chip::ClusterId clusterId);
 /**
- * @brief  Cluster ResetAllAlarms Command callback
+ * @brief  Cluster ResetAllAlarms Command callback (from client)
  */
-bool emberAfAlarmsClusterResetAllAlarmsCallback(chip::app::Command * commandObj);
-
+bool emberAfAlarmsClusterResetAllAlarmsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetAlarmResponse Command callback
+ * @brief  Cluster GetAlarmResponse Command callback (from server)
  */
-bool emberAfAlarmsClusterGetAlarmResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t alarmCode,
+bool emberAfAlarmsClusterGetAlarmResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint8_t alarmCode,
                                                   chip::ClusterId clusterId, uint32_t timeStamp);
-
 /**
- * @brief  Cluster GetAlarm Command callback
+ * @brief  Cluster GetAlarm Command callback (from client)
  */
-bool emberAfAlarmsClusterGetAlarmCallback(chip::app::Command * commandObj);
-
+bool emberAfAlarmsClusterGetAlarmCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ResetAlarmLog Command callback
+ * @brief  Cluster ResetAlarmLog Command callback (from client)
  */
-bool emberAfAlarmsClusterResetAlarmLogCallback(chip::app::Command * commandObj);
-
+bool emberAfAlarmsClusterResetAlarmLogCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster PowerProfileRequest Command callback
+ * @brief  Cluster PowerProfileRequest Command callback (from client)
  */
-bool emberAfPowerProfileClusterPowerProfileRequestCallback(chip::app::Command * commandObj, uint8_t powerProfileId);
-
+bool emberAfPowerProfileClusterPowerProfileRequestCallback(chip::app::CommandHandler * commandObj, uint8_t powerProfileId);
 /**
- * @brief  Cluster PowerProfileNotification Command callback
+ * @brief  Cluster PowerProfileNotification Command callback (from server)
  */
 bool emberAfPowerProfileClusterPowerProfileNotificationCallback(
-    chip::app::Command * commandObj, uint8_t totalProfileNum, uint8_t powerProfileId, uint8_t numOfTransferredPhases,
+    chip::app::CommandSender * commandObj, uint8_t totalProfileNum, uint8_t powerProfileId, uint8_t numOfTransferredPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * transferredPhases);
-
 /**
- * @brief  Cluster PowerProfileStateRequest Command callback
+ * @brief  Cluster PowerProfileStateRequest Command callback (from client)
  */
-bool emberAfPowerProfileClusterPowerProfileStateRequestCallback(chip::app::Command * commandObj);
-
+bool emberAfPowerProfileClusterPowerProfileStateRequestCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster PowerProfileResponse Command callback
+ * @brief  Cluster PowerProfileResponse Command callback (from server)
  */
 bool emberAfPowerProfileClusterPowerProfileResponseCallback(
-    chip::app::Command * commandObj, uint8_t totalProfileNum, uint8_t powerProfileId, uint8_t numOfTransferredPhases,
+    chip::app::CommandSender * commandObj, uint8_t totalProfileNum, uint8_t powerProfileId, uint8_t numOfTransferredPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * transferredPhases);
-
 /**
- * @brief  Cluster GetPowerProfilePriceResponse Command callback
+ * @brief  Cluster GetPowerProfilePriceResponse Command callback (from client)
  */
-bool emberAfPowerProfileClusterGetPowerProfilePriceResponseCallback(chip::app::Command * commandObj, uint8_t powerProfileId,
+bool emberAfPowerProfileClusterGetPowerProfilePriceResponseCallback(chip::app::CommandHandler * commandObj, uint8_t powerProfileId,
                                                                     uint16_t currency, uint32_t price, uint8_t priceTrailingDigit);
-
 /**
- * @brief  Cluster PowerProfileStateResponse Command callback
+ * @brief  Cluster PowerProfileStateResponse Command callback (from server)
  */
 bool emberAfPowerProfileClusterPowerProfileStateResponseCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileCount,
+    chip::app::CommandSender * commandObj, uint8_t powerProfileCount,
     /* TYPE WARNING: array array defaults to */ uint8_t * powerProfileRecords);
-
 /**
- * @brief  Cluster GetOverallSchedulePriceResponse Command callback
+ * @brief  Cluster GetOverallSchedulePriceResponse Command callback (from client)
  */
-bool emberAfPowerProfileClusterGetOverallSchedulePriceResponseCallback(chip::app::Command * commandObj, uint16_t currency,
+bool emberAfPowerProfileClusterGetOverallSchedulePriceResponseCallback(chip::app::CommandHandler * commandObj, uint16_t currency,
                                                                        uint32_t price, uint8_t priceTrailingDigit);
-
 /**
- * @brief  Cluster GetPowerProfilePrice Command callback
+ * @brief  Cluster GetPowerProfilePrice Command callback (from server)
  */
-bool emberAfPowerProfileClusterGetPowerProfilePriceCallback(chip::app::Command * commandObj, uint8_t powerProfileId);
-
+bool emberAfPowerProfileClusterGetPowerProfilePriceCallback(chip::app::CommandSender * commandObj, uint8_t powerProfileId);
 /**
- * @brief  Cluster EnergyPhasesScheduleNotification Command callback
+ * @brief  Cluster EnergyPhasesScheduleNotification Command callback (from client)
  */
 bool emberAfPowerProfileClusterEnergyPhasesScheduleNotificationCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
+    chip::app::CommandHandler * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * scheduledPhases);
-
 /**
- * @brief  Cluster PowerProfilesStateNotification Command callback
+ * @brief  Cluster PowerProfilesStateNotification Command callback (from server)
  */
 bool emberAfPowerProfileClusterPowerProfilesStateNotificationCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileCount,
+    chip::app::CommandSender * commandObj, uint8_t powerProfileCount,
     /* TYPE WARNING: array array defaults to */ uint8_t * powerProfileRecords);
-
 /**
- * @brief  Cluster EnergyPhasesScheduleResponse Command callback
+ * @brief  Cluster EnergyPhasesScheduleResponse Command callback (from client)
  */
 bool emberAfPowerProfileClusterEnergyPhasesScheduleResponseCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
+    chip::app::CommandHandler * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * scheduledPhases);
-
 /**
- * @brief  Cluster GetOverallSchedulePrice Command callback
+ * @brief  Cluster GetOverallSchedulePrice Command callback (from server)
  */
-bool emberAfPowerProfileClusterGetOverallSchedulePriceCallback(chip::app::Command * commandObj);
-
+bool emberAfPowerProfileClusterGetOverallSchedulePriceCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster PowerProfileScheduleConstraintsRequest Command callback
+ * @brief  Cluster PowerProfileScheduleConstraintsRequest Command callback (from client)
  */
-bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsRequestCallback(chip::app::Command * commandObj,
+bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsRequestCallback(chip::app::CommandHandler * commandObj,
                                                                               uint8_t powerProfileId);
-
 /**
- * @brief  Cluster EnergyPhasesScheduleRequest Command callback
+ * @brief  Cluster EnergyPhasesScheduleRequest Command callback (from server)
  */
-bool emberAfPowerProfileClusterEnergyPhasesScheduleRequestCallback(chip::app::Command * commandObj, uint8_t powerProfileId);
-
+bool emberAfPowerProfileClusterEnergyPhasesScheduleRequestCallback(chip::app::CommandSender * commandObj, uint8_t powerProfileId);
 /**
- * @brief  Cluster EnergyPhasesScheduleStateRequest Command callback
+ * @brief  Cluster EnergyPhasesScheduleStateRequest Command callback (from client)
  */
-bool emberAfPowerProfileClusterEnergyPhasesScheduleStateRequestCallback(chip::app::Command * commandObj, uint8_t powerProfileId);
-
+bool emberAfPowerProfileClusterEnergyPhasesScheduleStateRequestCallback(chip::app::CommandHandler * commandObj,
+                                                                        uint8_t powerProfileId);
 /**
- * @brief  Cluster EnergyPhasesScheduleStateResponse Command callback
+ * @brief  Cluster EnergyPhasesScheduleStateResponse Command callback (from server)
  */
 bool emberAfPowerProfileClusterEnergyPhasesScheduleStateResponseCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
+    chip::app::CommandSender * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * scheduledPhases);
-
 /**
- * @brief  Cluster GetPowerProfilePriceExtendedResponse Command callback
+ * @brief  Cluster GetPowerProfilePriceExtendedResponse Command callback (from client)
  */
-bool emberAfPowerProfileClusterGetPowerProfilePriceExtendedResponseCallback(chip::app::Command * commandObj, uint8_t powerProfileId,
-                                                                            uint16_t currency, uint32_t price,
-                                                                            uint8_t priceTrailingDigit);
-
+bool emberAfPowerProfileClusterGetPowerProfilePriceExtendedResponseCallback(chip::app::CommandHandler * commandObj,
+                                                                            uint8_t powerProfileId, uint16_t currency,
+                                                                            uint32_t price, uint8_t priceTrailingDigit);
 /**
- * @brief  Cluster EnergyPhasesScheduleStateNotification Command callback
+ * @brief  Cluster EnergyPhasesScheduleStateNotification Command callback (from server)
  */
 bool emberAfPowerProfileClusterEnergyPhasesScheduleStateNotificationCallback(
-    chip::app::Command * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
+    chip::app::CommandSender * commandObj, uint8_t powerProfileId, uint8_t numOfScheduledPhases,
     /* TYPE WARNING: array array defaults to */ uint8_t * scheduledPhases);
-
 /**
- * @brief  Cluster PowerProfileScheduleConstraintsNotification Command callback
+ * @brief  Cluster PowerProfileScheduleConstraintsNotification Command callback (from server)
  */
-bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsNotificationCallback(chip::app::Command * commandObj,
+bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsNotificationCallback(chip::app::CommandSender * commandObj,
                                                                                    uint8_t powerProfileId, uint16_t startAfter,
                                                                                    uint16_t stopBefore);
-
 /**
- * @brief  Cluster PowerProfileScheduleConstraintsResponse Command callback
+ * @brief  Cluster PowerProfileScheduleConstraintsResponse Command callback (from server)
  */
-bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsResponseCallback(chip::app::Command * commandObj,
+bool emberAfPowerProfileClusterPowerProfileScheduleConstraintsResponseCallback(chip::app::CommandSender * commandObj,
                                                                                uint8_t powerProfileId, uint16_t startAfter,
                                                                                uint16_t stopBefore);
-
 /**
- * @brief  Cluster GetPowerProfilePriceExtended Command callback
+ * @brief  Cluster GetPowerProfilePriceExtended Command callback (from server)
  */
-bool emberAfPowerProfileClusterGetPowerProfilePriceExtendedCallback(chip::app::Command * commandObj, uint8_t options,
+bool emberAfPowerProfileClusterGetPowerProfilePriceExtendedCallback(chip::app::CommandSender * commandObj, uint8_t options,
                                                                     uint8_t powerProfileId, uint16_t powerProfileStartTime);
-
 /**
- * @brief  Cluster ExecutionOfACommand Command callback
+ * @brief  Cluster ExecutionOfACommand Command callback (from client)
  */
-bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::app::Command * commandObj, uint8_t commandId);
-
+bool emberAfApplianceControlClusterExecutionOfACommandCallback(chip::app::CommandHandler * commandObj, uint8_t commandId);
 /**
- * @brief  Cluster SignalStateResponse Command callback
+ * @brief  Cluster SignalStateResponse Command callback (from server)
  */
-bool emberAfApplianceControlClusterSignalStateResponseCallback(chip::app::Command * commandObj, uint8_t applianceStatus,
+bool emberAfApplianceControlClusterSignalStateResponseCallback(chip::app::CommandSender * commandObj, uint8_t applianceStatus,
                                                                uint8_t remoteEnableFlagsAndDeviceStatus2,
                                                                uint32_t applianceStatus2);
-
 /**
- * @brief  Cluster SignalState Command callback
+ * @brief  Cluster SignalState Command callback (from client)
  */
-bool emberAfApplianceControlClusterSignalStateCallback(chip::app::Command * commandObj);
-
+bool emberAfApplianceControlClusterSignalStateCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SignalStateNotification Command callback
+ * @brief  Cluster SignalStateNotification Command callback (from server)
  */
-bool emberAfApplianceControlClusterSignalStateNotificationCallback(chip::app::Command * commandObj, uint8_t applianceStatus,
+bool emberAfApplianceControlClusterSignalStateNotificationCallback(chip::app::CommandSender * commandObj, uint8_t applianceStatus,
                                                                    uint8_t remoteEnableFlagsAndDeviceStatus2,
                                                                    uint32_t applianceStatus2);
-
 /**
- * @brief  Cluster WriteFunctions Command callback
+ * @brief  Cluster WriteFunctions Command callback (from client)
  */
-bool emberAfApplianceControlClusterWriteFunctionsCallback(chip::app::Command * commandObj, uint16_t functionId,
+bool emberAfApplianceControlClusterWriteFunctionsCallback(chip::app::CommandHandler * commandObj, uint16_t functionId,
                                                           uint8_t functionDataType,
                                                           /* TYPE WARNING: array array defaults to */ uint8_t * functionData);
-
 /**
- * @brief  Cluster OverloadPauseResume Command callback
+ * @brief  Cluster OverloadPauseResume Command callback (from client)
  */
-bool emberAfApplianceControlClusterOverloadPauseResumeCallback(chip::app::Command * commandObj);
-
+bool emberAfApplianceControlClusterOverloadPauseResumeCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster OverloadPause Command callback
+ * @brief  Cluster OverloadPause Command callback (from client)
  */
-bool emberAfApplianceControlClusterOverloadPauseCallback(chip::app::Command * commandObj);
-
+bool emberAfApplianceControlClusterOverloadPauseCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster OverloadWarning Command callback
+ * @brief  Cluster OverloadWarning Command callback (from client)
  */
-bool emberAfApplianceControlClusterOverloadWarningCallback(chip::app::Command * commandObj, uint8_t warningEvent);
-
+bool emberAfApplianceControlClusterOverloadWarningCallback(chip::app::CommandHandler * commandObj, uint8_t warningEvent);
 /**
- * @brief  Cluster CheckIn Command callback
+ * @brief  Cluster CheckIn Command callback (from server)
  */
-bool emberAfPollControlClusterCheckInCallback(chip::app::Command * commandObj);
-
+bool emberAfPollControlClusterCheckInCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster CheckInResponse Command callback
+ * @brief  Cluster CheckInResponse Command callback (from client)
  */
-bool emberAfPollControlClusterCheckInResponseCallback(chip::app::Command * commandObj, uint8_t startFastPolling,
+bool emberAfPollControlClusterCheckInResponseCallback(chip::app::CommandHandler * commandObj, uint8_t startFastPolling,
                                                       uint16_t fastPollTimeout);
-
 /**
- * @brief  Cluster FastPollStop Command callback
+ * @brief  Cluster FastPollStop Command callback (from client)
  */
-bool emberAfPollControlClusterFastPollStopCallback(chip::app::Command * commandObj);
-
+bool emberAfPollControlClusterFastPollStopCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SetLongPollInterval Command callback
+ * @brief  Cluster SetLongPollInterval Command callback (from client)
  */
-bool emberAfPollControlClusterSetLongPollIntervalCallback(chip::app::Command * commandObj, uint32_t newLongPollInterval);
-
+bool emberAfPollControlClusterSetLongPollIntervalCallback(chip::app::CommandHandler * commandObj, uint32_t newLongPollInterval);
 /**
- * @brief  Cluster SetShortPollInterval Command callback
+ * @brief  Cluster SetShortPollInterval Command callback (from client)
  */
-bool emberAfPollControlClusterSetShortPollIntervalCallback(chip::app::Command * commandObj, uint16_t newShortPollInterval);
-
+bool emberAfPollControlClusterSetShortPollIntervalCallback(chip::app::CommandHandler * commandObj, uint16_t newShortPollInterval);
 /**
- * @brief  Cluster StartUp Command callback
+ * @brief  Cluster StartUp Command callback (from server)
  */
-bool emberAfBasicClusterStartUpCallback(chip::app::Command * commandObj);
-
+bool emberAfBasicClusterStartUpCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster MfgSpecificPing Command callback
+ * @brief  Cluster MfgSpecificPing Command callback (from client)
  */
-bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj);
-
+bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ShutDown Command callback
+ * @brief  Cluster ShutDown Command callback (from server)
  */
-bool emberAfBasicClusterShutDownCallback(chip::app::Command * commandObj);
-
+bool emberAfBasicClusterShutDownCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster Leave Command callback
+ * @brief  Cluster Leave Command callback (from server)
  */
-bool emberAfBasicClusterLeaveCallback(chip::app::Command * commandObj);
-
+bool emberAfBasicClusterLeaveCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster QueryImage Command callback
+ * @brief  Cluster QueryImage Command callback (from client)
  */
 bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(
-    chip::app::Command * commandObj, uint16_t vendorId, uint16_t productId, uint16_t imageType, uint16_t hardwareVersion,
+    chip::app::CommandHandler * commandObj, uint16_t vendorId, uint16_t productId, uint16_t imageType, uint16_t hardwareVersion,
     uint32_t currentVersion, /* TYPE WARNING: array array defaults to */ uint8_t * protocolsSupported, uint8_t * location,
     uint8_t requestorCanConsent, chip::ByteSpan metadataForProvider);
-
 /**
- * @brief  Cluster ApplyUpdateRequest Command callback
+ * @brief  Cluster ApplyUpdateRequest Command callback (from client)
  */
-bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
-                                                                       uint32_t newVersion);
-
+bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::app::CommandHandler * commandObj,
+                                                                       chip::ByteSpan updateToken, uint32_t newVersion);
 /**
- * @brief  Cluster NotifyUpdateApplied Command callback
+ * @brief  Cluster NotifyUpdateApplied Command callback (from client)
  */
-bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
-                                                                        uint32_t currentVersion);
-
+bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::app::CommandHandler * commandObj,
+                                                                        chip::ByteSpan updateToken, uint32_t currentVersion);
 /**
- * @brief  Cluster QueryImageResponse Command callback
+ * @brief  Cluster QueryImageResponse Command callback (from server)
  */
-bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::app::Command * commandObj, uint8_t status,
+bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
                                                                        uint32_t delayedActionTime, uint8_t * imageURI,
                                                                        uint32_t softwareVersion, chip::ByteSpan updateToken,
                                                                        uint8_t userConsentNeeded,
                                                                        chip::ByteSpan metadataForRequestor);
-
 /**
- * @brief  Cluster ApplyUpdateRequestResponse Command callback
+ * @brief  Cluster ApplyUpdateRequestResponse Command callback (from server)
  */
-bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(chip::app::Command * commandObj, uint8_t action,
-                                                                               uint32_t delayedActionTime);
-
+bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(chip::app::CommandSender * commandObj,
+                                                                               uint8_t action, uint32_t delayedActionTime);
 /**
- * @brief  Cluster AnnounceOtaProvider Command callback
+ * @brief  Cluster AnnounceOtaProvider Command callback (from client)
  */
-bool emberAfOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderCallback(chip::app::Command * commandObj,
+bool emberAfOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderCallback(chip::app::CommandHandler * commandObj,
                                                                          chip::ByteSpan serverLocation, uint16_t vendorId,
                                                                          uint8_t announcementReason,
                                                                          chip::ByteSpan metadataForNode);
-
 /**
- * @brief  Cluster ArmFailSafe Command callback
+ * @brief  Cluster ArmFailSafe Command callback (from client)
  */
-bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
+bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::CommandHandler * commandObj, uint16_t expiryLengthSeconds,
                                                            uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster ArmFailSafeResponse Command callback
+ * @brief  Cluster ArmFailSafeResponse Command callback (from server)
  */
-bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                    uint8_t * debugText);
-
 /**
- * @brief  Cluster SetRegulatoryConfig Command callback
+ * @brief  Cluster SetRegulatoryConfig Command callback (from client)
  */
-bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
+bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::CommandHandler * commandObj, uint8_t location,
                                                                    uint8_t * countryCode, uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster SetRegulatoryConfigResponse Command callback
+ * @brief  Cluster SetRegulatoryConfigResponse Command callback (from server)
  */
-bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                            uint8_t * debugText);
-
 /**
- * @brief  Cluster CommissioningComplete Command callback
+ * @brief  Cluster CommissioningComplete Command callback (from client)
  */
-bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::Command * commandObj);
-
+bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster CommissioningCompleteResponse Command callback
+ * @brief  Cluster CommissioningCompleteResponse Command callback (from server)
  */
-bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
-                                                                             uint8_t * debugText);
-
+bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::CommandSender * commandObj,
+                                                                             uint8_t errorCode, uint8_t * debugText);
 /**
- * @brief  Cluster ScanNetworks Command callback
+ * @brief  Cluster ScanNetworks Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
+bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan ssid,
                                                             uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster ScanNetworksResponse Command callback
+ * @brief  Cluster ScanNetworksResponse Command callback (from server)
  */
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    chip::app::Command * commandObj, uint8_t errorCode, uint8_t * debugText,
+    chip::app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults);
-
 /**
- * @brief  Cluster AddWiFiNetwork Command callback
+ * @brief  Cluster AddWiFiNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
+bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan ssid,
                                                               chip::ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster AddWiFiNetworkResponse Command callback
+ * @brief  Cluster AddWiFiNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                       uint8_t * debugText);
-
 /**
- * @brief  Cluster UpdateWiFiNetwork Command callback
+ * @brief  Cluster UpdateWiFiNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
+bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan ssid,
                                                                  chip::ByteSpan credentials, uint64_t breadcrumb,
                                                                  uint32_t timeoutMs);
-
 /**
- * @brief  Cluster UpdateWiFiNetworkResponse Command callback
+ * @brief  Cluster UpdateWiFiNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                          uint8_t * debugText);
-
 /**
- * @brief  Cluster AddThreadNetwork Command callback
+ * @brief  Cluster AddThreadNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
-                                                                uint64_t breadcrumb, uint32_t timeoutMs);
-
+bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::CommandHandler * commandObj,
+                                                                chip::ByteSpan operationalDataset, uint64_t breadcrumb,
+                                                                uint32_t timeoutMs);
 /**
- * @brief  Cluster AddThreadNetworkResponse Command callback
+ * @brief  Cluster AddThreadNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                         uint8_t * debugText);
-
 /**
- * @brief  Cluster UpdateThreadNetwork Command callback
+ * @brief  Cluster UpdateThreadNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
+bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::CommandHandler * commandObj,
                                                                    chip::ByteSpan operationalDataset, uint64_t breadcrumb,
                                                                    uint32_t timeoutMs);
-
 /**
- * @brief  Cluster UpdateThreadNetworkResponse Command callback
+ * @brief  Cluster UpdateThreadNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                            uint8_t * debugText);
-
 /**
- * @brief  Cluster RemoveNetwork Command callback
+ * @brief  Cluster RemoveNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
+bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan NetworkID,
                                                              uint64_t Breadcrumb, uint32_t TimeoutMs);
-
 /**
- * @brief  Cluster RemoveNetworkResponse Command callback
+ * @brief  Cluster RemoveNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                      uint8_t * debugText);
-
 /**
- * @brief  Cluster EnableNetwork Command callback
+ * @brief  Cluster EnableNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
+bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan networkID,
                                                              uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster EnableNetworkResponse Command callback
+ * @brief  Cluster EnableNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                      uint8_t * debugText);
-
 /**
- * @brief  Cluster DisableNetwork Command callback
+ * @brief  Cluster DisableNetwork Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
+bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan networkID,
                                                               uint64_t breadcrumb, uint32_t timeoutMs);
-
 /**
- * @brief  Cluster DisableNetworkResponse Command callback
+ * @brief  Cluster DisableNetworkResponse Command callback (from server)
  */
-bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                       uint8_t * debugText);
-
 /**
- * @brief  Cluster GetLastNetworkCommissioningResult Command callback
+ * @brief  Cluster GetLastNetworkCommissioningResult Command callback (from client)
  */
-bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
+bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::CommandHandler * commandObj,
                                                                                  uint32_t timeoutMs);
-
 /**
- * @brief  Cluster RetrieveLogsRequest Command callback
+ * @brief  Cluster RetrieveLogsRequest Command callback (from client)
  */
-bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::app::Command * commandObj, uint8_t intent,
+bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::app::CommandHandler * commandObj, uint8_t intent,
                                                              uint8_t requestedProtocol, chip::ByteSpan transferFileDesignator);
-
 /**
- * @brief  Cluster RetrieveLogsResponse Command callback
+ * @brief  Cluster RetrieveLogsResponse Command callback (from server)
  */
-bool emberAfDiagnosticLogsClusterRetrieveLogsResponseCallback(chip::app::Command * commandObj, uint8_t status,
+bool emberAfDiagnosticLogsClusterRetrieveLogsResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
                                                               chip::ByteSpan content,
                                                               /* TYPE WARNING: utc defaults to */ uint8_t * timeStamp,
                                                               uint32_t timeSinceBoot);
-
 /**
- * @brief  Cluster ResetWatermarks Command callback
+ * @brief  Cluster ResetWatermarks Command callback (from client)
  */
-bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(chip::app::Command * commandObj);
-
+bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ResetCounts Command callback
+ * @brief  Cluster ResetCounts Command callback (from client)
  */
-bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(chip::app::Command * commandObj);
-
+bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ResetCounts Command callback
+ * @brief  Cluster ResetCounts Command callback (from client)
  */
-bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(chip::app::Command * commandObj);
-
+bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ResetCounts Command callback
+ * @brief  Cluster ResetCounts Command callback (from client)
  */
-bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::app::Command * commandObj);
-
+bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster StartUp Command callback
+ * @brief  Cluster StartUp Command callback (from server)
  */
-bool emberAfBridgedDeviceBasicClusterStartUpCallback(chip::app::Command * commandObj);
-
+bool emberAfBridgedDeviceBasicClusterStartUpCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster ShutDown Command callback
+ * @brief  Cluster ShutDown Command callback (from server)
  */
-bool emberAfBridgedDeviceBasicClusterShutDownCallback(chip::app::Command * commandObj);
-
+bool emberAfBridgedDeviceBasicClusterShutDownCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster Leave Command callback
+ * @brief  Cluster Leave Command callback (from server)
  */
-bool emberAfBridgedDeviceBasicClusterLeaveCallback(chip::app::Command * commandObj);
-
+bool emberAfBridgedDeviceBasicClusterLeaveCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster ReachableChanged Command callback
+ * @brief  Cluster ReachableChanged Command callback (from server)
  */
-bool emberAfBridgedDeviceBasicClusterReachableChangedCallback(chip::app::Command * commandObj);
-
+bool emberAfBridgedDeviceBasicClusterReachableChangedCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster SetFabric Command callback
+ * @brief  Cluster SetFabric Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * commandObj, uint16_t VendorId);
-
+bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::CommandHandler * commandObj, uint16_t VendorId);
 /**
- * @brief  Cluster SetFabricResponse Command callback
+ * @brief  Cluster SetFabricResponse Command callback (from server)
  */
-bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Command * commandObj, chip::FabricId FabricId);
-
+bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::CommandSender * commandObj, chip::FabricId FabricId);
 /**
- * @brief  Cluster OpCSRRequest Command callback
+ * @brief  Cluster OpCSRRequest Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::Command * commandObj, chip::ByteSpan CSRNonce);
-
+bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan CSRNonce);
 /**
- * @brief  Cluster OpCSRResponse Command callback
+ * @brief  Cluster OpCSRResponse Command callback (from server)
  */
-bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Command * commandObj, chip::ByteSpan CSR,
+bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::CommandSender * commandObj, chip::ByteSpan CSR,
                                                                chip::ByteSpan CSRNonce, chip::ByteSpan VendorReserved1,
                                                                chip::ByteSpan VendorReserved2, chip::ByteSpan VendorReserved3,
                                                                chip::ByteSpan Signature);
-
 /**
- * @brief  Cluster AddOpCert Command callback
+ * @brief  Cluster AddOpCert Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::Command * commandObj, chip::ByteSpan NOCArray,
+bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::CommandHandler * commandObj, chip::ByteSpan NOCArray,
                                                            chip::ByteSpan IPKValue, chip::NodeId CaseAdminNode,
                                                            uint16_t AdminVendorId);
-
 /**
- * @brief  Cluster OpCertResponse Command callback
+ * @brief  Cluster OpCertResponse Command callback (from server)
  */
-bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Command * commandObj, uint8_t StatusCode,
+bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::CommandSender * commandObj, uint8_t StatusCode,
                                                                 uint64_t FabricIndex, uint8_t * DebugText);
-
 /**
- * @brief  Cluster UpdateFabricLabel Command callback
+ * @brief  Cluster UpdateFabricLabel Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Command * commandObj, uint8_t * Label);
-
+bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::CommandHandler * commandObj, uint8_t * Label);
 /**
- * @brief  Cluster RemoveFabric Command callback
+ * @brief  Cluster RemoveFabric Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::Command * commandObj, chip::FabricId FabricId,
+bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::CommandHandler * commandObj, chip::FabricId FabricId,
                                                               chip::NodeId NodeId, uint16_t VendorId);
-
 /**
- * @brief  Cluster RemoveAllFabrics Command callback
+ * @brief  Cluster RemoveAllFabrics Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::Command * commandObj);
-
+bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster AddTrustedRootCertificate Command callback
+ * @brief  Cluster AddTrustedRootCertificate Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip::app::Command * commandObj,
+bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip::app::CommandHandler * commandObj,
                                                                            chip::ByteSpan RootCertificate);
-
 /**
- * @brief  Cluster RemoveTrustedRootCertificate Command callback
+ * @brief  Cluster RemoveTrustedRootCertificate Command callback (from client)
  */
-bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(chip::app::Command * commandObj,
+bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(chip::app::CommandHandler * commandObj,
                                                                               chip::ByteSpan TrustedRootIdentifier);
-
 /**
- * @brief  Cluster LockDoor Command callback
+ * @brief  Cluster LockDoor Command callback (from client)
  */
-bool emberAfDoorLockClusterLockDoorCallback(chip::app::Command * commandObj, uint8_t * PIN);
-
+bool emberAfDoorLockClusterLockDoorCallback(chip::app::CommandHandler * commandObj, uint8_t * PIN);
 /**
- * @brief  Cluster LockDoorResponse Command callback
+ * @brief  Cluster LockDoorResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster UnlockDoor Command callback
+ * @brief  Cluster UnlockDoor Command callback (from client)
  */
-bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::Command * commandObj, uint8_t * PIN);
-
+bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::CommandHandler * commandObj, uint8_t * PIN);
 /**
- * @brief  Cluster UnlockDoorResponse Command callback
+ * @brief  Cluster UnlockDoorResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster Toggle Command callback
+ * @brief  Cluster Toggle Command callback (from client)
  */
-bool emberAfDoorLockClusterToggleCallback(chip::app::Command * commandObj, uint8_t * pin);
-
+bool emberAfDoorLockClusterToggleCallback(chip::app::CommandHandler * commandObj, uint8_t * pin);
 /**
- * @brief  Cluster ToggleResponse Command callback
+ * @brief  Cluster ToggleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterToggleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterToggleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster UnlockWithTimeout Command callback
+ * @brief  Cluster UnlockWithTimeout Command callback (from client)
  */
-bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::Command * commandObj, uint16_t timeoutInSeconds, uint8_t * pin);
-
+bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::CommandHandler * commandObj, uint16_t timeoutInSeconds,
+                                                     uint8_t * pin);
 /**
- * @brief  Cluster UnlockWithTimeoutResponse Command callback
+ * @brief  Cluster UnlockWithTimeoutResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetLogRecord Command callback
+ * @brief  Cluster GetLogRecord Command callback (from client)
  */
-bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::Command * commandObj, uint16_t logIndex);
-
+bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::CommandHandler * commandObj, uint16_t logIndex);
 /**
- * @brief  Cluster GetLogRecordResponse Command callback
+ * @brief  Cluster GetLogRecordResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * commandObj, uint16_t logEntryId, uint32_t timestamp,
-                                                        uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode,
-                                                        uint16_t userId, uint8_t * pin);
-
+bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::CommandSender * commandObj, uint16_t logEntryId,
+                                                        uint32_t timestamp, uint8_t eventType, uint8_t source,
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin);
 /**
- * @brief  Cluster SetPin Command callback
+ * @brief  Cluster SetPin Command callback (from client)
  */
-bool emberAfDoorLockClusterSetPinCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                          uint8_t * pin);
-
+bool emberAfDoorLockClusterSetPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userStatus,
+                                          uint8_t userType, uint8_t * pin);
 /**
- * @brief  Cluster SetPinResponse Command callback
+ * @brief  Cluster SetPinResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetPin Command callback
+ * @brief  Cluster GetPin Command callback (from client)
  */
-bool emberAfDoorLockClusterGetPinCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterGetPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster GetPinResponse Command callback
+ * @brief  Cluster GetPinResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
+bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userStatus,
                                                   uint8_t userType, uint8_t * pin);
-
 /**
- * @brief  Cluster ClearPin Command callback
+ * @brief  Cluster ClearPin Command callback (from client)
  */
-bool emberAfDoorLockClusterClearPinCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterClearPinCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster ClearPinResponse Command callback
+ * @brief  Cluster ClearPinResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster ClearAllPins Command callback
+ * @brief  Cluster ClearAllPins Command callback (from client)
  */
-bool emberAfDoorLockClusterClearAllPinsCallback(chip::app::Command * commandObj);
-
+bool emberAfDoorLockClusterClearAllPinsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ClearAllPinsResponse Command callback
+ * @brief  Cluster ClearAllPinsResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster SetUserStatus Command callback
+ * @brief  Cluster SetUserStatus Command callback (from client)
  */
-bool emberAfDoorLockClusterSetUserStatusCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus);
-
+bool emberAfDoorLockClusterSetUserStatusCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userStatus);
 /**
- * @brief  Cluster SetUserStatusResponse Command callback
+ * @brief  Cluster SetUserStatusResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetUserStatusResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetUserStatusResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetUserStatus Command callback
+ * @brief  Cluster GetUserStatus Command callback (from client)
  */
-bool emberAfDoorLockClusterGetUserStatusCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterGetUserStatusCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster GetUserStatusResponse Command callback
+ * @brief  Cluster GetUserStatusResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetUserStatusResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t status);
-
+bool emberAfDoorLockClusterGetUserStatusResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t status);
 /**
- * @brief  Cluster SetWeekdaySchedule Command callback
+ * @brief  Cluster SetWeekdaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
+bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId,
                                                       uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour,
                                                       uint8_t endMinute);
-
 /**
- * @brief  Cluster SetWeekdayScheduleResponse Command callback
+ * @brief  Cluster SetWeekdayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetWeekdaySchedule Command callback
+ * @brief  Cluster GetWeekdaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
-
+bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId);
 /**
- * @brief  Cluster GetWeekdayScheduleResponse Command callback
+ * @brief  Cluster GetWeekdayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
-                                                              uint8_t status, uint8_t daysMask, uint8_t startHour,
+bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint16_t userId, uint8_t status, uint8_t daysMask, uint8_t startHour,
                                                               uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
-
 /**
- * @brief  Cluster ClearWeekdaySchedule Command callback
+ * @brief  Cluster ClearWeekdaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
-
+bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                        uint16_t userId);
 /**
- * @brief  Cluster ClearWeekdayScheduleResponse Command callback
+ * @brief  Cluster ClearWeekdayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster SetYeardaySchedule Command callback
+ * @brief  Cluster SetYeardaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
+bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId,
                                                       uint32_t localStartTime, uint32_t localEndTime);
-
 /**
- * @brief  Cluster SetYeardayScheduleResponse Command callback
+ * @brief  Cluster SetYeardayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetYeardaySchedule Command callback
+ * @brief  Cluster GetYeardaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
-
+bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId, uint16_t userId);
 /**
- * @brief  Cluster GetYeardayScheduleResponse Command callback
+ * @brief  Cluster GetYeardayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
-                                                              uint8_t status, uint32_t localStartTime, uint32_t localEndTime);
-
+bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint16_t userId, uint8_t status, uint32_t localStartTime,
+                                                              uint32_t localEndTime);
 /**
- * @brief  Cluster ClearYeardaySchedule Command callback
+ * @brief  Cluster ClearYeardaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
-
+bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                        uint16_t userId);
 /**
- * @brief  Cluster ClearYeardayScheduleResponse Command callback
+ * @brief  Cluster ClearYeardayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster SetHolidaySchedule Command callback
+ * @brief  Cluster SetHolidaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint32_t localStartTime,
-                                                      uint32_t localEndTime, uint8_t operatingModeDuringHoliday);
-
+bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                      uint32_t localStartTime, uint32_t localEndTime,
+                                                      uint8_t operatingModeDuringHoliday);
 /**
- * @brief  Cluster SetHolidayScheduleResponse Command callback
+ * @brief  Cluster SetHolidayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetHolidaySchedule Command callback
+ * @brief  Cluster GetHolidaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId);
-
+bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId);
 /**
- * @brief  Cluster GetHolidayScheduleResponse Command callback
+ * @brief  Cluster GetHolidayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint8_t status,
-                                                              uint32_t localStartTime, uint32_t localEndTime,
+bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint8_t status, uint32_t localStartTime, uint32_t localEndTime,
                                                               uint8_t operatingModeDuringHoliday);
-
 /**
- * @brief  Cluster ClearHolidaySchedule Command callback
+ * @brief  Cluster ClearHolidaySchedule Command callback (from client)
  */
-bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId);
-
+bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t scheduleId);
 /**
- * @brief  Cluster ClearHolidayScheduleResponse Command callback
+ * @brief  Cluster ClearHolidayScheduleResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster SetUserType Command callback
+ * @brief  Cluster SetUserType Command callback (from client)
  */
-bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
-
+bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userType);
 /**
- * @brief  Cluster SetUserTypeResponse Command callback
+ * @brief  Cluster SetUserTypeResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetUserType Command callback
+ * @brief  Cluster GetUserType Command callback (from client)
  */
-bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster GetUserTypeResponse Command callback
+ * @brief  Cluster GetUserTypeResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
-
+bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userType);
 /**
- * @brief  Cluster SetRfid Command callback
+ * @brief  Cluster SetRfid Command callback (from client)
  */
-bool emberAfDoorLockClusterSetRfidCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
-                                           uint8_t * id);
-
+bool emberAfDoorLockClusterSetRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId, uint8_t userStatus,
+                                           uint8_t userType, uint8_t * id);
 /**
- * @brief  Cluster SetRfidResponse Command callback
+ * @brief  Cluster SetRfidResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetRfid Command callback
+ * @brief  Cluster GetRfid Command callback (from client)
  */
-bool emberAfDoorLockClusterGetRfidCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterGetRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster GetRfidResponse Command callback
+ * @brief  Cluster GetRfidResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
+bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userStatus,
                                                    uint8_t userType, uint8_t * rfid);
-
 /**
- * @brief  Cluster ClearRfid Command callback
+ * @brief  Cluster ClearRfid Command callback (from client)
  */
-bool emberAfDoorLockClusterClearRfidCallback(chip::app::Command * commandObj, uint16_t userId);
-
+bool emberAfDoorLockClusterClearRfidCallback(chip::app::CommandHandler * commandObj, uint16_t userId);
 /**
- * @brief  Cluster ClearRfidResponse Command callback
+ * @brief  Cluster ClearRfidResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster ClearAllRfids Command callback
+ * @brief  Cluster ClearAllRfids Command callback (from client)
  */
-bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::Command * commandObj);
-
+bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ClearAllRfidsResponse Command callback
+ * @brief  Cluster ClearAllRfidsResponse Command callback (from server)
  */
-bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster OperationEventNotification Command callback
+ * @brief  Cluster OperationEventNotification Command callback (from server)
  */
-bool emberAfDoorLockClusterOperationEventNotificationCallback(chip::app::Command * commandObj, uint8_t source, uint8_t eventCode,
-                                                              uint16_t userId, uint8_t * pin, uint32_t timeStamp, uint8_t * data);
-
+bool emberAfDoorLockClusterOperationEventNotificationCallback(chip::app::CommandSender * commandObj, uint8_t source,
+                                                              uint8_t eventCode, uint16_t userId, uint8_t * pin, uint32_t timeStamp,
+                                                              uint8_t * data);
 /**
- * @brief  Cluster ProgrammingEventNotification Command callback
+ * @brief  Cluster ProgrammingEventNotification Command callback (from server)
  */
-bool emberAfDoorLockClusterProgrammingEventNotificationCallback(chip::app::Command * commandObj, uint8_t source, uint8_t eventCode,
-                                                                uint16_t userId, uint8_t * pin, uint8_t userType,
+bool emberAfDoorLockClusterProgrammingEventNotificationCallback(chip::app::CommandSender * commandObj, uint8_t source,
+                                                                uint8_t eventCode, uint16_t userId, uint8_t * pin, uint8_t userType,
                                                                 uint8_t userStatus, uint32_t timeStamp, uint8_t * data);
-
 /**
- * @brief  Cluster UpOrOpen Command callback
+ * @brief  Cluster UpOrOpen Command callback (from client)
  */
-bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::app::Command * commandObj);
-
+bool emberAfWindowCoveringClusterUpOrOpenCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster DownOrClose Command callback
+ * @brief  Cluster DownOrClose Command callback (from client)
  */
-bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::app::Command * commandObj);
-
+bool emberAfWindowCoveringClusterDownOrCloseCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster StopMotion Command callback
+ * @brief  Cluster StopMotion Command callback (from client)
  */
-bool emberAfWindowCoveringClusterStopMotionCallback(chip::app::Command * commandObj);
-
+bool emberAfWindowCoveringClusterStopMotionCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GoToLiftValue Command callback
+ * @brief  Cluster GoToLiftValue Command callback (from client)
  */
-bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::app::Command * commandObj, uint16_t liftValue);
-
+bool emberAfWindowCoveringClusterGoToLiftValueCallback(chip::app::CommandHandler * commandObj, uint16_t liftValue);
 /**
- * @brief  Cluster GoToLiftPercentage Command callback
+ * @brief  Cluster GoToLiftPercentage Command callback (from client)
  */
-bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::Command * commandObj, uint8_t liftPercentageValue,
+bool emberAfWindowCoveringClusterGoToLiftPercentageCallback(chip::app::CommandHandler * commandObj, uint8_t liftPercentageValue,
                                                             uint16_t liftPercent100thsValue);
-
 /**
- * @brief  Cluster GoToTiltValue Command callback
+ * @brief  Cluster GoToTiltValue Command callback (from client)
  */
-bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::app::Command * commandObj, uint16_t tiltValue);
-
+bool emberAfWindowCoveringClusterGoToTiltValueCallback(chip::app::CommandHandler * commandObj, uint16_t tiltValue);
 /**
- * @brief  Cluster GoToTiltPercentage Command callback
+ * @brief  Cluster GoToTiltPercentage Command callback (from client)
  */
-bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::Command * commandObj, uint8_t tiltPercentageValue,
+bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(chip::app::CommandHandler * commandObj, uint8_t tiltPercentageValue,
                                                             uint16_t tiltPercent100thsValue);
-
 /**
- * @brief  Cluster BarrierControlGoToPercent Command callback
+ * @brief  Cluster BarrierControlGoToPercent Command callback (from client)
  */
-bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Command * commandObj, uint8_t percentOpen);
-
+bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::CommandHandler * commandObj, uint8_t percentOpen);
 /**
- * @brief  Cluster BarrierControlStop Command callback
+ * @brief  Cluster BarrierControlStop Command callback (from client)
  */
-bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::app::Command * commandObj);
-
+bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SetpointRaiseLower Command callback
+ * @brief  Cluster SetpointRaiseLower Command callback (from client)
  */
-bool emberAfThermostatClusterSetpointRaiseLowerCallback(chip::app::Command * commandObj, uint8_t mode, int8_t amount);
-
+bool emberAfThermostatClusterSetpointRaiseLowerCallback(chip::app::CommandHandler * commandObj, uint8_t mode, int8_t amount);
 /**
- * @brief  Cluster CurrentWeeklySchedule Command callback
+ * @brief  Cluster CurrentWeeklySchedule Command callback (from server)
  */
-bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(chip::app::Command * commandObj, uint8_t numberOfTransitionsForSequence,
-                                                           uint8_t dayOfWeekForSequence, uint8_t modeForSequence,
+bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(chip::app::CommandSender * commandObj,
+                                                           uint8_t numberOfTransitionsForSequence, uint8_t dayOfWeekForSequence,
+                                                           uint8_t modeForSequence,
                                                            /* TYPE WARNING: array array defaults to */ uint8_t * payload);
-
 /**
- * @brief  Cluster SetWeeklySchedule Command callback
+ * @brief  Cluster SetWeeklySchedule Command callback (from client)
  */
-bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::Command * commandObj, uint8_t numberOfTransitionsForSequence,
-                                                       uint8_t dayOfWeekForSequence, uint8_t modeForSequence,
+bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj,
+                                                       uint8_t numberOfTransitionsForSequence, uint8_t dayOfWeekForSequence,
+                                                       uint8_t modeForSequence,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * payload);
-
 /**
- * @brief  Cluster RelayStatusLog Command callback
+ * @brief  Cluster RelayStatusLog Command callback (from server)
  */
-bool emberAfThermostatClusterRelayStatusLogCallback(chip::app::Command * commandObj, uint16_t timeOfDay, uint16_t relayStatus,
+bool emberAfThermostatClusterRelayStatusLogCallback(chip::app::CommandSender * commandObj, uint16_t timeOfDay, uint16_t relayStatus,
                                                     int16_t localTemperature, uint8_t humidityInPercentage, int16_t setpoint,
                                                     uint16_t unreadEntries);
-
 /**
- * @brief  Cluster GetWeeklySchedule Command callback
+ * @brief  Cluster GetWeeklySchedule Command callback (from client)
  */
-bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::Command * commandObj, uint8_t daysToReturn, uint8_t modeToReturn);
-
+bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t daysToReturn,
+                                                       uint8_t modeToReturn);
 /**
- * @brief  Cluster ClearWeeklySchedule Command callback
+ * @brief  Cluster ClearWeeklySchedule Command callback (from client)
  */
-bool emberAfThermostatClusterClearWeeklyScheduleCallback(chip::app::Command * commandObj);
-
+bool emberAfThermostatClusterClearWeeklyScheduleCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetRelayStatusLog Command callback
+ * @brief  Cluster GetRelayStatusLog Command callback (from client)
  */
-bool emberAfThermostatClusterGetRelayStatusLogCallback(chip::app::Command * commandObj);
-
+bool emberAfThermostatClusterGetRelayStatusLogCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MoveToHue Command callback
+ * @brief  Cluster MoveToHue Command callback (from client)
  */
-bool emberAfColorControlClusterMoveToHueCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t direction,
+bool emberAfColorControlClusterMoveToHueCallback(chip::app::CommandHandler * commandObj, uint8_t hue, uint8_t direction,
                                                  uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveHue Command callback
+ * @brief  Cluster MoveHue Command callback (from client)
  */
-bool emberAfColorControlClusterMoveHueCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                               uint8_t optionsOverride);
-
+bool emberAfColorControlClusterMoveHueCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
+                                               uint8_t optionsMask, uint8_t optionsOverride);
 /**
- * @brief  Cluster StepHue Command callback
+ * @brief  Cluster StepHue Command callback (from client)
  */
-bool emberAfColorControlClusterStepHueCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfColorControlClusterStepHueCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveToSaturation Command callback
+ * @brief  Cluster MoveToSaturation Command callback (from client)
  */
-bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::Command * commandObj, uint8_t saturation,
+bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t saturation,
                                                         uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveSaturation Command callback
+ * @brief  Cluster MoveSaturation Command callback (from client)
  */
-bool emberAfColorControlClusterMoveSaturationCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate,
+bool emberAfColorControlClusterMoveSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
                                                       uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster StepSaturation Command callback
+ * @brief  Cluster StepSaturation Command callback (from client)
  */
-bool emberAfColorControlClusterStepSaturationCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
+bool emberAfColorControlClusterStepSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint8_t stepSize,
                                                       uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveToHueAndSaturation Command callback
+ * @brief  Cluster MoveToHueAndSaturation Command callback (from client)
  */
-bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t saturation,
-                                                              uint16_t transitionTime, uint8_t optionsMask,
+bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::CommandHandler * commandObj, uint8_t hue,
+                                                              uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
                                                               uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveToColor Command callback
+ * @brief  Cluster MoveToColor Command callback (from client)
  */
-bool emberAfColorControlClusterMoveToColorCallback(chip::app::Command * commandObj, uint16_t colorX, uint16_t colorY,
+bool emberAfColorControlClusterMoveToColorCallback(chip::app::CommandHandler * commandObj, uint16_t colorX, uint16_t colorY,
                                                    uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveColor Command callback
+ * @brief  Cluster MoveColor Command callback (from client)
  */
-bool emberAfColorControlClusterMoveColorCallback(chip::app::Command * commandObj, int16_t rateX, int16_t rateY, uint8_t optionsMask,
-                                                 uint8_t optionsOverride);
-
+bool emberAfColorControlClusterMoveColorCallback(chip::app::CommandHandler * commandObj, int16_t rateX, int16_t rateY,
+                                                 uint8_t optionsMask, uint8_t optionsOverride);
 /**
- * @brief  Cluster StepColor Command callback
+ * @brief  Cluster StepColor Command callback (from client)
  */
-bool emberAfColorControlClusterStepColorCallback(chip::app::Command * commandObj, int16_t stepX, int16_t stepY,
+bool emberAfColorControlClusterStepColorCallback(chip::app::CommandHandler * commandObj, int16_t stepX, int16_t stepY,
                                                  uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster MoveToColorTemperature Command callback
+ * @brief  Cluster MoveToColorTemperature Command callback (from client)
  */
-bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::Command * commandObj, uint16_t colorTemperature,
+bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint16_t colorTemperature,
                                                               uint16_t transitionTime, uint8_t optionsMask,
                                                               uint8_t optionsOverride);
-
 /**
- * @brief  Cluster EnhancedMoveToHue Command callback
+ * @brief  Cluster EnhancedMoveToHue Command callback (from client)
  */
-bool emberAfColorControlClusterEnhancedMoveToHueCallback(chip::app::Command * commandObj, uint16_t enhancedHue, uint8_t direction,
-                                                         uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
+bool emberAfColorControlClusterEnhancedMoveToHueCallback(chip::app::CommandHandler * commandObj, uint16_t enhancedHue,
+                                                         uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
+                                                         uint8_t optionsOverride);
 /**
- * @brief  Cluster EnhancedMoveHue Command callback
+ * @brief  Cluster EnhancedMoveHue Command callback (from client)
  */
-bool emberAfColorControlClusterEnhancedMoveHueCallback(chip::app::Command * commandObj, uint8_t moveMode, uint16_t rate,
+bool emberAfColorControlClusterEnhancedMoveHueCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint16_t rate,
                                                        uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster EnhancedStepHue Command callback
+ * @brief  Cluster EnhancedStepHue Command callback (from client)
  */
-bool emberAfColorControlClusterEnhancedStepHueCallback(chip::app::Command * commandObj, uint8_t stepMode, uint16_t stepSize,
+bool emberAfColorControlClusterEnhancedStepHueCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode, uint16_t stepSize,
                                                        uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster EnhancedMoveToHueAndSaturation Command callback
+ * @brief  Cluster EnhancedMoveToHueAndSaturation Command callback (from client)
  */
-bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(chip::app::Command * commandObj, uint16_t enhancedHue,
+bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(chip::app::CommandHandler * commandObj, uint16_t enhancedHue,
                                                                       uint8_t saturation, uint16_t transitionTime,
                                                                       uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster ColorLoopSet Command callback
+ * @brief  Cluster ColorLoopSet Command callback (from client)
  */
-bool emberAfColorControlClusterColorLoopSetCallback(chip::app::Command * commandObj, uint8_t updateFlags, uint8_t action,
+bool emberAfColorControlClusterColorLoopSetCallback(chip::app::CommandHandler * commandObj, uint8_t updateFlags, uint8_t action,
                                                     uint8_t direction, uint16_t time, uint16_t startHue, uint8_t optionsMask,
                                                     uint8_t optionsOverride);
-
 /**
- * @brief  Cluster StopMoveStep Command callback
+ * @brief  Cluster StopMoveStep Command callback (from client)
  */
-bool emberAfColorControlClusterStopMoveStepCallback(chip::app::Command * commandObj, uint8_t optionsMask, uint8_t optionsOverride);
-
+bool emberAfColorControlClusterStopMoveStepCallback(chip::app::CommandHandler * commandObj, uint8_t optionsMask,
+                                                    uint8_t optionsOverride);
 /**
- * @brief  Cluster MoveColorTemperature Command callback
+ * @brief  Cluster MoveColorTemperature Command callback (from client)
  */
-bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::Command * commandObj, uint8_t moveMode, uint16_t rate,
+bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint8_t moveMode, uint16_t rate,
                                                             uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
                                                             uint8_t optionsMask, uint8_t optionsOverride);
-
 /**
- * @brief  Cluster StepColorTemperature Command callback
+ * @brief  Cluster StepColorTemperature Command callback (from client)
  */
-bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::Command * commandObj, uint8_t stepMode, uint16_t stepSize,
-                                                            uint16_t transitionTime, uint16_t colorTemperatureMinimum,
-                                                            uint16_t colorTemperatureMaximum, uint8_t optionsMask,
-                                                            uint8_t optionsOverride);
-
+bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::CommandHandler * commandObj, uint8_t stepMode,
+                                                            uint16_t stepSize, uint16_t transitionTime,
+                                                            uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
+                                                            uint8_t optionsMask, uint8_t optionsOverride);
 /**
- * @brief  Cluster ZoneEnrollResponse Command callback
+ * @brief  Cluster ZoneEnrollResponse Command callback (from client)
  */
-bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::app::Command * commandObj, uint8_t enrollResponseCode, uint8_t zoneId);
-
+bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::app::CommandHandler * commandObj, uint8_t enrollResponseCode,
+                                                     uint8_t zoneId);
 /**
- * @brief  Cluster ZoneStatusChangeNotification Command callback
+ * @brief  Cluster ZoneStatusChangeNotification Command callback (from server)
  */
-bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::Command * commandObj, uint16_t zoneStatus,
+bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::CommandSender * commandObj, uint16_t zoneStatus,
                                                                uint8_t extendedStatus, uint8_t zoneId, uint16_t delay);
-
 /**
- * @brief  Cluster InitiateNormalOperationMode Command callback
+ * @brief  Cluster InitiateNormalOperationMode Command callback (from client)
  */
-bool emberAfIasZoneClusterInitiateNormalOperationModeCallback(chip::app::Command * commandObj);
-
+bool emberAfIasZoneClusterInitiateNormalOperationModeCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ZoneEnrollRequest Command callback
+ * @brief  Cluster ZoneEnrollRequest Command callback (from server)
  */
-bool emberAfIasZoneClusterZoneEnrollRequestCallback(chip::app::Command * commandObj, uint16_t zoneType, uint16_t manufacturerCode);
-
+bool emberAfIasZoneClusterZoneEnrollRequestCallback(chip::app::CommandSender * commandObj, uint16_t zoneType,
+                                                    uint16_t manufacturerCode);
 /**
- * @brief  Cluster InitiateTestMode Command callback
+ * @brief  Cluster InitiateTestMode Command callback (from client)
  */
-bool emberAfIasZoneClusterInitiateTestModeCallback(chip::app::Command * commandObj, uint8_t testModeDuration,
+bool emberAfIasZoneClusterInitiateTestModeCallback(chip::app::CommandHandler * commandObj, uint8_t testModeDuration,
                                                    uint8_t currentZoneSensitivityLevel);
-
 /**
- * @brief  Cluster InitiateNormalOperationModeResponse Command callback
+ * @brief  Cluster InitiateNormalOperationModeResponse Command callback (from server)
  */
-bool emberAfIasZoneClusterInitiateNormalOperationModeResponseCallback(chip::app::Command * commandObj);
-
+bool emberAfIasZoneClusterInitiateNormalOperationModeResponseCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster InitiateTestModeResponse Command callback
+ * @brief  Cluster InitiateTestModeResponse Command callback (from server)
  */
-bool emberAfIasZoneClusterInitiateTestModeResponseCallback(chip::app::Command * commandObj);
-
+bool emberAfIasZoneClusterInitiateTestModeResponseCallback(chip::app::CommandSender * commandObj);
 /**
- * @brief  Cluster Arm Command callback
+ * @brief  Cluster Arm Command callback (from client)
  */
-bool emberAfIasAceClusterArmCallback(chip::app::Command * commandObj, uint8_t armMode, uint8_t * armDisarmCode, uint8_t zoneId);
-
+bool emberAfIasAceClusterArmCallback(chip::app::CommandHandler * commandObj, uint8_t armMode, uint8_t * armDisarmCode,
+                                     uint8_t zoneId);
 /**
- * @brief  Cluster ArmResponse Command callback
+ * @brief  Cluster ArmResponse Command callback (from server)
  */
-bool emberAfIasAceClusterArmResponseCallback(chip::app::Command * commandObj, uint8_t armNotification);
-
+bool emberAfIasAceClusterArmResponseCallback(chip::app::CommandSender * commandObj, uint8_t armNotification);
 /**
- * @brief  Cluster Bypass Command callback
+ * @brief  Cluster Bypass Command callback (from client)
  */
-bool emberAfIasAceClusterBypassCallback(chip::app::Command * commandObj, uint8_t numberOfZones,
+bool emberAfIasAceClusterBypassCallback(chip::app::CommandHandler * commandObj, uint8_t numberOfZones,
                                         /* TYPE WARNING: array array defaults to */ uint8_t * zoneIds, uint8_t * armDisarmCode);
-
 /**
- * @brief  Cluster GetZoneIdMapResponse Command callback
+ * @brief  Cluster GetZoneIdMapResponse Command callback (from server)
  */
-bool emberAfIasAceClusterGetZoneIdMapResponseCallback(chip::app::Command * commandObj, uint16_t section0, uint16_t section1,
+bool emberAfIasAceClusterGetZoneIdMapResponseCallback(chip::app::CommandSender * commandObj, uint16_t section0, uint16_t section1,
                                                       uint16_t section2, uint16_t section3, uint16_t section4, uint16_t section5,
                                                       uint16_t section6, uint16_t section7, uint16_t section8, uint16_t section9,
                                                       uint16_t section10, uint16_t section11, uint16_t section12,
                                                       uint16_t section13, uint16_t section14, uint16_t section15);
-
 /**
- * @brief  Cluster Emergency Command callback
+ * @brief  Cluster Emergency Command callback (from client)
  */
-bool emberAfIasAceClusterEmergencyCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterEmergencyCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetZoneInformationResponse Command callback
+ * @brief  Cluster GetZoneInformationResponse Command callback (from server)
  */
-bool emberAfIasAceClusterGetZoneInformationResponseCallback(chip::app::Command * commandObj, uint8_t zoneId, uint16_t zoneType,
-                                                            chip::NodeId ieeeAddress, uint8_t * zoneLabel);
-
+bool emberAfIasAceClusterGetZoneInformationResponseCallback(chip::app::CommandSender * commandObj, uint8_t zoneId,
+                                                            uint16_t zoneType, chip::NodeId ieeeAddress, uint8_t * zoneLabel);
 /**
- * @brief  Cluster Fire Command callback
+ * @brief  Cluster Fire Command callback (from client)
  */
-bool emberAfIasAceClusterFireCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterFireCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster ZoneStatusChanged Command callback
+ * @brief  Cluster ZoneStatusChanged Command callback (from server)
  */
-bool emberAfIasAceClusterZoneStatusChangedCallback(chip::app::Command * commandObj, uint8_t zoneId, uint16_t zoneStatus,
+bool emberAfIasAceClusterZoneStatusChangedCallback(chip::app::CommandSender * commandObj, uint8_t zoneId, uint16_t zoneStatus,
                                                    uint8_t audibleNotification, uint8_t * zoneLabel);
-
 /**
- * @brief  Cluster Panic Command callback
+ * @brief  Cluster Panic Command callback (from client)
  */
-bool emberAfIasAceClusterPanicCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterPanicCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster PanelStatusChanged Command callback
+ * @brief  Cluster PanelStatusChanged Command callback (from server)
  */
-bool emberAfIasAceClusterPanelStatusChangedCallback(chip::app::Command * commandObj, uint8_t panelStatus, uint8_t secondsRemaining,
-                                                    uint8_t audibleNotification, uint8_t alarmStatus);
-
+bool emberAfIasAceClusterPanelStatusChangedCallback(chip::app::CommandSender * commandObj, uint8_t panelStatus,
+                                                    uint8_t secondsRemaining, uint8_t audibleNotification, uint8_t alarmStatus);
 /**
- * @brief  Cluster GetZoneIdMap Command callback
+ * @brief  Cluster GetZoneIdMap Command callback (from client)
  */
-bool emberAfIasAceClusterGetZoneIdMapCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterGetZoneIdMapCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetPanelStatusResponse Command callback
+ * @brief  Cluster GetPanelStatusResponse Command callback (from server)
  */
-bool emberAfIasAceClusterGetPanelStatusResponseCallback(chip::app::Command * commandObj, uint8_t panelStatus,
+bool emberAfIasAceClusterGetPanelStatusResponseCallback(chip::app::CommandSender * commandObj, uint8_t panelStatus,
                                                         uint8_t secondsRemaining, uint8_t audibleNotification, uint8_t alarmStatus);
-
 /**
- * @brief  Cluster GetZoneInformation Command callback
+ * @brief  Cluster GetZoneInformation Command callback (from client)
  */
-bool emberAfIasAceClusterGetZoneInformationCallback(chip::app::Command * commandObj, uint8_t zoneId);
-
+bool emberAfIasAceClusterGetZoneInformationCallback(chip::app::CommandHandler * commandObj, uint8_t zoneId);
 /**
- * @brief  Cluster SetBypassedZoneList Command callback
+ * @brief  Cluster SetBypassedZoneList Command callback (from server)
  */
-bool emberAfIasAceClusterSetBypassedZoneListCallback(chip::app::Command * commandObj, uint8_t numberOfZones,
+bool emberAfIasAceClusterSetBypassedZoneListCallback(chip::app::CommandSender * commandObj, uint8_t numberOfZones,
                                                      /* TYPE WARNING: array array defaults to */ uint8_t * zoneIds);
-
 /**
- * @brief  Cluster GetPanelStatus Command callback
+ * @brief  Cluster GetPanelStatus Command callback (from client)
  */
-bool emberAfIasAceClusterGetPanelStatusCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterGetPanelStatusCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster BypassResponse Command callback
+ * @brief  Cluster BypassResponse Command callback (from server)
  */
-bool emberAfIasAceClusterBypassResponseCallback(chip::app::Command * commandObj, uint8_t numberOfZones,
+bool emberAfIasAceClusterBypassResponseCallback(chip::app::CommandSender * commandObj, uint8_t numberOfZones,
                                                 /* TYPE WARNING: array array defaults to */ uint8_t * bypassResult);
-
 /**
- * @brief  Cluster GetBypassedZoneList Command callback
+ * @brief  Cluster GetBypassedZoneList Command callback (from client)
  */
-bool emberAfIasAceClusterGetBypassedZoneListCallback(chip::app::Command * commandObj);
-
+bool emberAfIasAceClusterGetBypassedZoneListCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetZoneStatusResponse Command callback
+ * @brief  Cluster GetZoneStatusResponse Command callback (from server)
  */
-bool emberAfIasAceClusterGetZoneStatusResponseCallback(chip::app::Command * commandObj, uint8_t zoneStatusComplete,
+bool emberAfIasAceClusterGetZoneStatusResponseCallback(chip::app::CommandSender * commandObj, uint8_t zoneStatusComplete,
                                                        uint8_t numberOfZones,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * zoneStatusResult);
-
 /**
- * @brief  Cluster GetZoneStatus Command callback
+ * @brief  Cluster GetZoneStatus Command callback (from client)
  */
-bool emberAfIasAceClusterGetZoneStatusCallback(chip::app::Command * commandObj, uint8_t startingZoneId, uint8_t maxNumberOfZoneIds,
-                                               uint8_t zoneStatusMaskFlag, uint16_t zoneStatusMask);
-
+bool emberAfIasAceClusterGetZoneStatusCallback(chip::app::CommandHandler * commandObj, uint8_t startingZoneId,
+                                               uint8_t maxNumberOfZoneIds, uint8_t zoneStatusMaskFlag, uint16_t zoneStatusMask);
 /**
- * @brief  Cluster StartWarning Command callback
+ * @brief  Cluster StartWarning Command callback (from client)
  */
-bool emberAfIasWdClusterStartWarningCallback(chip::app::Command * commandObj, uint8_t warningInfo, uint16_t warningDuration,
+bool emberAfIasWdClusterStartWarningCallback(chip::app::CommandHandler * commandObj, uint8_t warningInfo, uint16_t warningDuration,
                                              uint8_t strobeDutyCycle, uint8_t strobeLevel);
-
 /**
- * @brief  Cluster Squawk Command callback
+ * @brief  Cluster Squawk Command callback (from client)
  */
-bool emberAfIasWdClusterSquawkCallback(chip::app::Command * commandObj, uint8_t squawkInfo);
-
+bool emberAfIasWdClusterSquawkCallback(chip::app::CommandHandler * commandObj, uint8_t squawkInfo);
 /**
- * @brief  Cluster ChangeChannel Command callback
+ * @brief  Cluster ChangeChannel Command callback (from client)
  */
-bool emberAfTvChannelClusterChangeChannelCallback(chip::app::Command * commandObj, uint8_t * match);
-
+bool emberAfTvChannelClusterChangeChannelCallback(chip::app::CommandHandler * commandObj, uint8_t * match);
 /**
- * @brief  Cluster ChangeChannelResponse Command callback
+ * @brief  Cluster ChangeChannelResponse Command callback (from server)
  */
-bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * commandObj,
+bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::CommandSender * commandObj,
                                                           /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch,
                                                           uint8_t ErrorType);
-
 /**
- * @brief  Cluster ChangeChannelByNumber Command callback
+ * @brief  Cluster ChangeChannelByNumber Command callback (from client)
  */
-bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::Command * commandObj, uint16_t majorNumber,
+bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::CommandHandler * commandObj, uint16_t majorNumber,
                                                           uint16_t minorNumber);
-
 /**
- * @brief  Cluster SkipChannel Command callback
+ * @brief  Cluster SkipChannel Command callback (from client)
  */
-bool emberAfTvChannelClusterSkipChannelCallback(chip::app::Command * commandObj, uint16_t Count);
-
+bool emberAfTvChannelClusterSkipChannelCallback(chip::app::CommandHandler * commandObj, uint16_t Count);
 /**
- * @brief  Cluster NavigateTarget Command callback
+ * @brief  Cluster NavigateTarget Command callback (from client)
  */
-bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::app::Command * commandObj, uint8_t target, uint8_t * data);
-
+bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::app::CommandHandler * commandObj, uint8_t target, uint8_t * data);
 /**
- * @brief  Cluster NavigateTargetResponse Command callback
+ * @brief  Cluster NavigateTargetResponse Command callback (from server)
  */
-bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
-
+bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
+                                                                 uint8_t * data);
 /**
- * @brief  Cluster MediaPlay Command callback
+ * @brief  Cluster MediaPlay Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaPlayResponse Command callback
+ * @brief  Cluster MediaPlayResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaPause Command callback
+ * @brief  Cluster MediaPause Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaPauseResponse Command callback
+ * @brief  Cluster MediaPauseResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaStop Command callback
+ * @brief  Cluster MediaStop Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaStopCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaStopCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaStopResponse Command callback
+ * @brief  Cluster MediaStopResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaStartOver Command callback
+ * @brief  Cluster MediaStartOver Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaStartOverCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaStartOverCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaStartOverResponse Command callback
+ * @brief  Cluster MediaStartOverResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaPrevious Command callback
+ * @brief  Cluster MediaPrevious Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaPreviousCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaPreviousCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaPreviousResponse Command callback
+ * @brief  Cluster MediaPreviousResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaNext Command callback
+ * @brief  Cluster MediaNext Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaNextCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaNextCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaNextResponse Command callback
+ * @brief  Cluster MediaNextResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaRewind Command callback
+ * @brief  Cluster MediaRewind Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaRewindResponse Command callback
+ * @brief  Cluster MediaRewindResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaFastForward Command callback
+ * @brief  Cluster MediaFastForward Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaFastForwardCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaPlaybackClusterMediaFastForwardCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster MediaFastForwardResponse Command callback
+ * @brief  Cluster MediaFastForwardResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::CommandSender * commandObj,
+                                                                 uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaSkipForward Command callback
+ * @brief  Cluster MediaSkipForward Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::Command * commandObj, uint64_t deltaPositionMilliseconds);
-
+bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::CommandHandler * commandObj,
+                                                         uint64_t deltaPositionMilliseconds);
 /**
- * @brief  Cluster MediaSkipForwardResponse Command callback
+ * @brief  Cluster MediaSkipForwardResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::CommandSender * commandObj,
+                                                                 uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaSkipBackward Command callback
+ * @brief  Cluster MediaSkipBackward Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::Command * commandObj, uint64_t deltaPositionMilliseconds);
-
+bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::CommandHandler * commandObj,
+                                                          uint64_t deltaPositionMilliseconds);
 /**
- * @brief  Cluster MediaSkipBackwardResponse Command callback
+ * @brief  Cluster MediaSkipBackwardResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::CommandSender * commandObj,
+                                                                  uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster MediaSeek Command callback
+ * @brief  Cluster MediaSeek Command callback (from client)
  */
-bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::app::Command * commandObj, uint64_t position);
-
+bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::app::CommandHandler * commandObj, uint64_t position);
 /**
- * @brief  Cluster MediaSeekResponse Command callback
+ * @brief  Cluster MediaSeekResponse Command callback (from server)
  */
-bool emberAfMediaPlaybackClusterMediaSeekResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
-
+bool emberAfMediaPlaybackClusterMediaSeekResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus);
 /**
- * @brief  Cluster SelectInput Command callback
+ * @brief  Cluster SelectInput Command callback (from client)
  */
-bool emberAfMediaInputClusterSelectInputCallback(chip::app::Command * commandObj, uint8_t index);
-
+bool emberAfMediaInputClusterSelectInputCallback(chip::app::CommandHandler * commandObj, uint8_t index);
 /**
- * @brief  Cluster ShowInputStatus Command callback
+ * @brief  Cluster ShowInputStatus Command callback (from client)
  */
-bool emberAfMediaInputClusterShowInputStatusCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaInputClusterShowInputStatusCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster HideInputStatus Command callback
+ * @brief  Cluster HideInputStatus Command callback (from client)
  */
-bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::Command * commandObj);
-
+bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster RenameInput Command callback
+ * @brief  Cluster RenameInput Command callback (from client)
  */
-bool emberAfMediaInputClusterRenameInputCallback(chip::app::Command * commandObj, uint8_t index, uint8_t * name);
-
+bool emberAfMediaInputClusterRenameInputCallback(chip::app::CommandHandler * commandObj, uint8_t index, uint8_t * name);
 /**
- * @brief  Cluster Sleep Command callback
+ * @brief  Cluster Sleep Command callback (from client)
  */
-bool emberAfLowPowerClusterSleepCallback(chip::app::Command * commandObj);
-
+bool emberAfLowPowerClusterSleepCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster SendKey Command callback
+ * @brief  Cluster SendKey Command callback (from client)
  */
-bool emberAfKeypadInputClusterSendKeyCallback(chip::app::Command * commandObj, uint8_t keyCode);
-
+bool emberAfKeypadInputClusterSendKeyCallback(chip::app::CommandHandler * commandObj, uint8_t keyCode);
 /**
- * @brief  Cluster SendKeyResponse Command callback
+ * @brief  Cluster SendKeyResponse Command callback (from server)
  */
-bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::CommandSender * commandObj, uint8_t status);
 /**
- * @brief  Cluster LaunchContent Command callback
+ * @brief  Cluster LaunchContent Command callback (from client)
  */
-bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::Command * commandObj, uint8_t autoPlay, uint8_t * data);
-
+bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::CommandHandler * commandObj, uint8_t autoPlay, uint8_t * data);
 /**
- * @brief  Cluster LaunchContentResponse Command callback
+ * @brief  Cluster LaunchContentResponse Command callback (from server)
  */
-bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::app::Command * commandObj, uint8_t * data,
+bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::app::CommandSender * commandObj, uint8_t * data,
                                                                 uint8_t contentLaunchStatus);
-
 /**
- * @brief  Cluster LaunchURL Command callback
+ * @brief  Cluster LaunchURL Command callback (from client)
  */
-bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::Command * commandObj, uint8_t * contentURL, uint8_t * displayString);
-
+bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::CommandHandler * commandObj, uint8_t * contentURL,
+                                                    uint8_t * displayString);
 /**
- * @brief  Cluster LaunchURLResponse Command callback
+ * @brief  Cluster LaunchURLResponse Command callback (from server)
  */
-bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::app::Command * commandObj, uint8_t * data,
+bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::app::CommandSender * commandObj, uint8_t * data,
                                                             uint8_t contentLaunchStatus);
-
 /**
- * @brief  Cluster SelectOutput Command callback
+ * @brief  Cluster SelectOutput Command callback (from client)
  */
-bool emberAfAudioOutputClusterSelectOutputCallback(chip::app::Command * commandObj, uint8_t index);
-
+bool emberAfAudioOutputClusterSelectOutputCallback(chip::app::CommandHandler * commandObj, uint8_t index);
 /**
- * @brief  Cluster RenameOutput Command callback
+ * @brief  Cluster RenameOutput Command callback (from client)
  */
-bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::Command * commandObj, uint8_t index, uint8_t * name);
-
+bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::CommandHandler * commandObj, uint8_t index, uint8_t * name);
 /**
- * @brief  Cluster LaunchApp Command callback
+ * @brief  Cluster LaunchApp Command callback (from client)
  */
-bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::Command * commandObj, uint8_t * data, uint16_t catalogVendorId,
-                                                        uint8_t * applicationId);
-
+bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::CommandHandler * commandObj, uint8_t * data,
+                                                        uint16_t catalogVendorId, uint8_t * applicationId);
 /**
- * @brief  Cluster LaunchAppResponse Command callback
+ * @brief  Cluster LaunchAppResponse Command callback (from server)
  */
-bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
-
+bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
+                                                                uint8_t * data);
 /**
- * @brief  Cluster ChangeStatus Command callback
+ * @brief  Cluster ChangeStatus Command callback (from client)
  */
-bool emberAfApplicationBasicClusterChangeStatusCallback(chip::app::Command * commandObj, uint8_t status);
-
+bool emberAfApplicationBasicClusterChangeStatusCallback(chip::app::CommandHandler * commandObj, uint8_t status);
 /**
- * @brief  Cluster GetSetupPIN Command callback
+ * @brief  Cluster GetSetupPIN Command callback (from client)
  */
-bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::Command * commandObj, uint8_t * tempAccountIdentifier);
-
+bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::CommandHandler * commandObj, uint8_t * tempAccountIdentifier);
 /**
- * @brief  Cluster GetSetupPINResponse Command callback
+ * @brief  Cluster GetSetupPINResponse Command callback (from server)
  */
-bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::Command * commandObj, uint8_t * setupPIN);
-
+bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::CommandSender * commandObj, uint8_t * setupPIN);
 /**
- * @brief  Cluster Login Command callback
+ * @brief  Cluster Login Command callback (from client)
  */
-bool emberAfAccountLoginClusterLoginCallback(chip::app::Command * commandObj, uint8_t * tempAccountIdentifier, uint8_t * setupPIN);
-
+bool emberAfAccountLoginClusterLoginCallback(chip::app::CommandHandler * commandObj, uint8_t * tempAccountIdentifier,
+                                             uint8_t * setupPIN);
 /**
- * @brief  Cluster Test Command callback
+ * @brief  Cluster Test Command callback (from client)
  */
-bool emberAfTestClusterClusterTestCallback(chip::app::Command * commandObj);
-
+bool emberAfTestClusterClusterTestCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster TestSpecificResponse Command callback
+ * @brief  Cluster TestSpecificResponse Command callback (from server)
  */
-bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::Command * commandObj, uint8_t returnValue);
-
+bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::CommandSender * commandObj, uint8_t returnValue);
 /**
- * @brief  Cluster TestNotHandled Command callback
+ * @brief  Cluster TestNotHandled Command callback (from client)
  */
-bool emberAfTestClusterClusterTestNotHandledCallback(chip::app::Command * commandObj);
-
+bool emberAfTestClusterClusterTestNotHandledCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster TestSpecific Command callback
+ * @brief  Cluster TestSpecific Command callback (from client)
  */
-bool emberAfTestClusterClusterTestSpecificCallback(chip::app::Command * commandObj);
-
+bool emberAfTestClusterClusterTestSpecificCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster TestUnknownCommand Command callback
+ * @brief  Cluster TestUnknownCommand Command callback (from client)
  */
-bool emberAfTestClusterClusterTestUnknownCommandCallback(chip::app::Command * commandObj);
-
+bool emberAfTestClusterClusterTestUnknownCommandCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster DisplayMessage Command callback
+ * @brief  Cluster DisplayMessage Command callback (from server)
  */
-bool emberAfMessagingClusterDisplayMessageCallback(chip::app::Command * commandObj, uint32_t messageId, uint8_t messageControl,
-                                                   /* TYPE WARNING: utc defaults to */ uint8_t * startTime,
+bool emberAfMessagingClusterDisplayMessageCallback(chip::app::CommandSender * commandObj, uint32_t messageId,
+                                                   uint8_t messageControl, /* TYPE WARNING: utc defaults to */ uint8_t * startTime,
                                                    uint16_t durationInMinutes, uint8_t * message,
                                                    uint8_t optionalExtendedMessageControl);
-
 /**
- * @brief  Cluster GetLastMessage Command callback
+ * @brief  Cluster GetLastMessage Command callback (from client)
  */
-bool emberAfMessagingClusterGetLastMessageCallback(chip::app::Command * commandObj);
-
+bool emberAfMessagingClusterGetLastMessageCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster CancelMessage Command callback
+ * @brief  Cluster CancelMessage Command callback (from server)
  */
-bool emberAfMessagingClusterCancelMessageCallback(chip::app::Command * commandObj, uint32_t messageId, uint8_t messageControl);
-
+bool emberAfMessagingClusterCancelMessageCallback(chip::app::CommandSender * commandObj, uint32_t messageId,
+                                                  uint8_t messageControl);
 /**
- * @brief  Cluster MessageConfirmation Command callback
+ * @brief  Cluster MessageConfirmation Command callback (from client)
  */
-bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::Command * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
                                                         /* TYPE WARNING: utc defaults to */ uint8_t * confirmationTime,
                                                         uint8_t messageConfirmationControl, chip::ByteSpan messageResponse);
-
 /**
- * @brief  Cluster DisplayProtectedMessage Command callback
+ * @brief  Cluster DisplayProtectedMessage Command callback (from server)
  */
-bool emberAfMessagingClusterDisplayProtectedMessageCallback(chip::app::Command * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterDisplayProtectedMessageCallback(chip::app::CommandSender * commandObj, uint32_t messageId,
                                                             uint8_t messageControl,
                                                             /* TYPE WARNING: utc defaults to */ uint8_t * startTime,
                                                             uint16_t durationInMinutes, uint8_t * message,
                                                             uint8_t optionalExtendedMessageControl);
-
 /**
- * @brief  Cluster GetMessageCancellation Command callback
+ * @brief  Cluster GetMessageCancellation Command callback (from client)
  */
 bool emberAfMessagingClusterGetMessageCancellationCallback(
-    chip::app::Command * commandObj, /* TYPE WARNING: utc defaults to */ uint8_t * earliestImplementationTime);
-
+    chip::app::CommandHandler * commandObj, /* TYPE WARNING: utc defaults to */ uint8_t * earliestImplementationTime);
 /**
- * @brief  Cluster CancelAllMessages Command callback
+ * @brief  Cluster CancelAllMessages Command callback (from server)
  */
-bool emberAfMessagingClusterCancelAllMessagesCallback(chip::app::Command * commandObj,
+bool emberAfMessagingClusterCancelAllMessagesCallback(chip::app::CommandSender * commandObj,
                                                       /* TYPE WARNING: utc defaults to */ uint8_t * implementationDateTime);
-
 /**
- * @brief  Cluster GetAlerts Command callback
+ * @brief  Cluster GetAlerts Command callback (from client)
  */
-bool emberAfApplianceEventsAndAlertClusterGetAlertsCallback(chip::app::Command * commandObj);
-
+bool emberAfApplianceEventsAndAlertClusterGetAlertsCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetAlertsResponse Command callback
+ * @brief  Cluster GetAlertsResponse Command callback (from server)
  */
 bool emberAfApplianceEventsAndAlertClusterGetAlertsResponseCallback(
-    chip::app::Command * commandObj, uint8_t alertsCount, /* TYPE WARNING: array array defaults to */ uint8_t * alertStructures);
-
+    chip::app::CommandSender * commandObj, uint8_t alertsCount,
+    /* TYPE WARNING: array array defaults to */ uint8_t * alertStructures);
 /**
- * @brief  Cluster AlertsNotification Command callback
+ * @brief  Cluster AlertsNotification Command callback (from server)
  */
 bool emberAfApplianceEventsAndAlertClusterAlertsNotificationCallback(
-    chip::app::Command * commandObj, uint8_t alertsCount, /* TYPE WARNING: array array defaults to */ uint8_t * alertStructures);
-
+    chip::app::CommandSender * commandObj, uint8_t alertsCount,
+    /* TYPE WARNING: array array defaults to */ uint8_t * alertStructures);
 /**
- * @brief  Cluster EventsNotification Command callback
+ * @brief  Cluster EventsNotification Command callback (from server)
  */
-bool emberAfApplianceEventsAndAlertClusterEventsNotificationCallback(chip::app::Command * commandObj, uint8_t eventHeader,
+bool emberAfApplianceEventsAndAlertClusterEventsNotificationCallback(chip::app::CommandSender * commandObj, uint8_t eventHeader,
                                                                      uint8_t eventId);
-
 /**
- * @brief  Cluster LogNotification Command callback
+ * @brief  Cluster LogNotification Command callback (from server)
  */
-bool emberAfApplianceStatisticsClusterLogNotificationCallback(chip::app::Command * commandObj,
+bool emberAfApplianceStatisticsClusterLogNotificationCallback(chip::app::CommandSender * commandObj,
                                                               /* TYPE WARNING: unknown defaults to */ uint8_t * timeStamp,
                                                               uint32_t logId, uint32_t logLength,
                                                               /* TYPE WARNING: array array defaults to */ uint8_t * logPayload);
-
 /**
- * @brief  Cluster LogRequest Command callback
+ * @brief  Cluster LogRequest Command callback (from client)
  */
-bool emberAfApplianceStatisticsClusterLogRequestCallback(chip::app::Command * commandObj, uint32_t logId);
-
+bool emberAfApplianceStatisticsClusterLogRequestCallback(chip::app::CommandHandler * commandObj, uint32_t logId);
 /**
- * @brief  Cluster LogResponse Command callback
+ * @brief  Cluster LogResponse Command callback (from server)
  */
-bool emberAfApplianceStatisticsClusterLogResponseCallback(chip::app::Command * commandObj,
+bool emberAfApplianceStatisticsClusterLogResponseCallback(chip::app::CommandSender * commandObj,
                                                           /* TYPE WARNING: unknown defaults to */ uint8_t * timeStamp,
                                                           uint32_t logId, uint32_t logLength,
                                                           /* TYPE WARNING: array array defaults to */ uint8_t * logPayload);
-
 /**
- * @brief  Cluster LogQueueRequest Command callback
+ * @brief  Cluster LogQueueRequest Command callback (from client)
  */
-bool emberAfApplianceStatisticsClusterLogQueueRequestCallback(chip::app::Command * commandObj);
-
+bool emberAfApplianceStatisticsClusterLogQueueRequestCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster LogQueueResponse Command callback
+ * @brief  Cluster LogQueueResponse Command callback (from server)
  */
-bool emberAfApplianceStatisticsClusterLogQueueResponseCallback(chip::app::Command * commandObj, uint8_t logQueueSize,
+bool emberAfApplianceStatisticsClusterLogQueueResponseCallback(chip::app::CommandSender * commandObj, uint8_t logQueueSize,
                                                                /* TYPE WARNING: array array defaults to */ uint8_t * logIds);
-
 /**
- * @brief  Cluster StatisticsAvailable Command callback
+ * @brief  Cluster StatisticsAvailable Command callback (from server)
  */
-bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(chip::app::Command * commandObj, uint8_t logQueueSize,
+bool emberAfApplianceStatisticsClusterStatisticsAvailableCallback(chip::app::CommandSender * commandObj, uint8_t logQueueSize,
                                                                   /* TYPE WARNING: array array defaults to */ uint8_t * logIds);
-
 /**
- * @brief  Cluster GetProfileInfoResponseCommand Command callback
+ * @brief  Cluster GetProfileInfoResponseCommand Command callback (from server)
  */
 bool emberAfElectricalMeasurementClusterGetProfileInfoResponseCommandCallback(
-    chip::app::Command * commandObj, uint8_t profileCount, uint8_t profileIntervalPeriod, uint8_t maxNumberOfIntervals,
+    chip::app::CommandSender * commandObj, uint8_t profileCount, uint8_t profileIntervalPeriod, uint8_t maxNumberOfIntervals,
     /* TYPE WARNING: array array defaults to */ uint8_t * listOfAttributes);
-
 /**
- * @brief  Cluster GetProfileInfoCommand Command callback
+ * @brief  Cluster GetProfileInfoCommand Command callback (from client)
  */
-bool emberAfElectricalMeasurementClusterGetProfileInfoCommandCallback(chip::app::Command * commandObj);
-
+bool emberAfElectricalMeasurementClusterGetProfileInfoCommandCallback(chip::app::CommandHandler * commandObj);
 /**
- * @brief  Cluster GetMeasurementProfileResponseCommand Command callback
+ * @brief  Cluster GetMeasurementProfileResponseCommand Command callback (from server)
  */
 bool emberAfElectricalMeasurementClusterGetMeasurementProfileResponseCommandCallback(
-    chip::app::Command * commandObj, uint32_t startTime, uint8_t status, uint8_t profileIntervalPeriod,
+    chip::app::CommandSender * commandObj, uint32_t startTime, uint8_t status, uint8_t profileIntervalPeriod,
     uint8_t numberOfIntervalsDelivered, uint16_t attributeId, /* TYPE WARNING: array array defaults to */ uint8_t * intervals);
-
 /**
- * @brief  Cluster GetMeasurementProfileCommand Command callback
+ * @brief  Cluster GetMeasurementProfileCommand Command callback (from client)
  */
-bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::app::Command * commandObj, uint16_t attributeId,
-                                                                             uint32_t startTime, uint8_t numberOfIntervals);
-
+bool emberAfElectricalMeasurementClusterGetMeasurementProfileCommandCallback(chip::app::CommandHandler * commandObj,
+                                                                             uint16_t attributeId, uint32_t startTime,
+                                                                             uint8_t numberOfIntervals);
 /**
- * @brief  Cluster Bind Command callback
+ * @brief  Cluster Bind Command callback (from client)
  */
-bool emberAfBindingClusterBindCallback(chip::app::Command * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
+bool emberAfBindingClusterBindCallback(chip::app::CommandHandler * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
                                        chip::EndpointId endpointId, chip::ClusterId clusterId);
-
 /**
- * @brief  Cluster Unbind Command callback
+ * @brief  Cluster Unbind Command callback (from client)
  */
-bool emberAfBindingClusterUnbindCallback(chip::app::Command * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
+bool emberAfBindingClusterUnbindCallback(chip::app::CommandHandler * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
                                          chip::EndpointId endpointId, chip::ClusterId clusterId);
-
 /**
- * @brief  Cluster CommandOne Command callback
+ * @brief  Cluster CommandOne Command callback (from client)
  */
-bool emberAfSampleMfgSpecificClusterClusterCommandOneCallback(chip::app::Command * commandObj, uint8_t argOne);
-
+bool emberAfSampleMfgSpecificClusterClusterCommandOneCallback(chip::app::CommandHandler * commandObj, uint8_t argOne);
 /**
- * @brief  Cluster CommandTwo Command callback
+ * @brief  Cluster CommandTwo Command callback (from client)
  */
-bool emberAfSampleMfgSpecificCluster2ClusterCommandTwoCallback(chip::app::Command * commandObj, uint8_t argOne);
+bool emberAfSampleMfgSpecificCluster2ClusterCommandTwoCallback(chip::app::CommandHandler * commandObj, uint8_t argOne);
 
 /** @brief Add To Current App Tasks
  *

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -65,7 +65,7 @@ constexpr CommandId kTestCommandId   = 4;
 namespace app {
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     chip::app::CommandPathParams commandPathParams = { aEndPointId, // Endpoint
                                                        0,           // GroupId
@@ -80,6 +80,14 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                                 Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::Success);
 
     chip::isCommandDispatched = true;
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Controller, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    // Nothing todo.
 }
 
 bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId)

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -499,7 +499,13 @@ bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCom
 }
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+{
+    // Nothing todo.
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
 {
     if (aClusterId != kTestClusterId || aCommandId != kTestCommandId || aEndPointId != kTestEndpointId)
     {

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -51,7 +51,7 @@ bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCom
 }
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     static bool statusCodeFlipper = false;
 
@@ -94,6 +94,14 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         ReturnOnFailure(apCommandObj->FinishCommand());
     }
     statusCodeFlipper = !statusCodeFlipper;
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Controller, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    // Nothing todo.
 }
 
 CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * apWriter, bool * apDataExists)

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -92,7 +92,7 @@ constexpr uint16_t kByteSpanSizeLengthInBytes = 2;
     }
 
 
-#define GET_CLUSTER_RESPONSE_CALLBACKS(name)                                                                                               \
+#define GET_CLUSTER_RESPONSE_CALLBACKS(name)                                                                                       \
     Callback::Cancelable * onSuccessCallback = nullptr;                                                                            \
     Callback::Cancelable * onFailureCallback = nullptr;                                                                            \
     NodeId sourceIdentifier                  = reinterpret_cast<NodeId>(commandObj);                                               \
@@ -837,7 +837,7 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_responses}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#chip_server_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_server_cluster_response_arguments}})
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::CommandSender * commandObj{{#chip_server_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_server_cluster_response_arguments}})
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
     {{#chip_server_cluster_response_arguments}}

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -8,6 +8,8 @@
 #include <app/util/basic-types.h>
 
 #include <app/Command.h>
+#include <app/CommandHandler.h>
+#include <app/CommandSender.h>
 #include <lib/support/Span.h>
 
 /** @brief Cluster Init
@@ -170,10 +172,11 @@ void emberAf{{asUpperCamelCase label}}ClusterClientTickCallback(chip::EndpointId
 {{#zcl_clusters}}
 {{#zcl_commands}}
 /**
-* @brief {{parent.name}} Cluster {{name}} Command callback
-*/
-bool emberAf{{asUpperCamelCase parent.label}}Cluster{{asUpperCamelCase name}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/zcl_command_arguments}});
-
+ * @brief {{parent.name}} Cluster {{name}} Command callback (from {{source}})
+ */
+bool emberAf{{asUpperCamelCase parent.label}}Cluster{{asUpperCamelCase name}}Callback(
+       {{#if (isServer source)}}chip::app::CommandSender{{else}}chip::app::CommandHandler{{/if}} * commandObj
+       {{#zcl_command_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/zcl_command_arguments}});
 {{/zcl_commands}}
 {{/zcl_clusters}}
 

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -25,7 +25,7 @@ namespace clusters {
 {{#if (user_cluster_has_enabled_command name side)}}
 namespace {{asCamelCased name false}} {
 
-void Dispatch{{asCamelCased side false}}Command(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void Dispatch{{asCamelCased side false}}Command({{#if (isServer side)}}app::CommandHandler{{else}}app::CommandSender{{/if}} * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -92,7 +92,7 @@ void Dispatch{{asCamelCased side false}}Command(app::Command * apCommandObj, Com
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                             chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                             chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);
@@ -101,13 +101,47 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
     switch (aClusterId)
     {
-    {{#all_user_clusters}}
+    {{#chip_server_clusters}}
     {{#if (user_cluster_has_enabled_command name side)}}
     case Clusters::{{asUpperCamelCase name}}::Id:
         clusters::{{asCamelCased name false}}::Dispatch{{asCamelCased side false}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
     {{/if}}
-    {{/all_user_clusters}}
+    {{/chip_server_clusters}}
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                       0, // GroupId
+                                                       aClusterId,
+                                                       aCommandId,
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                             chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
+    {{#chip_client_clusters}}
+    {{#if (user_cluster_has_enabled_command name side)}}
+    case Clusters::{{asUpperCamelCase name}}::Id:
+        clusters::{{asCamelCased name false}}::Dispatch{{asCamelCased side false}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
+        break;
+    {{/if}}
+    {{/chip_client_clusters}}
     default:
         // Unrecognized cluster ID, error status will apply.
         chip::app::CommandPathParams returnStatusParam = { aEndPointId,

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -624,7 +624,7 @@ void Device::CancelResponseHandler(uint8_t seqNum)
     mCallbacksMgr.CancelResponseCallback(mDeviceId, seqNum);
 }
 
-void Device::AddIMResponseHandler(app::Command * commandObj, Callback::Cancelable * onSuccessCallback,
+void Device::AddIMResponseHandler(app::CommandSender * commandObj, Callback::Cancelable * onSuccessCallback,
                                   Callback::Cancelable * onFailureCallback)
 {
     // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
@@ -636,7 +636,7 @@ void Device::AddIMResponseHandler(app::Command * commandObj, Callback::Cancelabl
                                       onFailureCallback);
 }
 
-void Device::CancelIMResponseHandler(app::Command * commandObj)
+void Device::CancelIMResponseHandler(app::CommandSender * commandObj)
 {
     // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
     // there are only one active command transaction on one command sender object. This is a bit tricky, we try to assume that

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -343,9 +343,9 @@ public:
     // the app side instead of register callbacks here. The IM delegate can provide more infomation then callback and it is
     // type-safe.
     // TODO: Implement interaction model delegate in the application.
-    void AddIMResponseHandler(app::Command * commandObj, Callback::Cancelable * onSuccessCallback,
+    void AddIMResponseHandler(app::CommandSender * commandObj, Callback::Cancelable * onSuccessCallback,
                               Callback::Cancelable * onFailureCallback);
-    void CancelIMResponseHandler(app::Command * commandObj);
+    void CancelIMResponseHandler(app::CommandSender * commandObj);
 
     void OperationalCertProvisioned();
     bool IsOperationalCertProvisioned() const { return mDeviceOperationalCertProvisioned; }

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -1695,7 +1695,7 @@ void ThreadNetworkDiagnosticsClusterActiveNetworkFaultsListListAttributeFilter(T
     cb->mCall(cb->mContext, count, data);
 }
 
-bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::Command * commandObj, uint8_t * setupPIN)
+bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::CommandSender * commandObj, uint8_t * setupPIN)
 {
     ChipLogProgress(Zcl, "GetSetupPINResponse:");
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
@@ -1709,7 +1709,8 @@ bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::Command * 
     return true;
 }
 
-bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data)
+bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
+                                                                uint8_t * data)
 {
     ChipLogProgress(Zcl, "LaunchAppResponse:");
     LogStatus(status);
@@ -1732,7 +1733,7 @@ bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::app::Command * commandObj, uint8_t * data,
+bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::app::CommandSender * commandObj, uint8_t * data,
                                                                 uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchContentResponse:");
@@ -1748,7 +1749,7 @@ bool emberAfContentLauncherClusterLaunchContentResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::app::Command * commandObj, uint8_t * data,
+bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::app::CommandSender * commandObj, uint8_t * data,
                                                             uint8_t contentLaunchStatus)
 {
     ChipLogProgress(Zcl, "LaunchURLResponse:");
@@ -1764,7 +1765,7 @@ bool emberAfContentLauncherClusterLaunchURLResponseCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearAllPinsResponse:");
     LogStatus(status);
@@ -1785,7 +1786,7 @@ bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * com
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearAllRfidsResponse:");
     LogStatus(status);
@@ -1806,7 +1807,7 @@ bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * co
     return true;
 }
 
-bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearHolidayScheduleResponse:");
     LogStatus(status);
@@ -1827,7 +1828,7 @@ bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearPinResponse:");
     LogStatus(status);
@@ -1848,7 +1849,7 @@ bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearRfidResponse:");
     LogStatus(status);
@@ -1869,7 +1870,7 @@ bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearWeekdayScheduleResponse:");
     LogStatus(status);
@@ -1890,7 +1891,7 @@ bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearYeardayScheduleResponse:");
     LogStatus(status);
@@ -1911,8 +1912,8 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint8_t status,
-                                                              uint32_t localStartTime, uint32_t localEndTime,
+bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint8_t status, uint32_t localStartTime, uint32_t localEndTime,
                                                               uint8_t operatingModeDuringHoliday)
 {
     ChipLogProgress(Zcl, "GetHolidayScheduleResponse:");
@@ -1938,9 +1939,9 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * commandObj, uint16_t logEntryId, uint32_t timestamp,
-                                                        uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode,
-                                                        uint16_t userId, uint8_t * pin)
+bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::CommandSender * commandObj, uint16_t logEntryId,
+                                                        uint32_t timestamp, uint8_t eventType, uint8_t source,
+                                                        uint8_t eventIdOrAlarmCode, uint16_t userId, uint8_t * pin)
 {
     ChipLogProgress(Zcl, "GetLogRecordResponse:");
     ChipLogProgress(Zcl, "  logEntryId: %" PRIu16 "", logEntryId);
@@ -1960,7 +1961,7 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * com
     return true;
 }
 
-bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
+bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userStatus,
                                                   uint8_t userType, uint8_t * pin)
 {
     ChipLogProgress(Zcl, "GetPinResponse:");
@@ -1978,7 +1979,7 @@ bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandOb
     return true;
 }
 
-bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
+bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userStatus,
                                                    uint8_t userType, uint8_t * rfid)
 {
     ChipLogProgress(Zcl, "GetRfidResponse:");
@@ -1996,7 +1997,7 @@ bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType)
+bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::CommandSender * commandObj, uint16_t userId, uint8_t userType)
 {
     ChipLogProgress(Zcl, "GetUserTypeResponse:");
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
@@ -2010,8 +2011,8 @@ bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * comm
     return true;
 }
 
-bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
-                                                              uint8_t status, uint8_t daysMask, uint8_t startHour,
+bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint16_t userId, uint8_t status, uint8_t daysMask, uint8_t startHour,
                                                               uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
 {
     ChipLogProgress(Zcl, "GetWeekdayScheduleResponse:");
@@ -2040,8 +2041,9 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
-                                                              uint8_t status, uint32_t localStartTime, uint32_t localEndTime)
+bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t scheduleId,
+                                                              uint16_t userId, uint8_t status, uint32_t localStartTime,
+                                                              uint32_t localEndTime)
 {
     ChipLogProgress(Zcl, "GetYeardayScheduleResponse:");
     ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", scheduleId);
@@ -2066,7 +2068,7 @@ bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "LockDoorResponse:");
     LogStatus(status);
@@ -2087,7 +2089,7 @@ bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetHolidayScheduleResponse:");
     LogStatus(status);
@@ -2108,7 +2110,7 @@ bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetPinResponse:");
     LogStatus(status);
@@ -2129,7 +2131,7 @@ bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandOb
     return true;
 }
 
-bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetRfidResponse:");
     LogStatus(status);
@@ -2150,7 +2152,7 @@ bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetUserTypeResponse:");
     LogStatus(status);
@@ -2171,7 +2173,7 @@ bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * comm
     return true;
 }
 
-bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetWeekdayScheduleResponse:");
     LogStatus(status);
@@ -2192,7 +2194,7 @@ bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetYeardayScheduleResponse:");
     LogStatus(status);
@@ -2213,7 +2215,7 @@ bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "UnlockDoorResponse:");
     LogStatus(status);
@@ -2234,7 +2236,7 @@ bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * comma
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "UnlockWithTimeoutResponse:");
     LogStatus(status);
@@ -2255,7 +2257,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command 
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                    uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "ArmFailSafeResponse:");
@@ -2271,8 +2273,8 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Co
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
-                                                                             uint8_t * debugText)
+bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::CommandSender * commandObj,
+                                                                             uint8_t errorCode, uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "CommissioningCompleteResponse:");
     ChipLogProgress(Zcl, "  errorCode: %" PRIu8 "", errorCode);
@@ -2287,7 +2289,7 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chi
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                            uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "SetRegulatoryConfigResponse:");
@@ -2303,7 +2305,7 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip:
     return true;
 }
 
-bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId)
+bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(Zcl, "AddGroupResponse:");
     LogStatus(status);
@@ -2325,7 +2327,8 @@ bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandOb
     return true;
 }
 
-bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
+bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::CommandSender * commandObj, uint8_t capacity,
+                                                            uint8_t groupCount,
                                                             /* TYPE WARNING: array array defaults to */ uint8_t * groupList)
 {
     ChipLogProgress(Zcl, "GetGroupMembershipResponse:");
@@ -2341,7 +2344,7 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId)
+bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(Zcl, "RemoveGroupResponse:");
     LogStatus(status);
@@ -2363,7 +2366,7 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                    uint8_t * groupName)
 {
     ChipLogProgress(Zcl, "ViewGroupResponse:");
@@ -2388,7 +2391,7 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout)
+bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::CommandSender * commandObj, uint16_t timeout)
 {
     ChipLogProgress(Zcl, "IdentifyQueryResponse:");
     ChipLogProgress(Zcl, "  timeout: %" PRIu16 "", timeout);
@@ -2401,7 +2404,7 @@ bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * co
     return true;
 }
 
-bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::Command * commandObj, uint8_t status)
+bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SendKeyResponse:");
     LogStatus(status);
@@ -2422,7 +2425,7 @@ bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::Command * comma
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaFastForwardResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2435,7 +2438,7 @@ bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::Comm
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaNextResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2448,7 +2451,7 @@ bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaPauseResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2461,7 +2464,7 @@ bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::Command * 
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaPlayResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2474,7 +2477,7 @@ bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaPreviousResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2487,7 +2490,7 @@ bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::Command
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaRewindResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2500,7 +2503,7 @@ bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSeekResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaSeekResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaSeekResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2513,7 +2516,8 @@ bool emberAfMediaPlaybackClusterMediaSeekResponseCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::CommandSender * commandObj,
+                                                                  uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaSkipBackwardResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2526,7 +2530,7 @@ bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::Com
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaSkipForwardResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2539,7 +2543,7 @@ bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::Comm
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaStartOverResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2552,7 +2556,7 @@ bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::Comman
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus)
+bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::CommandSender * commandObj, uint8_t mediaPlaybackStatus)
 {
     ChipLogProgress(Zcl, "MediaStopResponse:");
     ChipLogProgress(Zcl, "  mediaPlaybackStatus: %" PRIu8 "", mediaPlaybackStatus);
@@ -2565,7 +2569,7 @@ bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                         uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "AddThreadNetworkResponse:");
@@ -2581,7 +2585,7 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::ap
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                       uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "AddWiFiNetworkResponse:");
@@ -2597,7 +2601,7 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app:
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                       uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "DisableNetworkResponse:");
@@ -2613,7 +2617,7 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app:
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                      uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "EnableNetworkResponse:");
@@ -2629,7 +2633,7 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                      uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "RemoveNetworkResponse:");
@@ -2646,7 +2650,7 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::
 }
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
-    chip::app::Command * commandObj, uint8_t errorCode, uint8_t * debugText,
+    chip::app::CommandSender * commandObj, uint8_t errorCode, uint8_t * debugText,
     /* TYPE WARNING: array array defaults to */ uint8_t * wifiScanResults,
     /* TYPE WARNING: array array defaults to */ uint8_t * threadScanResults)
 {
@@ -2665,7 +2669,7 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                            uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "UpdateThreadNetworkResponse:");
@@ -2681,7 +2685,7 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip:
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
+bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::CommandSender * commandObj, uint8_t errorCode,
                                                                          uint8_t * debugText)
 {
     ChipLogProgress(Zcl, "UpdateWiFiNetworkResponse:");
@@ -2697,8 +2701,8 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::a
     return true;
 }
 
-bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(chip::app::Command * commandObj, uint8_t action,
-                                                                               uint32_t delayedActionTime)
+bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(chip::app::CommandSender * commandObj,
+                                                                               uint8_t action, uint32_t delayedActionTime)
 {
     ChipLogProgress(Zcl, "ApplyUpdateRequestResponse:");
     ChipLogProgress(Zcl, "  action: %" PRIu8 "", action);
@@ -2712,7 +2716,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback(c
     return true;
 }
 
-bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::app::Command * commandObj, uint8_t status,
+bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
                                                                        uint32_t delayedActionTime, uint8_t * imageURI,
                                                                        uint32_t softwareVersion, chip::ByteSpan updateToken,
                                                                        uint8_t userConsentNeeded,
@@ -2744,7 +2748,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::app
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Command * commandObj, chip::ByteSpan CSR,
+bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::CommandSender * commandObj, chip::ByteSpan CSR,
                                                                chip::ByteSpan CSRNonce, chip::ByteSpan VendorReserved1,
                                                                chip::ByteSpan VendorReserved2, chip::ByteSpan VendorReserved3,
                                                                chip::ByteSpan Signature)
@@ -2765,7 +2769,7 @@ bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Comman
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Command * commandObj, uint8_t StatusCode,
+bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::CommandSender * commandObj, uint8_t StatusCode,
                                                                 uint64_t FabricIndex, uint8_t * DebugText)
 {
     ChipLogProgress(Zcl, "OpCertResponse:");
@@ -2782,7 +2786,7 @@ bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Comma
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Command * commandObj, chip::FabricId FabricId)
+bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::CommandSender * commandObj, chip::FabricId FabricId)
 {
     ChipLogProgress(Zcl, "SetFabricResponse:");
     ChipLogProgress(Zcl, "  FabricId: %" PRIu64 "", FabricId);
@@ -2795,7 +2799,7 @@ bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Co
     return true;
 }
 
-bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterAddSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                   uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "AddSceneResponse:");
@@ -2819,7 +2823,7 @@ bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandOb
     return true;
 }
 
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint8_t capacity,
                                                             uint16_t groupId, uint8_t sceneCount,
                                                             /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
 {
@@ -2846,7 +2850,7 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command *
     return true;
 }
 
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId)
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(Zcl, "RemoveAllScenesResponse:");
     LogStatus(status);
@@ -2868,7 +2872,7 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * co
     return true;
 }
 
-bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                      uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "RemoveSceneResponse:");
@@ -2892,7 +2896,7 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * comman
     return true;
 }
 
-bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                     uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "StoreSceneResponse:");
@@ -2916,7 +2920,7 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * command
     return true;
 }
 
-bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterViewSceneResponseCallback(chip::app::CommandSender * commandObj, uint8_t status, uint16_t groupId,
                                                    uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
@@ -2945,7 +2949,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandO
     return true;
 }
 
-bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * commandObj,
+bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::CommandSender * commandObj,
                                                           /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch,
                                                           uint8_t ErrorType)
 {
@@ -2961,7 +2965,8 @@ bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * c
     return true;
 }
 
-bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data)
+bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::CommandSender * commandObj, uint8_t status,
+                                                                 uint8_t * data)
 {
     ChipLogProgress(Zcl, "NavigateTargetResponse:");
     LogStatus(status);
@@ -2984,7 +2989,7 @@ bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::Comm
     return true;
 }
 
-bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::Command * commandObj, uint8_t returnValue)
+bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::CommandSender * commandObj, uint8_t returnValue)
 {
     ChipLogProgress(Zcl, "TestSpecificResponse:");
     ChipLogProgress(Zcl, "  returnValue: %" PRIu8 "", returnValue);

--- a/src/controller/data_model/gen/IMClusterCommandHandler.cpp
+++ b/src/controller/data_model/gen/IMClusterCommandHandler.cpp
@@ -40,7 +40,8 @@ namespace clusters {
 
 namespace AccountLogin {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -153,7 +154,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ApplicationLauncher {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -271,7 +273,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace ContentLauncher {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -454,7 +457,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace DoorLock {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -1985,7 +1989,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace GeneralCommissioning {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2233,7 +2238,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Groups {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2549,7 +2555,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Identify {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2661,7 +2668,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace KeypadInput {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -2773,7 +2781,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace MediaPlayback {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -3475,7 +3484,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace NetworkCommissioning {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4058,7 +4068,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OtaSoftwareUpdateProvider {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4268,7 +4279,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace OperationalCredentials {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -4547,7 +4559,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace Scenes {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5023,7 +5036,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TvChannel {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5140,7 +5154,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TargetNavigator {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5258,7 +5273,8 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 
 namespace TestCluster {
 
-void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+                           TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
     // When TLVError is CHIP_END_OF_TLV, it means we have iterated all of the items, which is not a real error.
@@ -5371,7 +5387,33 @@ void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, En
 } // namespace clusters
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
-                                  chip::TLV::TLVReader & aReader, Command * apCommandObj)
+                                  chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+{
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
+                  aCommandId, aEndPointId);
+    Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
+    TLV::TLVType dataTlvType;
+    SuccessOrExit(aReader.EnterContainer(dataTlvType));
+    switch (aClusterId)
+    {
+    default:
+        // Unrecognized cluster ID, error status will apply.
+        chip::app::CommandPathParams returnStatusParam = { aEndPointId,
+                                                           0, // GroupId
+                                                           aClusterId, aCommandId,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+        apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                    Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
+        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        break;
+    }
+exit:
+    Compatibility::ResetEmberAfObjects();
+    aReader.ExitContainer(dataTlvType);
+}
+
+void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
+                                          chip::TLV::TLVReader & aReader, CommandSender * apCommandObj)
 {
     ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
                   aCommandId, aEndPointId);


### PR DESCRIPTION
#### Problem
Currently, CommandSedner and CommandHandler share the same dispatch function, this can be a issue if a device acts as a server and a client at the same time.

#### Change overview
Seperate the dispatch route for CommandSender and CommandHandler.

#### Testing
- The CommandDispatch routing should be covered by TestSuite already.
