### PR TITLE
Fix Build on Linux (no_progress_logging) (pull_request)

### DIFF
--- a/src/app/MessageDef/SubscribeRequest.cpp
+++ b/src/app/MessageDef/SubscribeRequest.cpp
@@ -106,8 +106,8 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
                 ReturnLogErrorOnFailure(reader.Get(minInterval));
                 PRETTY_PRINT("\tMinInterval = 0x%" PRIx16 ",", minInterval);
             }
-            break;
 #endif // CHIP_DETAIL_LOGGING
+            break;
         case kCsTag_MaxInterval:
             VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxInterval)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MaxInterval);


### PR DESCRIPTION
#### Problem

`Builds / Build on Linux (no_progress_logging) (pull_request)` fails to
build due to a misplaced `break`.

#### Change overview

Move it.

#### Testing

`Builds / Build on Linux (no_progress_logging) (pull_request)`
