### PR TITLE
Add a peer cache table

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -146,10 +146,9 @@ void RendezvousServer::OnSessionEstablishmentError(CHIP_ERROR err)
 
 void RendezvousServer::OnSessionEstablished()
 {
-    CHIP_ERROR err =
-        mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-                                mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
-                                SecureSession::SessionRole::kResponder, mFabric->GetFabricIndex());
+    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
+                                             SecureSession::SessionRole::kResponder, mFabric->GetFabricIndex());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
@@ -165,7 +164,7 @@ void RendezvousServer::OnSessionEstablished()
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 
-    if (mPairingSession.PeerConnection().GetPeerAddress().GetTransportType() == Transport::Type::kBle)
+    if (mPairingSession.GetPeerAddress().GetTransportType() == Transport::Type::kBle)
     {
         Cleanup();
     }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -176,12 +176,11 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr)
             connection.GetPASESession(session);
 
             ChipLogProgress(AppServer, "Fetched the session information: from 0x" ChipLogFormatX64,
-                            ChipLogValueX64(session->PeerConnection().GetPeerNodeId()));
+                            ChipLogValueX64(session->GetPeerNodeId()));
             if (gSessionIDAllocator.Reserve(keyId) == CHIP_NO_ERROR)
             {
-                sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->PeerConnection().GetPeerAddress()),
-                                      session->PeerConnection().GetPeerNodeId(), session, SecureSession::SessionRole::kResponder,
-                                      connection.GetFabricIndex());
+                sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->GetPeerAddress()), session->GetPeerNodeId(),
+                                      session, SecureSession::SessionRole::kResponder, connection.GetFabricIndex());
             }
             else
             {

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -51,7 +51,7 @@ bool ChannelContext::MatchNodeId(NodeId nodeId)
         auto state = mExchangeManager->GetSessionMgr()->GetPeerConnectionState(GetReadyVars().mSession);
         if (state == nullptr)
             return false;
-        return nodeId == state->GetPeerNodeId();
+        return nodeId == state->GetPeerInfo().GetPeer().GetNodeId();
     }
     default:
         return false;
@@ -76,7 +76,7 @@ bool ChannelContext::MatchTransport(Transport::Type transport)
         auto state = mExchangeManager->GetSessionMgr()->GetPeerConnectionState(GetReadyVars().mSession);
         if (state == nullptr)
             return false;
-        return transport == state->GetPeerAddress().GetTransportType();
+        return transport == state->GetPeerInfo().GetPeerAddress().GetTransportType();
     }
     default:
         return false;
@@ -130,7 +130,7 @@ bool ChannelContext::MatchesSession(SecureSessionHandle session, SecureSessionMg
         {
         case PrepareState::kCasePairing: {
             auto state = ssm->GetPeerConnectionState(session);
-            return (state->GetPeerNodeId() == GetPrepareVars().mBuilder.GetPeerNodeId() &&
+            return (state->GetPeerInfo().GetPeer().GetNodeId() == GetPrepareVars().mBuilder.GetPeerNodeId() &&
                     state->GetPeerKeyID() == GetPrepareVars().mBuilder.GetPeerKeyID());
         }
         default:

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -129,7 +129,8 @@ CHIP_ERROR Device::LoadSecureSessionParametersIfNeeded(bool & didLoad)
         Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
 
         // Check if the connection state has the correct transport information
-        if (connectionState == nullptr || connectionState->GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)
+        if (connectionState == nullptr ||
+            connectionState->GetPeerInfo().GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)
         {
             mState = ConnectionState::NotConnected;
             ReturnErrorOnFailure(LoadSecureSessionParameters(ResetTransport::kNo));
@@ -407,7 +408,7 @@ CHIP_ERROR Device::UpdateAddress(const Transport::PeerAddress & addr)
         return CHIP_NO_ERROR;
     }
 
-    connectionState->SetPeerAddress(addr);
+    connectionState->GetPeerInfo().SetPeerAddress(addr);
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -565,7 +565,7 @@ void Device::OnSessionEstablishmentError(CHIP_ERROR error)
 
 void Device::OnSessionEstablished()
 {
-    mCASESession.PeerConnection().SetPeerNodeId(mDeviceId);
+    mCASESession.SetPeerNodeId(mDeviceId);
 
     CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mCASESession,
                                                  SecureSession::SessionRole::kInitiator, mFabricIndex);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1182,11 +1182,11 @@ void DeviceCommissioner::OnSessionEstablished()
 
     Device * device = &mActiveDevices[mDeviceBeingPaired];
 
-    mPairingSession.PeerConnection().SetPeerNodeId(device->GetDeviceId());
+    mPairingSession.SetPeerNodeId(device->GetDeviceId());
 
-    CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kInitiator, mFabricIndex);
+    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
+                                             SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -599,7 +599,7 @@ void DeviceController::OnNewConnection(SecureSessionHandle session, Messaging::E
 {
     VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnNewConnection was called in incorrect state"));
 
-    uint16_t index = FindDeviceIndex(mgr->GetSessionMgr()->GetPeerConnectionState(session)->GetPeerNodeId());
+    uint16_t index = FindDeviceIndex(mgr->GetSessionMgr()->GetPeerConnectionState(session)->GetPeerInfo().GetPeer().GetNodeId());
     VerifyOrReturn(index < kNumMaxActiveDevices,
                    ChipLogDetail(Controller, "OnNewConnection was called for unknown device, ignoring it."));
 

--- a/src/lib/core/PeerId.h
+++ b/src/lib/core/PeerId.h
@@ -30,7 +30,8 @@ constexpr uint16_t kUndefinedVendorId = 0U;
 class PeerId
 {
 public:
-    PeerId() {}
+    constexpr PeerId() {}
+    constexpr PeerId(NodeId nodeId, FabricId fabricId) : mNodeId(nodeId), mFabricId(fabricId) {}
 
     NodeId GetNodeId() const { return mNodeId; }
     PeerId & SetNodeId(NodeId id)

--- a/src/lib/support/ReferenceCountedHandle.h
+++ b/src/lib/support/ReferenceCountedHandle.h
@@ -36,6 +36,8 @@ public:
     bool operator==(const ReferenceCountedHandle & that) const { return &mTarget == &that.mTarget; }
     bool operator!=(const ReferenceCountedHandle & that) const { return !(*this == that); }
 
+    Target & Get() const { return mTarget; }
+
 private:
     Target & mTarget;
 };

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 
     state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(mSecureSession);
     // If sending via UDP and NoAutoRequestAck send flag is not specificed, request reliable transmission.
-    if (state != nullptr && state->GetPeerAddress().GetTransportType() != Transport::Type::kUdp)
+    if (state != nullptr && state->GetPeerInfo().GetPeerAddress().GetTransportType() != Transport::Type::kUdp)
     {
         reliableTransmissionRequested = false;
     }

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -99,7 +99,7 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, ec1->IsInitiator() == true);
     NL_TEST_ASSERT(inSuite, ec1->GetExchangeId() != 0);
     auto sessionPeerToLocal = ctx.GetSecureSessionManager().GetPeerConnectionState(ec1->GetSecureSession());
-    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerNodeId() == ctx.GetSourceNodeId());
+    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerInfo().GetPeer().GetNodeId() == ctx.GetSourceNodeId());
     NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerKeyID() == ctx.GetLocalKeyId());
     NL_TEST_ASSERT(inSuite, ec1->GetDelegate() == &mockAppDelegate);
 
@@ -107,7 +107,7 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, ec2 != nullptr);
     NL_TEST_ASSERT(inSuite, ec2->GetExchangeId() > ec1->GetExchangeId());
     auto sessionLocalToPeer = ctx.GetSecureSessionManager().GetPeerConnectionState(ec2->GetSecureSession());
-    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerNodeId() == ctx.GetDestinationNodeId());
+    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerInfo().GetPeer().GetNodeId() == ctx.GetDestinationNodeId());
     NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerKeyID() == ctx.GetPeerKeyId());
 
     ec1->Close();

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -130,11 +130,11 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    mSessionMgr->ExpireAllPairings(GetSession().PeerConnection().GetPeerNodeId(), mFabricIndex);
+    mSessionMgr->ExpireAllPairings(mPairingSession.GetPeerNodeId(), mFabricIndex);
 
-    CHIP_ERROR err = mSessionMgr->NewPairing(
-        Optional<Transport::PeerAddress>::Value(GetSession().PeerConnection().GetPeerAddress()),
-        GetSession().PeerConnection().GetPeerNodeId(), &GetSession(), SecureSession::SessionRole::kResponder, mFabricIndex);
+    CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
+                                             mPairingSession.GetPeerNodeId(), &mPairingSession,
+                                             SecureSession::SessionRole::kResponder, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -130,7 +130,7 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 void CASEServer::OnSessionEstablished()
 {
     ChipLogProgress(Inet, "CASE Session established. Setting up the secure channel.");
-    mSessionMgr->ExpireAllPairings(mPairingSession.GetPeerNodeId(), mFabricIndex);
+    mSessionMgr->ExpireAllPairings(PeerId{ mPairingSession.GetPeerNodeId(), mFabricIndex });
 
     CHIP_ERROR err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()),
                                              mPairingSession.GetPeerNodeId(), &mPairingSession,

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -92,7 +92,7 @@ void CASESession::Clear()
     mNextExpectedMsg = Protocols::SecureChannel::MsgType::CASE_SigmaErr;
     mCommissioningHash.Clear();
     mPairingComplete = false;
-    mConnectionState.Reset();
+    PairingSession::Clear();
 
     CloseExchange();
 }
@@ -148,7 +148,7 @@ CHIP_ERROR CASESession::Deserialize(CASESessionSerialized & input)
 
 CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
 {
-    const NodeId peerNodeId = mConnectionState.GetPeerNodeId();
+    const NodeId peerNodeId = GetPeerNodeId();
     VerifyOrReturnError(CanCastTo<uint16_t>(mSharedSecret.Length()), CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(mMessageDigest)), CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(mIPK)), CHIP_ERROR_INTERNAL);
@@ -160,8 +160,8 @@ CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
     serializable.mIPKLen           = static_cast<uint16_t>(sizeof(mIPK));
     serializable.mPairingComplete  = (mPairingComplete) ? 1 : 0;
     serializable.mPeerNodeId       = peerNodeId;
-    serializable.mLocalKeyId       = mConnectionState.GetLocalKeyID();
-    serializable.mPeerKeyId        = mConnectionState.GetPeerKeyID();
+    serializable.mLocalKeyId       = GetLocalKeyId();
+    serializable.mPeerKeyId        = GetPeerKeyId();
 
     memcpy(serializable.mSharedSecret, mSharedSecret, mSharedSecret.Length());
     memcpy(serializable.mMessageDigest, mMessageDigest, sizeof(mMessageDigest));
@@ -183,9 +183,9 @@ CHIP_ERROR CASESession::FromSerializable(const CASESessionSerializable & seriali
     memcpy(mMessageDigest, serializable.mMessageDigest, serializable.mMessageDigestLen);
     memcpy(mIPK, serializable.mIPK, serializable.mIPKLen);
 
-    mConnectionState.SetPeerNodeId(serializable.mPeerNodeId);
-    mConnectionState.SetLocalKeyID(serializable.mLocalKeyId);
-    mConnectionState.SetPeerKeyID(serializable.mPeerKeyId);
+    SetPeerNodeId(serializable.mPeerNodeId);
+    SetLocalKeyId(serializable.mLocalKeyId);
+    SetPeerKeyId(serializable.mPeerKeyId);
 
     return CHIP_NO_ERROR;
 }
@@ -202,7 +202,7 @@ CHIP_ERROR CASESession::Init(OperationalCredentialSet * operationalCredentialSet
     ReturnErrorOnFailure(mCommissioningHash.Begin());
 
     mDelegate = delegate;
-    mConnectionState.SetLocalKeyID(myKeyId);
+    SetLocalKeyId(myKeyId);
     mOpCredSet = operationalCredentialSet;
 
     mValidContext.Reset();
@@ -247,8 +247,8 @@ CHIP_ERROR CASESession::EstablishSession(const Transport::PeerAddress peerAddres
     SuccessOrExit(err);
 
     mExchangeCtxt->SetResponseTimeout(kSigma_Response_Timeout);
-    mConnectionState.SetPeerAddress(peerAddress);
-    mConnectionState.SetPeerNodeId(peerNodeId);
+    SetPeerAddress(peerAddress);
+    SetPeerNodeId(peerNodeId);
     mTrustedRootId = operationalCredentialSet->GetTrustedRootId(opCredSetIndex);
     VerifyOrExit(!mTrustedRootId.empty(), err = CHIP_ERROR_INTERNAL);
 
@@ -333,7 +333,7 @@ CHIP_ERROR CASESession::SendSigmaR1()
     ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(1), initiatorRandom, sizeof(initiatorRandom)));
     // Retrieve Session Identifier
-    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), mConnectionState.GetLocalKeyID(), true));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
     // Generate a Destination Identifier
     {
         const ChipCertificateData * rootCertificate = mOpCredSet->GetRootCertificate(mTrustedRootId);
@@ -350,8 +350,8 @@ CHIP_ERROR CASESession::SendSigmaR1()
         // retrieve Fabric IPK
         MutableByteSpan ipkSpan(mIPK);
         ReturnErrorOnFailure(RetrieveIPK(fabricId, ipkSpan));
-        ReturnErrorOnFailure(GenerateDestinationID(ByteSpan(initiatorRandom), rootCertificate->mPublicKey,
-                                                   mConnectionState.GetPeerNodeId(), fabricId, ByteSpan(mIPK), destinationIdSpan));
+        ReturnErrorOnFailure(GenerateDestinationID(ByteSpan(initiatorRandom), rootCertificate->mPublicKey, GetPeerNodeId(),
+                                                   fabricId, ByteSpan(mIPK), destinationIdSpan));
     }
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(3), destinationIdentifier, sizeof(destinationIdentifier)));
 
@@ -410,7 +410,7 @@ CHIP_ERROR CASESession::HandleSigmaR1(System::PacketBufferHandle & msg)
     SuccessOrExit(err = tlvReader.Get(initiatorSessionId));
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", initiatorSessionId);
-    mConnectionState.SetPeerKeyID(initiatorSessionId);
+    SetPeerKeyId(initiatorSessionId);
 
     SuccessOrExit(err = tlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(tlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
@@ -556,7 +556,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         tlvWriter.Init(std::move(msg_R2));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), msg_rand.Get(), kSigmaParamRandomNumberSize));
-        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), mConnectionState.GetLocalKeyID(), true));
+        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(),
                                                static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(4), msg_R2_Encrypted.Get(),
@@ -649,7 +649,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     SuccessOrExit(err = tlvReader.Get(responderSessionId));
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", responderSessionId);
-    mConnectionState.SetPeerKeyID(responderSessionId);
+    SetPeerKeyId(responderSessionId);
 
     // Retrieve Responder's Ephemeral Pubkey
     SuccessOrExit(err = tlvReader.Next());
@@ -1152,7 +1152,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const ByteSpan & respon
         // peer's operational identity from it.
         PeerId peerId;
         ReturnErrorOnFailure(ExtractPeerIdFromOpCert(certSet.GetCertSet()[0], &peerId));
-        mConnectionState.SetPeerNodeId(peerId.GetNodeId());
+        SetPeerNodeId(peerId.GetNodeId());
     }
 
     // Release the previously loaded NOC Certificate
@@ -1280,14 +1280,13 @@ CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const Pack
 
     if (packetHeader.GetSourceNodeId().HasValue())
     {
-        if (mConnectionState.GetPeerNodeId() == kUndefinedNodeId)
+        if (GetPeerNodeId() == kUndefinedNodeId)
         {
-            mConnectionState.SetPeerNodeId(packetHeader.GetSourceNodeId().Value());
+            SetPeerNodeId(packetHeader.GetSourceNodeId().Value());
         }
         else
         {
-            VerifyOrReturnError(packetHeader.GetSourceNodeId().Value() == mConnectionState.GetPeerNodeId(),
-                                CHIP_ERROR_WRONG_NODE_ID);
+            VerifyOrReturnError(packetHeader.GetSourceNodeId().Value() == GetPeerNodeId(), CHIP_ERROR_WRONG_NODE_ID);
         }
     }
 
@@ -1300,7 +1299,7 @@ CHIP_ERROR CASESession::OnMessageReceived(ExchangeContext * ec, const PacketHead
     CHIP_ERROR err = ValidateReceivedMessage(ec, packetHeader, payloadHeader, msg);
     SuccessOrExit(err);
 
-    mConnectionState.SetPeerAddress(mMessageDispatch.GetPeerAddress());
+    SetPeerAddress(mMessageDispatch.GetPeerAddress());
 
     switch (static_cast<Protocols::SecureChannel::MsgType>(payloadHeader.GetMessageType()))
     {

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -39,7 +39,6 @@
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/PairingSession.h>
-#include <transport/PeerConnectionState.h>
 #include <transport/SecureSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -134,35 +133,9 @@ public:
      */
     virtual CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
-    /**
-     * @brief
-     *  Return the associated secure session peer NodeId
-     *
-     * @return NodeId The associated peer NodeId
-     */
-    NodeId GetPeerNodeId() const { return mConnectionState.GetPeerNodeId(); }
-
-    /**
-     * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    uint16_t GetPeerKeyId() override { return mConnectionState.GetPeerKeyID(); }
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The assocated local key id
-     */
-    uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
-
     const char * GetI2RSessionInfo() const override { return "Sigma I2R Key"; }
 
     const char * GetR2ISessionInfo() const override { return "Sigma R2I Key"; }
-
-    Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /**
      * @brief Serialize the Pairing Session to a string.
@@ -288,8 +261,6 @@ private:
 
 protected:
     bool mPairingComplete = false;
-
-    Transport::PeerConnectionState mConnectionState;
 
     virtual ByteSpan * GetIPKList() const
     {

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -99,7 +99,7 @@ void PASESession::Clear()
     mKeLen           = sizeof(mKe);
     mPairingComplete = false;
     mComputeVerifier = true;
-    mConnectionState.Reset();
+    PairingSession::Clear();
     CloseExchange();
 }
 
@@ -155,8 +155,8 @@ CHIP_ERROR PASESession::ToSerializable(PASESessionSerializable & serializable)
     memset(&serializable, 0, sizeof(serializable));
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
-    serializable.mLocalKeyId      = mConnectionState.GetLocalKeyID();
-    serializable.mPeerKeyId       = mConnectionState.GetPeerKeyID();
+    serializable.mLocalKeyId      = GetLocalKeyId();
+    serializable.mPeerKeyId       = GetPeerKeyId();
 
     memcpy(serializable.mKe, mKe, mKeLen);
 
@@ -172,8 +172,8 @@ CHIP_ERROR PASESession::FromSerializable(const PASESessionSerializable & seriali
     memset(mKe, 0, sizeof(mKe));
     memcpy(mKe, serializable.mKe, mKeLen);
 
-    mConnectionState.SetLocalKeyID(serializable.mLocalKeyId);
-    mConnectionState.SetPeerKeyID(serializable.mPeerKeyId);
+    SetLocalKeyId(serializable.mLocalKeyId);
+    SetPeerKeyId(serializable.mPeerKeyId);
 
     return CHIP_NO_ERROR;
 }
@@ -191,7 +191,7 @@ CHIP_ERROR PASESession::Init(uint16_t myKeyId, uint32_t setupCode, SessionEstabl
     mDelegate = delegate;
 
     ChipLogDetail(SecureChannel, "Assigned local session key ID %d", myKeyId);
-    mConnectionState.SetLocalKeyID(myKeyId);
+    SetLocalKeyId(myKeyId);
     mSetupPINCode    = setupCode;
     mComputeVerifier = true;
 
@@ -313,7 +313,7 @@ CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t 
     mExchangeCtxt = exchangeCtxt;
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout);
 
-    mConnectionState.SetPeerAddress(peerAddress);
+    SetPeerAddress(peerAddress);
 
     err = SendPBKDFParamRequest();
     SuccessOrExit(err);
@@ -503,7 +503,7 @@ CHIP_ERROR PASESession::SendMsg1()
 
     Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(sizeof(uint16_t) + X_len));
     VerifyOrReturnError(!bbuf.IsNull(), CHIP_ERROR_NO_MEMORY);
-    bbuf.Put16(mConnectionState.GetLocalKeyID());
+    bbuf.Put16(GetLocalKeyId());
     bbuf.Put(&X[0], X_len);
     VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
 
@@ -550,7 +550,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const System::PacketBufferHandle
     SuccessOrExit(err);
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", encryptionKeyId);
-    mConnectionState.SetPeerKeyID(encryptionKeyId);
+    SetPeerKeyId(encryptionKeyId);
 
     err = mSpake2p.ComputeRoundTwo(msg->Start(), msg->DataLength(), verifier, &verifier_len);
     SuccessOrExit(err);
@@ -563,7 +563,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const System::PacketBufferHandle
     {
         Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(data_len));
         VerifyOrExit(!bbuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-        bbuf.Put16(mConnectionState.GetLocalKeyID());
+        bbuf.Put16(GetLocalKeyId());
         bbuf.Put(&Y[0], Y_len);
         bbuf.Put(verifier, verifier_len);
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
@@ -616,7 +616,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(const System::PacketBufferHandle
     buf_len = msg->DataLength();
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", encryptionKeyId);
-    mConnectionState.SetPeerKeyID(encryptionKeyId);
+    SetPeerKeyId(encryptionKeyId);
 
     err = mSpake2p.ComputeRoundTwo(buf, kMAX_Point_Length, verifier, &verifier_len_raw);
     SuccessOrExit(err);
@@ -793,7 +793,7 @@ CHIP_ERROR PASESession::OnMessageReceived(ExchangeContext * exchange, const Pack
     CHIP_ERROR err = ValidateReceivedMessage(exchange, packetHeader, payloadHeader, std::move(msg));
     SuccessOrExit(err);
 
-    mConnectionState.SetPeerAddress(mMessageDispatch.GetPeerAddress());
+    SetPeerAddress(mMessageDispatch.GetPeerAddress());
 
     switch (static_cast<Protocols::SecureChannel::MsgType>(payloadHeader.GetMessageType()))
     {

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -39,7 +39,6 @@
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/PairingSession.h>
-#include <transport/PeerConnectionState.h>
 #include <transport/SecureSession.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -149,27 +148,9 @@ public:
      */
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
-    /**
-     * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    uint16_t GetPeerKeyId() override { return mConnectionState.GetPeerKeyID(); }
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The assocated local key id
-     */
-    uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
-
     const char * GetI2RSessionInfo() const override { return kSpake2pI2RSessionInfo; }
 
     const char * GetR2ISessionInfo() const override { return kSpake2pR2ISessionInfo; }
-
-    Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /** @brief Serialize the Pairing Session to a string.
      *
@@ -306,8 +287,6 @@ protected:
     size_t mKeLen = sizeof(mKe);
 
     bool mPairingComplete = false;
-
-    Transport::PeerConnectionState mConnectionState;
 };
 
 /*
@@ -327,9 +306,17 @@ constexpr chip::NodeId kTestDeviceNodeId     = 12344321;
 class SecurePairingUsingTestSecret : public PairingSession
 {
 public:
-    SecurePairingUsingTestSecret() {}
+    SecurePairingUsingTestSecret()
+    {
+        SetLocalKeyId(0);
+        SetPeerKeyId(0);
+    }
 
-    SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId) : mPeerKeyID(peerKeyId), mLocalKeyID(localKeyId) {}
+    SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId)
+    {
+        SetLocalKeyId(localKeyId);
+        SetPeerKeyId(peerKeyId);
+    }
 
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override
     {
@@ -345,16 +332,12 @@ public:
         memset(&serializable, 0, sizeof(serializable));
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
-        serializable.mLocalKeyId      = mLocalKeyID;
-        serializable.mPeerKeyId       = mPeerKeyID;
+        serializable.mLocalKeyId      = GetLocalKeyId();
+        serializable.mPeerKeyId       = GetPeerKeyId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);
         return CHIP_NO_ERROR;
     }
-
-    uint16_t GetPeerKeyId() override { return mPeerKeyID; }
-
-    uint16_t GetLocalKeyId() override { return mLocalKeyID; }
 
     const char * GetI2RSessionInfo() const override { return "i2r"; }
 
@@ -362,9 +345,6 @@ public:
 
 private:
     const char * kTestSecret = "Test secret for key derivation";
-
-    uint16_t mPeerKeyID  = 0;
-    uint16_t mLocalKeyID = 0;
 };
 
 typedef struct PASESessionSerialized

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -36,6 +36,28 @@ public:
     PairingSession() {}
     virtual ~PairingSession() {}
 
+    NodeId GetPeerNodeId() const { return mPeerNodeId; }
+    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
+
+    uint16_t GetPeerKeyId() const { return mPeerKeyId; }
+    void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
+    bool IsValidPeerKeyId() const { return mPeerKeyId != kInvalidKeyId; }
+
+    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
+    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
+    bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
+
+    const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
+    Transport::PeerAddress & GetPeerAddress() { return mPeerAddress; }
+    void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
+
+    void Clear()
+    {
+        mPeerAddress = Transport::PeerAddress::Uninitialized();
+        mPeerKeyId   = kInvalidKeyId;
+        mLocalKeyId  = kInvalidKeyId;
+    }
+
     /**
      * @brief
      *   Derive a secure session from the paired session. The API will return error
@@ -50,22 +72,6 @@ public:
 
     /**
      * @brief
-     *  Return the associated peer key id
-     *
-     * @return uint16_t The associated peer key id
-     */
-    virtual uint16_t GetPeerKeyId() = 0;
-
-    /**
-     * @brief
-     *  Return the associated local key id
-     *
-     * @return uint16_t The associated local key id
-     */
-    virtual uint16_t GetLocalKeyId() = 0;
-
-    /**
-     * @brief
      *   Get the value of peer session counter which is synced during session establishment
      */
     virtual uint32_t GetPeerCounter()
@@ -77,6 +83,14 @@ public:
     virtual const char * GetI2RSessionInfo() const = 0;
 
     virtual const char * GetR2ISessionInfo() const = 0;
+
+private:
+    NodeId mPeerNodeId = kUndefinedNodeId;
+    // TODO(#8206): Remove address and use peer cache instead.
+    Transport::PeerAddress mPeerAddress     = Transport::PeerAddress::Uninitialized();
+    static constexpr uint16_t kInvalidKeyId = UINT16_MAX;
+    uint16_t mPeerKeyId                     = kInvalidKeyId;
+    uint16_t mLocalKeyId                    = kInvalidKeyId;
 };
 
 } // namespace chip

--- a/src/transport/PeerCache.h
+++ b/src/transport/PeerCache.h
@@ -1,0 +1,181 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <core/CHIPError.h>
+#include <core/ReferenceCounted.h>
+#include <support/CodeUtils.h>
+#include <support/Pool.h>
+#include <support/ReferenceCountedHandle.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/TimeSource.h>
+#include <transport/raw/PeerAddress.h>
+
+namespace chip {
+namespace Transport {
+
+class PeerCacheEntry;
+using PeerHandle = ReferenceCountedHandle<PeerCacheEntry>;
+
+class PeerCacheEntryDeleter
+{
+public:
+    // This is a no-op because life-cycle of PeerCache is rotated by LRU
+    static void Release(PeerCacheEntry * entry) {}
+};
+
+/**
+ * @brief
+ *   A Peer table entry stores the binding of NodeId, TransportAddress, and message counters. For both secure and unsecure nodes.
+ *
+ *   The entries are rotated using LRU, but entry can be hold by using PeerHandle, which increase the reference count by 1. When the
+ * reference count is not 0, the entry won't be pruned.
+ */
+class PeerCacheEntry : public ReferenceCounted<PeerCacheEntry, PeerCacheEntryDeleter>
+{
+public:
+    PeerCacheEntry(const PeerId & peer) : mPeer(peer) {}
+
+    PeerCacheEntry(const PeerCacheEntry &) = delete;
+    PeerCacheEntry & operator=(const PeerCacheEntry &) = delete;
+    PeerCacheEntry(PeerCacheEntry &&)                  = delete;
+    PeerCacheEntry & operator=(PeerCacheEntry &&) = delete;
+
+    const PeerId & GetPeer() const { return mPeer; }
+
+    uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
+    void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
+
+    const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
+    PeerAddress & GetPeerAddress() { return mPeerAddress; }
+    void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
+
+private:
+    uint64_t mLastActivityTimeMs = 0;
+
+    const PeerId mPeer;
+
+    PeerAddress mPeerAddress = PeerAddress::Uninitialized();
+};
+
+template <size_t kMaxConnectionCount, Time::Source kTimeSource = Time::Source::kSystem>
+class PeerCache
+{
+public:
+    /**
+     * Allocates a new peer state object out of the internal resource pool.
+     *
+     * @returns CHIP_NO_ERROR if state could be initialized. May fail if maximum connection count
+     *          has been reached (with CHIP_ERROR_NO_MEMORY).
+     */
+    CHECK_RETURN_VALUE
+    CHIP_ERROR AllocEntry(const PeerId & peer, PeerCacheEntry *& entry)
+    {
+        entry = mEntries.CreateObject(peer);
+        if (entry != nullptr)
+            return CHIP_NO_ERROR;
+
+        entry = FindLeastRecentUsedEntry();
+        VerifyOrDie(entry != nullptr);
+
+        const uint64_t currentTime = mTimeSource.GetCurrentMonotonicTimeMs();
+        if (currentTime - entry->GetLastActivityTimeMs() < kMinimalActivityTimeMs)
+        {
+            // Protect the entry for a short period to prevent from rotating too fast.
+            entry = nullptr;
+            return CHIP_ERROR_NO_MEMORY;
+        }
+
+        mEntries.ResetObject(entry, peer);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * Get a peer given the peer id.
+     *
+     * @return the peer found, nullptr if not found
+     */
+    CHECK_RETURN_VALUE
+    PeerCacheEntry * FindEntry(const PeerId & peer)
+    {
+        PeerCacheEntry * result = nullptr;
+        mEntries.ForEachActiveObject([&](PeerCacheEntry * entry) {
+            if (entry->GetPeer() == peer)
+            {
+                result = entry;
+                return false;
+            }
+            return true;
+        });
+        return result;
+    }
+
+    /**
+     * Get a peer given the peer id. If the peer doesn't exist in the cache, allocate a new entry for it.
+     *
+     * @return the peer found or allocated, nullptr if not found and allocate failed.
+     */
+    CHECK_RETURN_VALUE
+    PeerCacheEntry * FindOrAllocateEntry(const PeerId & peer)
+    {
+        PeerCacheEntry * result = FindEntry(peer);
+        if (result != nullptr)
+            return result;
+
+        CHIP_ERROR err = AllocEntry(peer, result);
+        if (err == CHIP_NO_ERROR)
+        {
+            return result;
+        }
+        else
+        {
+            ChipLogError(Inet, "Peer cache exhausted: %s", ErrorStr(err));
+            return nullptr;
+        }
+    }
+
+    /// Mark a peer as active
+    void MarkPeerActive(PeerCacheEntry & entry) { entry.SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs()); }
+
+    /// Allows access to the underlying time source used for keeping track of connection active time
+    Time::TimeSource<kTimeSource> & GetTimeSource() { return mTimeSource; }
+
+private:
+    PeerCacheEntry * FindLeastRecentUsedEntry()
+    {
+        PeerCacheEntry * result = nullptr;
+        uint64_t oldestTimeMs   = std::numeric_limits<uint64_t>::max();
+
+        mEntries.ForEachActiveObject([&](PeerCacheEntry * entry) {
+            if (entry->GetReferenceCount() == 0 && entry->GetLastActivityTimeMs() < oldestTimeMs)
+            {
+                result       = entry;
+                oldestTimeMs = entry->GetLastActivityTimeMs();
+            }
+            return true;
+        });
+
+        return result;
+    }
+
+    static constexpr uint64_t kMinimalActivityTimeMs = 30000;
+    Time::TimeSource<Time::Source::kSystem> mTimeSource;
+    BitMapObjectPool<PeerCacheEntry, kMaxConnectionCount> mEntries;
+};
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -53,9 +53,10 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
         .SetMessageId(msgId)          //
         .SetEncryptionKeyID(state->GetPeerKeyID());
 
-    if (state->GetPeerNodeId() != kUndefinedNodeId)
+    NodeId peerNodeId = state->GetPeerInfo().GetPeer().GetNodeId();
+    if (peerNodeId != kUndefinedNodeId)
     {
-        packetHeader.SetDestinationNodeId(state->GetPeerNodeId());
+        packetHeader.SetDestinationNodeId(peerNodeId);
     }
 
     packetHeader.GetFlags().Set(Header::FlagValues::kEncryptedMessage);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -137,7 +137,7 @@ CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SecureSessionHandle se
     ChipLogProgress(Inet,
                     "Encrypted message %p from 0x" ChipLogFormatX64 " to 0x" ChipLogFormatX64 " of type %d and protocolId %" PRIu32
                     " on exchange %d.",
-                    &encryptedMessage, ChipLogValueX64(localNodeId), ChipLogValueX64(state->GetPeerNodeId()),
+                    &encryptedMessage, ChipLogValueX64(localNodeId), ChipLogValueX64(state->GetPeerInfo().GetPeer().GetNodeId()),
                     payloadHeader.GetMessageType(), payloadHeader.GetProtocolID().ToFullyQualifiedSpecForm(),
                     payloadHeader.GetExchangeID());
 
@@ -162,14 +162,15 @@ CHIP_ERROR SecureSessionMgr::SendPreparedMessage(SecureSessionHandle session, co
 
     // This marks any connection where we send data to as 'active'
     mPeerConnections.MarkConnectionActive(state);
+    mPeers.MarkPeerActive(state->GetPeerInfo());
 
     ChipLogProgress(Inet, "Sending msg %p to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec", &preparedMessage,
-                    ChipLogValueX64(state->GetPeerNodeId()), System::Clock::GetMonotonicMilliseconds());
+                    ChipLogValueX64(state->GetPeerInfo().GetPeer().GetNodeId()), System::Clock::GetMonotonicMilliseconds());
 
     if (mTransportMgr != nullptr)
     {
         ChipLogProgress(Inet, "Sending secure msg on generic transport");
-        err = mTransportMgr->SendMessage(state->GetPeerAddress(), std::move(msgBuf));
+        err = mTransportMgr->SendMessage(state->GetPeerInfo().GetPeerAddress(), std::move(msgBuf));
     }
     else
     {
@@ -202,33 +203,33 @@ void SecureSessionMgr::ExpirePairing(SecureSessionHandle session)
     }
 }
 
-void SecureSessionMgr::ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric)
+void SecureSessionMgr::ExpireAllPairings(const PeerId & peer)
 {
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
-    while (state != nullptr)
-    {
-        if (fabric == state->GetFabricIndex())
+    mPeerConnections.ForEachActiveConnection([&](PeerConnectionState * state) {
+        auto & entry = state->GetPeerInfo();
+        if (entry.GetPeer() == peer)
         {
             mPeerConnections.MarkConnectionExpired(
                 state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
-            state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
         }
-        else
-        {
-            state = mPeerConnections.FindPeerConnectionState(peerNodeId, state);
-        }
-    }
+        return true;
+    });
 }
 
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                                        PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
+                                        PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabricIndex)
 {
-    uint16_t peerKeyId          = pairing->GetPeerKeyId();
-    uint16_t localKeyId         = pairing->GetLocalKeyId();
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, nullptr);
+    uint16_t peerKeyId  = pairing->GetPeerKeyId();
+    uint16_t localKeyId = pairing->GetLocalKeyId();
+
+    Transport::FabricInfo * fabric = mFabrics->FindFabricWithIndex(fabricIndex);
+    ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    PeerId peerId{ peerNodeId, fabric->GetFabricId() };
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(peerId, peerKeyId);
 
     // Find any existing connection with the same node and key ID
-    if (state && (state->GetFabricIndex() == Transport::kUndefinedFabricIndex || state->GetFabricIndex() == fabric))
+    if (state)
     {
         mPeerConnections.MarkConnectionExpired(
             state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
@@ -236,20 +237,22 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
 
     ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
                   peerKeyId);
-    state = nullptr;
-    ReturnErrorOnFailure(
-        mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
-    ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
-    state->SetFabricIndex(fabric);
+    Transport::PeerCacheEntry * peer = mPeers.FindOrAllocateEntry(peerId);
+    VerifyOrReturnError(peer != nullptr, CHIP_ERROR_NO_MEMORY);
+    mPeers.MarkPeerActive(*peer);
+
+    state = nullptr;
+    ReturnErrorOnFailure(mPeerConnections.CreateNewPeerConnectionState(*peer, fabricIndex, peerKeyId, localKeyId, state));
+    ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
     if (peerAddr.HasValue() && peerAddr.Value().GetIPAddress() != Inet::IPAddress::Any)
     {
-        state->SetPeerAddress(peerAddr.Value());
+        peer->SetPeerAddress(peerAddr.Value());
     }
     else if (peerAddr.HasValue() && peerAddr.Value().GetTransportType() == Transport::Type::kBle)
     {
-        state->SetPeerAddress(peerAddr.Value());
+        peer->SetPeerAddress(peerAddr.Value());
     }
     else if (peerAddr.HasValue() &&
              (peerAddr.Value().GetTransportType() == Transport::Type::kTcp ||
@@ -263,7 +266,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     if (mCB != nullptr)
     {
         state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-        mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), fabric });
+        mCB->OnNewConnection(state->ToSessionHandle());
     }
 
     return CHIP_NO_ERROR;
@@ -318,7 +321,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetEncryptionKeyID(), nullptr);
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionStateByLocalKeyId(packetHeader.GetEncryptionKeyID());
 
     PayloadHeader payloadHeader;
 
@@ -348,9 +351,8 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         if (!state->GetSessionMessageCounter().GetPeerMessageCounter().IsSynchronized())
         {
             // Queue and start message sync procedure
-            err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
-                packetHeader, { state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex() }, state, peerAddress,
-                std::move(msg));
+            err = mMessageCounterManager->QueueReceivedMessageAndStartSync(packetHeader, state->ToSessionHandle(), state,
+                                                                           peerAddress, std::move(msg));
 
             if (err != CHIP_NO_ERROR)
             {
@@ -407,11 +409,12 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
                         static_cast<int>(state->GetFabricIndex()), packetHeader.GetEncryptionKeyID());
     }
 
-    mPeerConnections.MarkConnectionActive(state);
-
     // Decode the message
     VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decode(state, payloadHeader, packetHeader, msg),
                  ChipLogError(Inet, "Secure transport received message, but failed to decode it, discarding"));
+
+    mPeerConnections.MarkConnectionActive(state);
+    mPeers.MarkPeerActive(state->GetPeerInfo());
 
     if (isDuplicate == SecureSessionMgrDelegate::DuplicateMessage::Yes && !payloadHeader.NeedsAck())
     {
@@ -435,9 +438,9 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     // TODO: Remove temporary code once AddOptCert is implemented
     if (packetHeader.GetSourceNodeId().HasValue())
     {
-        if (state->GetPeerNodeId() == kUndefinedNodeId)
+        if (state->GetPeerInfo().GetPeer().GetNodeId() == kUndefinedNodeId)
         {
-            state->SetPeerNodeId(packetHeader.GetSourceNodeId().Value());
+            // state->SetPeerNodeId(packetHeader.GetSourceNodeId().Value());
         }
     }
 
@@ -475,15 +478,14 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     // TODO: once mDNS address resolution is available reconsider if this is required
     // This updates the peer address once a packet is received from a new address
     // and serves as a way to auto-detect peer changing IPs.
-    if (state->GetPeerAddress() != peerAddress)
+    if (state->GetPeerInfo().GetPeerAddress() != peerAddress)
     {
-        state->SetPeerAddress(peerAddress);
+        state->GetPeerInfo().SetPeerAddress(peerAddress);
     }
 
     if (mCB != nullptr)
     {
-        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex());
-        mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
+        mCB->OnMessageReceived(packetHeader, payloadHeader, state->ToSessionHandle(), peerAddress, isDuplicate, std::move(msg));
     }
 
 exit:
@@ -496,14 +498,14 @@ exit:
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
     ChipLogDetail(Inet, "Marking old secure session for device 0x" ChipLogFormatX64 " as expired",
-                  ChipLogValueX64(state.GetPeerNodeId()));
+                  ChipLogValueX64(state.GetPeerInfo().GetPeer().GetNodeId()));
 
     if (mCB != nullptr)
     {
-        mCB->OnConnectionExpired({ state.GetPeerNodeId(), state.GetPeerKeyID(), state.GetFabricIndex() });
+        mCB->OnConnectionExpired(state.ToSessionHandle());
     }
 
-    mTransportMgr->Disconnect(state.GetPeerAddress());
+    mTransportMgr->Disconnect(state.GetPeerInfo().GetPeerAddress());
 }
 
 void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param, CHIP_ERROR error)
@@ -521,7 +523,10 @@ void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param, 
 
 PeerConnectionState * SecureSessionMgr::GetPeerConnectionState(SecureSessionHandle session)
 {
-    return mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(session.mPeerNodeId), session.mPeerKeyId, nullptr);
+    Transport::FabricInfo * fabric = mFabrics->FindFabricWithIndex(session.mFabric);
+    if (fabric == nullptr)
+        return nullptr;
+    return mPeerConnections.FindPeerConnectionState(PeerId{ session.mPeerNodeId, fabric->GetFabricId() }, session.mPeerKeyId);
 }
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -224,7 +224,7 @@ public:
                           SecureSession::SessionRole direction, FabricIndex fabric);
 
     void ExpirePairing(SecureSessionHandle session);
-    void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
+    void ExpireAllPairings(const PeerId & peer);
 
     /**
      * @brief
@@ -279,6 +279,7 @@ private:
     };
 
     System::Layer * mSystemLayer = nullptr;
+    Transport::PeerCache<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeers;                 // < Active peers
     Transport::PeerConnections<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeerConnections; // < Active connections to other peers
     State mState;                                                                       // < Initialization state of the object
 

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -34,212 +34,109 @@ namespace {
 using namespace chip;
 using namespace chip::Transport;
 
-PeerAddress AddressFromString(const char * str)
-{
-    Inet::IPAddress addr;
-
-    VerifyOrDie(Inet::IPAddress::FromString(str, addr));
-
-    return PeerAddress::UDP(addr);
-}
-
-const PeerAddress kPeer1Addr = AddressFromString("10.1.2.3");
-const PeerAddress kPeer2Addr = AddressFromString("10.0.0.32");
-const PeerAddress kPeer3Addr = AddressFromString("100.200.0.1");
-
-const NodeId kPeer1NodeId = 123;
-const NodeId kPeer2NodeId = 6;
-const NodeId kPeer3NodeId = 81;
+constexpr PeerId kPeer1 = PeerId{ 123, kUndefinedFabricId };
+constexpr PeerId kPeer2 = PeerId{ 6, kUndefinedFabricId };
+constexpr PeerId kPeer3 = PeerId{ 81, kUndefinedFabricId };
 
 void TestBasicFunctionality(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
+    Transport::PeerCache<5> peers;
     PeerConnectionState * statePtr;
     PeerConnections<2, Time::Source::kTest> connections;
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(100);
 
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer1), kUndefinedFabricIndex, 1, 2, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, statePtr != nullptr);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerInfo().GetPeer() == kPeer1);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerKeyID() == 1);
+    NL_TEST_ASSERT(inSuite, statePtr->GetLocalKeyID() == 2);
+    NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTimeMs() == 100);
+
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer2), kUndefinedFabricIndex, 3, 4, statePtr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, statePtr != nullptr);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerInfo().GetPeer() == kPeer2);
+    NL_TEST_ASSERT(inSuite, statePtr->GetPeerKeyID() == 3);
+    NL_TEST_ASSERT(inSuite, statePtr->GetLocalKeyID() == 4);
     NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTimeMs() == 100);
 
     // Insufficient space for new connections. Object is max size 2
-    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer3), kUndefinedFabricIndex, 5, 6, statePtr);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 
-void TestFindByAddress(nlTestSuite * inSuite, void * inContext)
+void TestFindByPeer(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
+    Transport::PeerCache<5> peers;
     PeerConnectionState * statePtr;
     PeerConnections<3, Time::Source::kTest> connections;
 
-    PeerConnectionState * state1 = nullptr;
-    PeerConnectionState * state2 = nullptr;
-    PeerConnectionState * state3 = nullptr;
-
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, &state1);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer1), kUndefinedFabricIndex, 1, 2, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, &state2);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer2), kUndefinedFabricIndex, 3, 4, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &state3);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer1), kUndefinedFabricIndex, 5, 6, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, state1 != state2);
-    NL_TEST_ASSERT(inSuite, state1 != state3);
-    NL_TEST_ASSERT(inSuite, state2 != state3);
+    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1, 1));
+    NL_TEST_ASSERT(inSuite, statePtr->GetLocalKeyID() == 2);
 
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
+    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1, 5));
+    NL_TEST_ASSERT(inSuite, statePtr->GetLocalKeyID() == 6);
 
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1Addr, statePtr));
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
-
-    NL_TEST_ASSERT(inSuite, (statePtr = connections.FindPeerConnectionState(kPeer1Addr, statePtr)) == nullptr);
-
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer2Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, nullptr));
-}
-
-void TestFindByNodeId(nlTestSuite * inSuite, void * inContext)
-{
-    CHIP_ERROR err;
-    PeerConnectionState * statePtr;
-    PeerConnections<3, Time::Source::kTest> connections;
-
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, &statePtr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    statePtr->SetPeerNodeId(kPeer1NodeId);
-
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    statePtr->SetPeerNodeId(kPeer2NodeId);
-
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    statePtr->SetPeerNodeId(kPeer1NodeId);
-
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1NodeId, nullptr));
-    char buf[100];
-    statePtr->GetPeerAddress().ToString(buf);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer1NodeId);
-
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1NodeId, statePtr));
-    statePtr->GetPeerAddress().ToString(buf);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer1NodeId);
-
-    NL_TEST_ASSERT(inSuite, (statePtr = connections.FindPeerConnectionState(kPeer1NodeId, statePtr)) == nullptr);
-
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer2NodeId, nullptr));
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
-    NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer2NodeId);
-
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3NodeId, nullptr));
-}
-
-void TestFindByKeyId(nlTestSuite * inSuite, void * inContext)
-{
-    CHIP_ERROR err;
-    PeerConnectionState * statePtr;
-    PeerConnections<2, Time::Source::kTest> connections;
-
-    // No Node ID, peer key 1, local key 2
-    err = connections.CreateNewPeerConnectionState(Optional<NodeId>::Missing(), 1, 2, &statePtr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    // Lookup using no node, and peer key
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(Optional<NodeId>::Missing(), 1, nullptr));
-    // Lookup using no node, and local key
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Missing(), 2, nullptr));
-
-    // Lookup using no node, and incorrect peer key
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(Optional<NodeId>::Missing(), 2, nullptr));
-
-    // Lookup using no node, and incorrect local key
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Missing(), 1, nullptr));
-
-    // Lookup using a node ID, and peer key
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(Optional<NodeId>::Value(kPeer1NodeId), 1, nullptr));
-
-    // Lookup using a node ID, and local key
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(kPeer1NodeId), 2, nullptr));
-
-    // Some Node ID, peer key 3, local key 4
-    err = connections.CreateNewPeerConnectionState(Optional<NodeId>::Value(kPeer1NodeId), 3, 4, &statePtr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    // Lookup using correct node (or no node), and correct keys
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(Optional<NodeId>::Value(kPeer1NodeId), 3, nullptr));
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(kPeer1NodeId), 4, nullptr));
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(Optional<NodeId>::Missing(), 3, nullptr));
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Missing(), 4, nullptr));
-
-    // Lookup using incorrect keys
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(Optional<NodeId>::Value(kPeer1NodeId), 4, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(kPeer1NodeId), 3, nullptr));
-
-    // Lookup using incorrect node, but correct keys
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(Optional<NodeId>::Value(kPeer2NodeId), 3, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(kPeer2NodeId), 4, nullptr));
+    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer2, 3));
+    NL_TEST_ASSERT(inSuite, statePtr->GetLocalKeyID() == 4);
 }
 
 struct ExpiredCallInfo
 {
-    int callCount                   = 0;
-    NodeId lastCallNodeId           = 0;
-    PeerAddress lastCallPeerAddress = PeerAddress::Uninitialized();
+    int callCount = 0;
+    PeerId lastCallPeer;
 };
 
 void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
     ExpiredCallInfo callInfo;
+    Transport::PeerCache<5> peers;
     PeerConnectionState * statePtr;
     PeerConnections<2, Time::Source::kTest> connections;
 
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(100);
 
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer1), kUndefinedFabricIndex, 1, 2, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(200);
-    err = connections.CreateNewPeerConnectionState(kPeer2Addr, &statePtr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer2), kUndefinedFabricIndex, 3, 4, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    statePtr->SetPeerNodeId(kPeer2NodeId);
 
     // cannot add before expiry
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(300);
-    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer3), kUndefinedFabricIndex, 5, 6, statePtr);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
     // at time 300, this expires ip addr 1
     connections.ExpireInactiveConnections(150, [&callInfo](const PeerConnectionState & state) {
         callInfo.callCount++;
-        callInfo.lastCallNodeId      = state.GetPeerNodeId();
-        callInfo.lastCallPeerAddress = state.GetPeerAddress();
+        callInfo.lastCallPeer = state.GetPeerInfo().GetPeer();
     });
     NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kUndefinedNodeId);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer1Addr);
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1NodeId, nullptr));
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeer == kPeer1);
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1, 1));
 
     // now that the connections were expired, we can add peer3
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(300);
-    err = connections.CreateNewPeerConnectionState(kPeer3Addr, &statePtr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer3), kUndefinedFabricIndex, 7, 8, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    statePtr->SetPeerNodeId(kPeer3NodeId);
 
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(400);
-    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer2NodeId, nullptr));
+    NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer2, 3));
 
     connections.MarkConnectionActive(statePtr);
     NL_TEST_ASSERT(inSuite, statePtr->GetLastActivityTimeMs() == connections.GetTimeSource().GetCurrentMonotonicTimeMs());
@@ -252,36 +149,39 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
     callInfo.callCount = 0;
     connections.ExpireInactiveConnections(150, [&callInfo](const PeerConnectionState & state) {
         callInfo.callCount++;
-        callInfo.lastCallNodeId      = state.GetPeerNodeId();
-        callInfo.lastCallPeerAddress = state.GetPeerAddress();
+        callInfo.lastCallPeer = state.GetPeerInfo().GetPeer();
     });
 
     // peer 2 stays active
     NL_TEST_ASSERT(inSuite, callInfo.callCount == 1);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallNodeId == kPeer3NodeId);
-    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeerAddress == kPeer3Addr);
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, nullptr));
+    NL_TEST_ASSERT(inSuite, callInfo.lastCallPeer == kPeer3);
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1, 1));
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2, 3));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 5));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 7));
 
-    err = connections.CreateNewPeerConnectionState(kPeer1Addr, nullptr);
+    err = connections.CreateNewPeerConnectionState(*peers.FindOrAllocateEntry(kPeer1), kUndefinedFabricIndex, 9, 10, statePtr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, nullptr));
+
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1, 1));
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer1, 9));
+    NL_TEST_ASSERT(inSuite, connections.FindPeerConnectionState(kPeer2, 3));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 5));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 7));
 
     // peer 1 and 2 are active
     connections.GetTimeSource().SetCurrentMonotonicTimeMs(1000);
     callInfo.callCount = 0;
     connections.ExpireInactiveConnections(100, [&callInfo](const PeerConnectionState & state) {
         callInfo.callCount++;
-        callInfo.lastCallNodeId      = state.GetPeerNodeId();
-        callInfo.lastCallPeerAddress = state.GetPeerAddress();
+        callInfo.lastCallPeer = state.GetPeerInfo().GetPeer();
     });
     NL_TEST_ASSERT(inSuite, callInfo.callCount == 2); // everything expired
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer2Addr, nullptr));
-    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3Addr, nullptr));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1, 1));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer1, 9));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer2, 3));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 5));
+    NL_TEST_ASSERT(inSuite, !connections.FindPeerConnectionState(kPeer3, 7));
 }
 
 } // namespace
@@ -290,9 +190,7 @@ void TestExpireConnections(nlTestSuite * inSuite, void * inContext)
 static const nlTest sTests[] =
 {
     NL_TEST_DEF("BasicFunctionality", TestBasicFunctionality),
-    NL_TEST_DEF("FindByPeerAddress", TestFindByAddress),
-    NL_TEST_DEF("FindByNodeId", TestFindByNodeId),
-    NL_TEST_DEF("FindByKeyId", TestFindByKeyId),
+    NL_TEST_DEF("FindByPeer", TestFindByPeer),
     NL_TEST_DEF("ExpireConnections", TestExpireConnections),
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
#### Problem
In order to let `SecureSessionManager` also handle unsecure messages, some fields like node id and address in `PeerConnectionState` also used by unsecure message should be extract into another object.

#### Change overview
Split `PeerConnectionState` into 2 part:
  * PeerCacheEntry: stores the binding of NodeId, TransportAddress, and message counters. For both secure and unsecure nodes.
  * Secure fields: key id, cipher context, session message counter

Add a `PeerCache` class to manage `PeerCacheEntry` entries. The `PeerCache` is also a map from (NodeId, AdminId) to PeerAddress.

#### Testing
 * Manually verified using unit-tests
 * Manually verified using im-initiator and im-responder