### PR TITLE
Rename seconds to Ms for IM subscribe

### DIFF
--- a/src/app/MessageDef/SubscribeRequest.cpp
+++ b/src/app/MessageDef/SubscribeRequest.cpp
@@ -96,9 +96,9 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_MinInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_MinInterval);
+        case kCsTag_MinIntervalMs:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinIntervalMs)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MinIntervalMs);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -108,9 +108,9 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_MaxInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_MaxInterval);
+        case kCsTag_MaxIntervalMs:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalMs)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MaxIntervalMs);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -153,7 +153,7 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
     PRETTY_PRINT("");
     if (CHIP_END_OF_TLV == err)
     {
-        const uint16_t RequiredFields = (1 << kCsTag_MinInterval) | (1 << kCsTag_MaxInterval);
+        const uint16_t RequiredFields = (1 << kCsTag_MinIntervalMs) | (1 << kCsTag_MaxIntervalMs);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -195,14 +195,14 @@ CHIP_ERROR SubscribeRequest::Parser::GetEventNumber(uint64_t * const apEventNumb
     return GetUnsignedInteger(kCsTag_EventNumber, apEventNumber);
 }
 
-CHIP_ERROR SubscribeRequest::Parser::GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const
+CHIP_ERROR SubscribeRequest::Parser::GetMinIntervalMs(uint16_t * const apMinIntervalMs) const
 {
-    return GetUnsignedInteger(kCsTag_EventNumber, apMinIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_EventNumber, apMinIntervalMs);
 }
 
-CHIP_ERROR SubscribeRequest::Parser::GetMaxIntervalSeconds(uint16_t * const apMaxIntervalSeconds) const
+CHIP_ERROR SubscribeRequest::Parser::GetMaxIntervalMs(uint16_t * const apMaxIntervalMs) const
 {
-    return GetUnsignedInteger(kCsTag_EventNumber, apMaxIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_EventNumber, apMaxIntervalMs);
 }
 
 CHIP_ERROR SubscribeRequest::Parser::GetKeepExistingSubscriptions(bool * const apKeepExistingSubscription) const
@@ -263,21 +263,21 @@ SubscribeRequest::Builder & SubscribeRequest::Builder::EventNumber(const uint64_
     return *this;
 }
 
-SubscribeRequest::Builder & SubscribeRequest::Builder::MinIntervalSeconds(const uint16_t aMinIntervalSeconds)
+SubscribeRequest::Builder & SubscribeRequest::Builder::MinIntervalMs(const uint16_t aMinIntervalMs)
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MinInterval), aMinIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MinIntervalMs), aMinIntervalMs);
         ChipLogFunctError(mError);
     }
     return *this;
 }
 
-SubscribeRequest::Builder & SubscribeRequest::Builder::MaxIntervalSeconds(const uint16_t aMaxIntervalSeconds)
+SubscribeRequest::Builder & SubscribeRequest::Builder::MaxIntervalMs(const uint16_t aMaxIntervalMs)
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MaxInterval), aMaxIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MaxIntervalMs), aMaxIntervalMs);
         ChipLogFunctError(mError);
     }
     return *this;

--- a/src/app/MessageDef/SubscribeRequest.h
+++ b/src/app/MessageDef/SubscribeRequest.h
@@ -38,8 +38,8 @@ enum
     kCsTag_EventPathList             = 1,
     kCsTag_AttributeDataVersionList  = 2,
     kCsTag_EventNumber               = 3,
-    kCsTag_MinInterval               = 4,
-    kCsTag_MaxInterval               = 5,
+    kCsTag_MinIntervalMs             = 4,
+    kCsTag_MaxIntervalMs             = 5,
     kCsTag_KeepExistingSubscriptions = 6,
     kCsTag_IsProxy                   = 7,
 };
@@ -104,14 +104,14 @@ public:
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const;
+    CHIP_ERROR GetMinIntervalMs(uint16_t * const apMinIntervalMs) const;
 
     /**
      *  @brief Get Max Interval. Next() must be called before accessing them.
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetMaxIntervalSeconds(uint16_t * const apMaxIntervalSeconds) const;
+    CHIP_ERROR GetMaxIntervalMs(uint16_t * const apMaxIntervalMs) const;
 
     /**
      *  @brief Check if subscription is kept. Next() must be called before accessing them.
@@ -151,9 +151,9 @@ public:
      */
     SubscribeRequest::Builder & EventNumber(const uint64_t aEventNumber);
 
-    SubscribeRequest::Builder & MinIntervalSeconds(const uint16_t aMinIntervalSeconds);
+    SubscribeRequest::Builder & MinIntervalMs(const uint16_t aMinIntervalMs);
 
-    SubscribeRequest::Builder & MaxIntervalSeconds(const uint16_t aMinIntervalSeconds);
+    SubscribeRequest::Builder & MaxIntervalMs(const uint16_t aMinIntervalMs);
 
     /**
      *  @brief This is set to 'true' by the subscriber to indicate preservation of previous subscriptions. If omitted, it implies

--- a/src/app/MessageDef/SubscribeResponse.cpp
+++ b/src/app/MessageDef/SubscribeResponse.cpp
@@ -59,9 +59,9 @@ CHIP_ERROR SubscribeResponse::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_FinalSyncInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_FinalSyncInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_FinalSyncInterval);
+        case kCsTag_FinalSyncIntervalMs:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_FinalSyncIntervalMs)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_FinalSyncIntervalMs);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -80,7 +80,7 @@ CHIP_ERROR SubscribeResponse::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const uint16_t RequiredFields = (1 << kCsTag_SubscriptionId) | (1 << kCsTag_FinalSyncInterval);
+        const uint16_t RequiredFields = (1 << kCsTag_SubscriptionId) | (1 << kCsTag_FinalSyncIntervalMs);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -97,9 +97,9 @@ CHIP_ERROR SubscribeResponse::Parser::GetSubscriptionId(uint64_t * const apSubsc
     return GetUnsignedInteger(kCsTag_SubscriptionId, apSubscribeId);
 }
 
-CHIP_ERROR SubscribeResponse::Parser::GetFinalSyncIntervalSeconds(uint16_t * const apFinalSyncIntervalSeconds) const
+CHIP_ERROR SubscribeResponse::Parser::GetFinalSyncIntervalMs(uint16_t * const apFinalSyncIntervalMs) const
 {
-    return GetUnsignedInteger(kCsTag_FinalSyncInterval, apFinalSyncIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_FinalSyncIntervalMs, apFinalSyncIntervalMs);
 }
 
 CHIP_ERROR SubscribeResponse::Builder::Init(chip::TLV::TLVWriter * const apWriter)
@@ -117,11 +117,11 @@ SubscribeResponse::Builder & SubscribeResponse::Builder::SubscriptionId(const ui
     return *this;
 }
 
-SubscribeResponse::Builder & SubscribeResponse::Builder::FinalSyncIntervalSeconds(const uint16_t aFinalSyncIntervalSeconds)
+SubscribeResponse::Builder & SubscribeResponse::Builder::FinalSyncIntervalMs(const uint16_t aFinalSyncIntervalMs)
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FinalSyncInterval), aFinalSyncIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FinalSyncIntervalMs), aFinalSyncIntervalMs);
         ChipLogFunctError(mError);
     }
     return *this;

--- a/src/app/MessageDef/SubscribeResponse.h
+++ b/src/app/MessageDef/SubscribeResponse.h
@@ -31,8 +31,8 @@ namespace app {
 namespace SubscribeResponse {
 enum
 {
-    kCsTag_SubscriptionId    = 0,
-    kCsTag_FinalSyncInterval = 1,
+    kCsTag_SubscriptionId      = 0,
+    kCsTag_FinalSyncIntervalMs = 1,
 };
 
 class Parser : public chip::app::Parser
@@ -71,7 +71,7 @@ public:
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetFinalSyncIntervalSeconds(uint16_t * const apFinalSyncIntervalSeconds) const;
+    CHIP_ERROR GetFinalSyncIntervalMs(uint16_t * const apFinalSyncIntervalMs) const;
 };
 
 class Builder : public chip::app::Builder
@@ -87,7 +87,7 @@ public:
     /**
      *  @brief Final Sync Interval for the subscription back to the clients.
      */
-    SubscribeResponse::Builder & FinalSyncIntervalSeconds(const uint16_t aFinalSyncIntervalSeconds);
+    SubscribeResponse::Builder & FinalSyncIntervalMs(const uint16_t aFinalSyncIntervalMs);
 
     /**
      *  @brief Mark the end of this SubscribeResponse

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -907,10 +907,10 @@ void BuildSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter
     subscribeRequestBuilder.EventNumber(1);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
-    subscribeRequestBuilder.MinIntervalSeconds(1);
+    subscribeRequestBuilder.MinIntervalMs(1);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
-    subscribeRequestBuilder.MaxIntervalSeconds(1);
+    subscribeRequestBuilder.MaxIntervalMs(1);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
     subscribeRequestBuilder.KeepExistingSubscriptions(true);
@@ -932,8 +932,8 @@ void ParseSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader
     EventPathList::Parser eventPathListParser;
     AttributeDataVersionList::Parser attributeDataVersionListParser;
     uint64_t eventNumber          = 0;
-    uint16_t minIntervalSeconds   = 0;
-    uint16_t maxIntervalSeconds   = 0;
+    uint16_t minIntervalMs        = 0;
+    uint16_t maxIntervalMs        = 0;
     bool keepExistingSubscription = false;
     bool isProxy                  = false;
 
@@ -955,11 +955,11 @@ void ParseSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader
     err = subscribeRequestParser.GetEventNumber(&eventNumber);
     NL_TEST_ASSERT(apSuite, eventNumber == 1 && err == CHIP_NO_ERROR);
 
-    err = subscribeRequestParser.GetMinIntervalSeconds(&minIntervalSeconds);
-    NL_TEST_ASSERT(apSuite, minIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+    err = subscribeRequestParser.GetMinIntervalMs(&minIntervalMs);
+    NL_TEST_ASSERT(apSuite, minIntervalMs == 1 && err == CHIP_NO_ERROR);
 
-    err = subscribeRequestParser.GetMaxIntervalSeconds(&maxIntervalSeconds);
-    NL_TEST_ASSERT(apSuite, maxIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+    err = subscribeRequestParser.GetMaxIntervalMs(&maxIntervalMs);
+    NL_TEST_ASSERT(apSuite, maxIntervalMs == 1 && err == CHIP_NO_ERROR);
 
     err = subscribeRequestParser.GetKeepExistingSubscriptions(&keepExistingSubscription);
     NL_TEST_ASSERT(apSuite, keepExistingSubscription && err == CHIP_NO_ERROR);
@@ -979,7 +979,7 @@ void BuildSubscribeResponse(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWrite
     subscribeResponseBuilder.SubscriptionId(1);
     NL_TEST_ASSERT(apSuite, subscribeResponseBuilder.GetError() == CHIP_NO_ERROR);
 
-    subscribeResponseBuilder.FinalSyncIntervalSeconds(1);
+    subscribeResponseBuilder.FinalSyncIntervalMs(1);
     NL_TEST_ASSERT(apSuite, subscribeResponseBuilder.GetError() == CHIP_NO_ERROR);
 
     subscribeResponseBuilder.EndOfSubscribeResponse();
@@ -991,8 +991,8 @@ void ParseSubscribeResponse(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     SubscribeResponse::Parser subscribeResponseParser;
-    uint64_t subscriptionId           = 0;
-    uint16_t finalSyncIntervalSeconds = 0;
+    uint64_t subscriptionId      = 0;
+    uint16_t finalSyncIntervalMs = 0;
 
     err = subscribeResponseParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1003,8 +1003,8 @@ void ParseSubscribeResponse(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     err = subscribeResponseParser.GetSubscriptionId(&subscriptionId);
     NL_TEST_ASSERT(apSuite, subscriptionId == 1 && err == CHIP_NO_ERROR);
 
-    err = subscribeResponseParser.GetFinalSyncIntervalSeconds(&finalSyncIntervalSeconds);
-    NL_TEST_ASSERT(apSuite, finalSyncIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+    err = subscribeResponseParser.GetFinalSyncIntervalMs(&finalSyncIntervalMs);
+    NL_TEST_ASSERT(apSuite, finalSyncIntervalMs == 1 && err == CHIP_NO_ERROR);
 }
 
 void AttributePathTest(nlTestSuite * apSuite, void * apContext)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* In IM subscribe, the interval timing name should be ms instead of seconds.

#### Change overview
Fix wrong interval timing name from seconds to ms

#### Testing
The existing test cover this.
