### PR TITLE
Use to_underlying instead of manually writing it out or static asserts.

### DIFF
--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "SetupPayloadParseCommand.h"
+#include <lib/support/TypeTraits.h>
 #include <setup_payload/ManualSetupPayloadParser.h>
 #include <setup_payload/QRCodeSetupPayloadParser.h>
 #include <setup_payload/SetupPayload.h>
@@ -48,8 +49,7 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
     std::vector<OptionalQRCodeInfo> optionalVendorData;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogProgress(SetupPayload, "CommissioningFlow: %" PRIu8,
-                    static_cast<std::underlying_type_t<decltype(payload.commissioningFlow)>>(payload.commissioningFlow));
+    ChipLogProgress(SetupPayload, "CommissioningFlow: %" PRIu8, to_underlying(payload.commissioningFlow));
     ChipLogProgress(SetupPayload, "VendorID: %u", payload.vendorID);
     ChipLogProgress(SetupPayload, "Version: %u", payload.version);
     ChipLogProgress(SetupPayload, "ProductID: %u", payload.productID);

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -42,6 +42,7 @@
 #include <app/util/af.h>
 #include <app/util/config.h>
 #include <app/util/util.h>
+#include <lib/support/TypeTraits.h>
 
 using namespace chip;
 
@@ -184,7 +185,7 @@ void emberAfPutInt16sInResp(int16_t value)
 
 void emberAfPutStatusInResp(EmberAfStatus value)
 {
-    emberAfPutInt8uInResp(static_cast<std::underlying_type_t<EmberAfStatus>>(value));
+    emberAfPutInt8uInResp(to_underlying(value));
 }
 
 // ------------------------------------

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -48,6 +48,7 @@
 #include <support/ErrorStr.h>
 #include <support/PersistentStorageMacros.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <support/logging/CHIPLogging.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/MessageCounter.h>
@@ -184,9 +185,7 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
 
     serializable.mDeviceOperationalCertProvisioned = (mDeviceOperationalCertProvisioned) ? 1 : 0;
 
-    static_assert(std::is_same<std::underlying_type<decltype(mDeviceAddress.GetTransportType())>::type, uint8_t>::value,
-                  "The underlying type of Transport::Type is not uint8_t.");
-    serializable.mDeviceTransport = static_cast<uint8_t>(mDeviceAddress.GetTransportType());
+    serializable.mDeviceTransport = to_underlying(mDeviceAddress.GetTransportType());
 
     ReturnErrorOnFailure(Inet::GetInterfaceName(mDeviceAddress.GetInterface(), Uint8::to_char(serializable.mInterfaceName),
                                                 sizeof(serializable.mInterfaceName)));

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -42,6 +42,7 @@
 #include <setup_payload/SetupPayload.h>
 #include <support/Base64.h>
 #include <support/DLLUtil.h>
+#include <support/TypeTraits.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/MessageHeader.h>
@@ -135,9 +136,7 @@ public:
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
     CHIP_ERROR SendMessage(MessageType msgType, System::PacketBufferHandle && message)
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), static_cast<uint8_t>(msgType),
-                           std::move(message));
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), std::move(message));
     }
 
     CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -33,6 +33,7 @@
 
 #include <support/DLLUtil.h>
 #include <support/Span.h>
+#include <support/TypeTraits.h>
 
 #include <stdarg.h>
 #include <stdlib.h>
@@ -1115,7 +1116,7 @@ public:
     template <typename T>
     CHIP_ERROR Put(uint64_t tag, T data)
     {
-        return Put(tag, static_cast<std::underlying_type_t<T>>(data));
+        return Put(tag, to_underlying(data));
     }
 
     /**

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -31,6 +31,7 @@
 #include <protocols/Protocols.h>
 #include <support/BitFlags.h>
 #include <support/DLLUtil.h>
+#include <support/TypeTraits.h>
 #include <system/SystemTimer.h>
 #include <transport/SecureSessionMgr.h>
 
@@ -104,9 +105,8 @@ public:
     CHIP_ERROR SendMessage(MessageType msgType, System::PacketBufferHandle && msgPayload,
                            const SendFlags & sendFlags = SendFlags(SendMessageFlags::kNone))
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), static_cast<uint8_t>(msgType),
-                           std::move(msgPayload), sendFlags);
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), std::move(msgPayload),
+                           sendFlags);
     }
 
     /**

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -32,6 +32,7 @@
 #include <protocols/Protocols.h>
 #include <support/DLLUtil.h>
 #include <support/Pool.h>
+#include <support/TypeTraits.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 
@@ -138,9 +139,8 @@ public:
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
     CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, ExchangeDelegate * delegate)
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
         return RegisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
-                                                        static_cast<uint8_t>(msgType), delegate);
+                                                        to_underlying(msgType), delegate);
     }
 
     /**
@@ -173,9 +173,8 @@ public:
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
     CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(MessageType msgType)
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
         return UnregisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
-                                                          static_cast<uint8_t>(msgType));
+                                                          to_underlying(msgType));
     }
 
     /**

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -12,6 +12,7 @@
 #include <protocols/secure_channel/StatusReport.h>
 #include <support/BufferReader.h>
 #include <support/CodeUtils.h>
+#include <support/TypeTraits.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SecureSessionMgr.h>
 
@@ -754,12 +755,10 @@ CHIP_ERROR TransferSession::VerifyProposedMode(const BitFlags<TransferControlFla
 
 void TransferSession::PrepareStatusReport(StatusCode code)
 {
-    static_assert(std::is_same<std::underlying_type_t<decltype(code)>, uint16_t>::value, "Cast is not safe");
-
     mStatusReportData.statusCode = code;
 
     Protocols::SecureChannel::StatusReport report(Protocols::SecureChannel::GeneralStatusCode::kFailure,
-                                                  Protocols::BDX::Id.ToFullyQualifiedSpecForm(), static_cast<uint16_t>(code));
+                                                  Protocols::BDX::Id.ToFullyQualifiedSpecForm(), to_underlying(code));
     size_t msgSize = report.Size();
     Encoding::LittleEndian::PacketBufferWriter bbuf(chip::MessagePacketBuffer::New(msgSize), msgSize);
     VerifyOrExit(!bbuf.IsNull(), mPendingOutput = OutputEventType::kInternalError);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -35,6 +35,7 @@
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
 #include <support/ScopedBuffer.h>
+#include <support/TypeTraits.h>
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
@@ -300,7 +301,7 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
     VerifyOrReturn(mExchangeCtxt == ec, ChipLogError(SecureChannel, "CASESession::OnResponseTimeout exchange doesn't match"));
     ChipLogError(SecureChannel,
                  "CASESession timed out while waiting for a response from the peer. Expected message type was %" PRIu8,
-                 static_cast<std::underlying_type_t<decltype(mNextExpectedMsg)>>(mNextExpectedMsg));
+                 to_underlying(mNextExpectedMsg));
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
     Clear();
 }

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -42,6 +42,7 @@
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/SafeInt.h>
+#include <support/TypeTraits.h>
 #include <transport/SecureSessionMgr.h>
 
 namespace chip {
@@ -330,7 +331,7 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
                    ChipLogError(SecureChannel, "PASESession::OnResponseTimeout exchange doesn't match"));
     ChipLogError(SecureChannel,
                  "PASESession timed out while waiting for a response from the peer. Expected message type was %" PRIu8,
-                 static_cast<std::underlying_type_t<decltype(mNextExpectedMsg)>>(mNextExpectedMsg));
+                 to_underlying(mNextExpectedMsg));
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
     Clear();
 }

--- a/src/protocols/secure_channel/StatusReport.cpp
+++ b/src/protocols/secure_channel/StatusReport.cpp
@@ -21,6 +21,7 @@
 
 #include <support/BufferReader.h>
 #include <support/CodeUtils.h>
+#include <support/TypeTraits.h>
 
 #include <type_traits>
 
@@ -77,8 +78,7 @@ CHIP_ERROR StatusReport::Parse(System::PacketBufferHandle buf)
 
 Encoding::LittleEndian::BufferWriter & StatusReport::WriteToBuffer(Encoding::LittleEndian::BufferWriter & buf) const
 {
-    static_assert(std::is_same<std::underlying_type_t<decltype(mGeneralCode)>, uint16_t>::value, "Cast is not safe");
-    buf.Put16(static_cast<uint16_t>(mGeneralCode)).Put32(mProtocolId).Put16(mProtocolCode);
+    buf.Put16(to_underlying(mGeneralCode)).Put32(mProtocolId).Put16(mProtocolCode);
     if (!mProtocolData.IsNull())
     {
         buf.Put(mProtocolData->Start(), mProtocolData->DataLength());

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -319,7 +319,7 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encod
     LittleEndian::Write16(p, mExchangeID);
     if (HaveVendorId())
     {
-        LittleEndian::Write16(p, static_cast<std::underlying_type_t<VendorId>>(mProtocolID.GetVendorId()));
+        LittleEndian::Write16(p, to_underlying(mProtocolID.GetVendorId()));
     }
     LittleEndian::Write16(p, mProtocolID.GetProtocolId());
     if (mAckId.HasValue())

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -33,6 +33,7 @@
 #include <core/PeerId.h>
 #include <protocols/Protocols.h>
 #include <support/BitFlags.h>
+#include <support/TypeTraits.h>
 #include <system/SystemPacketBuffer.h>
 
 namespace chip {
@@ -341,8 +342,7 @@ public:
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
     bool HasMessageType(MessageType type) const
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return HasProtocol(Protocols::MessageTypeTraits<MessageType>::ProtocolId()) && HasMessageType(static_cast<uint8_t>(type));
+        return HasProtocol(Protocols::MessageTypeTraits<MessageType>::ProtocolId()) && HasMessageType(to_underlying(type));
     }
 
     /**
@@ -373,8 +373,7 @@ public:
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
     PayloadHeader & SetMessageType(MessageType type)
     {
-        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        SetMessageType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), static_cast<uint8_t>(type));
+        SetMessageType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(type));
         return *this;
     }
 


### PR DESCRIPTION
Cleans up some code now that we don't have to choose between
cumbersome template bits with decltype and std::underlying_type_t and
cassting to a fixed type which might be wrong.

#### Problem
Code is uglier than it has to be.

#### Change overview
Use our shiny new to_underlying to make it less ugly.

#### Testing
Should be no behavior changes.  Normal CI tests for that.