### PR TITLE
Building chip-cert tool in the same location with other tools

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -183,6 +183,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     # Enable building chip with gcc & mbedtls.
     enable_host_gcc_mbedtls_build = enable_default_builds && host_os != "win"
 
+    # Build the chip-cert tool.
+    enable_standalone_chip_cert_build =
+        enable_default_builds && host_os != "win" && chip_crypto == "openssl"
+
     # Build the chip-tool example.
     enable_standalone_chip_tool_build =
         enable_default_builds && host_os != "win"
@@ -273,6 +277,12 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   standalone_toolchain = "${chip_root}/config/standalone/toolchain:standalone"
   not_needed([ "standalone_toolchain" ])  # Might not be needed.
+
+  if (enable_standalone_chip_cert_build) {
+    group("standalone_chip_cert") {
+      deps = [ "${chip_root}/src/tools/chip-cert(${standalone_toolchain})" ]
+    }
+  }
 
   if (enable_standalone_chip_tool_build) {
     group("standalone_chip_tool") {
@@ -389,6 +399,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         ":android_x64",
         ":android_x86",
       ]
+    }
+    if (enable_standalone_chip_cert_build) {
+      deps += [ ":standalone_chip_cert" ]
     }
     if (enable_standalone_chip_tool_build) {
       deps += [ ":standalone_chip_tool" ]

--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -45,4 +45,6 @@ executable("chip-cert") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]
+
+  output_dir = root_out_dir
 }


### PR DESCRIPTION
#### Problem


#### Change overview
Updated chip-cert tool to build in the same folder with other tools
Also building chip-cert tool for the standalone build

#### Testing
Visual testing that the chip-cert tool is building in the new location and also for the standalone build