### PR TITLE
Add IM subscribe request/response builder and parser

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -87,6 +87,8 @@ static_library("app") {
     "MessageDef/ReportData.h",
     "MessageDef/StatusElement.cpp",
     "MessageDef/StatusElement.h",
+    "MessageDef/SubscribeRequest.cpp",
+    "MessageDef/SubscribeResponse.cpp",
     "MessageDef/WriteRequest.cpp",
     "MessageDef/WriteResponse.cpp",
     "ReadClient.cpp",

--- a/src/app/MessageDef/SubscribeRequest.cpp
+++ b/src/app/MessageDef/SubscribeRequest.cpp
@@ -1,0 +1,312 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "SubscribeRequest.h"
+#include "MessageDefHelper.h"
+
+namespace chip {
+namespace app {
+CHIP_ERROR SubscribeRequest::Parser::Init(const chip::TLV::TLVReader & aReader)
+{
+    // make a copy of the reader here
+    mReader.Init(aReader);
+
+    VerifyOrReturnLogError(chip::TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
+    return CHIP_NO_ERROR;
+}
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
+{
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+    uint16_t TagPresenceMask = 0;
+    chip::TLV::TLVReader reader;
+    AttributePathList::Parser attributePathList;
+    EventPathList::Parser eventPathList;
+    AttributeDataVersionList::Parser attributeDataVersionList;
+    PRETTY_PRINT("SubscribeRequest =");
+    PRETTY_PRINT("{");
+
+    // make a copy of the reader
+    reader.Init(mReader);
+
+    while (CHIP_NO_ERROR == (err = reader.Next()))
+    {
+        VerifyOrReturnLogError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kCsTag_AttributePathList:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_AttributePathList)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_AttributePathList);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+
+            attributePathList.Init(reader);
+
+            PRETTY_PRINT_INCDEPTH();
+            ReturnLogErrorOnFailure(attributePathList.CheckSchemaValidity());
+            PRETTY_PRINT_DECDEPTH();
+            break;
+        case kCsTag_EventPathList:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_EventPathList)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_EventPathList);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+
+            eventPathList.Init(reader);
+
+            PRETTY_PRINT_INCDEPTH();
+
+            ReturnLogErrorOnFailure(eventPathList.CheckSchemaValidity());
+
+            PRETTY_PRINT_DECDEPTH();
+            break;
+        case kCsTag_AttributeDataVersionList:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_AttributeDataVersionList)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_AttributeDataVersionList);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+
+            attributeDataVersionList.Init(reader);
+
+            PRETTY_PRINT_INCDEPTH();
+            ReturnLogErrorOnFailure(attributeDataVersionList.CheckSchemaValidity());
+            PRETTY_PRINT_DECDEPTH();
+            break;
+        case kCsTag_EventNumber:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_EventNumber)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_EventNumber);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                uint64_t eventNumber;
+                ReturnLogErrorOnFailure(reader.Get(eventNumber));
+                PRETTY_PRINT("\tEventNumber = 0x%" PRIx64 ",", eventNumber);
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        case kCsTag_MinInterval:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinInterval)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MinInterval);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                uint16_t minInterval;
+                ReturnLogErrorOnFailure(reader.Get(minInterval));
+                PRETTY_PRINT("\tMinInterval = 0x%" PRIx16 ",", minInterval);
+            }
+            break;
+#endif // CHIP_DETAIL_LOGGING
+        case kCsTag_MaxInterval:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxInterval)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MaxInterval);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                uint16_t maxInterval;
+                ReturnLogErrorOnFailure(reader.Get(maxInterval));
+                PRETTY_PRINT("\tkMaxInterval = 0x%" PRIx16 ",", maxInterval);
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        case kCsTag_KeepExistingSubscriptions:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_KeepExistingSubscriptions)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_KeepExistingSubscriptions);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                bool keepExistingSubscriptions;
+                ReturnLogErrorOnFailure(reader.Get(keepExistingSubscriptions));
+                PRETTY_PRINT("\tKeepExistingSubscriptions = %s, ", keepExistingSubscriptions ? "true" : "false");
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        case kCsTag_IsProxy:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_IsProxy)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_IsProxy);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                bool isProxy;
+                ReturnLogErrorOnFailure(reader.Get(isProxy));
+                PRETTY_PRINT("\tIsProxy = %s, ", isProxy ? "true" : "false");
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        default:
+            ReturnLogErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
+        }
+    }
+
+    PRETTY_PRINT("}");
+    PRETTY_PRINT("");
+    if (CHIP_END_OF_TLV == err)
+    {
+        const uint16_t RequiredFields = (1 << kCsTag_MinInterval) | (1 << kCsTag_MaxInterval);
+
+        if ((TagPresenceMask & RequiredFields) == RequiredFields)
+        {
+            err = CHIP_NO_ERROR;
+        }
+    }
+    ReturnLogErrorOnFailure(err);
+    return reader.ExitContainer(mOuterContainerType);
+}
+#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
+CHIP_ERROR SubscribeRequest::Parser::GetAttributePathList(AttributePathList::Parser * const apAttributePathList) const
+{
+    TLV::TLVReader reader;
+    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributePathList), reader));
+    VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    return apAttributePathList->Init(reader);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetEventPathList(EventPathList::Parser * const apEventPathList) const
+{
+    TLV::TLVReader reader;
+    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_EventPathList), reader));
+    VerifyOrReturnLogError(chip::TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    return apEventPathList->Init(reader);
+}
+
+CHIP_ERROR
+SubscribeRequest::Parser::GetAttributeDataVersionList(AttributeDataVersionList::Parser * const apAttributeDataVersionList) const
+{
+    TLV::TLVReader reader;
+    ReturnLogErrorOnFailure(mReader.FindElementWithTag(chip::TLV::ContextTag(kCsTag_AttributeDataVersionList), reader));
+    VerifyOrReturnLogError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    return apAttributeDataVersionList->Init(reader);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetEventNumber(uint64_t * const apEventNumber) const
+{
+    return GetUnsignedInteger(kCsTag_EventNumber, apEventNumber);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const
+{
+    return GetUnsignedInteger(kCsTag_EventNumber, apMinIntervalSeconds);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetMaxIntervalSeconds(uint16_t * const apMaxIntervalSeconds) const
+{
+    return GetUnsignedInteger(kCsTag_EventNumber, apMaxIntervalSeconds);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetKeepExistingSubscriptions(bool * const apKeepExistingSubscription) const
+{
+    return GetSimpleValue(kCsTag_KeepExistingSubscriptions, chip::TLV::kTLVType_Boolean, apKeepExistingSubscription);
+}
+
+CHIP_ERROR SubscribeRequest::Parser::GetIsProxy(bool * const apIsProxy) const
+{
+    return GetSimpleValue(kCsTag_IsProxy, chip::TLV::kTLVType_Boolean, apIsProxy);
+}
+
+CHIP_ERROR SubscribeRequest::Builder::Init(chip::TLV::TLVWriter * const apWriter)
+{
+    return InitAnonymousStructure(apWriter);
+}
+
+AttributePathList::Builder & SubscribeRequest::Builder::CreateAttributePathListBuilder()
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributePathListBuilder.Init(mpWriter, kCsTag_AttributePathList);
+        ChipLogFunctError(mError);
+    }
+
+    return mAttributePathListBuilder;
+}
+
+EventPathList::Builder & SubscribeRequest::Builder::CreateEventPathListBuilder()
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mEventPathListBuilder.Init(mpWriter, kCsTag_EventPathList);
+        ChipLogFunctError(mError);
+    }
+
+    return mEventPathListBuilder;
+}
+
+AttributeDataVersionList::Builder & SubscribeRequest::Builder::CreateAttributeDataVersionListBuilder()
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mAttributeDataVersionListBuilder.Init(mpWriter, kCsTag_AttributeDataVersionList);
+        ChipLogFunctError(mError);
+    }
+
+    return mAttributeDataVersionListBuilder;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::EventNumber(const uint64_t aEventNumber)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_EventNumber), aEventNumber);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::MinIntervalSeconds(const uint16_t aMinIntervalSeconds)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MinInterval), aMinIntervalSeconds);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::MaxIntervalSeconds(const uint16_t aMaxIntervalSeconds)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MaxInterval), aMaxIntervalSeconds);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::KeepExistingSubscriptions(const bool aKeepExistingSubscriptions)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_KeepExistingSubscriptions), aKeepExistingSubscriptions);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::IsProxy(const bool aIsProxy)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_IsProxy), aIsProxy);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeRequest::Builder & SubscribeRequest::Builder::EndOfSubscribeRequest()
+{
+    EndOfContainer();
+    return *this;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/MessageDef/SubscribeRequest.h
+++ b/src/app/MessageDef/SubscribeRequest.h
@@ -1,0 +1,183 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "AttributeDataVersionList.h"
+#include "AttributePathList.h"
+#include "Builder.h"
+#include "EventPathList.h"
+#include "Parser.h"
+#include <app/AppBuildConfig.h>
+#include <app/util/basic-types.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace app {
+namespace SubscribeRequest {
+enum
+{
+    kCsTag_AttributePathList         = 0,
+    kCsTag_EventPathList             = 1,
+    kCsTag_AttributeDataVersionList  = 2,
+    kCsTag_EventNumber               = 3,
+    kCsTag_MinInterval               = 4,
+    kCsTag_MaxInterval               = 5,
+    kCsTag_KeepExistingSubscriptions = 6,
+    kCsTag_IsProxy                   = 7,
+};
+
+class Parser : public chip::app::Parser
+{
+public:
+    /**
+     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this request
+     */
+    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    /**
+     *  @brief Roughly verify the message is correctly formed
+     *   1) all mandatory tags are present
+     *   2) all elements have expected data type
+     *   3) any tag can only appear once
+     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
+     *  @note The main use of this function is to print out what we're
+     *    receiving during protocol development and debugging.
+     *    The encoding rule has changed in IM encoding spec so this
+     *    check is only "roughly" conformant now.
+     */
+    CHIP_ERROR CheckSchemaValidity() const;
+#endif
+
+    /**
+     *  @brief Get a TLVReader for the AttributePathList. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetAttributePathList(AttributePathList::Parser * const apAttributePathList) const;
+
+    /**
+     *  @brief Get a TLVReader for the EventPathList. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetEventPathList(EventPathList::Parser * const apEventPathList) const;
+
+    /**
+     *  @brief Get a parser for the AttributeDataVersionList. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetAttributeDataVersionList(AttributeDataVersionList::Parser * const apAttributeDataVersionList) const;
+
+    /**
+     *  @brief Get Event Number. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetEventNumber(uint64_t * const apEventNumber) const;
+
+    /**
+     *  @brief Get Min Interval. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const;
+
+    /**
+     *  @brief Get Max Interval. Next() must be called before accessing them.
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetMaxIntervalSeconds(uint16_t * const apMaxIntervalSeconds) const;
+
+    /**
+     *  @brief Check if subscription is kept. Next() must be called before accessing them.
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetKeepExistingSubscriptions(bool * const apKeepExistingSubscription) const;
+
+    /**
+     *  @brief Check if subscription is kept. Next() must be called before accessing them.
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetIsProxy(bool * const apIsProxy) const;
+};
+
+class Builder : public chip::app::Builder
+{
+public:
+    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
+
+    AttributePathList::Builder & CreateAttributePathListBuilder();
+
+    /**
+     *  @brief Initialize a EventPathList::Builder for writing into the TLV stream
+     */
+    EventPathList::Builder & CreateEventPathListBuilder();
+
+    /**
+     *  @brief Initialize a AttributeDataVersionList::Builder for writing into the TLV stream
+     */
+    AttributeDataVersionList::Builder & CreateAttributeDataVersionListBuilder();
+
+    /**
+     *  @brief An initiator can optionally specify an EventNumber it has already to limit the
+     *  set of retrieved events on the server for optimization purposes.
+     */
+    SubscribeRequest::Builder & EventNumber(const uint64_t aEventNumber);
+
+    SubscribeRequest::Builder & MinIntervalSeconds(const uint16_t aMinIntervalSeconds);
+
+    SubscribeRequest::Builder & MaxIntervalSeconds(const uint16_t aMinIntervalSeconds);
+
+    /**
+     *  @brief This is set to 'true' by the subscriber to indicate preservation of previous subscriptions. If omitted, it implies
+     * 'false' as a value.
+     */
+    SubscribeRequest::Builder & KeepExistingSubscriptions(const bool aKeepExistingSubscriptions);
+
+    /**
+     *  @brief This is set to true by the subscriber if it is a proxy-type device proxying for another client. This
+     *  confers it special privileges on the publisher that might result in evictions of other non-proxy subscriptions
+     *  to make way for the proxy.
+     */
+    SubscribeRequest::Builder & IsProxy(const bool aIsProxy);
+
+    /**
+     *  @brief Mark the end of this SubscribeRequest
+     */
+    SubscribeRequest::Builder & EndOfSubscribeRequest();
+
+private:
+    AttributePathList::Builder mAttributePathListBuilder;
+    EventPathList::Builder mEventPathListBuilder;
+    AttributeDataVersionList::Builder mAttributeDataVersionListBuilder;
+};
+} // namespace SubscribeRequest
+} // namespace app
+} // namespace chip

--- a/src/app/MessageDef/SubscribeResponse.cpp
+++ b/src/app/MessageDef/SubscribeResponse.cpp
@@ -1,0 +1,136 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "SubscribeResponse.h"
+#include "MessageDefHelper.h"
+
+namespace chip {
+namespace app {
+CHIP_ERROR SubscribeResponse::Parser::Init(const chip::TLV::TLVReader & aReader)
+{
+    // make a copy of the reader here
+    mReader.Init(aReader);
+
+    VerifyOrReturnLogError(chip::TLV::kTLVType_Structure == mReader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    ReturnLogErrorOnFailure(mReader.EnterContainer(mOuterContainerType));
+    return CHIP_NO_ERROR;
+}
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+CHIP_ERROR SubscribeResponse::Parser::CheckSchemaValidity() const
+{
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+    uint16_t TagPresenceMask = 0;
+    chip::TLV::TLVReader reader;
+    PRETTY_PRINT("SubscribeResponse =");
+    PRETTY_PRINT("{");
+
+    // make a copy of the reader
+    reader.Init(mReader);
+
+    while (CHIP_NO_ERROR == (err = reader.Next()))
+    {
+        VerifyOrReturnLogError(chip::TLV::IsContextTag(reader.GetTag()), CHIP_ERROR_INVALID_TLV_TAG);
+        switch (chip::TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case kCsTag_SubscriptionId:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_SubscriptionId)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_SubscriptionId);
+            VerifyOrReturnLogError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                uint64_t subscriptionId;
+                ReturnLogErrorOnFailure(reader.Get(subscriptionId));
+                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        case kCsTag_FinalSyncInterval:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_FinalSyncInterval)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_FinalSyncInterval);
+            VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+#if CHIP_DETAIL_LOGGING
+            {
+                uint16_t finalSyncInterval;
+                ReturnLogErrorOnFailure(reader.Get(finalSyncInterval));
+                PRETTY_PRINT("\tFinalSyncInterval = 0x%" PRIx16 ",", finalSyncInterval);
+            }
+#endif // CHIP_DETAIL_LOGGING
+            break;
+        default:
+            ReturnLogErrorOnFailure(CHIP_ERROR_INVALID_TLV_TAG);
+        }
+    }
+    PRETTY_PRINT("}");
+    PRETTY_PRINT("");
+
+    if (CHIP_END_OF_TLV == err)
+    {
+        const uint16_t RequiredFields = (1 << kCsTag_SubscriptionId) | (1 << kCsTag_FinalSyncInterval);
+
+        if ((TagPresenceMask & RequiredFields) == RequiredFields)
+        {
+            err = CHIP_NO_ERROR;
+        }
+    }
+    ReturnLogErrorOnFailure(err);
+    return reader.ExitContainer(mOuterContainerType);
+}
+#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
+CHIP_ERROR SubscribeResponse::Parser::GetSubscriptionId(uint64_t * const apSubscribeId) const
+{
+    return GetUnsignedInteger(kCsTag_SubscriptionId, apSubscribeId);
+}
+
+CHIP_ERROR SubscribeResponse::Parser::GetFinalSyncIntervalSeconds(uint16_t * const apFinalSyncIntervalSeconds) const
+{
+    return GetUnsignedInteger(kCsTag_FinalSyncInterval, apFinalSyncIntervalSeconds);
+}
+
+CHIP_ERROR SubscribeResponse::Builder::Init(chip::TLV::TLVWriter * const apWriter)
+{
+    return InitAnonymousStructure(apWriter);
+}
+
+SubscribeResponse::Builder & SubscribeResponse::Builder::SubscriptionId(const uint64_t aSubscribeId)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_SubscriptionId), aSubscribeId);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeResponse::Builder & SubscribeResponse::Builder::FinalSyncIntervalSeconds(const uint16_t aFinalSyncIntervalSeconds)
+{
+    if (mError == CHIP_NO_ERROR)
+    {
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FinalSyncInterval), aFinalSyncIntervalSeconds);
+        ChipLogFunctError(mError);
+    }
+    return *this;
+}
+
+SubscribeResponse::Builder & SubscribeResponse::Builder::EndOfSubscribeResponse()
+{
+    EndOfContainer();
+    return *this;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/MessageDef/SubscribeResponse.h
+++ b/src/app/MessageDef/SubscribeResponse.h
@@ -1,0 +1,99 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+#include "Builder.h"
+#include "EventPathList.h"
+#include "Parser.h"
+#include <app/AppBuildConfig.h>
+#include <app/util/basic-types.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace app {
+namespace SubscribeResponse {
+enum
+{
+    kCsTag_SubscriptionId    = 0,
+    kCsTag_FinalSyncInterval = 1,
+};
+
+class Parser : public chip::app::Parser
+{
+public:
+    /**
+     *  @param [in] aReader A pointer to a TLVReader, which should point to the beginning of this response
+     */
+    CHIP_ERROR Init(const chip::TLV::TLVReader & aReader);
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    /**
+     *  @brief Roughly verify the message is correctly formed
+     *   1) all mandatory tags are present
+     *   2) all elements have expected data type
+     *   3) any tag can only appear once
+     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
+     *  @note The main use of this function is to print out what we're
+     *    receiving during protocol development and debugging.
+     *    The encoding rule has changed in IM encoding spec so this
+     *    check is only "roughly" conformant now.
+     */
+    CHIP_ERROR CheckSchemaValidity() const;
+#endif
+
+    /**
+     *  @brief Get Subscription ID. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetSubscriptionId(uint64_t * const apSubscriptionId) const;
+
+    /**
+     *  @brief Get FinalSyncInterval. Next() must be called before accessing them.
+     *
+     *  @return #CHIP_NO_ERROR on success
+     *          #CHIP_END_OF_TLV if there is no such element
+     */
+    CHIP_ERROR GetFinalSyncIntervalSeconds(uint16_t * const apFinalSyncIntervalSeconds) const;
+};
+
+class Builder : public chip::app::Builder
+{
+public:
+    CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
+
+    /**
+     *  @brief final subscription Id for the subscription back to the client.s.
+     */
+    SubscribeResponse::Builder & SubscriptionId(const uint64_t SubscriptionId);
+
+    /**
+     *  @brief Final Sync Interval for the subscription back to the clients.
+     */
+    SubscribeResponse::Builder & FinalSyncIntervalSeconds(const uint16_t aFinalSyncIntervalSeconds);
+
+    /**
+     *  @brief Mark the end of this SubscribeResponse
+     */
+    SubscribeResponse::Builder & EndOfSubscribeResponse();
+};
+} // namespace SubscribeResponse
+} // namespace app
+} // namespace chip

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -28,6 +28,8 @@
 #include <app/MessageDef/InvokeCommand.h>
 #include <app/MessageDef/ReadRequest.h>
 #include <app/MessageDef/ReportData.h>
+#include <app/MessageDef/SubscribeRequest.h>
+#include <app/MessageDef/SubscribeResponse.h>
 #include <app/MessageDef/WriteRequest.h>
 #include <app/MessageDef/WriteResponse.h>
 #include <core/CHIPTLVDebug.hpp>
@@ -882,6 +884,129 @@ void ParseWriteResponse(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 
+void BuildSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    SubscribeRequest::Builder subscribeRequestBuilder;
+
+    err = subscribeRequestBuilder.Init(&aWriter);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    AttributePathList::Builder attributePathList = subscribeRequestBuilder.CreateAttributePathListBuilder();
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+    BuildAttributePathList(apSuite, attributePathList);
+
+    EventPathList::Builder eventPathList = subscribeRequestBuilder.CreateEventPathListBuilder();
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+    BuildEventPathList(apSuite, eventPathList);
+
+    AttributeDataVersionList::Builder attributeDataVersionList = subscribeRequestBuilder.CreateAttributeDataVersionListBuilder();
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+    BuildAttributeDataVersionList(apSuite, attributeDataVersionList);
+
+    subscribeRequestBuilder.EventNumber(1);
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeRequestBuilder.MinIntervalSeconds(1);
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeRequestBuilder.MaxIntervalSeconds(1);
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeRequestBuilder.KeepExistingSubscriptions(true);
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeRequestBuilder.IsProxy(true);
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeRequestBuilder.EndOfSubscribeRequest();
+    NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
+}
+
+void ParseSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    SubscribeRequest::Parser subscribeRequestParser;
+    AttributePathList::Parser attributePathListParser;
+    EventPathList::Parser eventPathListParser;
+    AttributeDataVersionList::Parser attributeDataVersionListParser;
+    uint64_t eventNumber          = 0;
+    uint16_t minIntervalSeconds   = 0;
+    uint16_t maxIntervalSeconds   = 0;
+    bool keepExistingSubscription = false;
+    bool isProxy                  = false;
+
+    err = subscribeRequestParser.Init(aReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    err = subscribeRequestParser.CheckSchemaValidity();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#endif
+    err = subscribeRequestParser.GetAttributePathList(&attributePathListParser);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetEventPathList(&eventPathListParser);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetAttributeDataVersionList(&attributeDataVersionListParser);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetEventNumber(&eventNumber);
+    NL_TEST_ASSERT(apSuite, eventNumber == 1 && err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetMinIntervalSeconds(&minIntervalSeconds);
+    NL_TEST_ASSERT(apSuite, minIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetMaxIntervalSeconds(&maxIntervalSeconds);
+    NL_TEST_ASSERT(apSuite, maxIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetKeepExistingSubscriptions(&keepExistingSubscription);
+    NL_TEST_ASSERT(apSuite, keepExistingSubscription && err == CHIP_NO_ERROR);
+
+    err = subscribeRequestParser.GetIsProxy(&isProxy);
+    NL_TEST_ASSERT(apSuite, isProxy && err == CHIP_NO_ERROR);
+}
+
+void BuildSubscribeResponse(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    SubscribeResponse::Builder subscribeResponseBuilder;
+
+    err = subscribeResponseBuilder.Init(&aWriter);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    subscribeResponseBuilder.SubscriptionId(1);
+    NL_TEST_ASSERT(apSuite, subscribeResponseBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeResponseBuilder.FinalSyncIntervalSeconds(1);
+    NL_TEST_ASSERT(apSuite, subscribeResponseBuilder.GetError() == CHIP_NO_ERROR);
+
+    subscribeResponseBuilder.EndOfSubscribeResponse();
+    NL_TEST_ASSERT(apSuite, subscribeResponseBuilder.GetError() == CHIP_NO_ERROR);
+}
+
+void ParseSubscribeResponse(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    SubscribeResponse::Parser subscribeResponseParser;
+    uint64_t subscriptionId           = 0;
+    uint16_t finalSyncIntervalSeconds = 0;
+
+    err = subscribeResponseParser.Init(aReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    err = subscribeResponseParser.CheckSchemaValidity();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#endif
+    err = subscribeResponseParser.GetSubscriptionId(&subscriptionId);
+    NL_TEST_ASSERT(apSuite, subscriptionId == 1 && err == CHIP_NO_ERROR);
+
+    err = subscribeResponseParser.GetFinalSyncIntervalSeconds(&finalSyncIntervalSeconds);
+    NL_TEST_ASSERT(apSuite, finalSyncIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+}
+
 void AttributePathTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1348,6 +1473,44 @@ void WriteResponseTest(nlTestSuite * apSuite, void * apContext)
     ParseWriteResponse(apSuite, reader);
 }
 
+void SubscribeRequestTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
+    writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
+    BuildSubscribeRequest(apSuite, writer);
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    DebugPrettyPrint(buf);
+
+    reader.Init(std::move(buf));
+    err = reader.Next();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    ParseSubscribeRequest(apSuite, reader);
+}
+
+void SubscribeResponseTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
+    writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
+    BuildSubscribeResponse(apSuite, writer);
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    DebugPrettyPrint(buf);
+
+    reader.Init(std::move(buf));
+    err = reader.Next();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    ParseSubscribeResponse(apSuite, reader);
+}
+
 void CheckPointRollbackTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
@@ -1429,6 +1592,8 @@ const nlTest sTests[] =
                 NL_TEST_DEF("ReadRequestTest", ReadRequestTest),
                 NL_TEST_DEF("WriteRequestTest", WriteRequestTest),
                 NL_TEST_DEF("WriteResponseTest", WriteResponseTest),
+                NL_TEST_DEF("SubscribeRequestTest", SubscribeRequestTest),
+                NL_TEST_DEF("SubscribeResponseTest", SubscribeResponseTest),
                 NL_TEST_DEF("CheckPointRollbackTest", CheckPointRollbackTest),
                 NL_TEST_SENTINEL()
         };

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -184,6 +184,32 @@ constexpr inline const _T & max(const _T & a, const _T & b)
     } while (false)
 
 /**
+ *  @def ReturnLogErrorOnFailure(expr)
+ *
+ *  @brief
+ *    Returns the error code if the expression returns something different
+ *    than CHIP_NO_ERROR.
+ *
+ *  Example usage:
+ *
+ *  @code
+ *    ReturnLogErrorOnFailure(channel->SendMsg(msg));
+ *  @endcode
+ *
+ *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
+ */
+#define ReturnLogErrorOnFailure(expr)                                                                                              \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (__err != CHIP_NO_ERROR)                                                                                                \
+        {                                                                                                                          \
+            ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(__err), __FILE__, __LINE__);                                        \
+            return __err;                                                                                                          \
+        }                                                                                                                          \
+    } while (false)
+
+/**
  *  @def ReturnOnFailure(expr)
  *
  *  @brief
@@ -251,6 +277,31 @@ constexpr inline const _T & max(const _T & a, const _T & b)
     {                                                                                                                              \
         if (!(expr))                                                                                                               \
         {                                                                                                                          \
+            return code;                                                                                                           \
+        }                                                                                                                          \
+    } while (false)
+
+/**
+ *  @def VerifyOrReturnLogError(expr, code)
+ *
+ *  @brief
+ *    Returns and print a specified error code if expression evaluates to false
+ *
+ *  Example usage:
+ *
+ *  @code
+ *    VerifyOrReturnLogError(param != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+ *  @endcode
+ *
+ *  @param[in]  expr        A Boolean expression to be evaluated.
+ *  @param[in]  code        A value to return if @a expr is false.
+ */
+#define VerifyOrReturnLogError(expr, code)                                                                                         \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (!(expr))                                                                                                               \
+        {                                                                                                                          \
+            ChipLogError(NotSpecified, "%s at %s:%d", ErrorStr(code), __FILE__, __LINE__);                                         \
             return code;                                                                                                           \
         }                                                                                                                          \
     } while (false)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Per IM encoding spec, add subscribe request/response builder/parser(https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Encoding-Specification.adoc#subscriberequestmessage )
* Fixes #7977

#### Change overview
Add IM subscribe request/response builder and parser
Add ReturnLogErrorOnFailure and VerifyOrReturnLogError to log the error in original place.
#### Testing
Add unit test to cover subscriber request/response builder and parser
