### PR TITLE
Remove error erasures

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -543,11 +543,11 @@ void InitServer(AppDelegate * delegate)
 
     // Register to receive unsolicited legacy ZCL messages from the exchange manager.
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::TempZCL::Id, &gCallbacks);
-    VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER);
+    SuccessOrExit(err);
 
     // Register to receive unsolicited Service Provisioning messages from the exchange manager.
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::ServiceProvisioning::Id, &gCallbacks);
-    VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER);
+    SuccessOrExit(err);
 
     err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable(),
                                                     &gSessionIDAllocator);

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1428,7 +1428,7 @@ bool BLEEndPoint::SendIndication(PacketBufferHandle && buf)
 CHIP_ERROR BLEEndPoint::StartConnectTimer()
 {
     const CHIP_ERROR timerErr = mBle->mSystemLayer->StartTimer(BLE_CONNECT_TIMEOUT_MS, HandleConnectTimeout, this);
-    VerifyOrReturnError(timerErr == CHIP_NO_ERROR, BLE_ERROR_START_TIMER_FAILED);
+    ReturnErrorOnFailure(timerErr);
     mTimerStateFlags.Set(TimerStateFlag::kConnectTimerRunning);
 
     return CHIP_NO_ERROR;
@@ -1437,7 +1437,7 @@ CHIP_ERROR BLEEndPoint::StartConnectTimer()
 CHIP_ERROR BLEEndPoint::StartReceiveConnectionTimer()
 {
     const CHIP_ERROR timerErr = mBle->mSystemLayer->StartTimer(BLE_CONNECT_TIMEOUT_MS, HandleReceiveConnectionTimeout, this);
-    VerifyOrReturnError(timerErr == CHIP_NO_ERROR, BLE_ERROR_START_TIMER_FAILED);
+    ReturnErrorOnFailure(timerErr);
     mTimerStateFlags.Set(TimerStateFlag::kReceiveConnectionTimerRunning);
 
     return CHIP_NO_ERROR;
@@ -1448,7 +1448,7 @@ CHIP_ERROR BLEEndPoint::StartAckReceivedTimer()
     if (!mTimerStateFlags.Has(TimerStateFlag::kAckReceivedTimerRunning))
     {
         const CHIP_ERROR timerErr = mBle->mSystemLayer->StartTimer(BTP_ACK_RECEIVED_TIMEOUT_MS, HandleAckReceivedTimeout, this);
-        VerifyOrReturnError(timerErr == CHIP_NO_ERROR, BLE_ERROR_START_TIMER_FAILED);
+        ReturnErrorOnFailure(timerErr);
 
         mTimerStateFlags.Set(TimerStateFlag::kAckReceivedTimerRunning);
     }
@@ -1473,7 +1473,7 @@ CHIP_ERROR BLEEndPoint::StartSendAckTimer()
     {
         ChipLogDebugBleEndPoint(Ble, "starting new SendAckTimer");
         const CHIP_ERROR timerErr = mBle->mSystemLayer->StartTimer(BTP_ACK_SEND_TIMEOUT_MS, HandleSendAckTimeout, this);
-        VerifyOrReturnError(timerErr == CHIP_NO_ERROR, BLE_ERROR_START_TIMER_FAILED);
+        ReturnErrorOnFailure(timerErr);
 
         mTimerStateFlags.Set(TimerStateFlag::kSendAckTimerRunning);
     }
@@ -1484,7 +1484,7 @@ CHIP_ERROR BLEEndPoint::StartSendAckTimer()
 CHIP_ERROR BLEEndPoint::StartUnsubscribeTimer()
 {
     const CHIP_ERROR timerErr = mBle->mSystemLayer->StartTimer(BLE_UNSUBSCRIBE_TIMEOUT_MS, HandleUnsubscribeTimeout, this);
-    VerifyOrReturnError(timerErr == CHIP_NO_ERROR, BLE_ERROR_START_TIMER_FAILED);
+    ReturnErrorOnFailure(timerErr);
     mTimerStateFlags.Set(TimerStateFlag::kUnsubscribeTimerRunning);
 
     return CHIP_NO_ERROR;

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -248,7 +248,8 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
     mRxCharCount++;
 
     // Get header flags, always in first byte.
-    VerifyOrExit(reader.Read8(rx_flags.RawStorage()).StatusCode() == CHIP_NO_ERROR, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
+    err = reader.Read8(rx_flags.RawStorage()).StatusCode();
+    SuccessOrExit(err);
 #if CHIP_ENABLE_CHIPOBLE_TEST
     if (rx_flags.Has(HeaderFlags::kCommandMessage))
         SetRxPacketType(kType_Control);
@@ -261,14 +262,16 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
     // Get ack number, if any.
     if (didReceiveAck)
     {
-        VerifyOrExit(reader.Read8(&receivedAck).StatusCode() == CHIP_NO_ERROR, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
+        err = reader.Read8(&receivedAck).StatusCode();
+        SuccessOrExit(err);
 
         err = HandleAckReceived(receivedAck);
         SuccessOrExit(err);
     }
 
     // Get sequence number.
-    VerifyOrExit(reader.Read8(&mRxNewestUnackedSeqNum).StatusCode() == CHIP_NO_ERROR, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
+    err = reader.Read8(&mRxNewestUnackedSeqNum).StatusCode();
+    SuccessOrExit(err);
 
     // Verify that received sequence number is the next one we'd expect.
     VerifyOrExit(mRxNewestUnackedSeqNum == mRxNextSeqNum, err = BLE_ERROR_INVALID_BTP_SEQUENCE_NUMBER);
@@ -304,7 +307,8 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
         // Verify StartMessage header flag set.
         VerifyOrExit(rx_flags.Has(HeaderFlags::kStartMessage), err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
-        VerifyOrExit(startReader.Read16(&mRxLength).StatusCode() == CHIP_NO_ERROR, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
+        err = startReader.Read16(&mRxLength).StatusCode();
+        SuccessOrExit(err);
 
         mRxState = kState_InProgress;
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -255,7 +255,7 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         UNLOCK_TCPIP_CORE();
 #endif
-        VerifyOrReturnError(CHIP_NO_ERROR == inetErr, CHIP_ERROR_INTERNAL);
+        ReturnErrorOnFailure(inetErr);
     }
 
     static_assert(std::is_same<std::underlying_type<decltype(mDeviceAddress.GetTransportType())>::type, uint8_t>::value,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -345,8 +345,8 @@ CHIP_ERROR DeviceController::Shutdown()
     //
     ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
 #else
-    VerifyOrReturnError(mInetLayer->Shutdown() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(mSystemLayer->Shutdown() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(mInetLayer->Shutdown());
+    ReturnErrorOnFailure(mSystemLayer->Shutdown());
     chip::Platform::Delete(mInetLayer);
     chip::Platform::Delete(mSystemLayer);
 #endif // CONFIG_DEVICE_LAYER
@@ -894,13 +894,13 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     // If the CSRNonce is passed in, using that else using a random one..
     if (params.HasCSRNonce())
     {
-        VerifyOrReturnError(device->SetCSRNonce(params.GetCSRNonce().Value()) == CHIP_NO_ERROR, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(device->SetCSRNonce(params.GetCSRNonce().Value()));
     }
     else
     {
         uint8_t mCSRNonce[kOpCSRNonceLength];
         Crypto::DRBG_get_bytes(mCSRNonce, sizeof(mCSRNonce));
-        VerifyOrReturnError(device->SetCSRNonce(ByteSpan(mCSRNonce)) == CHIP_NO_ERROR, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(device->SetCSRNonce(ByteSpan(mCSRNonce)));
     }
 
     mIsIPRendezvous = (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle);

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -350,7 +350,7 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                 ASN1_PARSE_ENTER_SEQUENCE
                 {
                     err = reader.Next();
-                    VerifyOrExit(err == CHIP_NO_ERROR, err = ASN1_ERROR_INVALID_ENCODING);
+                    SuccessOrExit(err);
 
                     // keyIdentifier [0] IMPLICIT KeyIdentifier,
                     // KeyIdentifier ::= OCTET STRING

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1341,8 +1341,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::MacVerify(const uint8_t * key, size_t 
     VerifyOrReturnError(mac_len == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
 
     uint8_t computed_mac[kSHA256_Hash_Length];
-    const CHIP_ERROR error = Mac(key, key_len, in, in_len, computed_mac);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(Mac(key, key_len, in, in_len, computed_mac));
 
     VerifyOrReturnError(CRYPTO_memcmp(mac, computed_mac, mac_len) == 0, CHIP_ERROR_INTERNAL);
 
@@ -1436,11 +1435,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
     scratch = EC_POINT_new(context->curve);
     VerifyOrExit(scratch != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    error = PointMul(scratch, P1, fe1);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-
-    error = PointMul(R, P2, fe2);
-    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    SuccessOrExit(error = PointMul(scratch, P1, fe1));
+    SuccessOrExit(error = PointMul(R, P2, fe2));
 
     error_openssl = EC_POINT_add(context->curve, static_cast<EC_POINT *>(R), static_cast<EC_POINT *>(R),
                                  static_cast<const EC_POINT *>(scratch), context->bn_ctx);

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
@@ -314,18 +314,18 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) peer_identity, peer_identity_len, (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 #endif
 
     ReturnErrorOnFailure(se05x_set_key(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
@@ -338,7 +338,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_v, 0, Lin_id_v);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::VERIFIER;
@@ -388,18 +388,18 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) my_identity, my_identity_len, (uint8_t *) peer_identity, peer_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 #endif
 
     ReturnErrorOnFailure(se05x_set_key(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
@@ -412,7 +412,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_p, w1in_id_p, 0);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kPlatform, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
@@ -314,18 +314,18 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) peer_identity, peer_identity_len, (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 #endif
 
     ReturnErrorOnFailure(se05x_set_key(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
@@ -338,7 +338,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_v, 0, Lin_id_v);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::VERIFIER;
@@ -388,18 +388,18 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) my_identity, my_identity_len, (uint8_t *) peer_identity, peer_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 #endif
 
     ReturnErrorOnFailure(se05x_set_key(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
@@ -412,7 +412,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_p, w1in_id_p, 0);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
+    VerifyOrReturnError(smstatus == SM_OK, chip::ChipError::Encapsulate(chip::ChipError::Range::kSe05x, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_Spake2p.cpp
@@ -91,12 +91,12 @@ CHIP_ERROR create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE role, hsm_pake
     se05x_delete_key(m_id);
     error = se05x_set_key(m_id, chip::Crypto::spake2p_M_p256, sizeof(chip::Crypto::spake2p_M_p256), kSSS_KeyPart_Public,
                           kSSS_CipherType_EC_NIST_P);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(error);
 
     se05x_delete_key(n_id);
     error = se05x_set_key(n_id, chip::Crypto::spake2p_N_p256, sizeof(chip::Crypto::spake2p_N_p256), kSSS_KeyPart_Public,
                           kSSS_CipherType_EC_NIST_P);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(error);
 
     VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
 
@@ -307,37 +307,29 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
 
     ChipLogProgress(Crypto, "HSM - BeginVerifier \n");
 
-    error = FELoad(w0in, w0in_len, w0);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = FEWrite(w0, w0in_mod, w0in_mod_len);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER, &hsm_pake_context);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(FELoad(w0in, w0in_len, w0));
+    ReturnErrorOnFailure(FEWrite(w0, w0in_mod, w0in_mod_len));
+    ReturnErrorOnFailure(create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::VERIFIER, &hsm_pake_context));
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) peer_identity, peer_identity_len, (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_B,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 #endif
 
-    error = se05x_set_key(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = se05x_set_key(Lin_id_v, Lin, Lin_len, kSSS_KeyPart_Public, kSSS_CipherType_EC_NIST_P);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(se05x_set_key(w0in_id_v, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
+    ReturnErrorOnFailure(se05x_set_key(Lin_id_v, Lin, Lin_len, kSSS_KeyPart_Public, kSSS_CipherType_EC_NIST_P));
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEInitCredentials(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
@@ -346,7 +338,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_v, 0, Lin_id_v);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::VERIFIER;
@@ -387,43 +379,31 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
 
     ChipLogProgress(Crypto, "HSM - BeginProver \n");
 
-    error = FELoad(w0in, w0in_len, w0);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = FEWrite(w0, w0in_mod, w0in_mod_len);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = FELoad(w1in, w1in_len, w1);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = FEWrite(w1, w1in_mod, w1in_mod_len);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER, &hsm_pake_context);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(FELoad(w0in, w0in_len, w0));
+    ReturnErrorOnFailure(FEWrite(w0, w0in_mod, w0in_mod_len));
+    ReturnErrorOnFailure(FELoad(w1in, w1in_len, w1));
+    ReturnErrorOnFailure(FEWrite(w1, w1in_mod, w1in_mod_len));
+    ReturnErrorOnFailure(create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER, &hsm_pake_context));
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         (uint8_t *) hsm_pake_context.spake_context, hsm_pake_context.spake_context_len,
                                         (uint8_t *) my_identity, my_identity_len, (uint8_t *) peer_identity, peer_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 #else
     smstatus = Se05x_API_PAKEConfigDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, SE05x_SPAKEDevice_A,
                                           hsm_pake_context.spake_objId, (uint8_t *) hsm_pake_context.spake_context,
                                           hsm_pake_context.spake_context_len, (uint8_t *) peer_identity, peer_identity_len,
                                           (uint8_t *) my_identity, my_identity_len);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 #endif
 
-    error = se05x_set_key(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-
-    error = se05x_set_key(w1in_id_p, w1in_mod, w1in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES);
-    VerifyOrReturnError(error == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(se05x_set_key(w0in_id_p, w0in_mod, w0in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
+    ReturnErrorOnFailure(se05x_set_key(w1in_id_p, w1in_mod, w1in_mod_len, kSSS_KeyPart_Default, kSSS_CipherType_AES));
 
 #if SSS_HAVE_SE05X_VER_GTE_16_02
     smstatus = Se05x_API_PAKEInitCredentials(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx,
@@ -432,7 +412,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     smstatus = Se05x_API_PAKEInitDevice(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, hsm_pake_context.spake_objId,
                                         w0in_id_p, w1in_id_p, 0);
 #endif
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(smstatus == SM_OK, ChipError::Encapsulate(ChipError::Range::kSe05x, smstatus));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -563,7 +563,6 @@ static SecurityManagerEventHandler sSecurityManagerEventHandler;
  */
 CHIP_ERROR BLEManagerImpl::_Init()
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
     ble_error_t mbed_err = BLE_ERROR_NONE;
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
@@ -573,8 +572,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     ble::BLE & ble_interface = ble::BLE::Instance();
 
     ble_interface.gap().setEventHandler(&sMbedGapEventHandler);
-    err = sCHIPService.init(ble_interface);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(sCHIPService.init(ble_interface));
 
     ble_interface.onEventsToProcess(FunctionPointerWithContext<ble::BLE::OnEventsToProcessCallbackContext *>{
         [](ble::BLE::OnEventsToProcessCallbackContext * context) { PlatformMgr().ScheduleWork(DoBLEProcessing, 0); } });
@@ -582,10 +580,9 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mbed_err = ble_interface.init([](ble::BLE::InitializationCompleteCallbackContext * context) {
         BLEMgrImpl().HandleInitComplete(context->error == BLE_ERROR_NONE);
     });
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 /* Process all the events from the mbed-os BLE subsystem.
@@ -624,10 +621,10 @@ void BLEManagerImpl::HandleInitComplete(bool no_error)
         /*const Passkey_t passkey        */ nullptr,
         /*bool signing                   */ true,
         /*const char *dbFilepath         */ nullptr);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     mbed_err = security_mgr.setPairingRequestAuthorisation(true);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
     security_mgr.setSecurityManagerEventHandler(&sSecurityManagerEventHandler);
 
     err = BleLayer::Init(this, this, &SystemLayer);
@@ -754,16 +751,16 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     if (gap.isAdvertisingActive(ble::LEGACY_ADVERTISING_HANDLE))
     {
         mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
         ChipLogDetail(DeviceLayer, "Advertising already active. Restarting.");
     }
 
     mbed_err = gap.setAdvertisingParameters(ble::LEGACY_ADVERTISING_HANDLE, adv_params);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     mbed_err =
         adv_data_builder.setFlags(ble::adv_data_flags_t::BREDR_NOT_SUPPORTED | ble::adv_data_flags_t::LE_GENERAL_DISCOVERABLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     if (!mFlags.Has(kFlag_UseCustomDeviceName))
     {
@@ -773,24 +770,24 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
     }
     mbed_err = adv_data_builder.setName(mDeviceName);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     dev_id_info.Init();
     SuccessOrExit(ConfigurationMgr().GetBLEDeviceIdentificationInfo(dev_id_info));
     mbed_err = adv_data_builder.setServiceData(
         ShortUUID_CHIPoBLEService, mbed::make_Span<const uint8_t>(reinterpret_cast<uint8_t *>(&dev_id_info), sizeof dev_id_info));
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     mbed_err = gap.setAdvertisingPayload(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     adv_data_builder.clear();
     adv_data_builder.setLocalServiceList(mbed::make_Span<const UUID>(&ShortUUID_CHIPoBLEService, 1));
     mbed_err = gap.setAdvertisingScanResponse(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     mbed_err = gap.startAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
     ChipLogDetail(DeviceLayer, "Advertising started, type: 0x%x (%sconnectable), interval: [%lu:%lu] ms, device name: %s)",
                   adv_params.getType().value(), connectable ? "" : "non-", adv_params.getMinPrimaryInterval().valueInMs(),
@@ -817,7 +814,7 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
         return err;
     }
     mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)
@@ -1031,7 +1028,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
                   conId, att_handle, pBuf->DataLength());
 
     mbed_err = gatt_server.write(att_handle, pBuf->Start(), pBuf->DataLength(), false);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -580,7 +580,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mbed_err = ble_interface.init([](ble::BLE::InitializationCompleteCallbackContext * context) {
         BLEMgrImpl().HandleInitComplete(context->error == BLE_ERROR_NONE);
     });
-    VerifyOrReturnError(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrReturnError(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     return CHIP_NO_ERROR;
 }
@@ -621,10 +621,10 @@ void BLEManagerImpl::HandleInitComplete(bool no_error)
         /*const Passkey_t passkey        */ nullptr,
         /*bool signing                   */ true,
         /*const char *dbFilepath         */ nullptr);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     mbed_err = security_mgr.setPairingRequestAuthorisation(true);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
     security_mgr.setSecurityManagerEventHandler(&sSecurityManagerEventHandler);
 
     err = BleLayer::Init(this, this, &SystemLayer);
@@ -751,16 +751,16 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     if (gap.isAdvertisingActive(ble::LEGACY_ADVERTISING_HANDLE))
     {
         mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
         ChipLogDetail(DeviceLayer, "Advertising already active. Restarting.");
     }
 
     mbed_err = gap.setAdvertisingParameters(ble::LEGACY_ADVERTISING_HANDLE, adv_params);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     mbed_err =
         adv_data_builder.setFlags(ble::adv_data_flags_t::BREDR_NOT_SUPPORTED | ble::adv_data_flags_t::LE_GENERAL_DISCOVERABLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     if (!mFlags.Has(kFlag_UseCustomDeviceName))
     {
@@ -770,24 +770,24 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
     }
     mbed_err = adv_data_builder.setName(mDeviceName);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     dev_id_info.Init();
     SuccessOrExit(ConfigurationMgr().GetBLEDeviceIdentificationInfo(dev_id_info));
     mbed_err = adv_data_builder.setServiceData(
         ShortUUID_CHIPoBLEService, mbed::make_Span<const uint8_t>(reinterpret_cast<uint8_t *>(&dev_id_info), sizeof dev_id_info));
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     mbed_err = gap.setAdvertisingPayload(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     adv_data_builder.clear();
     adv_data_builder.setLocalServiceList(mbed::make_Span<const UUID>(&ShortUUID_CHIPoBLEService, 1));
     mbed_err = gap.setAdvertisingScanResponse(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     mbed_err = gap.startAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
     ChipLogDetail(DeviceLayer, "Advertising started, type: 0x%x (%sconnectable), interval: [%lu:%lu] ms, device name: %s)",
                   adv_params.getType().value(), connectable ? "" : "non-", adv_params.getMinPrimaryInterval().valueInMs(),
@@ -814,7 +814,7 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
         return err;
     }
     mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)
@@ -1028,7 +1028,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
                   conId, att_handle, pBuf->DataLength());
 
     mbed_err = gatt_server.write(att_handle, pBuf->Start(), pBuf->DataLength(), false);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::kOS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -580,7 +580,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mbed_err = ble_interface.init([](ble::BLE::InitializationCompleteCallbackContext * context) {
         BLEMgrImpl().HandleInitComplete(context->error == BLE_ERROR_NONE);
     });
-    VerifyOrReturnError(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrReturnError(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     return CHIP_NO_ERROR;
 }
@@ -621,10 +621,10 @@ void BLEManagerImpl::HandleInitComplete(bool no_error)
         /*const Passkey_t passkey        */ nullptr,
         /*bool signing                   */ true,
         /*const char *dbFilepath         */ nullptr);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     mbed_err = security_mgr.setPairingRequestAuthorisation(true);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
     security_mgr.setSecurityManagerEventHandler(&sSecurityManagerEventHandler);
 
     err = BleLayer::Init(this, this, &SystemLayer);
@@ -751,16 +751,16 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     if (gap.isAdvertisingActive(ble::LEGACY_ADVERTISING_HANDLE))
     {
         mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+        VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
         ChipLogDetail(DeviceLayer, "Advertising already active. Restarting.");
     }
 
     mbed_err = gap.setAdvertisingParameters(ble::LEGACY_ADVERTISING_HANDLE, adv_params);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     mbed_err =
         adv_data_builder.setFlags(ble::adv_data_flags_t::BREDR_NOT_SUPPORTED | ble::adv_data_flags_t::LE_GENERAL_DISCOVERABLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     if (!mFlags.Has(kFlag_UseCustomDeviceName))
     {
@@ -770,24 +770,24 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
     }
     mbed_err = adv_data_builder.setName(mDeviceName);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     dev_id_info.Init();
     SuccessOrExit(ConfigurationMgr().GetBLEDeviceIdentificationInfo(dev_id_info));
     mbed_err = adv_data_builder.setServiceData(
         ShortUUID_CHIPoBLEService, mbed::make_Span<const uint8_t>(reinterpret_cast<uint8_t *>(&dev_id_info), sizeof dev_id_info));
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     mbed_err = gap.setAdvertisingPayload(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     adv_data_builder.clear();
     adv_data_builder.setLocalServiceList(mbed::make_Span<const UUID>(&ShortUUID_CHIPoBLEService, 1));
     mbed_err = gap.setAdvertisingScanResponse(ble::LEGACY_ADVERTISING_HANDLE, adv_data_builder.getAdvertisingData());
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     mbed_err = gap.startAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
     ChipLogDetail(DeviceLayer, "Advertising started, type: 0x%x (%sconnectable), interval: [%lu:%lu] ms, device name: %s)",
                   adv_params.getType().value(), connectable ? "" : "non-", adv_params.getMinPrimaryInterval().valueInMs(),
@@ -814,7 +814,7 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
         return err;
     }
     mbed_err = gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)
@@ -1028,7 +1028,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
                   conId, att_handle, pBuf->DataLength());
 
     mbed_err = gatt_server.write(att_handle, pBuf->Start(), pBuf->DataLength(), false);
-    VerifyOrExit(mbed_err == BLE_ERROR_NONE, ChipError::Encapsulate(ChipError::Range::OS, mbed_err));
+    VerifyOrExit(mbed_err == BLE_ERROR_NONE, chip::ChipError::Encapsulate(chip::ChipError::Range::OS, mbed_err));
 
 exit:
     if (mbed_err != BLE_ERROR_NONE)


### PR DESCRIPTION
#### Problem

Various code of the form

    error = chipf();
    Verify(error != CHIP_NO_ERROR, error = CHIP_OTHER_ERROR)

simply discards an error and replaces it with another, usually
CHIP_ERROR_INTERNAL. This has two problems:

- on small platforms, it uses extra code;
- on large platforms, it is planned that the CHIP_ERROR type will
  track the original source location of the error, and throwing
  this away will impede troubleshooting.

#### Change overview

Use the original error code instead of replacing it.

#### Testing

No affected tests check for specific error codes. Unit tests should
be expected to catch any unintended changes to functionality.
