### PR TITLE
Conduct platform shutdown after RunEventLoop returns

### DIFF
--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -58,7 +58,6 @@ exit:
 
 void ShutdownChip(void)
 {
-    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -98,12 +98,12 @@ void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_E
         if (err != CHIP_NO_ERROR)
         {
             printf("Send request failed: %s\n", chip::ErrorStr(err));
-            Shutdown();
+            chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
         }
     }
     else
     {
-        Shutdown();
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
     }
 }
 
@@ -276,12 +276,9 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        Shutdown();
-    }
+    Shutdown();
 
+exit:
     if ((err != CHIP_NO_ERROR) || (gEchoRespCount != kMaxEchoCount))
     {
         printf("ChipEchoClient failed: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
What is being fixed?  
* PR #8100 moved all processing in chip-echo-requester into single event loop and calls Shutdown() on a PlatformManager before RunEventLoop has returned. This is not allowed per the API contract.

* Fixes #8180 

#### Change overview
1. Conduct platform shutdown after RunEventLoop returns in echo-requester.
2. No need to call StopEventLoopTask after RunEventLoop returns in echo-responder.

#### Testing
How was this tested? (at least one bullet point required)
1. Run ./chip-echo-responder on the server side
2. Run ./chip-echo-requester 192.168.86.171 on the client side
Confirm Platform is shutdown after RunEventLoop returns from log 
