### PR TITLE
[ESP32]Add ColorControl for ESP32C3-DevKitM

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -24,12 +24,11 @@ set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
 )
 if(${IDF_TARGET} STREQUAL "esp32")
-set(EXTRA_COMPONENT_DIRS
-    ${EXTRA_COMPONENT_DIRS}
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/spidriver"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework"
-)
+    list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/tft"
+                                     "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components/spidriver"
+                                     "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework")
+elseif(${IDF_TARGET} STREQUAL "esp32c3")
+    list(APPEND EXTRA_COMPONENT_DIRS "$ENV{IDF_PATH}/examples/peripherals/rmt/led_strip/components")
 endif()
 
 project(chip-all-clusters-app)

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -209,11 +209,23 @@ commissioning and cluster control.
 
 ### Cluster control
 
--   After successful commissioning, use the OnOff cluster command to control the
-    OnOff attribute. This allows you to toggle a parameter implemented by the
-    device to be On or Off.
+-   After successful commissioning, use the OnOff cluster commands to control
+    the OnOff attribute. This allows you to toggle a parameter implemented by
+    the device to be On or Off.
 
-    `chip-device-ctrl > zcl OnOff Off 135246 1 0`
+    `chip-device-ctrl > zcl OnOff Off 135246 1 1`
+
+-   Use the LevelControl cluster commands to control the CurrentLevel attribute.
+    This allows you to control the brightness of the led.
+
+    `chip-device-ctrl > zcl LevelControl MoveToLevel 135246 1 1 level=10 transitionTime=0 optionMask=0 optionOverride=0`
+
+-   For ESP32C3-DevKitM, use the ColorContorl cluster commands to control the
+    CurrentHue and CurrentSaturation attribute. This allows you to control the
+    color of on-board LED.
+
+    `zcl ColorControl MoveToHue 135246 1 1 hue=100 direction=0 transitionTime=0 optionsMask=0 optionsOverride=0`
+    `zcl ColorControl MoveToSaturation 135245 1 1 saturation=200 transitionTime=0 optionsMask=0 optionsOverride=0`
 
 ### Flashing app using script
 
@@ -243,5 +255,6 @@ through the on/off/toggle commands from the `python-controller`. For `M5Stack`,
 a virtual Green LED on the display is used for the same.
 
 If you wish to see the actual effect of the commands on `ESP32-DevKitC`,
-`ESP32-WROVER-KIT_V4.1` and `ESP32C3-DevKitM`, you will have to connect an
-external LED to GPIO `STATUS_LED_GPIO_NUM`.
+`ESP32-WROVER-KIT_V4.1`, you will have to connect an external LED to GPIO
+`STATUS_LED_GPIO_NUM`. For `ESP32C3-DevKitM`, the on-board LED will show the
+actual effect of the commands.

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -69,11 +69,15 @@ set(SRC_DIRS_LIST
 )
 
 if(("${CONFIG_DEVICE_TYPE_ESP32_DEVKITC}" STREQUAL "y") OR ("${CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM}" STREQUAL "y"))
-    set(PRIV_INCLUDE_DIRS_LIST ${PRIV_INCLUDE_DIRS_LIST}
-                               "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/screen-framework/include")
+    list(APPEND PRIV_INCLUDE_DIRS_LIST
+                "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/screen-framework/include")
     set(PRIV_REQUIRES_LIST chip QRCode bt)
 elseif(("${CONFIG_DEVICE_TYPE_M5STACK}" STREQUAL "y") OR ("${CONFIG_DEVICE_TYPE_ESP32_WROVER_KIT}" STREQUAL "y"))
     set(PRIV_REQUIRES_LIST chip QRCode bt tft spidrier screen-framework)
+endif()
+
+if("${CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM}" STREQUAL "y")
+    list(APPEND PRIV_REQUIRES_LIST led_strip)
 endif()
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}

--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -95,7 +95,11 @@ void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, Cluster
     case ZCL_LEVEL_CONTROL_CLUSTER_ID:
         OnLevelControlAttributeChangeCallback(endpointId, attributeId, value);
         break;
-
+#if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
+    case ZCL_COLOR_CONTROL_CLUSTER_ID:
+        OnColorControlAttributeChangeCallback(endpointId, attributeId, value);
+        break;
+#endif
     default:
         ESP_LOGI(TAG, "Unhandled cluster ID: %d", clusterId);
         break;
@@ -163,6 +167,36 @@ void DeviceCallbacks::OnLevelControlAttributeChangeCallback(EndpointId endpointI
 exit:
     return;
 }
+
+// Currently we only support ColorControl cluster for ESP32C3_DEVKITM which has an on-board RGB-LED
+#if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
+void DeviceCallbacks::OnColorControlAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
+{
+    VerifyOrExit(attributeId == ZCL_COLOR_CONTROL_CURRENT_HUE_ATTRIBUTE_ID ||
+                     attributeId == ZCL_COLOR_CONTROL_CURRENT_SATURATION_ATTRIBUTE_ID,
+                 ESP_LOGI(TAG, "Unhandled AttributeId ID: '0x%04x", attributeId));
+    VerifyOrExit(endpointId == 1 || endpointId == 2, ESP_LOGE(TAG, "Unexpected EndPoint ID: `0x%02x'", endpointId));
+    if (endpointId == 1)
+    {
+        uint8_t hue, saturation;
+        if (attributeId == ZCL_COLOR_CONTROL_CURRENT_HUE_ATTRIBUTE_ID)
+        {
+            hue = *value;
+            emberAfReadServerAttribute(endpointId, ZCL_COLOR_CONTROL_CLUSTER_ID, ZCL_COLOR_CONTROL_CURRENT_SATURATION_ATTRIBUTE_ID,
+                                       &saturation, sizeof(uint8_t));
+        }
+        else
+        {
+            saturation = *value;
+            emberAfReadServerAttribute(endpointId, ZCL_COLOR_CONTROL_CLUSTER_ID, ZCL_COLOR_CONTROL_CURRENT_HUE_ATTRIBUTE_ID, &hue,
+                                       sizeof(uint8_t));
+        }
+        statusLED1.SetColor(hue, saturation);
+    }
+exit:
+    return;
+}
+#endif
 
 void IdentifyTimerHandler(Layer * systemLayer, void * appState, CHIP_ERROR error)
 {

--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -22,7 +22,8 @@ menu "Demo"
 
     choice
         prompt "Device Type"
-        default DEVICE_TYPE_ESP32_DEVKITC
+        default DEVICE_TYPE_ESP32_DEVKITC if IDF_TARGET_ESP32
+        default DEVICE_TYPE_ESP32_C3_DEVKITM if IDF_TARGET_ESP32C3
         help
             Specifies the type of ESP32 device.
 

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -42,6 +42,9 @@ private:
     void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnLevelControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+#if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
+    void OnColorControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
+#endif
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 
     bool mEndpointOnOffState[2];

--- a/examples/all-clusters-app/esp32/main/include/LEDWidget.h
+++ b/examples/all-clusters-app/esp32/main/include/LEDWidget.h
@@ -45,7 +45,11 @@ public:
     void BlinkOnError();
 
     void Animate();
+#if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
+    void SetColor(uint8_t Hue, uint8_t Saturation);
 
+    void HSB2rgb(uint16_t Hue, uint8_t Saturation, uint8_t brightness, uint8_t & red, uint8_t & green, uint8_t & blue);
+#endif
 #if CONFIG_HAVE_DISPLAY
     void SetVLED(int id1, int id2);
 #endif
@@ -55,6 +59,10 @@ private:
     uint32_t mBlinkOnTimeMS;
     uint32_t mBlinkOffTimeMS;
     uint8_t mDefaultOnBrightness;
+#if CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
+    uint16_t mHue;       // mHue [0, 360]
+    uint8_t mSaturation; // mSaturation [0, 100]
+#endif
     gpio_num_t mGPIONum;
     int mVLED1;
     int mVLED2;

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -87,7 +87,7 @@ using namespace ::chip::DeviceLayer;
 
 #elif CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM
 
-#define STATUS_LED_GPIO_NUM GPIO_NUM_2
+#define STATUS_LED_GPIO_NUM GPIO_NUM_8
 
 #else // !CONFIG_DEVICE_TYPE_ESP32_DEVKITC
 


### PR DESCRIPTION
#### Problem
We should use the on-board RGB-LED instead of an external LED for ESP32C3-DevKitM.

#### Change overview
1. Use onboard RGB-LED(WS2812) for status-LED in all-clusters-app
2. Add ColorControl cluster support for ESP32C3_DevkitM

#### Testing
Tested the On/Off/Toggle, MoveToLevel, MoveToHue/MoveToSaturation commands manually.

Used the following commands to change the hue and saturation.
```
zcl ColorControl MoveToHue 12345 1 1 hue=100 direction=0 transitionTime=0 optionsMask=0 optionsOverride=0
zcl ColorControl MoveToSaturation 12345 1 1 saturation=200 transitionTime=0 optionsMask=0 optionsOverride=0
```