### PR TITLE
[dns-sd] Add support for service subtypes on Thread devices

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -93,9 +93,9 @@ public:
     CHIP_ERROR SetThreadEnabled(bool val);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    CHIP_ERROR
-    AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
-                  size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
+    CHIP_ERROR AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort,
+                             const Span<const char * const> & aSubTypes, const Span<const Mdns::TextEntry> & aTxtEntries,
+                             uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR RemoveAllSrpServices();
     CHIP_ERROR SetupSrpHost(const char * aHostName);
@@ -241,10 +241,11 @@ inline CHIP_ERROR ThreadStackManager::SetThreadEnabled(bool val)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 inline CHIP_ERROR ThreadStackManager::AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort,
-                                                    chip::Mdns::TextEntry * aTxtEntries, size_t aTxtEntiresSize,
-                                                    uint32_t aLeaseInterval = 0, uint32_t aKeyLeaseInterval = 0)
+                                                    const Span<const char * const> & aSubTypes,
+                                                    const Span<const Mdns::TextEntry> & aTxtEntries, uint32_t aLeaseInterval = 0,
+                                                    uint32_t aKeyLeaseInterval = 0)
 {
-    return static_cast<ImplClass *>(this)->_AddSrpService(aInstanceName, aName, aPort, aTxtEntries, aTxtEntiresSize, aLeaseInterval,
+    return static_cast<ImplClass *>(this)->_AddSrpService(aInstanceName, aName, aPort, aSubTypes, aTxtEntries, aLeaseInterval,
                                                           aKeyLeaseInterval);
 }
 

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -44,12 +44,14 @@ static constexpr size_t kKeyRotatingIdMaxLength         = 100;
 static constexpr size_t kKeyPairingInstructionMaxLength = 128;
 static constexpr size_t kKeyPairingHintMaxLength        = 10;
 
-static constexpr size_t kSubTypeShortDiscriminatorMaxLength = 3;
-static constexpr size_t kSubTypeLongDiscriminatorMaxLength  = 4;
-static constexpr size_t kSubTypeVendorMaxLength             = 5;
-static constexpr size_t kSubTypeDeviceTypeMaxLength         = 5;
-static constexpr size_t kSubTypeCommissioningModeMaxLength  = 1;
-static constexpr size_t kSubTypeAdditionalPairingMaxLength  = 1;
+static constexpr size_t kSubTypeShortDiscriminatorMaxLength = 4; // _S<dd>
+static constexpr size_t kSubTypeLongDiscriminatorMaxLength  = 6; // _L<dddd>
+static constexpr size_t kSubTypeVendorMaxLength             = 7; // _V<ddddd>
+static constexpr size_t kSubTypeDeviceTypeMaxLength         = 5; // _T<ddd>
+static constexpr size_t kSubTypeCommissioningModeMaxLength  = 3; // _C<d>
+static constexpr size_t kSubTypeAdditionalPairingMaxLength  = 3; // _A<d>
+static constexpr size_t kSubTypeMaxNumber                   = 6;
+static constexpr size_t kSubTypeMaxLength                   = 7;
 
 enum class CommssionAdvertiseMode : uint8_t
 {

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -51,7 +51,9 @@ static constexpr size_t kSubTypeDeviceTypeMaxLength         = 5; // _T<ddd>
 static constexpr size_t kSubTypeCommissioningModeMaxLength  = 3; // _C<d>
 static constexpr size_t kSubTypeAdditionalPairingMaxLength  = 3; // _A<d>
 static constexpr size_t kSubTypeMaxNumber                   = 6;
-static constexpr size_t kSubTypeMaxLength                   = 7;
+static constexpr size_t kSubTypeMaxLength =
+    std::max({ kSubTypeShortDiscriminatorMaxLength, kSubTypeLongDiscriminatorMaxLength, kSubTypeVendorMaxLength,
+               kSubTypeDeviceTypeMaxLength, kSubTypeCommissioningModeMaxLength, kSubTypeAdditionalPairingMaxLength });
 
 enum class CommssionAdvertiseMode : uint8_t
 {

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -136,14 +136,14 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     TextEntry textEntries[9];
     size_t textEntrySize = 0;
     // add underscore, character and newline to lengths for sub types (ex. _S<ddd>)
-    char shortDiscriminatorSubtype[kSubTypeShortDiscriminatorMaxLength + 3];
-    char longDiscriminatorSubtype[kSubTypeLongDiscriminatorMaxLength + 4];
-    char vendorSubType[kSubTypeVendorMaxLength + 3];
-    char commissioningModeSubType[kSubTypeCommissioningModeMaxLength + 3];
-    char openWindowSubType[kSubTypeAdditionalPairingMaxLength + 3];
-    char deviceTypeSubType[kSubTypeDeviceTypeMaxLength + 3];
+    char shortDiscriminatorSubtype[kSubTypeShortDiscriminatorMaxLength + 1];
+    char longDiscriminatorSubtype[kSubTypeLongDiscriminatorMaxLength + 1];
+    char vendorSubType[kSubTypeVendorMaxLength + 1];
+    char commissioningModeSubType[kSubTypeCommissioningModeMaxLength + 1];
+    char openWindowSubType[kSubTypeAdditionalPairingMaxLength + 1];
+    char deviceTypeSubType[kSubTypeDeviceTypeMaxLength + 1];
     // size of subTypes array should be count of SubTypes above
-    const char * subTypes[6];
+    const char * subTypes[kSubTypeMaxNumber];
     size_t subTypeSize = 0;
 
     if (!mMdnsInitialized)

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     // size of textEntries array should be count of Bufs above
     TextEntry textEntries[9];
     size_t textEntrySize = 0;
-    // add underscore, character and newline to lengths for sub types (ex. _S<ddd>)
+    // add null-character to the subtypes
     char shortDiscriminatorSubtype[kSubTypeShortDiscriminatorMaxLength + 1];
     char longDiscriminatorSubtype[kSubTypeLongDiscriminatorMaxLength + 1];
     char vendorSubType[kSubTypeVendorMaxLength + 1];

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -34,7 +34,7 @@ template <class T>
 class Span
 {
 public:
-    using pointer = T *;
+    using pointer       = T *;
     using const_pointer = const T *;
 
     constexpr Span() : mDataBuf(nullptr), mDataLen(0) {}

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -35,6 +35,7 @@ class Span
 {
 public:
     using pointer = T *;
+    using const_pointer = const T *;
 
     constexpr Span() : mDataBuf(nullptr), mDataLen(0) {}
     constexpr Span(pointer databuf, size_t datalen) : mDataBuf(databuf), mDataLen(datalen) {}
@@ -45,6 +46,10 @@ public:
     constexpr pointer data() const { return mDataBuf; }
     constexpr size_t size() const { return mDataLen; }
     constexpr bool empty() const { return size() == 0; }
+    constexpr const_pointer begin() const { return data(); }
+    constexpr const_pointer end() const { return data() + size(); }
+    constexpr pointer begin() { return data(); }
+    constexpr pointer end() { return data() + size(); }
 
     // Allow data_equal for spans that are over the same type up to const-ness.
     template <class U, typename = std::enable_if_t<std::is_same<std::remove_const_t<T>, std::remove_const_t<U>>::value>>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -97,9 +97,9 @@ protected:
     void _OnWoBLEAdvertisingStop(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    CHIP_ERROR
-    _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
-                   size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
+    CHIP_ERROR _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort,
+                              const Span<const char * const> & aSubTypes, const Span<const Mdns::TextEntry> & aTxtEntries,
+                              uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _RemoveAllSrpServices();
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
@@ -153,6 +153,11 @@ private:
             otSrpClientService mService;
             char mInstanceName[kMaxInstanceNameSize + 1];
             char mName[kMaxNameSize + 1];
+#if OPENTHREAD_API_VERSION >= 132
+            // TODO: use fixed buffer allocator to reduce the memory footprint from N*M to sum(M_i)
+            char mSubTypeBuffers[chip::Mdns::kSubTypeMaxNumber][chip::Mdns::kSubTypeMaxLength + 1];
+            const char * mSubTypes[chip::Mdns::kSubTypeMaxNumber + 1]; // extra entry for nullptr at the end
+#endif
             otDnsTxtEntry mTxtEntries[kMaxTxtEntriesNumber];
             uint8_t mTxtValueBuffers[kMaxTxtEntriesNumber][kMaxTxtValueSize];
             char mTxtKeyBuffers[kMaxTxtEntriesNumber][kMaxTxtKeySize];


### PR DESCRIPTION
#### Problem
Our OpenThread-based DNS-SD Advertiser implementation does not support service subtypes while it is necessary to enable commissionable node advertising for Thread devices.

#### Change overview
* Extend the existing `ThreadStackManager::AddSrpService` method to support additional service subtypes.
* Fix subtype-related constants in `Advertiser.h`
* Clean up the existing code a bit by adding `begin()/end()` methods to `Span`.

#### Testing
Tested using nRF Connect Lock example with manually enabled commissionable node advertising:
* Verified using `ot srp client service` shell command that a proper service is registered
* Verified E2E with a modified OpenThread Border Router (I made another PR to otbr-posix).

**Note:**
@jmartinez-silabs @doru91 @tima-q you will need to update OpenThread soon to make use of this addition on your platforms.

