### PR TITLE
Fix PacketBuffer allocation size when using LwIP

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -466,7 +466,7 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
 #if CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_POOL ||                                                  \
     CHIP_SYSTEM_PACKETBUFFER_STORE == CHIP_SYSTEM_PACKETBUFFER_STORE_LWIP_CUSTOM
 
-    lPacket = static_cast<PacketBuffer *>(pbuf_alloc(PBUF_RAW, static_cast<uint16_t>(lBlockSize), PBUF_POOL));
+    lPacket = static_cast<PacketBuffer *>(pbuf_alloc(PBUF_RAW, static_cast<uint16_t>(lAllocSize), PBUF_POOL));
 
     SYSTEM_STATS_UPDATE_LWIP_PBUF_COUNTS();
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -191,7 +191,7 @@ private:
     std::vector<PacketBufferHandle> handles;
 };
 
-const uint16_t sTestReservedSizes[] = { 0, 10, 128, 1536, PacketBufferTest::kBlockSize };
+const uint16_t sTestReservedSizes[] = { 0, 10, 128, 1536, PacketBuffer::kMaxSizeWithoutReserve, PacketBufferTest::kBlockSize };
 const uint16_t sTestLengths[]       = { 0, 1, 10, 128, PacketBufferTest::kBlockSize, UINT16_MAX };
 
 PacketBufferTest::TestContext sContext = {


### PR DESCRIPTION
#### Problem

LwIP `pbuf_alloc()` was called with a size including the `struct pbuf`
header, but expects the size to exclude that.

#### Change overview

Call `pbuf_alloc()` with the correct size.

This imports a fragment of https://github.com/openweave/openweave-core/pull/608

#### Testing

Added `PacketBuffer::kMaxSizeWithoutReserve` to the cases checked
by `PacketBufferTest::CheckNew()`.
