### PR TITLE
Zap use chip::ErrorStr into the BasicFilter template of CHIPClientCallbacks.h

### DIFF
--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.h
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.h
@@ -69,7 +69,7 @@ void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelabl
     }
     else
     {
-        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %d", err);
+        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
         chip::Callback::Callback<DefaultFailureCallback> * cb =
             chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
         cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.h
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.h
@@ -69,7 +69,7 @@ void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelabl
     }
     else
     {
-        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %d", err);
+        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
         chip::Callback::Callback<DefaultFailureCallback> * cb =
             chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
         cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -52,7 +52,7 @@ void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelabl
     }
     else
     {
-        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %d", err);
+        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
         chip::Callback::Callback<DefaultFailureCallback> * cb =
             chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
         cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);

--- a/src/controller/data_model/gen/CHIPClientCallbacks.h
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.h
@@ -69,7 +69,7 @@ void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelabl
     }
     else
     {
-        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %d", err);
+        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
         chip::Callback::Callback<DefaultFailureCallback> * cb =
             chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
         cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);


### PR DESCRIPTION
#### Problem

Onto some platforms `CHIPClientCallbacks.h` will not compile.

#### Change overview
* Use `%s` with `chip::ErrorStr(err)` instead of `%d` with `err`.

#### Testing
 * That is just a compilation error that should be fixed with the update.
