### PR TITLE
Added buffer overflow check to ASN1Writer method.

### DIFF
--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -318,7 +318,10 @@ CHIP_ERROR EncodeChipECDSASignature(Crypto::P256ECDSASignature & signature, ASN1
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ASN1_START_BIT_STRING_ENCAPSULATED { writer.PutConstructedType(signature, (uint16_t) signature.Length()); }
+    ASN1_START_BIT_STRING_ENCAPSULATED
+    {
+        ReturnErrorOnFailure(writer.PutConstructedType(signature, (uint16_t) signature.Length()));
+    }
     ASN1_END_ENCAPSULATED;
 
 exit:

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -295,6 +295,8 @@ CHIP_ERROR ASN1Writer::PutConstructedType(const uint8_t * val, uint16_t valLen)
     // Do nothing for a null writer.
     VerifyOrReturnError(mBuf != nullptr, CHIP_NO_ERROR);
 
+    VerifyOrReturnError((mWritePoint + valLen) <= mBufEnd, ASN1_ERROR_OVERFLOW);
+
     memcpy(mWritePoint, val, valLen);
     mWritePoint += valLen;
 


### PR DESCRIPTION
#### Problem
Potential buffer overflow issue in the ASN1Writer::PutConstructedType() method.

#### Change overview
Added check

#### Testing
ASN1 Unit tests and other unit tests that use ASN1Writer