### PR TITLE
Fix fallthrough when logging is disabled

### DIFF
--- a/src/app/MessageDef/SubscribeRequest.cpp
+++ b/src/app/MessageDef/SubscribeRequest.cpp
@@ -106,8 +106,8 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
                 ReturnLogErrorOnFailure(reader.Get(minInterval));
                 PRETTY_PRINT("\tMinInterval = 0x%" PRIx16 ",", minInterval);
             }
-            break;
 #endif // CHIP_DETAIL_LOGGING
+            break;
         case kCsTag_MaxInterval:
             VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxInterval)), CHIP_ERROR_INVALID_TLV_TAG);
             TagPresenceMask |= (1 << kCsTag_MaxInterval);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix new presumit failure when the detailed log is disabled

#### Change overview
Move the break below to avoid the potential fallthrough when detail log is disabled.

#### Testing
The existing presubmit cover this
