### PR TITLE
[fix] emberAfCopyString should accept size_t size[TE4]

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -559,13 +559,13 @@ void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x);
  * parameter should indicate the maximum number of characters to copy to the
  * destination buffer not including the length byte.
  */
-void emberAfCopyString(uint8_t * dest, const uint8_t * src, uint8_t size);
+void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size);
 /*
  * @brief Function that copies a ZCL long string into a buffer.  The size
  * parameter should indicate the maximum number of characters to copy to the
  * destination buffer not including the length bytes.
  */
-void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, uint16_t size);
+void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, size_t size);
 /*
  * @brief Function that determines the length of a zigbee Cluster Library string
  *   (where the first byte is assumed to be the length).

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -480,7 +480,7 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
         {
             return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
         }
-        emberAfCopyString(dest, src, static_cast<size_t>(bufferSize - 1));
+        emberAfCopyString(dest, src, bufferSize - 1);
     }
     else if (emberAfIsLongStringAttributeType(attributeType))
     {
@@ -488,7 +488,7 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
         {
             return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
         }
-        emberAfCopyLongString(dest, src, static_cast<size_t>(bufferSize - 2));
+        emberAfCopyLongString(dest, src, bufferSize - 2);
     }
     else if (emberAfIsThisDataTypeAListType(attributeType))
     {

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -480,7 +480,7 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
         {
             return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
         }
-        emberAfCopyString(dest, src, static_cast<uint8_t>(bufferSize - 1));
+        emberAfCopyString(dest, src, static_cast<size_t>(bufferSize - 1));
     }
     else if (emberAfIsLongStringAttributeType(attributeType))
     {
@@ -488,7 +488,7 @@ static EmberAfStatus typeSensitiveMemCopy(ClusterId clusterId, uint8_t * dest, u
         {
             return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
         }
-        emberAfCopyLongString(dest, src, static_cast<uint16_t>(bufferSize - 2));
+        emberAfCopyLongString(dest, src, static_cast<size_t>(bufferSize - 2));
     }
     else if (emberAfIsThisDataTypeAListType(attributeType))
     {

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -878,7 +878,7 @@ void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x)
     data[index + 3] = (uint8_t)(((x) >> 24) & 0xFF);
 }
 
-void emberAfCopyString(uint8_t * dest, const uint8_t * src, uint8_t size)
+void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)
 {
     if (src == NULL)
     {
@@ -893,14 +893,15 @@ void emberAfCopyString(uint8_t * dest, const uint8_t * src, uint8_t size)
         uint8_t length = emberAfStringLength(src);
         if (size < length)
         {
-            length = size;
+            // Here, since we have checked that size < length, so size must be able to fit into length.
+            length = static_cast<decltype(length)>(size);
         }
         memmove(dest + 1, src + 1, length);
         dest[0] = length;
     }
 }
 
-void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, uint16_t size)
+void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, size_t size)
 {
     if (src == NULL)
     {
@@ -916,7 +917,8 @@ void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, uint16_t size)
         uint16_t length = emberAfLongStringLength(src);
         if (size < length)
         {
-            length = size;
+            // Here, since we have checked that size < length, so size must be able to fit into length.
+            length = static_cast<decltype(length)>(size);
         }
         memmove(dest + 2, src + 2, length);
         dest[0] = EMBER_LOW_BYTE(length);

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -893,7 +893,7 @@ void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)
         uint8_t length = emberAfStringLength(src);
         if (size < length)
         {
-            // Here, since we have checked that size < length, so size must be able to fit into length.
+            // Since we have checked that size < length, size must be able to fit into the type of length.
             length = static_cast<decltype(length)>(size);
         }
         memmove(dest + 1, src + 1, length);
@@ -917,7 +917,7 @@ void emberAfCopyLongString(uint8_t * dest, const uint8_t * src, size_t size)
         uint16_t length = emberAfLongStringLength(src);
         if (size < length)
         {
-            // Here, since we have checked that size < length, so size must be able to fit into length.
+            // Since we have checked that size < length, size must be able to fit into the type of length.
             length = static_cast<decltype(length)>(size);
         }
         memmove(dest + 2, src + 2, length);


### PR DESCRIPTION
#### Problem
emberAfCopyString accepts uint8_t currently, however we should be able to pass longer buffer to emberAfCopyString.

#### Change overview

```diff
- void emberAfCopyString(uint8_t * dest, const uint8_t * src, uint8_t size);
+ void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size);
```

#### Testing

Manaully tested.

This actually fixed the issue that lighting app will return empty string for some fields.

Run lighting app with this PR:

```
chip-device-ctrl > zclread Basic VendorName 1 0 0
[1625810123.223412][2381993:2381993] CHIP:IN: Marking old secure session for device 0x0000000000000001 as expired
[1625810123.223448][2381993:2381993] CHIP:CTL: OnConnectionExpired was called for unknown device, ignoring it.
[1625810123.223466][2381993:2381993] CHIP:IN: New secure session created for device 0x0000000000000001, key 0!!
[1625810123.223547][2381993:2381993] CHIP:DMG: SendReadRequest: Client[0] [ INIT]
[1625810123.223640][2381993:2381993] CHIP:IN: Secure message was encrypted: Msg ID 6
[1625810123.223652][2381993:2381993] CHIP:IN: Encrypted message 0x1094fb8 from 0x000000000001B669 to 0x0000000000000001 of type 2 and protocolId 5 on exchange 39021.
[1625810123.223665][2381993:2381993] CHIP:IN: Sending msg 0x1094fb8 to 0x0000000000000001 at utc time: 360074982 msec
[1625810123.223675][2381993:2381993] CHIP:IN: Sending secure msg on generic transport
[1625810123.223760][2381993:2381993] CHIP:IN: Secure msg send status No Error
[1625810123.223787][2381993:2381993] CHIP:DMG: Client[0] moving to [AwaitingResponse]
[1625810123.225107][2381993:2382000] CHIP:IN: Secure transport received message destined to fabric 0, node 0x000000000001B669. Key ID 1
[1625810123.225175][2381993:2382000] CHIP:EM: Received message of type 5 and protocolId 5 on exchange 39021
[1625810123.225212][2381993:2382000] CHIP:EM: Rxd Ack; Removing MsgId:00000006 from Retrans Table
[1625810123.225230][2381993:2382000] CHIP:EM: Removed CHIP MsgId:00000006 from RetransTable
[1625810123.225272][2381993:2382000] CHIP:DMG: ReportData =
[1625810123.225291][2381993:2382000] CHIP:DMG: {
[1625810123.225308][2381993:2382000] CHIP:DMG:  AttributeDataList =
[1625810123.225327][2381993:2382000] CHIP:DMG:  [
[1625810123.225344][2381993:2382000] CHIP:DMG:          AttributeDataElement =
[1625810123.225364][2381993:2382000] CHIP:DMG:          {
[1625810123.225383][2381993:2382000] CHIP:DMG:                  AttributePath =
[1625810123.225408][2381993:2382000] CHIP:DMG:                  {
[1625810123.225432][2381993:2382000] CHIP:DMG:                          NodeId = 0x1,
[1625810123.225451][2381993:2382000] CHIP:DMG:                          EndpointId = 0x0,
[1625810123.225490][2381993:2382000] CHIP:DMG:                          ClusterId = 0x28,
[1625810123.225509][2381993:2382000] CHIP:DMG:                          FieldTag = 0x1,
[1625810123.225526][2381993:2382000] CHIP:DMG:                  }
[1625810123.225548][2381993:2382000] CHIP:DMG: 
[1625810123.225570][2381993:2382000] CHIP:DMG:                  Data = "TEST_VENDOR", 
[1625810123.225590][2381993:2382000] CHIP:DMG:                  DataElementVersion = 0x0,
[1625810123.225609][2381993:2382000] CHIP:DMG:          },
[1625810123.225632][2381993:2382000] CHIP:DMG: 
[1625810123.225650][2381993:2382000] CHIP:DMG:  ],
[1625810123.225672][2381993:2382000] CHIP:DMG: 
[1625810123.225688][2381993:2382000] CHIP:DMG: }
[1625810123.225735][2381993:2382000] CHIP:ZCL: ReadAttributesResponse:
[1625810123.225751][2381993:2382000] CHIP:ZCL:   ClusterId: 0x0028
[1625810123.225770][2381993:2382000] CHIP:ZCL:   attributeId: 0x0001
[1625810123.225786][2381993:2382000] CHIP:ZCL:   status: Success                (0x0000)
[1625810123.225803][2381993:2382000] CHIP:ZCL:   attribute TLV Type: 0x0c
[1625810123.225822][2381993:2382000] CHIP:ZCL:   value: TEST_VENDOR
[1625810123.225850][2381993:2382000] CHIP:ZCL:   attributeValue: (span of length 11)  84 69 83 84 95 86 69 78 68 79 82
[1625810123.225953][2381993:2382000] CHIP:EM: Sending Standalone Ack for MsgId:00000004
[1625810123.226001][2381993:2382000] CHIP:IN: Secure message was encrypted: Msg ID 7
[1625810123.226023][2381993:2382000] CHIP:IN: Encrypted message 0x7fad5affc248 from 0x000000000001B669 to 0x0000000000000001 of type 16 and protocolId 0 on exchange 39021.
[1625810123.226050][2381993:2382000] CHIP:IN: Sending msg 0x7fad5affc248 to 0x0000000000000001 at utc time: 360074985 msec
[1625810123.226071][2381993:2382000] CHIP:IN: Sending secure msg on generic transport
chip-device-ctrl > [1625810123.226154][2381993:2382000] CHIP:IN: Secure msg send status No Error
[1625810123.226176][2381993:2382000] CHIP:EM: Flushed pending ack for MsgId:00000004
[1625810123.226195][2381993:2382000] CHIP:DMG: Client[0] moving to [INIT]
[1625810123.226213][2381993:2382000] CHIP:DMG: Client[0] moving to [UNINIT]
```