### PR TITLE
Make TestWriteHandler test something closer to the actual write flow.

### DIFF
--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -83,7 +83,6 @@ public:
                                       const Protocols::InteractionModel::ProtocolCode aProtocolCode);
 
 private:
-    friend class TestWriteInteraction;
     enum class State
     {
         Uninitialized = 0,      // The handler has not been initialized


### PR DESCRIPTION
Now that TestWriteInteraction implements WriteSingleClusterData we don't need to manually encode a success response.  We can just call OnWriteRequest and have it handle all the work.

This is still not ideal because of the manual exchange handling, but
at least it tests something closer to the codepath that would actually
run in practice.

#### Problem
TestWriteHandler tests a codepath that does not look much like our normal code.

#### Change overview
Make it test something closer to the normal thing.

#### Testing
CI still passes.