### PR TITLE
Don't reset ExchangeContext's "waiting to send" state when sending standalone ack.

### DIFF
--- a/src/protocols/Protocols.h
+++ b/src/protocols/Protocols.h
@@ -42,6 +42,8 @@ public:
         return mVendorId == aOther.mVendorId && mProtocolId == aOther.mProtocolId;
     }
 
+    constexpr bool operator!=(const Id & aOther) const { return !(*this == aOther); }
+
     // Convert the Protocols::Id to a TLV profile id.
     // NOTE: We may want to change the TLV reader/writer to take Protocols::Id
     // directly later on and get rid of this method.


### PR DESCRIPTION
This state is meant to track app-level sends, and standalone acks are
not app-level.

#### Problem
Standalone acks are being treated as "message send", necessitating workarounds in other places (e.g. in exchange context closing logic).

#### Change overview
Be more careful about what we treat as a "message send" so we can avoid the workarounds in the future.

#### Testing
Passes CI.  Will keep doing that as the workarounds are removed.