### PR TITLE
Refactor the exchange auto-close code into a separate method.

### DIFF
--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -195,6 +195,13 @@ private:
     bool IsResponseExpected() const;
 
     /**
+     * Determine whether we are expecting our consumer to send a message on
+     * this exchange (i.e. WillSendMessage was called and the message has not
+     * yet been sent).
+     */
+    bool IsSendExpected() const { return mFlags.Has(Flags::kFlagWillSendMessage); }
+
+    /**
      *  Track whether we are now expecting a response to a message sent via this exchange (because that
      *  message had the kExpectResponse flag set in its sendFlags).
      *
@@ -235,6 +242,12 @@ private:
     static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
 
     void DoClose(bool clearRetransTable);
+
+    /**
+     * We have handled an application-level message in some way and should
+     * re-evaluate out state to see whether we should still be open.
+     */
+    void MessageHandled();
 };
 
 } // namespace Messaging


### PR DESCRIPTION
This makes it easier to use from other places, like timeouts or send handling

#### Problem
We will want to possibly auto-close exchanges at a few different points in the code.

#### Change overview
Factor out the relevang logic into a helper method.

#### Testing
No behavior change so far; CI is passing.