### PR TITLE
Add some better memory safety in discovery controller code.

### DIFF
--- a/src/controller/AbstractMdnsDiscoveryController.cpp
+++ b/src/controller/AbstractMdnsDiscoveryController.cpp
@@ -31,25 +31,25 @@ namespace Controller {
 
 void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData)
 {
-    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
-    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    auto discoveredNodes = GetDiscoveredNodes();
+    for (auto & discoveredNode : discoveredNodes)
     {
-        if (!mDiscoveredNodes[i].IsValid())
+        if (!discoveredNode.IsValid())
         {
             continue;
         }
-        if (strcmp(mDiscoveredNodes[i].hostName, nodeData.hostName) == 0)
+        if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0)
         {
-            mDiscoveredNodes[i] = nodeData;
+            discoveredNode = nodeData;
             return;
         }
     }
     // Node not yet in the list
-    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    for (auto & discoveredNode : discoveredNodes)
     {
-        if (!mDiscoveredNodes[i].IsValid())
+        if (!discoveredNode.IsValid())
         {
-            mDiscoveredNodes[i] = nodeData;
+            discoveredNode = nodeData;
             return;
         }
     }
@@ -63,10 +63,10 @@ CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscovery()
     ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().StartResolver(&DeviceLayer::InetLayer, kMdnsPort));
 #endif
 
-    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
-    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
+    auto discoveredNodes = GetDiscoveredNodes();
+    for (auto & discoveredNode : discoveredNodes)
     {
-        mDiscoveredNodes[i].Reset();
+        discoveredNode.Reset();
     }
     return CHIP_NO_ERROR;
 }
@@ -74,10 +74,10 @@ CHIP_ERROR AbstractMdnsDiscoveryController::SetUpNodeDiscovery()
 const Mdns::DiscoveredNodeData * AbstractMdnsDiscoveryController::GetDiscoveredNode(int idx)
 {
     // TODO(cecille): Add assertion about main loop.
-    Mdns::DiscoveredNodeData * mDiscoveredNodes = GetDiscoveredNodes();
-    if (mDiscoveredNodes[idx].IsValid())
+    auto discoveredNodes = GetDiscoveredNodes();
+    if (0 <= idx && idx < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES && discoveredNodes.data()[idx].IsValid())
     {
-        return &mDiscoveredNodes[idx];
+        return discoveredNodes.data() + idx;
     }
     return nullptr;
 }

--- a/src/controller/AbstractMdnsDiscoveryController.h
+++ b/src/controller/AbstractMdnsDiscoveryController.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <lib/support/Span.h>
 #include <mdns/Resolver.h>
 #include <platform/CHIPDeviceConfig.h>
 
@@ -45,9 +46,10 @@ public:
     void OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNodeData & nodeData) override;
 
 protected:
+    using DiscoveredNodeList = FixedSpan<Mdns::DiscoveredNodeData, CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES>;
     CHIP_ERROR SetUpNodeDiscovery();
     const Mdns::DiscoveredNodeData * GetDiscoveredNode(int idx);
-    virtual Mdns::DiscoveredNodeData * GetDiscoveredNodes() = 0;
+    virtual DiscoveredNodeList GetDiscoveredNodes() = 0;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -55,7 +55,7 @@ public:
     }
 
 protected:
-    Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mDiscoveredCommissioners; }
+    DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mDiscoveredCommissioners); }
 
 private:
     Mdns::DiscoveredNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -348,7 +348,7 @@ protected:
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData) override;
     void OnNodeIdResolutionFailed(const chip::PeerId & peerId, CHIP_ERROR error) override;
-    Mdns::DiscoveredNodeData * GetDiscoveredNodes() override { return mCommissionableNodes; }
+    DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mCommissionableNodes); }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
     // This function uses `OperationalCredentialsDelegate` to generate the operational certificates

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -173,6 +173,13 @@ static void TestFixedByteSpan(nlTestSuite * inSuite, void * inContext)
     uint8_t arr2[] = { 3, 2, 1 };
     FixedByteSpan<3> s4(arr2);
     NL_TEST_ASSERT(inSuite, !s4.data_equal(s2));
+
+    size_t idx = 0;
+    for (auto & entry : s4)
+    {
+        NL_TEST_ASSERT(inSuite, entry == arr2[idx++]);
+    }
+    NL_TEST_ASSERT(inSuite, idx == 3);
 }
 
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)


### PR DESCRIPTION
Instead of assuming that subclasses give us a buffer of size at least CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES, just enforce that via the type system.

Also switch to ranged for loops over the resulting buffers.

The changes to Span.h are for two reasons:

1) To support ranged for over a FixedSpan.
2) To disallow constructing a FixedSpan from a buffer known to be too small.

#### Problem
Code makes assumptions about buffer sizes that are not enforced.

#### Change overview
Enforce assumptions through type system.

#### Testing
Compiles and passes CI.  Should be no behavior changes.