### PR TITLE
Prepare the code for OpenThread update

### DIFF
--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -95,8 +95,14 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
 {
 #if CHIP_DETAIL_LOGGING
 
+#if OPENTHREAD_API_VERSION >= 126
+    const uint32_t kKeyChanged = OT_CHANGED_NETWORK_KEY;
+#else
+    const uint32_t kKeyChanged = OT_CHANGED_MASTER_KEY;
+#endif
+
     const uint32_t kParamsChanged = (OT_CHANGED_THREAD_NETWORK_NAME | OT_CHANGED_THREAD_PANID | OT_CHANGED_THREAD_EXT_PANID |
-                                     OT_CHANGED_THREAD_CHANNEL | OT_CHANGED_MASTER_KEY | OT_CHANGED_PSKC);
+                                     OT_CHANGED_THREAD_CHANNEL | kKeyChanged | OT_CHANGED_PSKC);
 
     static char strBuf[64];
 


### PR DESCRIPTION
#### Problem
Current CHIP code will not build with the recent OpenThread version.

#### Change overview
Make sure the code builds after changing "master" to "network" in the OpenThread repository.

#### Testing
Verified build of nRF Connect examples with newer OpenThread version.
