### PR TITLE
ESP32: Fix lock-app protos

### DIFF
--- a/examples/lock-app/esp32/main/Rpc.cpp
+++ b/examples/lock-app/esp32/main/Rpc.cpp
@@ -46,14 +46,14 @@ class Locking final : public generated::Locking<Locking>
 {
 
 public:
-    pw::Status Set(ServerContext &, const chip_rpc_LockingState & request, pw_protobuf_Empty & response)
+    pw::Status Set(ServerContext &, const chip_rpc_LockingState & request, chip_rpc_Empty & response)
     {
         BoltLockMgr().InitiateAction(AppEvent::kEventType_Lock,
                                      request.locked ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
         return pw::OkStatus();
     }
 
-    pw::Status Get(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_LockingState & response)
+    pw::Status Get(ServerContext &, const chip_rpc_Empty & request, chip_rpc_LockingState & response)
     {
         response.locked = BoltLockMgr().IsUnlocked();
         return pw::OkStatus();

--- a/examples/lock-app/esp32/main/locking_service.proto
+++ b/examples/lock-app/esp32/main/locking_service.proto
@@ -1,8 +1,9 @@
 syntax = "proto3";
 
-import 'pw_protobuf_protos/common.proto';
-
 package chip.rpc;
+
+message Empty {
+}
 
 message LockingState {
   bool locked = 1;
@@ -12,10 +13,10 @@ service Locking {
   // Set will return OK if all supported fields are successfully applied, any
   // unsupported fields will be ignored.
   // Get can be used to determine which fields are supported.
-  rpc Set(LockingState) returns (pw.protobuf.Empty){}
+  rpc Set(LockingState) returns (Empty){}
 
   // Get will populate all of the supported locking state fields with the
   // current values. This can be used to discover the devices supported
   // locking features.
-  rpc Get(pw.protobuf.Empty) returns (LockingState){}
+  rpc Get(Empty) returns (LockingState){}
 }


### PR DESCRIPTION
#### Problem
Compilation of lock-app fails when Pigweed is enabled.

#### Change overview
Made the necessary changes in the lighting service proto.

#### Testing
Compiled the app successfully and tested using pigweed HDLC console.
However, for a successful compilation, I have added the necessary changes of this PR #8129.
