### PR TITLE
Support to use heap for pool based on actual usage for large systems

### DIFF
--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -106,6 +106,7 @@ public:
      */
     typedef void (*OnReceiveErrorFunct)(IPEndPointBasis * endPoint, CHIP_ERROR err, const IPPacketInfo * pktInfo);
 
+    IPEndPointBasis() = default;
     CHIP_ERROR SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback);
     CHIP_ERROR JoinMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress);
     CHIP_ERROR LeaveMulticastGroup(InterfaceId aInterfaceId, const IPAddress & aAddress);
@@ -178,9 +179,7 @@ private:
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 
 private:
-    IPEndPointBasis()                        = delete;
     IPEndPointBasis(const IPEndPointBasis &) = delete;
-    ~IPEndPointBasis()                       = delete;
 };
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -319,14 +319,13 @@ CHIP_ERROR InetLayer::Shutdown()
     {
 #if INET_CONFIG_ENABLE_DNS_RESOLVER
         // Cancel all DNS resolution requests owned by this instance.
-        for (size_t i = 0; i < DNSResolver::sPool.Size(); i++)
-        {
-            DNSResolver * lResolver = DNSResolver::sPool.Get(*mSystemLayer, i);
+        DNSResolver::sPool.ForEachActiveObject([&](DNSResolver * lResolver) {
             if ((lResolver != nullptr) && lResolver->IsCreatedByInetLayer(*this))
             {
                 lResolver->Cancel();
             }
-        }
+            return true;
+        });
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
 
@@ -337,38 +336,35 @@ CHIP_ERROR InetLayer::Shutdown()
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
         // Close all raw endpoints owned by this Inet layer instance.
-        for (size_t i = 0; i < RawEndPoint::sPool.Size(); i++)
-        {
-            RawEndPoint * lEndPoint = RawEndPoint::sPool.Get(*mSystemLayer, i);
+        RawEndPoint::sPool.ForEachActiveObject([&](RawEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Close();
             }
-        }
+            return true;
+        });
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
         // Abort all TCP endpoints owned by this instance.
-        for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
-        {
-            TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
+        TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Abort();
             }
-        }
+            return true;
+        });
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 #if INET_CONFIG_ENABLE_UDP_ENDPOINT
         // Close all UDP endpoints owned by this instance.
-        for (size_t i = 0; i < UDPEndPoint::sPool.Size(); i++)
-        {
-            UDPEndPoint * lEndPoint = UDPEndPoint::sPool.Get(*mSystemLayer, i);
+        UDPEndPoint::sPool.ForEachActiveObject([&](UDPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
                 lEndPoint->Close();
             }
-        }
+            return true;
+        });
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
     }
 
@@ -410,17 +406,15 @@ bool InetLayer::IsIdleTimerRunning()
 {
     bool timerRunning = false;
 
-    // see if there are any TCP connections with the idle timer check in use.
-    for (size_t i = 0; i < TCPEndPoint::sPool.Size(); i++)
-    {
-        TCPEndPoint * lEndPoint = TCPEndPoint::sPool.Get(*mSystemLayer, i);
-
+    // See if there are any TCP connections with the idle timer check in use.
+    TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
         if ((lEndPoint != nullptr) && (lEndPoint->mIdleTimeout != 0))
         {
             timerRunning = true;
-            break;
+            return false;
         }
-    }
+        return true;
+    });
 
     return timerRunning;
 }
@@ -879,40 +873,32 @@ void InetLayer::CancelResolveHostAddress(DNSResolveCompleteFunct onComplete, voi
     if (State != kState_Initialized)
         return;
 
-    for (size_t i = 0; i < DNSResolver::sPool.Size(); i++)
-    {
-        DNSResolver * lResolver = DNSResolver::sPool.Get(*mSystemLayer, i);
-
-        if (lResolver == nullptr)
-        {
-            continue;
-        }
-
+    DNSResolver::sPool.ForEachActiveObject([&](DNSResolver * lResolver) {
         if (!lResolver->IsCreatedByInetLayer(*this))
         {
-            continue;
+            return true;
         }
 
         if (lResolver->OnComplete != onComplete)
         {
-            continue;
+            return true;
         }
 
         if (lResolver->AppState != appState)
         {
-            continue;
+            return true;
         }
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
         if (lResolver->mState == DNSResolver::kState_Canceled)
         {
-            continue;
+            return true;
         }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
 
         lResolver->Cancel();
-        break;
-    }
+        return false;
+    });
 }
 
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER

--- a/src/inet/RawEndPoint.h
+++ b/src/inet/RawEndPoint.h
@@ -74,6 +74,7 @@ public:
      */
     IPProtocol IPProto; // This data member is read-only
 
+    RawEndPoint() = default;
     CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, InterfaceId intfId = INET_NULL_INTERFACEID);
     CHIP_ERROR BindIPv6LinkLocal(InterfaceId intfId, const IPAddress & addr);
     CHIP_ERROR BindInterface(IPAddressType addrType, InterfaceId intfId);
@@ -88,9 +89,7 @@ public:
     void Free();
 
 private:
-    RawEndPoint()                    = delete;
     RawEndPoint(const RawEndPoint &) = delete;
-    ~RawEndPoint()                   = delete;
 
     static chip::System::ObjectPool<RawEndPoint, INET_CONFIG_NUM_RAW_ENDPOINTS> sPool;
 

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -91,6 +91,8 @@ public:
         kState_Closed          = 8                   /**< Endpoint closed, ready for release. */
     } State;
 
+    TCPEndPoint() = default;
+
     /**
      * @brief   Bind the endpoint to an interface IP address.
      *
@@ -637,9 +639,7 @@ private:
 
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
-    TCPEndPoint();                    // not defined
     TCPEndPoint(const TCPEndPoint &); // not defined
-    ~TCPEndPoint();                   // not defined
 
     void Init(InetLayer * inetLayer);
     CHIP_ERROR DriveSending();

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -56,6 +56,8 @@ class DLL_EXPORT UDPEndPoint : public IPEndPointBasis
     friend class InetLayer;
 
 public:
+    UDPEndPoint() = default;
+
     CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId = INET_NULL_INTERFACEID);
     CHIP_ERROR BindInterface(IPAddressType addrType, InterfaceId intfId);
     InterfaceId GetBoundInterface();
@@ -69,9 +71,7 @@ public:
     void Free();
 
 private:
-    UDPEndPoint()                    = delete;
     UDPEndPoint(const UDPEndPoint &) = delete;
-    ~UDPEndPoint()                   = delete;
 
     static chip::System::ObjectPool<UDPEndPoint, INET_CONFIG_NUM_UDP_ENDPOINTS> sPool;
 

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -488,6 +488,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     testTCPEP1->Shutdown();
 }
 
+#if !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 // Test the InetLayer resource limitation
 static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
 {
@@ -496,7 +497,7 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
 #endif //
     UDPEndPoint * testUDPEP = nullptr;
     TCPEndPoint * testTCPEP = nullptr;
-    CHIP_ERROR err;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
     char numTimersTest[CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1];
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
@@ -527,6 +528,7 @@ static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
     ShutdownNetwork();
     ShutdownSystemLayer();
 }
+#endif
 
 // Test Suite
 
@@ -541,7 +543,9 @@ static const nlTest sTests[] = { NL_TEST_DEF("InetEndPoint::PreTest", TestInetPr
                                  NL_TEST_DEF("InetEndPoint::TestInetError", TestInetError),
                                  NL_TEST_DEF("InetEndPoint::TestInetInterface", TestInetInterface),
                                  NL_TEST_DEF("InetEndPoint::TestInetEndPoint", TestInetEndPointInternal),
+#if !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
                                  NL_TEST_DEF("InetEndPoint::TestEndPointLimit", TestInetEndPointLimit),
+#endif
                                  NL_TEST_SENTINEL() };
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/platform/Linux/SystemPlatformConfig.h
+++ b/src/platform/Linux/SystemPlatformConfig.h
@@ -38,6 +38,7 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_NO_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
+#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1
 
 // ========== Platform-specific Configuration Overrides =========
 

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -214,6 +214,15 @@
 #define CHIP_SYSTEM_CONFIG_MBED_LOCKING 0
 #endif /* CHIP_SYSTEM_CONFIG_MBED_LOCKING */
 
+/**
+ *  @def CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+ *
+ *  @brief
+ *      Allocate Pool from Heap for large systems (e.g. Linux).
+ */
+#ifndef CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 0
+#endif /* CHIP_SYSTEM_CONFIG_POOL_USE_HEAP */
 
 /**
  *  @def CHIP_SYSTEM_CONFIG_NO_LOCKING

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -53,9 +53,9 @@ DLL_EXPORT void Object::Release()
         this->mSystemLayer = nullptr;
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
         std::lock_guard<std::mutex> lock(*mMutexRef);
-        this->prev->next = this->next;
-        if (this->next)
-            this->next->prev = this->prev;
+        this->mPrev->mNext = this->mNext;
+        if (this->mNext)
+            this->mNext->mPrev = this->mPrev;
         delete this;
 #endif
         __sync_synchronize();

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -35,7 +35,6 @@
 // Include local headers
 #include <stddef.h>
 #include <stdlib.h>
-#include <string.h>
 
 namespace chip {
 namespace System {
@@ -52,6 +51,13 @@ DLL_EXPORT void Object::Release()
     if (oldCount == 1)
     {
         this->mSystemLayer = nullptr;
+#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+        std::lock_guard<std::mutex> lock(*mMutexRef);
+        this->prev->next = this->next;
+        if (this->next)
+            this->next->prev = this->prev;
+        delete this;
+#endif
         __sync_synchronize();
     }
     else if (oldCount == 0)

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -312,13 +312,11 @@ inline T * ObjectPool<T, N>::TryCreate(Layer & aLayer)
     {
         std::lock_guard<std::mutex> lock(mMutex);
         Object * p = &mDummyHead;
-
-        // Traverse down to the end of the list
-        while (p->next)
+        if (p->next)
         {
-            p = p->next;
+            p->next->prev = newNode;
         }
-
+        newNode->next      = p->next;
         p->next            = newNode;
         newNode->prev      = p;
         newNode->mMutexRef = &mMutex;

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -135,6 +135,8 @@ public:
         MutexedList & operator=(const MutexedList &) = delete;
     };
 
+    Timer() = default;
+
     static Timer * New(System::Layer & systemLayer, uint32_t delayMilliseconds, Timers::OnCompleteFunct onComplete,
                        void * appState);
     void Clear();

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -74,6 +74,7 @@ class TestObject : public Object
 public:
     CHIP_ERROR Init();
 
+    static void CheckIteration(nlTestSuite * inSuite, void * aContext);
     static void CheckRetention(nlTestSuite * inSuite, void * aContext);
     static void CheckConcurrency(nlTestSuite * inSuite, void * aContext);
 #if !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
@@ -134,7 +135,107 @@ struct TestContext
 struct TestContext sContext;
 } // namespace
 
+// Test Object Iteration
+
+void TestObject::CheckIteration(nlTestSuite * inSuite, void * aContext)
+{
+    TestContext & lContext = *static_cast<TestContext *>(aContext);
+    Layer lLayer;
+    unsigned int i;
+
+    lLayer.Init();
+    sPool.Reset();
+
+    for (i = 0; i < kPoolSize; ++i)
+    {
+        TestObject * lCreated = sPool.TryCreate(lLayer);
+
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
+        lCreated->Init();
+    }
+
+    i = 0;
+    sPool.ForEachActiveObject([&](TestObject * lCreated) {
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained(lLayer));
+        NL_TEST_ASSERT(lContext.mTestSuite, &(lCreated->SystemLayer()) == &lLayer);
+        i++;
+        return true;
+    });
+    NL_TEST_ASSERT(lContext.mTestSuite, i == kPoolSize);
+
+    i = 0;
+    sPool.ForEachActiveObject([&](TestObject * lCreated) {
+        i++;
+        if (i == kPoolSize / 2)
+            return false;
+
+        return true;
+    });
+    NL_TEST_ASSERT(lContext.mTestSuite, i == kPoolSize / 2);
+
+    lLayer.Shutdown();
+}
+
 // Test Object retention
+
+#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
+{
+    TestContext & lContext = *static_cast<TestContext *>(aContext);
+    Layer lLayer;
+    unsigned int i, j;
+
+    lLayer.Init();
+    sPool.Reset();
+
+    for (i = 0; i < kPoolSize; ++i)
+    {
+        TestObject * lCreated = sPool.TryCreate(lLayer);
+
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained(lLayer));
+        NL_TEST_ASSERT(lContext.mTestSuite, &(lCreated->SystemLayer()) == &lLayer);
+
+        lCreated->Init();
+
+        for (j = 0; j < kPoolSize; ++j)
+        {
+            TestObject * lGotten = sPool.Get(lLayer, j);
+
+            if (j > i)
+            {
+                NL_TEST_ASSERT(lContext.mTestSuite, lGotten == nullptr);
+            }
+            else
+            {
+                NL_TEST_ASSERT(lContext.mTestSuite, lGotten != nullptr);
+                lGotten->Retain();
+            }
+        }
+    }
+
+    for (i = 0; i < kPoolSize; ++i)
+    {
+        TestObject * lGotten = sPool.Get(lLayer, 0);
+
+        NL_TEST_ASSERT(lContext.mTestSuite, lGotten != nullptr);
+
+        for (j = 0; j < i + 1; ++j)
+        {
+            NL_TEST_ASSERT(lContext.mTestSuite, lGotten->IsRetained(lLayer));
+            lGotten->Release();
+        }
+
+        NL_TEST_ASSERT(lContext.mTestSuite, lGotten->IsRetained(lLayer));
+        lGotten->Release();
+        NL_TEST_ASSERT(lContext.mTestSuite, !lGotten->IsRetained(lLayer));
+    }
+
+    NL_TEST_ASSERT(lContext.mTestSuite, sPool.Size() == 0);
+    lLayer.Shutdown();
+}
+
+#else  // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
 void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
 {
@@ -173,11 +274,7 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
 
     for (i = 0; i < kPoolSize; ++i)
     {
-#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-        TestObject * lGotten = sPool.Get(lLayer, 0);
-#else
         TestObject * lGotten = sPool.Get(lLayer, i);
-#endif
 
         NL_TEST_ASSERT(lContext.mTestSuite, lGotten != nullptr);
 
@@ -192,19 +289,16 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
         NL_TEST_ASSERT(lContext.mTestSuite, !lGotten->IsRetained(lLayer));
     }
 
-#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-    NL_TEST_ASSERT(lContext.mTestSuite, sPool.Size() == 0);
-#else
     for (i = 0; i < kPoolSize; ++i)
     {
         TestObject * lGotten = sPool.Get(lLayer, i);
 
         NL_TEST_ASSERT(lContext.mTestSuite, lGotten == nullptr);
     }
-#endif
 
     lLayer.Shutdown();
 }
+#endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 
 // Test Object concurrency
 
@@ -240,6 +334,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
 
     for (i = 0; i < kNumObjects; ++i)
     {
+        lObject = nullptr;
         while (lObject == nullptr)
         {
             lObject = sPool.TryCreate(lLayer);
@@ -299,8 +394,6 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
             NL_TEST_ASSERT(lContext.mTestSuite, !lObject->IsRetained(lLayer));
             break;
         }
-
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject != nullptr);
     }
 
     // Cleanup
@@ -484,6 +577,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
 // clang-format off
 static const nlTest sTests[] =
 {
+    NL_TEST_DEF("Iteration",                TestObject::CheckIteration),
     NL_TEST_DEF("Retention",                TestObject::CheckRetention),
     NL_TEST_DEF("Concurrency",              TestObject::CheckConcurrency),
 #if !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP


### PR DESCRIPTION
#### Problem
What is being fixed?  
Currently, the pool implementation in Matter stack always need to be over-provisioned for the worst case because we have no idea up front what the workload will look like. Picking the right size for these pools is very hard, and reserve space from data section for each pool waste RAM and this adds up the more memory when we have more pools. 

One plausible solution to that problem is to just not use a fixed-size pool at all and instead heap-allocate the objects on large systems (e.g. Linux). On small devices which do not support heap or easily run up to dynamic allocation limit, we still reserve memory statically for those pools, but on the "large" systems, we should use dynamic allocation based on actual pool usage.

* Fixes #7716 

#### Change overview
* Add configuration to support to use heap for pool for large systems.
* Only enable CHIP_SYSTEM_CONFIG_POOL_USE_HEAP on Linux platform in this PR, will evaluate this feature on other platforms with separate PRs.

#### Testing
How was this tested? (at least one bullet point required)
* Run $ ./TestSystemObject and make sure all test pass
* Run Echo ping test and confirm the test succeed with this change.
