### PR TITLE
Revise System Layer clock code

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -238,7 +238,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         sStatusLED.Animate();
         sLightLED.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastChangeTimeUS + 5 * 1000 * 1000UL;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/lighting-app/mbed/main/AppTask.cpp
+++ b/examples/lighting-app/mbed/main/AppTask.cpp
@@ -192,7 +192,7 @@ int AppTask::StartApp()
 
         sStatusLED.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastPublishServiceTimeUS + kPublishServicePeriodUs;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -214,7 +214,7 @@ int AppTask::StartApp()
         sUnusedLED.Animate();
         sUnusedLED_1.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastPublishServiceTimeUS + kPublishServicePeriodUs;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -234,7 +234,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         sStatusLED.Animate();
         sLockLED.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastChangeTimeUS + 5 * 1000 * 1000UL;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -187,7 +187,7 @@ void AppTask::AppTaskMain(void * pvParameter)
         sStatusLED.Animate();
         sLockLED.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastChangeTimeUS + 5 * 1000 * 1000UL;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/lock-app/esp32/main/LEDWidget.cpp
+++ b/examples/lock-app/esp32/main/LEDWidget.cpp
@@ -20,8 +20,6 @@
 #include "AppTask.h"
 #include <platform/CHIPDeviceLayer.h>
 
-using namespace chip::System::Platform::Layer;
-
 void LEDWidget::Init(gpio_num_t gpioNum)
 {
     mLastChangeTimeUS = 0;
@@ -63,7 +61,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS            = System::Clock::GetMonotonicMicroseconds();
+        int64_t nowUS            = ::chip::System::Clock::GetMonotonicMicroseconds();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 

--- a/examples/lock-app/esp32/main/LEDWidget.cpp
+++ b/examples/lock-app/esp32/main/LEDWidget.cpp
@@ -63,7 +63,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS            = GetClock_MonotonicHiRes();
+        int64_t nowUS            = System::Clock::GetMonotonicMicroseconds();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -206,7 +206,7 @@ int AppTask::StartApp()
         sUnusedLED.Animate();
         sUnusedLED_1.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastPublishServiceTimeUS + kPublishServicePeriodUs;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/platform/efr32/LEDWidget.cpp
+++ b/examples/platform/efr32/LEDWidget.cpp
@@ -66,7 +66,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS            = ::chip::System::Layer::GetClock_MonotonicHiRes();
+        int64_t nowUS            = ::chip::System::Clock::GetMonotonicMicroseconds();
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;
 

--- a/examples/platform/k32w/util/LEDWidget.cpp
+++ b/examples/platform/k32w/util/LEDWidget.cpp
@@ -59,7 +59,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        int64_t nowUS = chip::System::Platform::Layer::GetClock_Monotonic();
+        int64_t nowUS = chip::System::Clock::GetMonotonicMicroseconds();
         ;
         int64_t stateDurUS       = ((mState) ? mBlinkOnTimeMS : mBlinkOffTimeMS) * 1000LL;
         int64_t nextChangeTimeUS = mLastChangeTimeUS + stateDurUS;

--- a/examples/platform/mbed/util/LEDWidget.cpp
+++ b/examples/platform/mbed/util/LEDWidget.cpp
@@ -57,7 +57,7 @@ void LEDWidget::Animate()
 {
     if (mBlinkOnTimeMS != 0 && mBlinkOffTimeMS != 0)
     {
-        uint64_t nowMS      = chip::System::Platform::Layer::GetClock_MonotonicMS();
+        uint64_t nowMS      = chip::System::Clock::GetMonotonicMilliseconds();
         uint32_t stateDurMS = (mLED == LED_ACTIVE_STATE) ? mBlinkOnTimeMS : mBlinkOffTimeMS;
 
         if (nowMS > mLastChangeTimeMS + stateDurMS)

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -197,7 +197,7 @@ int AppTask::StartApp()
         sUnusedLED.Animate();
         sUnusedLED_1.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastPublishServiceTimeUS + kPublishServicePeriodUs;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -197,7 +197,7 @@ int AppTask::StartApp()
         sUnusedLED.Animate();
         sUnusedLED_1.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = mLastPublishServiceTimeUS + kPublishServicePeriodUs;
 
         if (nowUS > nextChangeTimeUS)

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -211,7 +211,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
         sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
     }
 
-    gPingArguments.SetLastEchoTime(System::Timer::GetCurrentEpoch());
+    gPingArguments.SetLastEchoTime(System::Clock::GetMonotonicMilliseconds());
     SuccessOrExit(chip::DeviceLayer::SystemLayer.StartTimer(gPingArguments.GetEchoInterval(), EchoTimerHandler, NULL));
 
     streamer_printf(stream, "\nSend echo request message with payload size: %d bytes to Node: %" PRIu64 "\n", payloadSize,
@@ -256,7 +256,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Establish secure session failed, err: %s\n", ErrorStr(err));
-        gPingArguments.SetLastEchoTime(System::Timer::GetCurrentEpoch());
+        gPingArguments.SetLastEchoTime(System::Clock::GetMonotonicMilliseconds());
     }
     else
     {
@@ -268,7 +268,7 @@ exit:
 
 void HandleEchoResponseReceived(Messaging::ExchangeContext * ec, System::PacketBufferHandle && payload)
 {
-    uint32_t respTime    = System::Timer::GetCurrentEpoch();
+    uint32_t respTime    = System::Clock::GetMonotonicMilliseconds();
     uint32_t transitTime = respTime - gPingArguments.GetLastEchoTime();
     streamer_t * sout    = streamer_get();
 

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -103,7 +103,7 @@ public:
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
                                  const PayloadHeader & payloadHeader, System::PacketBufferHandle && buffer) override
     {
-        uint32_t respTime    = System::Timer::GetCurrentEpoch();
+        uint32_t respTime    = System::Clock::GetMonotonicMilliseconds();
         uint32_t transitTime = respTime - gSendArguments.GetLastSendTime();
         streamer_t * sout    = streamer_get();
 
@@ -162,7 +162,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     gExchangeCtx->SetResponseTimeout(kResponseTimeOut);
     sendFlags.Set(Messaging::SendMessageFlags::kExpectResponse);
 
-    gSendArguments.SetLastSendTime(System::Timer::GetCurrentEpoch());
+    gSendArguments.SetLastSendTime(System::Clock::GetMonotonicMilliseconds());
 
     streamer_printf(stream, "\nSend CHIP message with payload size: %d bytes to Node: %" PRIu64 "\n", payloadSize,
                     kTestDeviceNodeId);
@@ -203,7 +203,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         streamer_printf(stream, "Establish secure session failed, err: %s\n", ErrorStr(err));
-        gSendArguments.SetLastSendTime(System::Timer::GetCurrentEpoch());
+        gSendArguments.SetLastSendTime(System::Clock::GetMonotonicMilliseconds());
     }
     else
     {

--- a/examples/window-app/efr32/src/AppTask.cpp
+++ b/examples/window-app/efr32/src/AppTask.cpp
@@ -176,7 +176,7 @@ void AppTask::Main(void * pvParameter)
         app.mStatusLED.Animate();
         app.mActionLED.Animate();
 
-        uint64_t nowUS            = chip::System::Platform::Layer::GetClock_Monotonic();
+        uint64_t nowUS            = chip::System::Clock::GetMonotonicMicroseconds();
         uint64_t nextChangeTimeUS = lastChangeTimeUS + 5 * 1000 * 1000UL;
 
         if (nowUS > nextChangeTimeUS)

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -499,7 +499,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, E
     CircularEventBuffer * buffer   = nullptr;
     EventLoadOutContext ctxt       = EventLoadOutContext(writer, aEventOptions.mpEventSchema->mPriority,
                                                    GetPriorityBuffer(aEventOptions.mpEventSchema->mPriority)->GetLastEventNumber());
-    Timestamp timestamp(Timestamp::Type::kSystem, System::Timer::GetCurrentEpoch());
+    Timestamp timestamp(Timestamp::Type::kSystem, System::Clock::GetMonotonicMilliseconds());
     EventOptions opts = EventOptions(timestamp);
     // Start the event container (anonymous structure) in the circular buffer
     writer.Init(*mpEventBuffer);

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -407,7 +407,7 @@ EmberStatus emberAfPluginIasZoneServerUpdateZoneStatus(EndpointId endpoint, uint
     IasZoneStatusQueueEntry newBufferEntry;
     newBufferEntry.endpoint    = endpoint;
     newBufferEntry.status      = newStatus;
-    newBufferEntry.eventTimeMs = System::Layer::GetClock_MonotonicMS();
+    newBufferEntry.eventTimeMs = System::Clock::GetMonotonicMilliseconds();
 #endif
     EmberStatus sendStatus = EMBER_SUCCESS;
 
@@ -905,7 +905,7 @@ static int16_t popFromBuffer(IasZoneStatusQueue * ring, IasZoneStatusQueueEntry 
 
 uint16_t computeElapsedTimeQs(IasZoneStatusQueueEntry * entry)
 {
-    uint32_t currentTimeMs = System::Layer::GetClock_MonotonicMS();
+    uint32_t currentTimeMs = System::Clock::GetMonotonicMilliseconds();
     int64_t deltaTimeMs    = currentTimeMs - entry->eventTimeMs;
 
     if (deltaTimeMs < 0)

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -217,7 +217,7 @@ void emberAfPluginReportingTickEventHandler(void)
         // reportable change has occurred and the minimum interval has elapsed or
         // if the maximum interval is set and has elapsed.
         elapsedMs =
-            elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, chip::System::Layer::GetClock_MonotonicMS());
+            elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, chip::System::Clock::GetMonotonicMilliseconds());
         if (entry.endpoint == EMBER_AF_PLUGIN_REPORTING_UNUSED_ENDPOINT_ID ||
             entry.direction != EMBER_ZCL_REPORTING_DIRECTION_REPORTED ||
             (elapsedMs < entry.data.reported.minInterval * MILLISECOND_TICKS_PER_SECOND) ||
@@ -326,7 +326,7 @@ void emberAfPluginReportingTickEventHandler(void)
         // and changes.  We only track changes for data types that are small enough
         // for us to compare. For CHAR and OCTET strings, we substitute a 32-bit hash.
         emAfPluginReportVolatileData[i].reportableChange = false;
-        emAfPluginReportVolatileData[i].lastReportTimeMs = static_cast<uint32_t>(chip::System::Layer::GetClock_MonotonicMS());
+        emAfPluginReportVolatileData[i].lastReportTimeMs = static_cast<uint32_t>(chip::System::Clock::GetMonotonicMilliseconds());
         uint32_t stringHash                              = 0;
         uint8_t * copyData                               = readData;
         uint16_t copySize                                = dataSize;
@@ -808,9 +808,9 @@ static void scheduleTick(void)
         {
             uint32_t minIntervalMs = (entry.data.reported.minInterval * MILLISECOND_TICKS_PER_SECOND);
             uint32_t maxIntervalMs = (entry.data.reported.maxInterval * MILLISECOND_TICKS_PER_SECOND);
-            uint32_t elapsedMs =
-                elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs, chip::System::Layer::GetClock_MonotonicMS());
-            uint32_t remainingMs = MAX_INT32U_VALUE;
+            uint32_t elapsedMs     = elapsedTimeInt32u(emAfPluginReportVolatileData[i].lastReportTimeMs,
+                                                   chip::System::Clock::GetMonotonicMilliseconds());
+            uint32_t remainingMs   = MAX_INT32U_VALUE;
             if (emAfPluginReportVolatileData[i].reportableChange)
             {
                 remainingMs = (minIntervalMs < elapsedMs ? 0 : minIntervalMs - elapsedMs);
@@ -941,7 +941,7 @@ EmberAfStatus emberAfPluginReportingConfigureReportedAttribute(const EmberAfPlug
         if (index < REPORT_TABLE_SIZE)
         {
             emAfPluginReportVolatileData[index].lastReportTimeMs =
-                static_cast<uint32_t>(chip::System::Layer::GetClock_MonotonicMS());
+                static_cast<uint32_t>(chip::System::Clock::GetMonotonicMilliseconds());
             emAfPluginReportVolatileData[index].lastReportValue = 0;
         }
     }

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
 
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+    gLastMessageTime = chip::System::Clock::GetMonotonicMilliseconds();
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
@@ -146,7 +146,7 @@ CHIP_ERROR SendBadCommandRequest(chip::app::CommandSender * commandSender)
 
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+    gLastMessageTime = chip::System::Clock::GetMonotonicMilliseconds();
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
@@ -217,7 +217,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClient * apWriteClient)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::TLV::TLVWriter * writer;
-    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+    gLastMessageTime = chip::System::Clock::GetMonotonicMilliseconds();
     chip::app::AttributePathParams attributePathParams;
 
     printf("\nSend write request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
@@ -264,7 +264,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
-        gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+        gLastMessageTime = chip::System::Clock::GetMonotonicMilliseconds();
     }
     else
     {
@@ -276,7 +276,7 @@ exit:
 
 void HandleReadComplete()
 {
-    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+    uint32_t respTime    = chip::System::Clock::GetMonotonicMilliseconds();
     uint32_t transitTime = respTime - gLastMessageTime;
 
     gReadRespCount++;
@@ -287,7 +287,7 @@ void HandleReadComplete()
 
 void HandleWriteComplete()
 {
-    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+    uint32_t respTime    = chip::System::Clock::GetMonotonicMilliseconds();
     uint32_t transitTime = respTime - gLastMessageTime;
 
     gWriteRespCount++;
@@ -464,7 +464,7 @@ public:
     CHIP_ERROR CommandResponseProcessed(const chip::app::CommandSender * apCommandSender) override
     {
 
-        uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+        uint32_t respTime    = chip::System::Clock::GetMonotonicMilliseconds();
         uint32_t transitTime = respTime - gLastMessageTime;
 
         gCommandRespCount++;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -94,7 +94,7 @@ namespace Controller {
 
 using namespace chip::Encoding;
 
-constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondPerSecond;
+constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondsPerSecond;
 
 constexpr uint32_t kMaxCHIPCSRLength = 1024;
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -202,7 +202,7 @@ template <class ImplClass>
 void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent * event)
 {
 #if CHIP_PROGRESS_LOGGING
-    uint64_t startUS = System::Layer::GetClock_MonotonicHiRes();
+    uint64_t startUS = System::Clock::GetMonotonicMicroseconds();
 #endif // CHIP_PROGRESS_LOGGING
 
     switch (event->Type)
@@ -237,7 +237,7 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
 
     // TODO: make this configurable
 #if CHIP_PROGRESS_LOGGING
-    uint32_t delta = (static_cast<uint32_t>(System::Layer::GetClock_MonotonicHiRes() - startUS)) / 1000;
+    uint32_t delta = (static_cast<uint32_t>(System::Clock::GetMonotonicMicroseconds() - startUS)) / 1000;
     if (delta > 100)
     {
         ChipLogError(DeviceLayer, "Long dispatch time: %" PRId32 " ms", delta);

--- a/src/inet/tests/TestInetLayerDNS.cpp
+++ b/src/inet/tests/TestInetLayerDNS.cpp
@@ -654,7 +654,7 @@ static void HandleResolutionComplete(void * appState, CHIP_ERROR err, uint8_t ad
 
 static void ServiceNetworkUntilDone(uint32_t timeoutMS)
 {
-    uint64_t timeoutTimeMS = System::Layer::GetClock_MonotonicMS() + timeoutMS;
+    uint64_t timeoutTimeMS = System::Clock::GetMonotonicMilliseconds() + timeoutMS;
     struct timeval sleepTime;
     sleepTime.tv_sec  = 0;
     sleepTime.tv_usec = 10000;
@@ -663,7 +663,7 @@ static void ServiceNetworkUntilDone(uint32_t timeoutMS)
     {
         ServiceNetwork(sleepTime);
 
-        if (System::Layer::GetClock_MonotonicMS() >= timeoutTimeMS)
+        if (System::Clock::GetMonotonicMilliseconds() >= timeoutTimeMS)
         {
             break;
         }

--- a/src/lib/mdns/minimal/ResponseSender.cpp
+++ b/src/lib/mdns/minimal/ResponseSender.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
 
     // send all 'Answer' replies
     {
-        const uint64_t kTimeNowMs = chip::System::Platform::Layer::GetClock_MonotonicMS();
+        const uint64_t kTimeNowMs = chip::System::Clock::GetMonotonicMilliseconds();
 
         QueryReplyFilter queryReplyFilter(query);
         QueryResponderRecordFilter responseFilter;

--- a/src/lib/support/TimeUtils.cpp
+++ b/src/lib/support/TimeUtils.cpp
@@ -227,7 +227,7 @@ void CalendarDateToOrdinalDate(uint16_t year, uint8_t month, uint8_t dayOfMonth,
 }
 
 /**
- *  @def CalendarDateToDaysSinceEpoch
+ *  @def CalendarDateToDaysSinceUnixEpoch
  *
  *  @brief
  *    Convert a calendar date to the number of days since 1970-01-01.
@@ -252,12 +252,12 @@ void CalendarDateToOrdinalDate(uint16_t year, uint8_t month, uint8_t dayOfMonth,
  *    This function makes no attempt to verify the correct range of any arguments other than year.
  *    Therefore callers must make sure the supplied values are valid prior to calling the function.
  */
-bool CalendarDateToDaysSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint32_t & daysSinceEpoch)
+bool CalendarDateToDaysSinceUnixEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint32_t & daysSinceEpoch)
 {
     // NOTE: This algorithm is based on the logic described in http://howardhinnant.github.io/date_algorithms.html.
 
     // Return immediately if the year is out of range.
-    if (year < kEpochYear || year > kMaxYearInDaysSinceEpoch32)
+    if (year < kUnixEpochYear || year > kMaxYearInDaysSinceUnixEpoch32)
     {
         daysSinceEpoch = UINT32_MAX;
         return false;
@@ -295,7 +295,7 @@ bool CalendarDateToDaysSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMon
 }
 
 /**
- *  @def DaysSinceEpochToCalendarDate
+ *  @def DaysSinceUnixEpochToCalendarDate
  *
  *  @brief
  *    Convert the number of days since 1970-01-01 to a calendar date.
@@ -316,7 +316,7 @@ bool CalendarDateToDaysSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMon
  *     True if the conversion was successful.  False if the year would not fit
  *     in uint16_t.
  */
-bool DaysSinceEpochToCalendarDate(uint32_t daysSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
+bool DaysSinceUnixEpochToCalendarDate(uint32_t daysSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)
 {
     // NOTE: This algorithm is based on the logic described in http://howardhinnant.github.io/date_algorithms.html.
     if (daysSinceEpoch / kDaysPerStandardYear + 1 > std::numeric_limits<std::remove_reference<decltype(year)>::type>::max())
@@ -389,7 +389,7 @@ bool DaysSinceEpochToCalendarDate(uint32_t daysSinceEpoch, uint16_t & year, uint
 bool AdjustCalendarDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, int32_t relativeDays)
 {
     uint32_t daysSinceEpoch;
-    if (!CalendarDateToDaysSinceEpoch(year, month, dayOfMonth, daysSinceEpoch))
+    if (!CalendarDateToDaysSinceUnixEpoch(year, month, dayOfMonth, daysSinceEpoch))
     {
         return false;
     }
@@ -401,11 +401,11 @@ bool AdjustCalendarDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, 
         return false;
     }
 
-    return DaysSinceEpochToCalendarDate(static_cast<uint32_t>(adjustedDays), year, month, dayOfMonth);
+    return DaysSinceUnixEpochToCalendarDate(static_cast<uint32_t>(adjustedDays), year, month, dayOfMonth);
 }
 
 /**
- *  @def CalendarTimeToSecondsSinceEpoch
+ *  @def CalendarTimeToSecondsSinceUnixEpoch
  *
  *  @brief
  *    Convert a calendar date and time to the number of seconds since 1970-01-01 00:00:00 UTC.
@@ -445,19 +445,19 @@ bool AdjustCalendarDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, 
  *    True if the date/time was converted successfully.  False if the given year falls outside the
  *    representable range.
  */
-bool CalendarTimeToSecondsSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute, uint8_t second,
-                                     uint32_t & secondsSinceEpoch)
+bool CalendarTimeToSecondsSinceUnixEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute,
+                                         uint8_t second, uint32_t & secondsSinceEpoch)
 {
     uint32_t daysSinceEpoch;
 
     // Return immediately if the year is out of range.
-    if (year < kEpochYear || year > kMaxYearInSecondsSinceEpoch32)
+    if (year < kUnixEpochYear || year > kMaxYearInSecondsSinceUnixEpoch32)
     {
         secondsSinceEpoch = UINT32_MAX;
         return false;
     }
 
-    CalendarDateToDaysSinceEpoch(year, month, dayOfMonth, daysSinceEpoch);
+    CalendarDateToDaysSinceUnixEpoch(year, month, dayOfMonth, daysSinceEpoch);
 
     secondsSinceEpoch = (daysSinceEpoch * kSecondsPerDay) + (hour * kSecondsPerHour) + (minute * kSecondsPerMinute) + second;
 
@@ -473,8 +473,8 @@ bool CalendarTimeToSecondsSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOf
  *    possible value of secondsSinceEpoch input is (UINT32_MAX + kChipEpochSecondsSinceUnixEpoch),
  *    when it is called from ChipEpochToCalendarTime().
  */
-static void SecondsSinceEpochToCalendarTime(uint64_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
-                                            uint8_t & hour, uint8_t & minute, uint8_t & second)
+static void SecondsSinceUnixEpochToCalendarTime(uint64_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
+                                                uint8_t & hour, uint8_t & minute, uint8_t & second)
 {
     uint32_t daysSinceEpoch = static_cast<uint32_t>(secondsSinceEpoch / kSecondsPerDay);
     static_assert((static_cast<uint64_t>(UINT32_MAX) + kChipEpochSecondsSinceUnixEpoch) / kSecondsPerDay <=
@@ -482,14 +482,14 @@ static void SecondsSinceEpochToCalendarTime(uint64_t secondsSinceEpoch, uint16_t
                   "daysSinceEpoch would overflow");
     uint32_t timeOfDay = static_cast<uint32_t>(secondsSinceEpoch - (daysSinceEpoch * kSecondsPerDay));
 
-    // Note: This call to DaysSinceEpochToCalendarDate can't fail, because we
+    // Note: This call to DaysSinceUnixEpochToCalendarDate can't fail, because we
     // can't overflow a uint16_t year with a muximum possible value of the
     // secondsSinceEpoch input.
     static_assert((static_cast<uint64_t>(UINT32_MAX) + kChipEpochSecondsSinceUnixEpoch) / (kDaysPerStandardYear * kSecondsPerDay) +
                           1 <=
                       std::numeric_limits<std::remove_reference<decltype(year)>::type>::max(),
                   "What happened to our year or day lengths?");
-    DaysSinceEpochToCalendarDate(daysSinceEpoch, year, month, dayOfMonth);
+    DaysSinceUnixEpochToCalendarDate(daysSinceEpoch, year, month, dayOfMonth);
 
     hour = static_cast<uint8_t>(timeOfDay / kSecondsPerHour);
     timeOfDay -= (hour * kSecondsPerHour);
@@ -499,7 +499,7 @@ static void SecondsSinceEpochToCalendarTime(uint64_t secondsSinceEpoch, uint16_t
 }
 
 /**
- *  @def SecondsSinceEpochToCalendarTime
+ *  @def SecondsSinceUnixEpochToCalendarTime
  *
  *  @brief
  *    Convert the number of seconds since 1970-01-01 00:00:00 UTC to a calendar date and time.
@@ -536,10 +536,10 @@ static void SecondsSinceEpochToCalendarTime(uint64_t secondsSinceEpoch, uint16_t
  *  @param second
  *    [OUTPUT] Second (0-59).
  */
-void SecondsSinceEpochToCalendarTime(uint32_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
-                                     uint8_t & hour, uint8_t & minute, uint8_t & second)
+void SecondsSinceUnixEpochToCalendarTime(uint32_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
+                                         uint8_t & hour, uint8_t & minute, uint8_t & second)
 {
-    SecondsSinceEpochToCalendarTime(static_cast<uint64_t>(secondsSinceEpoch), year, month, dayOfMonth, hour, minute, second);
+    SecondsSinceUnixEpochToCalendarTime(static_cast<uint64_t>(secondsSinceEpoch), year, month, dayOfMonth, hour, minute, second);
 }
 
 bool CalendarToChipEpochTime(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute, uint8_t second,
@@ -548,7 +548,7 @@ bool CalendarToChipEpochTime(uint16_t year, uint8_t month, uint8_t dayOfMonth, u
     VerifyOrReturnError(year >= kChipEpochBaseYear && year <= kChipEpochMaxYear, false);
 
     uint32_t daysSinceUnixEpoch;
-    CalendarDateToDaysSinceEpoch(year, month, dayOfMonth, daysSinceUnixEpoch);
+    CalendarDateToDaysSinceUnixEpoch(year, month, dayOfMonth, daysSinceUnixEpoch);
 
     chipEpochTime = ((daysSinceUnixEpoch - kChipEpochDaysSinceUnixEpoch) * kSecondsPerDay) + (hour * kSecondsPerHour) +
         (minute * kSecondsPerMinute) + second;
@@ -559,8 +559,8 @@ bool CalendarToChipEpochTime(uint16_t year, uint8_t month, uint8_t dayOfMonth, u
 void ChipEpochToCalendarTime(uint32_t chipEpochTime, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour,
                              uint8_t & minute, uint8_t & second)
 {
-    SecondsSinceEpochToCalendarTime(static_cast<uint64_t>(chipEpochTime) + kChipEpochSecondsSinceUnixEpoch, year, month, dayOfMonth,
-                                    hour, minute, second);
+    SecondsSinceUnixEpochToCalendarTime(static_cast<uint64_t>(chipEpochTime) + kChipEpochSecondsSinceUnixEpoch, year, month,
+                                        dayOfMonth, hour, minute, second);
 }
 
 bool UnixEpochToChipEpochTime(uint32_t unixEpochTime, uint32_t & chipEpochTime)

--- a/src/lib/support/TimeUtils.h
+++ b/src/lib/support/TimeUtils.h
@@ -56,7 +56,12 @@ enum
 
     kMillisecondPerSecond = 1000,
 
-    kMicrosecondsPerSecond = 1000000
+    kMicrosecondsPerSecond      = 1000000,
+    kMicrosecondsPerMillisecond = 1000,
+
+    kNanosecondsPerSecond      = 1000000000,
+    kNanosecondsPerMillisecond = 1000000,
+    kNanosecondsPerMicrosecond = 1000,
 };
 
 enum
@@ -80,13 +85,13 @@ enum
 enum
 {
     // First year of the standard unix epoch.
-    kEpochYear = 1970,
+    kUnixEpochYear = 1970,
 
     // Last fully-representable year that can be stored in an unsigned 32-bit seconds-since-epoch value.
-    kMaxYearInSecondsSinceEpoch32 = 2105,
+    kMaxYearInSecondsSinceUnixEpoch32 = 2105,
 
     // Last fully-representable year that can be stored in an unsigned 32-bit days-since-epoch value.
-    kMaxYearInDaysSinceEpoch32 = 28276
+    kMaxYearInDaysSinceUnixEpoch32 = 28276
 };
 
 /* CHIP Epoch time.
@@ -111,13 +116,13 @@ extern uint8_t DaysInMonth(uint16_t year, uint8_t month);
 extern uint8_t FirstWeekdayOfYear(uint16_t year);
 extern void OrdinalDateToCalendarDate(uint16_t year, uint16_t dayOfYear, uint8_t & month, uint8_t & dayOfMonth);
 extern void CalendarDateToOrdinalDate(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint16_t & dayOfYear);
-extern bool CalendarDateToDaysSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint32_t & daysSinceEpoch);
-extern bool DaysSinceEpochToCalendarDate(uint32_t daysSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
+extern bool CalendarDateToDaysSinceUnixEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint32_t & daysSinceEpoch);
+extern bool DaysSinceUnixEpochToCalendarDate(uint32_t daysSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
 extern bool AdjustCalendarDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, int32_t relativeDays);
-extern bool CalendarTimeToSecondsSinceEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute,
-                                            uint8_t second, uint32_t & secondsSinceEpoch);
-extern void SecondsSinceEpochToCalendarTime(uint32_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
-                                            uint8_t & hour, uint8_t & minute, uint8_t & second);
+extern bool CalendarTimeToSecondsSinceUnixEpoch(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t minute,
+                                                uint8_t second, uint32_t & secondsSinceEpoch);
+extern void SecondsSinceUnixEpochToCalendarTime(uint32_t secondsSinceEpoch, uint16_t & year, uint8_t & month, uint8_t & dayOfMonth,
+                                                uint8_t & hour, uint8_t & minute, uint8_t & second);
 
 /**
  *  @brief Convert a calendar date and time to the number of seconds since CHIP Epoch (2020-01-01 00:00:00 UTC).

--- a/src/lib/support/TimeUtils.h
+++ b/src/lib/support/TimeUtils.h
@@ -54,7 +54,7 @@ enum
     kSecondsPerWeek         = kSecondsPerDay * kDaysPerWeek,
     kSecondsPerStandardYear = kSecondsPerDay * kDaysPerStandardYear,
 
-    kMillisecondPerSecond = 1000,
+    kMillisecondsPerSecond = 1000,
 
     kMicrosecondsPerSecond      = 1000000,
     kMicrosecondsPerMillisecond = 1000,
@@ -185,7 +185,7 @@ extern bool UnixEpochToChipEpochTime(uint32_t unixEpochTime, uint32_t & chipEpoc
  */
 inline uint32_t secondsToMilliseconds(uint32_t seconds)
 {
-    return (seconds * kMillisecondPerSecond);
+    return (seconds * kMillisecondsPerSecond);
 }
 
 } // namespace chip

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -826,40 +826,40 @@ void TestDaysSinceEpochConversion()
 {
     uint32_t daysSinceEpoch = 0;
 
-    for (uint16_t year = kEpochYear; year <= kMaxYearInDaysSinceEpoch32; year++)
+    for (uint16_t year = kUnixEpochYear; year <= kMaxYearInDaysSinceUnixEpoch32; year++)
     {
         for (uint8_t month = kJanuary; month <= kDecember; month++)
         {
             for (uint8_t dayOfMonth = 1; dayOfMonth <= DaysInMonth(year, month); dayOfMonth++)
             {
-                // Test CalendarDateToDaysSinceEpoch()
+                // Test CalendarDateToDaysSinceUnixEpoch()
                 {
                     uint32_t calculatedDaysSinceEpoch;
 
-                    CalendarDateToDaysSinceEpoch(year, month, dayOfMonth, calculatedDaysSinceEpoch);
+                    CalendarDateToDaysSinceUnixEpoch(year, month, dayOfMonth, calculatedDaysSinceEpoch);
 
                     if (calculatedDaysSinceEpoch != daysSinceEpoch)
                         printf("%04u/%02u/%02u %u %u\n", year, month, dayOfMonth, daysSinceEpoch, calculatedDaysSinceEpoch);
 
                     TestAssert(calculatedDaysSinceEpoch == daysSinceEpoch,
-                               "CalendarDateToDaysSinceEpoch() returned unexpected value");
+                               "CalendarDateToDaysSinceUnixEpoch() returned unexpected value");
                 }
 
-                // Test DaysSinceEpochToCalendarDate()
+                // Test DaysSinceUnixEpochToCalendarDate()
                 {
                     uint16_t calculatedYear;
                     uint8_t calculatedMonth, calculatedDayOfMonth;
 
-                    DaysSinceEpochToCalendarDate(daysSinceEpoch, calculatedYear, calculatedMonth, calculatedDayOfMonth);
+                    DaysSinceUnixEpochToCalendarDate(daysSinceEpoch, calculatedYear, calculatedMonth, calculatedDayOfMonth);
 
                     if (calculatedYear != year || calculatedMonth != month || calculatedDayOfMonth != dayOfMonth)
                         printf("%04u/%02u/%02u %04u/%02u/%02u\n", year, month, dayOfMonth, calculatedYear, calculatedMonth,
                                calculatedDayOfMonth);
 
-                    TestAssert(calculatedYear == year, "DaysSinceEpochToCalendarDate() returned unexpected year value");
-                    TestAssert(calculatedMonth == month, "DaysSinceEpochToCalendarDate() returned unexpected month value");
+                    TestAssert(calculatedYear == year, "DaysSinceUnixEpochToCalendarDate() returned unexpected year value");
+                    TestAssert(calculatedMonth == month, "DaysSinceUnixEpochToCalendarDate() returned unexpected month value");
                     TestAssert(calculatedDayOfMonth == dayOfMonth,
-                               "DaysSinceEpochToCalendarDate() returned unexpected dayOfMonth value");
+                               "DaysSinceUnixEpochToCalendarDate() returned unexpected dayOfMonth value");
                 }
 
                 daysSinceEpoch++;
@@ -873,7 +873,7 @@ void TestSecondsSinceEpochConversion()
     uint32_t daysSinceEpoch = 0;
     uint32_t timeOfDay      = 0; // in seconds
 
-    for (uint16_t year = kEpochYear; year <= kMaxYearInSecondsSinceEpoch32; year++)
+    for (uint16_t year = kUnixEpochYear; year <= kMaxYearInSecondsSinceUnixEpoch32; year++)
     {
         for (uint8_t month = kJanuary; month <= kDecember; month++)
         {
@@ -904,34 +904,37 @@ void TestSecondsSinceEpochConversion()
                     }
 #endif
 
-                    // Test SecondsSinceEpochToCalendarTime()
+                    // Test SecondsSinceUnixEpochToCalendarTime()
                     {
                         uint16_t calculatedYear;
                         uint8_t calculatedMonth, calculatedDayOfMonth, calculatedHour, calculatedMinute, calculatedSecond;
 
-                        SecondsSinceEpochToCalendarTime(secondsSinceEpoch, calculatedYear, calculatedMonth, calculatedDayOfMonth,
-                                                        calculatedHour, calculatedMinute, calculatedSecond);
+                        SecondsSinceUnixEpochToCalendarTime(secondsSinceEpoch, calculatedYear, calculatedMonth,
+                                                            calculatedDayOfMonth, calculatedHour, calculatedMinute,
+                                                            calculatedSecond);
 
-                        TestAssert(calculatedYear == year, "SecondsSinceEpochToCalendarTime() returned unexpected year value");
-                        TestAssert(calculatedMonth == month, "SecondsSinceEpochToCalendarTime() returned unexpected month value");
+                        TestAssert(calculatedYear == year, "SecondsSinceUnixEpochToCalendarTime() returned unexpected year value");
+                        TestAssert(calculatedMonth == month,
+                                   "SecondsSinceUnixEpochToCalendarTime() returned unexpected month value");
                         TestAssert(calculatedDayOfMonth == dayOfMonth,
-                                   "SecondsSinceEpochToCalendarTime() returned unexpected dayOfMonth value");
-                        TestAssert(calculatedHour == hour, "SecondsSinceEpochToCalendarTime() returned unexpected hour value");
+                                   "SecondsSinceUnixEpochToCalendarTime() returned unexpected dayOfMonth value");
+                        TestAssert(calculatedHour == hour, "SecondsSinceUnixEpochToCalendarTime() returned unexpected hour value");
                         TestAssert(calculatedMinute == minute,
-                                   "SecondsSinceEpochToCalendarTime() returned unexpected minute value");
+                                   "SecondsSinceUnixEpochToCalendarTime() returned unexpected minute value");
                         TestAssert(calculatedSecond == second,
-                                   "SecondsSinceEpochToCalendarTime() returned unexpected second value");
+                                   "SecondsSinceUnixEpochToCalendarTime() returned unexpected second value");
                     }
 
-                    // Test CalendarTimeToSecondsSinceEpoch()
+                    // Test CalendarTimeToSecondsSinceUnixEpoch()
 
                     {
                         uint32_t calculatedSecondsSinceEpoch;
 
-                        CalendarTimeToSecondsSinceEpoch(year, month, dayOfMonth, hour, minute, second, calculatedSecondsSinceEpoch);
+                        CalendarTimeToSecondsSinceUnixEpoch(year, month, dayOfMonth, hour, minute, second,
+                                                            calculatedSecondsSinceEpoch);
 
                         TestAssert(calculatedSecondsSinceEpoch == secondsSinceEpoch,
-                                   "CalendarTimeToSecondsSinceEpoch() returned unexpected value");
+                                   "CalendarTimeToSecondsSinceUnixEpoch() returned unexpected value");
                     }
 
                     // Iterate through times of day by skipping a large prime number of seconds.
@@ -996,7 +999,7 @@ void TestChipEpochTimeConversion()
                         TestAssert(calculatedSecond == second, "ChipEpochToCalendarTime() returned unexpected second value");
                     }
 
-                    // Test CalendarTimeToSecondsSinceEpoch()
+                    // Test CalendarTimeToSecondsSinceUnixEpoch()
 
                     {
                         uint32_t calculatedChipEpochTime;
@@ -1004,7 +1007,7 @@ void TestChipEpochTimeConversion()
                         CalendarToChipEpochTime(year, month, dayOfMonth, hour, minute, second, calculatedChipEpochTime);
 
                         TestAssert(calculatedChipEpochTime == chipEpochTime,
-                                   "CalendarTimeToSecondsSinceEpoch() returned unexpected value");
+                                   "CalendarTimeToSecondsSinceUnixEpoch() returned unexpected value");
                     }
 
                     // Iterate through times of day by skipping a large prime number of seconds.

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -236,7 +236,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<M
         SetPendingPeerAckId(MessageId);
         mNextAckTimeTick =
             static_cast<uint16_t>(CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK +
-                                  GetReliableMessageMgr()->GetTickCounterFromTimeDelta(System::Timer::GetCurrentEpoch()));
+                                  GetReliableMessageMgr()->GetTickCounterFromTimeDelta(System::Clock::GetMonotonicMilliseconds()));
     }
 
 exit:

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -51,7 +51,7 @@ void ReliableMessageMgr::Init(chip::System::Layer * systemLayer, SecureSessionMg
     mSystemLayer = systemLayer;
     mSessionMgr  = sessionMgr;
 
-    mTimeStampBase      = System::Timer::GetCurrentEpoch();
+    mTimeStampBase      = System::Clock::GetMonotonicMilliseconds();
     mCurrentTimerExpiry = 0;
 }
 
@@ -188,7 +188,7 @@ static void TickProceed(uint16_t & time, uint64_t ticks)
 
 void ReliableMessageMgr::ExpireTicks()
 {
-    uint64_t now = System::Timer::GetCurrentEpoch();
+    uint64_t now = System::Clock::GetMonotonicMilliseconds();
 
     // Number of full ticks elapsed since last timer processing.  We always round down
     // to the previous tick.  If we are between tick boundaries, the extra time since the
@@ -299,7 +299,7 @@ void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
                    ChipLogError(ExchangeManager, "StartRetransmission was called for invalid entry"));
 
     entry->nextRetransTimeTick = static_cast<uint16_t>(entry->rc->GetInitialRetransmitTimeoutTick() +
-                                                       GetTickCounterFromTimeDelta(System::Timer::GetCurrentEpoch()));
+                                                       GetTickCounterFromTimeDelta(System::Clock::GetMonotonicMilliseconds()));
 
     // Check if the timer needs to be started and start it.
     StartTimer();
@@ -468,18 +468,18 @@ void ReliableMessageMgr::StartTimer()
     if (foundWake)
     {
         // Set timer for next tick boundary - subtract the elapsed time from the current tick
-        System::Timer::Epoch timerExpiryEpoch = (nextWakeTimeTick << mTimerIntervalShift) + mTimeStampBase;
+        System::Clock::MonotonicMilliseconds timerExpiry = (nextWakeTimeTick << mTimerIntervalShift) + mTimeStampBase;
 
 #if defined(RMP_TICKLESS_DEBUG)
         ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer wake at %" PRIu64 " ms (%" PRIu64 " %" PRIu64 ")",
-                      timerExpiryEpoch, nextWakeTimeTick, mTimeStampBase);
+                      timerExpiry, nextWakeTimeTick, mTimeStampBase);
 #endif
-        if (timerExpiryEpoch != mCurrentTimerExpiry)
+        if (timerExpiry != mCurrentTimerExpiry)
         {
             // If the tick boundary has expired in the past (delayed processing of event due to other system activity),
             // expire the timer immediately
-            uint64_t now           = System::Timer::GetCurrentEpoch();
-            uint64_t timerArmValue = (timerExpiryEpoch > now) ? timerExpiryEpoch - now : 0;
+            uint64_t now           = System::Clock::GetMonotonicMilliseconds();
+            uint64_t timerArmValue = (timerExpiry > now) ? timerExpiry - now : 0;
 
 #if defined(RMP_TICKLESS_DEBUG)
             ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer set timer for %" PRIu64, timerArmValue);
@@ -488,19 +488,20 @@ void ReliableMessageMgr::StartTimer()
             res = mSystemLayer->StartTimer((uint32_t) timerArmValue, Timeout, this);
 
             VerifyOrDieWithMsg(res == CHIP_NO_ERROR, ExchangeManager, "Cannot start ReliableMessageMgr::Timeout\n");
-            mCurrentTimerExpiry = timerExpiryEpoch;
+            mCurrentTimerExpiry = timerExpiry;
 #if defined(RMP_TICKLESS_DEBUG)
         }
         else
         {
-            ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer timer already set for %" PRIu64, timerExpiryEpoch);
+            ChipLogDetail(ExchangeManager, "ReliableMessageMgr::StartTimer timer already set for %" PRIu64, timerExpiry);
 #endif
         }
     }
     else
     {
 #if defined(RMP_TICKLESS_DEBUG)
-        ChipLogDetail(ExchangeManager, "Not setting ReliableMessageProtocol timeout at %" PRIu64, System::Timer::GetCurrentEpoch());
+        ChipLogDetail(ExchangeManager, "Not setting ReliableMessageProtocol timeout at %" PRIu64,
+                      System::Clock::GetMonotonicMilliseconds());
 #endif
         StopTimer();
     }

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -229,9 +229,9 @@ private:
     BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & mContextPool;
     chip::System::Layer * mSystemLayer;
     SecureSessionMgr * mSessionMgr;
-    uint64_t mTimeStampBase;                  // ReliableMessageProtocol timer base value to add offsets to evaluate timeouts
-    System::Timer::Epoch mCurrentTimerExpiry; // Tracks when the ReliableMessageProtocol timer will next expire
-    uint16_t mTimerIntervalShift;             // ReliableMessageProtocol Timer tick period shift
+    uint64_t mTimeStampBase; // ReliableMessageProtocol timer base value to add offsets to evaluate timeouts
+    System::Clock::MonotonicMilliseconds mCurrentTimerExpiry; // Tracks when the ReliableMessageProtocol timer will next expire
+    uint16_t mTimerIntervalShift;                             // ReliableMessageProtocol Timer tick period shift
 
     /* Placeholder function to run a function for all exchanges */
     template <typename Function>

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -121,7 +121,7 @@ CHIP_ERROR SendEchoRequest()
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    gLastEchoTime = chip::System::Timer::GetCurrentEpoch();
+    gLastEchoTime = chip::System::Clock::GetMonotonicMilliseconds();
 
     err = chip::DeviceLayer::SystemLayer.StartTimer(gEchoInterval, EchoTimerHandler, NULL);
     if (err != CHIP_NO_ERROR)
@@ -173,7 +173,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
-        gLastEchoTime = chip::System::Timer::GetCurrentEpoch();
+        gLastEchoTime = chip::System::Clock::GetMonotonicMilliseconds();
     }
     else
     {
@@ -185,7 +185,7 @@ exit:
 
 void HandleEchoResponseReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle && payload)
 {
-    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+    uint32_t respTime    = chip::System::Clock::GetMonotonicMilliseconds();
     uint32_t transitTime = respTime - gLastEchoTime;
 
     gEchoRespCount++;

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -146,7 +146,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP(void)
 {
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
-        mLastAPDemandTime = System::Layer::GetClock_MonotonicMS();
+        mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
         SystemLayer.ScheduleWork(DriveAPState, NULL);
     }
 }
@@ -166,7 +166,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP(void)
     {
         if (mWiFiAPState == kWiFiAPState_Activating || mWiFiAPState == kWiFiAPState_Active)
         {
-            mLastAPDemandTime = System::Layer::GetClock_MonotonicMS();
+            mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
         }
     }
 }
@@ -608,7 +608,7 @@ void ConnectivityManagerImpl::DriveStationState()
     // Otherwise the station interface is NOT connected to an AP, so...
     else
     {
-        uint64_t now = System::Layer::GetClock_MonotonicMS();
+        uint64_t now = System::Clock::GetMonotonicMilliseconds();
 
         // Advance the station state to NotConnected if it was previously Connected or Disconnecting,
         // or if a previous initiated connect attempt failed.
@@ -775,7 +775,7 @@ void ConnectivityManagerImpl::DriveAPState()
         // has been demand for the AP within the idle timeout period.
         else if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
         {
-            now = System::Layer::GetClock_MonotonicMS();
+            now = System::Clock::GetMonotonicMilliseconds();
 
             if (mLastAPDemandTime != 0 && now < (mLastAPDemandTime + mWiFiAPIdleTimeoutMS))
             {

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -180,7 +180,7 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     if (val)
     {
-        mAdvertiseStartTime = System::Timer::GetCurrentEpoch();
+        mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
         SystemLayer.StartTimer(kAdvertiseTimeout, &mAdvertiseTimerCallback);
         SystemLayer.StartTimer(kFastAdvertiseTimeout, &mFastAdvertiseTimerCallback);
     }
@@ -199,7 +199,7 @@ void BLEManagerImpl::HandleAdvertisementTimer(void * context)
 
 void BLEManagerImpl::HandleAdvertisementTimer()
 {
-    uint64_t currentTimestamp = System::Timer::GetCurrentEpoch();
+    uint64_t currentTimestamp = System::Clock::GetMonotonicMilliseconds();
 
     if (currentTimestamp - mAdvertiseStartTime >= kAdvertiseTimeout)
     {
@@ -215,7 +215,7 @@ void BLEManagerImpl::HandleFastAdvertisementTimer(void * context)
 
 void BLEManagerImpl::HandleFastAdvertisementTimer()
 {
-    uint64_t currentTimestamp = System::Timer::GetCurrentEpoch();
+    uint64_t currentTimestamp = System::Clock::GetMonotonicMilliseconds();
 
     if (currentTimestamp - mAdvertiseStartTime >= kFastAdvertiseTimeout)
     {

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     if (val)
     {
-        mAdvertiseStartTime = System::Timer::GetCurrentEpoch();
+        mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
         SystemLayer.StartTimer(kAdvertiseTimeout, &mAdvertiseTimerCallback);
         SystemLayer.StartTimer(kFastAdvertiseTimeout, &mFastAdvertiseTimerCallback);
     }
@@ -194,7 +194,7 @@ void BLEManagerImpl::HandleAdvertisementTimer(void * context)
 
 void BLEManagerImpl::HandleAdvertisementTimer()
 {
-    uint64_t currentTimestamp = System::Timer::GetCurrentEpoch();
+    uint64_t currentTimestamp = System::Clock::GetMonotonicMilliseconds();
 
     if (currentTimestamp - mAdvertiseStartTime >= kAdvertiseTimeout)
     {
@@ -210,7 +210,7 @@ void BLEManagerImpl::HandleFastAdvertisementTimer(void * context)
 
 void BLEManagerImpl::HandleFastAdvertisementTimer()
 {
-    uint64_t currentTimestamp = System::Timer::GetCurrentEpoch();
+    uint64_t currentTimestamp = System::Clock::GetMonotonicMilliseconds();
 
     if (currentTimestamp - mAdvertiseStartTime >= kFastAdvertiseTimeout)
     {

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -96,7 +96,7 @@ uint64_t GetMonotonicMicroseconds(void)
 
 uint64_t GetMonotonicMilliseconds(void)
 {
-    return (FreeRTOSTicksSinceBoot() * kMillisecondPerSecond) / configTICK_RATE_HZ;
+    return (FreeRTOSTicksSinceBoot() * kMillisecondsPerSecond) / configTICK_RATE_HZ;
 }
 
 CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime)

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -32,7 +32,7 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace Layer {
+namespace Clock {
 
 namespace {
 
@@ -89,44 +89,29 @@ uint64_t FreeRTOSTicksSinceBoot(void)
     return static_cast<uint64_t>(timeOut.xTimeOnEntering) + (static_cast<uint64_t>(timeOut.xOverflowCount) << kTicksOverflowShift);
 }
 
-uint64_t GetClock_Monotonic(void)
+uint64_t GetMonotonicMicroseconds(void)
 {
     return (FreeRTOSTicksSinceBoot() * kMicrosecondsPerSecond) / configTICK_RATE_HZ;
 }
 
-uint64_t GetClock_MonotonicMS(void)
+uint64_t GetMonotonicMilliseconds(void)
 {
     return (FreeRTOSTicksSinceBoot() * kMillisecondPerSecond) / configTICK_RATE_HZ;
 }
 
-uint64_t GetClock_MonotonicHiRes(void)
-{
-    return GetClock_Monotonic();
-}
-
-CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
+CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime)
 {
     if (sBootTimeUS == 0)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
-    curTime = sBootTimeUS + GetClock_Monotonic();
+    curTime = sBootTimeUS + GetMonotonicMicroseconds();
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTime)
+CHIP_ERROR SetUnixTimeMicroseconds(uint64_t newCurTime)
 {
-    if (sBootTimeUS == 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    curTime = (sBootTimeUS + GetClock_Monotonic()) / 1000;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
-{
-    uint64_t timeSinceBootUS = GetClock_Monotonic();
+    uint64_t timeSinceBootUS = GetMonotonicMicroseconds();
     if (newCurTime > timeSinceBootUS)
     {
         sBootTimeUS = newCurTime - timeSinceBootUS;
@@ -138,7 +123,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Layer
+} // namespace Clock
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -412,7 +412,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP()
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand start WiFi AP");
-        mLastAPDemandTime = System::Layer::GetClock_MonotonicMS();
+        mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
         SystemLayer.ScheduleWork(DriveAPState, NULL);
     }
     else
@@ -441,7 +441,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP()
     {
         if (mWiFiAPState == kWiFiAPState_Active)
         {
-            mLastAPDemandTime = System::Layer::GetClock_MonotonicMS();
+            mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
         }
     }
 }
@@ -670,7 +670,7 @@ void ConnectivityManagerImpl::DriveAPState()
         // has been demand for the AP within the idle timeout period.
         else if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
         {
-            now = System::Layer::GetClock_MonotonicMS();
+            now = System::Clock::GetMonotonicMilliseconds();
 
             if (mLastAPDemandTime != 0 && now < (mLastAPDemandTime + mWiFiAPIdleTimeoutMS))
             {

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -35,9 +35,9 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace Layer {
+namespace Clock {
 
-uint64_t GetClock_Monotonic()
+uint64_t GetMonotonicMicroseconds()
 {
     std::chrono::microseconds epoch =
         std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch());
@@ -46,7 +46,7 @@ uint64_t GetClock_Monotonic()
     return static_cast<uint64_t>(epoch.count());
 }
 
-uint64_t GetClock_MonotonicMS()
+uint64_t GetMonotonicMilliseconds()
 {
     std::chrono::milliseconds epoch =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
@@ -55,16 +55,7 @@ uint64_t GetClock_MonotonicMS()
     return static_cast<uint64_t>(epoch.count());
 }
 
-uint64_t GetClock_MonotonicHiRes()
-{
-    std::chrono::microseconds epoch =
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch());
-    // count() is nominally signed, but for a monotonic clock it cannot be
-    // negative.
-    return static_cast<uint64_t>(epoch.count());
-}
-
-CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
+CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, nullptr);
@@ -81,36 +72,15 @@ CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    curTime = (static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec);
+    curTime = (static_cast<uint64_t>(tv.tv_sec) * kMicrosecondsPerSecond) + static_cast<uint64_t>(tv.tv_usec);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTime)
+CHIP_ERROR SetUnixTimeMicroseconds(uint64_t newCurTime)
 {
     struct timeval tv;
-    int res = gettimeofday(&tv, nullptr);
-    if (res != 0)
-    {
-        return MapErrorPOSIX(errno);
-    }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    if (tv.tv_usec < 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    curTime = (static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000);
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
-{
-    struct timeval tv;
-    tv.tv_sec  = static_cast<time_t>(newCurTime / UINT64_C(1000000));
-    tv.tv_usec = static_cast<long>(newCurTime % UINT64_C(1000000));
+    tv.tv_sec  = static_cast<time_t>(newCurTime / kMicrosecondsPerSecond);
+    tv.tv_usec = static_cast<long>(newCurTime % kMicrosecondsPerSecond);
     int res    = settimeofday(&tv, nullptr);
     if (res != 0)
     {
@@ -130,7 +100,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Layer
+} // namespace Clock
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/platform/SystemEventSupport.cpp
+++ b/src/platform/SystemEventSupport.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR PostEvent(System::Layer & aLayer, void * aContext, System::Object & a
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DispatchEvents(Layer & aLayer, void * aContext)
+CHIP_ERROR DispatchEvents(System::Layer & aLayer, void * aContext)
 {
     PlatformMgr().RunEventLoop();
 

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -33,49 +33,33 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace Layer {
+namespace Clock {
 
 static uint64_t sBootTimeUS = 0;
 
-uint64_t GetClock_Monotonic(void)
+uint64_t GetMonotonicMicroseconds(void)
 {
     return k_ticks_to_us_floor64(k_uptime_ticks());
 }
 
-uint64_t GetClock_MonotonicMS(void)
+uint64_t GetMonotonicMilliseconds(void)
 {
     return k_uptime_get();
 }
 
-uint64_t GetClock_MonotonicHiRes(void)
-{
-    return GetClock_Monotonic();
-}
-
-CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
+CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime)
 {
     if (sBootTimeUS == 0)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
-    curTime = sBootTimeUS + GetClock_Monotonic();
+    curTime = sBootTimeUS + GetMonotonicMicroseconds();
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTime)
+CHIP_ERROR SetUnixTimeMicroseconds(uint64_t newCurTime)
 {
-    if (sBootTimeUS == 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    curTime = (sBootTimeUS + GetClock_Monotonic()) / 1000;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
-{
-    // FIXME: make thread-safe or update comment in SystemClock.h
-    uint64_t timeSinceBootUS = GetClock_Monotonic();
+    uint64_t timeSinceBootUS = GetMonotonicMicroseconds();
     if (newCurTime > timeSinceBootUS)
     {
         sBootTimeUS = newCurTime - timeSinceBootUS;
@@ -87,7 +71,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Layer
+} // namespace Clock
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -35,33 +35,26 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace Layer {
+namespace Clock {
 
 // Platform-specific function for getting monotonic system time in microseconds.
 // Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.
-uint64_t GetClock_Monotonic()
+uint64_t GetMonotonicMicroseconds()
 {
-    return rtos::Kernel::get_ms_count() * UINT64_C(1000);
+    return rtos::Kernel::get_ms_count() * kMicrosecondsPerMillisecond;
 }
 
 // Platform-specific function for getting monotonic system time in milliseconds.
 // Return elapsed time in milliseconds since an arbitrary, platform-defined epoch.
-uint64_t GetClock_MonotonicMS()
+uint64_t GetMonotonicMilliseconds()
 {
     return rtos::Kernel::get_ms_count();
-}
-
-// Platform-specific function for getting high-resolution monotonic system time in microseconds.
-// Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.
-uint64_t GetClock_MonotonicHiRes()
-{
-    return GetClock_Monotonic();
 }
 
 // Platform-specific function for getting the current real (civil) time in microsecond Unix time format,
 // where |curTime| argument is the current time, expressed as Unix time scaled to microseconds.
 // Returns CHIP_NO_ERROR if the method succeeded.
-CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
+CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime)
 {
     struct timeval tv;
     int res = gettimeofday(&tv, NULL);
@@ -73,37 +66,18 @@ CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
-    curTime = (tv.tv_sec * UINT64_C(1000000)) + tv.tv_usec;
-    return CHIP_NO_ERROR;
-}
-
-// Platform-specific function for getting the current real (civil) time in millisecond Unix time
-// where |curTimeMS| is the current time, expressed as Unix time scaled to milliseconds.
-// Returns CHIP_NO_ERROR if the method succeeded.
-CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS)
-{
-    struct timeval tv;
-    int res = gettimeofday(&tv, NULL);
-    if (res != 0)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    curTimeMS = (tv.tv_sec * UINT64_C(1000)) + (tv.tv_usec / 1000);
+    curTime = (tv.tv_sec * kMicrosecondsPerSecond) + tv.tv_usec;
     return CHIP_NO_ERROR;
 }
 
 // Platform-specific function for setting the current real (civil) time
 // where |newCurTime| is the  new current time, expressed as Unix time scaled to microseconds.
 // Returns CHIP_NO_ERROR if the method succeeded.
-CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
+CHIP_ERROR SetUnixTimeMicroseconds(uint64_t newCurTime)
 {
     struct timeval tv;
-    tv.tv_sec  = static_cast<time_t>(newCurTime / UINT64_C(1000000));
-    tv.tv_usec = static_cast<long>(newCurTime % UINT64_C(1000000));
+    tv.tv_sec  = static_cast<time_t>(newCurTime / kMicrosecondsPerSecond);
+    tv.tv_usec = static_cast<long>(newCurTime % kMicrosecondsPerSecond);
     int res    = settimeofday(&tv, NULL);
     if (res != 0)
     {
@@ -113,7 +87,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     {
         uint16_t year;
         uint8_t month, dayOfMonth, hour, minute, second;
-        SecondsSinceEpochToCalendarTime((uint32_t) tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
+        SecondsSinceUnixEpochToCalendarTime((uint32_t) tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
         ChipLogProgress(DeviceLayer,
                         "Real time clock set to %" PRId64 " (%04" PRIu16 "/%02" PRIu8 "/%02" PRIu8 " %02" PRIu8 ":%02" PRIu8
                         ":%02" PRIu8 " UTC)",
@@ -123,7 +97,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     return CHIP_NO_ERROR;
 }
 
-} // namespace Layer
+} // namespace Clock
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -40,7 +40,7 @@
 
 using namespace chip;
 using namespace chip::Logging;
-using namespace chip::System::Platform::Layer;
+using namespace chip::System::Platform::Clock;
 
 // =================================
 //      Test Vectors
@@ -98,7 +98,7 @@ void test_os_sleep_us(uint64_t microsecs)
 //      Unit tests
 // =================================
 
-static void TestDevice_GetClock_Monotonic(nlTestSuite * inSuite, void * inContext)
+static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * inContext)
 {
     int numOfTestVectors = ArraySize(test_vector_system_time_us);
     int numOfTestsRan    = 0;
@@ -111,11 +111,11 @@ static void TestDevice_GetClock_Monotonic(nlTestSuite * inSuite, void * inContex
     {
         test_params = &test_vector_system_time_us[vectorIndex];
         Tdelay      = test_params->delay;
-        Tstart      = GetClock_Monotonic();
+        Tstart      = GetMonotonicMicroseconds();
 
         test_os_sleep_us(test_params->delay);
 
-        Tend   = GetClock_Monotonic();
+        Tend   = GetMonotonicMicroseconds();
         Tdelta = Tend - Tstart;
 
         ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart, Tend, Tdelta,
@@ -129,7 +129,7 @@ static void TestDevice_GetClock_Monotonic(nlTestSuite * inSuite, void * inContex
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestDevice_GetClock_MonotonicMS(nlTestSuite * inSuite, void * inContext)
+static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * inContext)
 {
     int numOfTestVectors = ArraySize(test_vector_system_time_ms);
     int numOfTestsRan    = 0;
@@ -142,11 +142,11 @@ static void TestDevice_GetClock_MonotonicMS(nlTestSuite * inSuite, void * inCont
     {
         test_params = &test_vector_system_time_ms[vectorIndex];
         Tdelay      = test_params->delay;
-        Tstart      = GetClock_MonotonicMS();
+        Tstart      = GetMonotonicMilliseconds();
 
         test_os_sleep_ms(test_params->delay);
 
-        Tend   = GetClock_MonotonicMS();
+        Tend   = GetMonotonicMilliseconds();
         Tdelta = Tend - Tstart;
 
         ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart, Tend, Tdelta,
@@ -160,42 +160,13 @@ static void TestDevice_GetClock_MonotonicMS(nlTestSuite * inSuite, void * inCont
     NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
 }
 
-static void TestDevice_GetClock_MonotonicHiRes(nlTestSuite * inSuite, void * inContext)
-{
-    int numOfTestVectors = ArraySize(test_vector_system_time_us);
-    int numOfTestsRan    = 0;
-    const struct time_test_vector * test_params;
-
-    uint64_t margin = TEST_TIME_MARGIN_US;
-    uint64_t Tstart, Tend, Tdelta, Tdelay;
-
-    for (int vectorIndex = 0; vectorIndex < numOfTestVectors; vectorIndex++)
-    {
-        test_params = &test_vector_system_time_us[vectorIndex];
-        Tdelay      = test_params->delay;
-        Tstart      = GetClock_MonotonicHiRes();
-
-        test_os_sleep_us(test_params->delay);
-
-        Tend   = GetClock_MonotonicHiRes();
-        Tdelta = Tend - Tstart;
-
-        ChipLogProgress(DeviceLayer, "Start=%" PRIu64 " End=%" PRIu64 " Delta=%" PRIu64 " Expected=%" PRIu64, Tstart, Tend, Tdelta,
-                        Tdelay);
-        NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
-        numOfTestsRan++;
-    }
-    NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
-}
-
 /**
  *   Test Suite. It lists all the test functions.
  */
 static const nlTest sTests[] = {
 
-    NL_TEST_DEF("Test DeviceLayer::GetClock_Monotonic", TestDevice_GetClock_Monotonic),
-    NL_TEST_DEF("Test DeviceLayer::GetClock_MonotonicMS", TestDevice_GetClock_MonotonicMS),
-    NL_TEST_DEF("Test DeviceLayer::GetClock_MonotonicHiRes", TestDevice_GetClock_MonotonicHiRes),
+    NL_TEST_DEF("Test DeviceLayer::GetMonotonicMicroseconds", TestDevice_GetMonotonicMicroseconds),
+    NL_TEST_DEF("Test DeviceLayer::GetMonotonicMilliseconds", TestDevice_GetMonotonicMilliseconds),
 
     NL_TEST_SENTINEL()
 };

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -29,117 +29,72 @@
 
 // Include dependent headers
 #include <support/DLLUtil.h>
+#include <support/TimeUtils.h>
 
 #include <system/SystemError.h>
 
 namespace chip {
 namespace System {
 
-enum
-{
-    kTimerFactor_nano_per_micro  = 1000, /** Number of nanoseconds in a microsecond. */
-    kTimerFactor_micro_per_milli = 1000, /** Number of microseconds in a millisecond. */
-    kTimerFactor_milli_per_unit  = 1000, /** Number of milliseconds in a second. */
-
-    kTimerFactor_nano_per_milli = 1000000, /** Number of nanoseconds in a millisecond. */
-    kTimerFactor_micro_per_unit = 1000000  /** Number of microseconds in a second. */
-};
-
 namespace Platform {
-namespace Layer {
+namespace Clock {
 
 /**
- * @brief
- *   Platform-specific function for getting monotonic system time in microseconds.
+ * Platform-specific function for getting monotonic system time in microseconds.
  *
  * This function is expected to return elapsed time in microseconds since an arbitrary, platform-defined
  * epoch.  Platform implementations are obligated to return a value that is ever-increasing (i.e. never
  * wraps) between reboots of the system.  Additionally, the underlying time source is required to tick
  * continuously during any system sleep modes that do not entail a restart upon wake.
  *
- * The epoch for time returned by this function is *not* required to be the same that for any of the
- * other GetClock... functions, including GetClock_MonotonicMS().
- *
  * This function is expected to be thread-safe on any platform that employs threading.
  *
  * @note
  *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_Monotonic().
+ *   Layer should call System::Layer::GetMonotonicMicroseconds().
  *
  * @returns             Elapsed time in microseconds since an arbitrary, platform-defined epoch.
  */
-extern uint64_t GetClock_Monotonic();
+extern uint64_t GetMonotonicMicroseconds();
 
 /**
- * @brief
- *   Platform-specific function for getting monotonic system time in milliseconds.
+ * Platform-specific function for getting monotonic system time in milliseconds.
  *
  * This function is expected to return elapsed time in milliseconds since an arbitrary, platform-defined
  * epoch.  Platform implementations are obligated to return a value that is ever-increasing (i.e. never
  * wraps) between reboots of the system.  Additionally, the underlying time source is required to tick
  * continuously during any system sleep modes that do not entail a restart upon wake.
  *
- * The epoch for time returned by this function is *not* required to be the same as that for any of the
- * other GetClock... functions, including GetClock_Monotonic().
- *
  * This function is expected to be thread-safe on any platform that employs threading.
  *
  * @note
  *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_MonotonicMS().
+ *   Layer should call System::Layer::GetMonotonicMilliseconds().
  *
  * @returns             Elapsed time in milliseconds since an arbitrary, platform-defined epoch.
  */
-extern uint64_t GetClock_MonotonicMS();
+extern uint64_t GetMonotonicMilliseconds();
 
 /**
- * @brief
- *   Platform-specific function for getting high-resolution monotonic system time in microseconds.
- *
- * This function is expected to return elapsed time in microseconds since an arbitrary, platform-defined
- * epoch.  Values returned by GetClock_MonotonicHiRes() are required to be ever-increasing (i.e. never
- * wrap).  However, the underlying timer is *not* required to tick continuously during system
- * deep-sleep states.
- *
- * Platform are encouraged to implement GetClock_MonotonicHiRes() using a high-resolution timer
- * that is not subject to gradual clock adjustments (slewing).  On platforms without such a timer,
- * GetClock_MonotonicHiRes() can return the same value as GetClock_Monotonic().
- *
- * The epoch for time returned by this function is not required to be the same that for any of the
- * other GetClock... functions.
- *
- * This function is expected to be thread-safe on any platform that employs threading.
- *
- * @note
- *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_MonotonicHiRes().
- *
- * @returns             Elapsed time in microseconds since an arbitrary, platform-defined epoch.
- */
-extern uint64_t GetClock_MonotonicHiRes();
-
-/**
- * @brief
- *   Platform-specific function for getting the current real (civil) time in microsecond Unix time
- *   format.
+ * Platform-specific function for getting the current real (civil) time in microsecond Unix time format.
  *
  * This function is expected to return the local platform's notion of current real time, expressed
  * as a Unix time value scaled to microseconds.  The underlying clock is required to tick at a
  * rate of least at whole seconds (values of 1,000,000), but may tick faster.
  *
- * On those platforms that are capable of tracking real time, GetClock_RealTime() must return the
+ * On those platforms that are capable of tracking real time, GetUnixTimeMicroseconds() must return the
  * error CHIP_ERROR_REAL_TIME_NOT_SYNCED whenever the system is unsynchronized with real time.
  *
- * Platforms that are incapable of tracking real time should not implement the GetClock_RealTime()
+ * Platforms that are incapable of tracking real time should not implement the GetUnixTimeMicroseconds()
  * function, thereby forcing link-time failures of features that depend on access to real time.
- * Alternatively, such platforms may supply an implementation of GetClock_RealTime() that returns
+ * Alternatively, such platforms may supply an implementation of GetUnixTimeMicroseconds() that returns
  * the error CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.
  *
  * This function is expected to be thread-safe on any platform that employs threading.
  *
  * @note
  *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_RealTime().
+ *   Layer should call System::Layer::GetUnixTimeMicroseconds().
  *
  * @param[out] curTime                  The current time, expressed as Unix time scaled to microseconds.
  *
@@ -150,36 +105,10 @@ extern uint64_t GetClock_MonotonicHiRes();
  * @retval #CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
  *                                      If the platform is incapable of tracking real time.
  */
-extern CHIP_ERROR GetClock_RealTime(uint64_t & curTime);
+extern CHIP_ERROR GetUnixTimeMicroseconds(uint64_t & curTime);
 
 /**
- * @brief
- *   Platform-specific function for getting the current real (civil) time in millisecond Unix time
- *   format.
- *
- * This function is expected to return the local platform's notion of current real time, expressed
- * as a Unix time value scaled to milliseconds.
- *
- * See the documentation for GetClock_RealTime() for details on the expected behavior.
- *
- * @note
- *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_RealTimeMS().
- *
- * @param[out] curTimeMS               The current time, expressed as Unix time scaled to milliseconds.
- *
- * @retval #CHIP_NO_ERROR       If the method succeeded.
- * @retval #CHIP_ERROR_REAL_TIME_NOT_SYNCED
- *                                      If the platform is capable of tracking real time, but is
- *                                      is currently unsynchronized.
- * @retval #CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
- *                                      If the platform is incapable of tracking real time.
- */
-extern CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS);
-
-/**
- * @brief
- *   Platform-specific function for setting the current real (civil) time.
+ * Platform-specific function for setting the current real (civil) time.
  *
  * CHIP calls this function to set the local platform's notion of current real time.  The new current
  * time is expressed as a Unix time value scaled to microseconds.
@@ -187,20 +116,18 @@ extern CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS);
  * Once set, underlying platform clock is expected to track real time with a granularity of at least whole
  * seconds.
  *
- * On platforms that support tracking real time, the SetClock_RealTime() function must return the error
+ * On platforms that support tracking real time, the SetUnixTimeMicroseconds() function must return the error
  * CHIP_ERROR_ACCESS_DENIED if the calling application does not have the privilege to set the
  * current time.
  *
  * Platforms that are incapable of tracking real time, or do not offer the ability to set real time,
- * should not implement the SetClock_RealTime() function, thereby forcing link-time failures of features
+ * should not implement the SetUnixTimeMicroseconds() function, thereby forcing link-time failures of features
  * that depend on setting real time.  Alternatively, such platforms may supply an implementation of
- * SetClock_RealTime() that returns the error CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.
- *
- * This function is expected to be thread-safe on any platform that employs threading.
+ * SetUnixTimeMicroseconds() that returns the error CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.
  *
  * @note
  *   This function is reserved for internal use by the CHIP System Layer.  Users of the CHIP System
- *   Layer should call System::Layer::GetClock_RealTimeMS().
+ *   Layer should call System::Layer::SetUnixTimeMicroseconds().
  *
  * @param[in] newCurTime                The new current time, expressed as Unix time scaled to microseconds.
  *
@@ -211,9 +138,120 @@ extern CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS);
  *                                      If the calling application does not have the privilege to set the
  *                                      current time.
  */
-extern CHIP_ERROR SetClock_RealTime(uint64_t newCurTime);
+extern CHIP_ERROR SetUnixTimeMicroseconds(uint64_t newCurTime);
 
-} // namespace Layer
+} // namespace Clock
 } // namespace Platform
+
+class Clock
+{
+public:
+    using MonotonicMicroseconds = uint64_t;
+    using MonotonicMilliseconds = uint64_t;
+    using UnixTimeMicroseconds  = uint64_t;
+
+    /**
+     * Returns a monotonic system time in units of microseconds.
+     *
+     * This function returns an elapsed time in microseconds since an arbitrary, platform-defined
+     * epoch.  The value returned is guaranteed to be ever-increasing (i.e. never wrapping) between
+     * reboots of the system.  Additionally, the underlying time source is guaranteed to tick
+     * continuously during any system sleep modes that do not entail a restart upon wake.
+     *
+     * Although some platforms may choose to return a value that measures the time since boot for the
+     * system, applications must *not* rely on this.
+     *
+     * @returns             Elapsed time in microseconds since an arbitrary, platform-defined epoch.
+     */
+    static inline MonotonicMicroseconds GetMonotonicMicroseconds()
+    {
+        // Current implementation is a simple pass-through to the platform.
+        return Platform::Clock::GetMonotonicMicroseconds();
+    }
+
+    /**
+     * Returns a monotonic system time in units of milliseconds.
+     *
+     * This function returns an elapsed time in milliseconds since an arbitrary, platform-defined
+     * epoch.  The value returned is guaranteed to be ever-increasing (i.e. never wrapping) between
+     * reboots of the system.  Additionally, the underlying time source is guaranteed to tick
+     * continuously during any system sleep modes that do not entail a restart upon wake.
+     *
+     * Although some platforms may choose to return a value that measures the time since boot for the
+     * system, applications must *not* rely on this.
+     *
+     * @returns             Elapsed time in milliseconds since an arbitrary, platform-defined epoch.
+     */
+    static inline MonotonicMilliseconds GetMonotonicMilliseconds()
+    {
+        // Current implementation is a simple pass-through to the platform.
+        return Platform::Clock::GetMonotonicMilliseconds();
+    }
+
+    /**
+     * Returns the current real (civil) time in microsecond Unix time format.
+     *
+     * This method returns the local platform's notion of current real time, expressed as a Unix time
+     * value scaled to microseconds.  The underlying clock is guaranteed to tick at a rate of least at
+     * whole seconds (values of 1,000,000), but on some platforms may tick faster.
+     *
+     * If the underlying platform is capable of tracking real time, but the system is currently
+     * unsynchronized, GetRealTime() will return the error CHIP_ERROR_REAL_TIME_NOT_SYNCED.
+     *
+     * On platforms that are incapable of tracking real time, the GetRealTime() method may be absent,
+     * resulting a link error for any application that references it.  Alternatively, such platforms may
+     * supply an implementation of GetRealTime() that always returns the error CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.
+     *
+     * @param[out] curTime                  The current time, expressed as Unix time scaled to microseconds.
+     *
+     * @retval #CHIP_NO_ERROR       If the method succeeded.
+     * @retval #CHIP_ERROR_REAL_TIME_NOT_SYNCED
+     *                                      If the platform is capable of tracking real time, but is
+     *                                      is currently unsynchronized.
+     * @retval #CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
+     *                                      If the platform is incapable of tracking real time.
+     */
+    static inline CHIP_ERROR GetUnixTimeMicroseconds(UnixTimeMicroseconds & curTime)
+    {
+        // Current implementation is a simple pass-through to the platform.
+        return Platform::Clock::GetUnixTimeMicroseconds(curTime);
+    }
+
+    /**
+     * Sets the platform's notion of current real (civil) time.
+     *
+     * Applications can call this function to set the local platform's notion of current real time.  The
+     * new current time is expressed as a Unix time value scaled to microseconds.
+     *
+     * Once set, underlying platform clock is guaranteed to track real time with a granularity of at least
+     * whole seconds.
+     *
+     * Some platforms may restrict which applications or processes can set real time.  If the caller is
+     * not permitted to change real time, the SetRealTime() function will return the error
+     * CHIP_ERROR_ACCESS_DENIED.
+     *
+     * On platforms that are incapable of tracking real time, or do not offer the ability to set real time,
+     * the SetRealTime() function may be absent, resulting a link error for any application that
+     * references it.  Alternatively, such platforms may supply an implementation of SetRealTime()
+     * that always returns the error CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.
+     *
+     * This function is guaranteed to be thread-safe on any platform that employs threading.
+     *
+     * @param[in] newCurTime                The new current time, expressed as Unix time scaled to microseconds.
+     *
+     * @retval #CHIP_NO_ERROR               If the method succeeded.
+     * @retval #CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE
+     *                                      If the platform is incapable of tracking real time.
+     * @retval #CHIP_ERROR_ACCESS_DENIED
+     *                                      If the calling application does not have the privilege to set the
+     *                                      current time.
+     */
+    static inline CHIP_ERROR SetUnixTimeMicroseconds(UnixTimeMicroseconds newCurTime)
+    {
+        // Current implementation is a simple pass-through to the platform.
+        return Platform::Clock::SetUnixTimeMicroseconds(newCurTime);
+    }
+};
+
 } // namespace System
 } // namespace chip

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -564,7 +564,7 @@ struct LwIPEvent;
  *  @brief
  *      Use LwIP time function for System Layer monotonic clock functions.
  *
- *  Use the LwIP sys_now() function to implement the System Layer GetClock_Monotonic... functions.
+ *  Use the LwIP sys_now() function to implement the System Clock functions.
  *
  *  Defaults to enabled if the system is using LwIP and not sockets.
  *

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -31,9 +31,11 @@
 #include <core/CHIPCallback.h>
 
 #include <support/DLLUtil.h>
+#include <system/SystemClock.h>
 #include <system/SystemError.h>
 #include <system/SystemEvent.h>
 #include <system/SystemObject.h>
+#include <system/SystemTimer.h>
 
 // Include dependent headers
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -142,11 +144,12 @@ public:
 
     CHIP_ERROR NewTimer(Timer *& aTimerPtr);
 
-    void StartTimer(uint32_t aMilliseconds, chip::Callback::Callback<> * aCallback);
-    void DispatchTimerCallbacks(uint64_t kCurrentEpoch);
+    void StartTimer(uint32_t aMilliseconds, chip::Callback::Callback<> * aCallback); // XXX
+    void DispatchTimerCallbacks(Clock::MonotonicMilliseconds aCurrentTime);
 
-    typedef void (*TimerCompleteFunct)(Layer * aLayer, void * aAppState, CHIP_ERROR aError);
-    CHIP_ERROR StartTimer(uint32_t aMilliseconds, TimerCompleteFunct aComplete, void * aAppState);
+    using TimerCompleteFunct = Timer::OnCompleteFunct;
+    // typedef void (*TimerCompleteFunct)(Layer * aLayer, void * aAppState, CHIP_ERROR aError);
+    CHIP_ERROR StartTimer(uint32_t aMilliseconds, TimerCompleteFunct aComplete, void * aAppState); // XXX
     void CancelTimer(TimerCompleteFunct aOnComplete, void * aAppState);
 
     CHIP_ERROR ScheduleWork(TimerCompleteFunct aComplete, void * aAppState);
@@ -179,18 +182,14 @@ public:
     dispatch_queue_t GetDispatchQueue() { return mDispatchQueue; };
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
-    static uint64_t GetClock_Monotonic();
-    static uint64_t GetClock_MonotonicMS();
-    static uint64_t GetClock_MonotonicHiRes();
-    static CHIP_ERROR GetClock_RealTime(uint64_t & curTime);
-    static CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTimeMS);
-    static CHIP_ERROR SetClock_RealTime(uint64_t newCurTime);
+    Clock & GetClock() { return mClock; }
 
 private:
     LayerState mLayerState;
     void * mContext;
     void * mPlatformData;
     chip::Callback::CallbackDeque mTimerCallbacks;
+    Clock mClock;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static LwIPEventHandlerDelegate sSystemEventHandlerDelegate;

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -59,15 +59,7 @@ class DLL_EXPORT Timer : public Object
     friend class Layer;
 
 public:
-    /**
-     *  Represents an epoch in the local system timescale, usually the POSIX timescale.
-     *
-     *  The units are dependent on the context. If used with values returned by GetCurrentEpoch, the units are milliseconds.
-     */
-    typedef uint64_t Epoch;
-
-    static Epoch GetCurrentEpoch();
-    static bool IsEarlierEpoch(const Epoch & first, const Epoch & second);
+    static bool IsEarlier(const Clock::MonotonicMilliseconds & first, const Clock::MonotonicMilliseconds & second);
 
     typedef void (*OnCompleteFunct)(Layer * aLayer, void * aAppState, CHIP_ERROR aError);
     OnCompleteFunct OnComplete;
@@ -80,7 +72,7 @@ public:
 private:
     static ObjectPool<Timer, CHIP_SYSTEM_CONFIG_NUM_TIMERS> sPool;
 
-    Epoch mAwakenEpoch;
+    Clock::MonotonicMilliseconds mAwakenTime;
 
     void HandleComplete();
 

--- a/src/system/TimeSource.h
+++ b/src/system/TimeSource.h
@@ -63,7 +63,7 @@ template <>
 class TimeSource<Source::kSystem>
 {
 public:
-    uint64_t GetCurrentMonotonicTimeMs() { return System::Platform::Layer::GetClock_MonotonicMS(); }
+    uint64_t GetCurrentMonotonicTimeMs() { return System::Clock::GetMonotonicMicroseconds(); }
 };
 
 /**

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -169,7 +169,7 @@ CHIP_ERROR SecureSessionMgr::SendPreparedMessage(SecureSessionHandle session, co
     mPeerConnections.MarkConnectionActive(state);
 
     ChipLogProgress(Inet, "Sending msg %p to 0x" ChipLogFormatX64 " at utc time: %" PRId64 " msec", &preparedMessage,
-                    ChipLogValueX64(state->GetPeerNodeId()), System::Layer::GetClock_MonotonicMS());
+                    ChipLogValueX64(state->GetPeerNodeId()), System::Clock::GetMonotonicMilliseconds());
 
     if (mTransportMgr != nullptr)
     {

--- a/src/transport/raw/tests/NetworkTestHelpers.cpp
+++ b/src/transport/raw/tests/NetworkTestHelpers.cpp
@@ -64,13 +64,13 @@ void IOContext::DriveIO()
 
 void IOContext::DriveIOUntil(unsigned maxWaitMs, std::function<bool(void)> completionFunction)
 {
-    uint64_t mStartTime = mSystemLayer->GetClock_MonotonicMS();
+    uint64_t mStartTime = mSystemLayer->GetClock().GetMonotonicMilliseconds();
 
     while (true)
     {
         DriveIO(); // at least one IO loop is guaranteed
 
-        if (completionFunction() || ((mSystemLayer->GetClock_MonotonicMS() - mStartTime) >= maxWaitMs))
+        if (completionFunction() || ((mSystemLayer->GetClock().GetMonotonicMilliseconds() - mStartTime) >= maxWaitMs))
         {
             break;
         }


### PR DESCRIPTION
#### Problem

System Layer contains some unnecessary coupling, and a number of
ambiguous names, involving clock and time.

(This is a standalone fragment of work toward event/threading
refactoring, issue #7725)

#### Change overview

SystemLayer / SystemClock

- Add distinct type names MonotonicMilliseconds,
  MonotonicMicroseconds, UnixTimeMicroseconds.
- Move System::Layer clock functions to their own class.
- Rename them to make the time units explicit.
- Use them in preference to the System::Platform::Layer versions.
- Remove the HiRes version, which has no separate implementation.
- Move the platform implementations from System::Platform::Layer
  (not to be confused with System::Layer) to System::Platform::Clock.
- Removed the statement that SetUnixTimeMicroseconds() must be
  thread-safe. Since this function is not currently used, this
  imposes no burden on existing code.

TimeUtils

- Rename functions to make clean when ‘Epoch’ means the UNIX epoch.
- Use the scale conversion constants more often.

SystemTimer

- Remove the Timer::Epoch typedef, which wasn't an epoch, and
  rename SetTimerEpoch() to SetTimestamp().
- Remove the deprecated System::Timer::GetCurrentEpoch().

#### Testing

This change largely just renames existing code, so no functional changes
are expected. Existing cases in TestPlatformTime.cpp should catch any
mistakes in unit substitutions or conversions constants.
