### PR TITLE
Fix IM interval typo and tests

### DIFF
--- a/src/app/MessageDef/SubscribeRequest.cpp
+++ b/src/app/MessageDef/SubscribeRequest.cpp
@@ -96,27 +96,27 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_MinInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_MinInterval);
+        case kCsTag_MinIntervalSeconds:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MinIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MinIntervalSeconds);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                uint16_t minInterval;
-                ReturnLogErrorOnFailure(reader.Get(minInterval));
-                PRETTY_PRINT("\tMinInterval = 0x%" PRIx16 ",", minInterval);
+                uint16_t minIntervalSeconds;
+                ReturnLogErrorOnFailure(reader.Get(minIntervalSeconds));
+                PRETTY_PRINT("\tMinIntervalSeconds = 0x%" PRIx16 ",", minIntervalSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_MaxInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_MaxInterval);
+        case kCsTag_MaxIntervalSeconds:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_MaxIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MaxIntervalSeconds);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                uint16_t maxInterval;
-                ReturnLogErrorOnFailure(reader.Get(maxInterval));
-                PRETTY_PRINT("\tkMaxInterval = 0x%" PRIx16 ",", maxInterval);
+                uint16_t maxIntervalSeconds;
+                ReturnLogErrorOnFailure(reader.Get(maxIntervalSeconds));
+                PRETTY_PRINT("\tkMaxInterval = 0x%" PRIx16 ",", maxIntervalSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -153,7 +153,7 @@ CHIP_ERROR SubscribeRequest::Parser::CheckSchemaValidity() const
     PRETTY_PRINT("");
     if (CHIP_END_OF_TLV == err)
     {
-        const uint16_t RequiredFields = (1 << kCsTag_MinInterval) | (1 << kCsTag_MaxInterval);
+        const uint16_t RequiredFields = (1 << kCsTag_MinIntervalSeconds) | (1 << kCsTag_MaxIntervalSeconds);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -197,12 +197,12 @@ CHIP_ERROR SubscribeRequest::Parser::GetEventNumber(uint64_t * const apEventNumb
 
 CHIP_ERROR SubscribeRequest::Parser::GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const
 {
-    return GetUnsignedInteger(kCsTag_EventNumber, apMinIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_MinIntervalSeconds, apMinIntervalSeconds);
 }
 
 CHIP_ERROR SubscribeRequest::Parser::GetMaxIntervalSeconds(uint16_t * const apMaxIntervalSeconds) const
 {
-    return GetUnsignedInteger(kCsTag_EventNumber, apMaxIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_MaxIntervalSeconds, apMaxIntervalSeconds);
 }
 
 CHIP_ERROR SubscribeRequest::Parser::GetKeepExistingSubscriptions(bool * const apKeepExistingSubscription) const
@@ -267,7 +267,7 @@ SubscribeRequest::Builder & SubscribeRequest::Builder::MinIntervalSeconds(const 
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MinInterval), aMinIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MinIntervalSeconds), aMinIntervalSeconds);
         ChipLogFunctError(mError);
     }
     return *this;
@@ -277,7 +277,7 @@ SubscribeRequest::Builder & SubscribeRequest::Builder::MaxIntervalSeconds(const 
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MaxInterval), aMaxIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_MaxIntervalSeconds), aMaxIntervalSeconds);
         ChipLogFunctError(mError);
     }
     return *this;

--- a/src/app/MessageDef/SubscribeRequest.h
+++ b/src/app/MessageDef/SubscribeRequest.h
@@ -38,8 +38,8 @@ enum
     kCsTag_EventPathList             = 1,
     kCsTag_AttributeDataVersionList  = 2,
     kCsTag_EventNumber               = 3,
-    kCsTag_MinInterval               = 4,
-    kCsTag_MaxInterval               = 5,
+    kCsTag_MinIntervalSeconds        = 4,
+    kCsTag_MaxIntervalSeconds        = 5,
     kCsTag_KeepExistingSubscriptions = 6,
     kCsTag_IsProxy                   = 7,
 };
@@ -99,7 +99,7 @@ public:
     CHIP_ERROR GetEventNumber(uint64_t * const apEventNumber) const;
 
     /**
-     *  @brief Get Min Interval. Next() must be called before accessing them.
+     *  @brief Get MinIntervalSeconds. Next() must be called before accessing them.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
@@ -107,7 +107,7 @@ public:
     CHIP_ERROR GetMinIntervalSeconds(uint16_t * const apMinIntervalSeconds) const;
 
     /**
-     *  @brief Get Max Interval. Next() must be called before accessing them.
+     *  @brief Get MaxIntervalSeconds. Next() must be called before accessing them.
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */

--- a/src/app/MessageDef/SubscribeResponse.cpp
+++ b/src/app/MessageDef/SubscribeResponse.cpp
@@ -59,15 +59,15 @@ CHIP_ERROR SubscribeResponse::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_FinalSyncInterval:
-            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_FinalSyncInterval)), CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_FinalSyncInterval);
+        case kCsTag_FinalSyncIntervalSeconds:
+            VerifyOrReturnLogError(!(TagPresenceMask & (1 << kCsTag_FinalSyncIntervalSeconds)), CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_FinalSyncIntervalSeconds);
             VerifyOrReturnLogError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                uint16_t finalSyncInterval;
-                ReturnLogErrorOnFailure(reader.Get(finalSyncInterval));
-                PRETTY_PRINT("\tFinalSyncInterval = 0x%" PRIx16 ",", finalSyncInterval);
+                uint16_t finalSyncIntervalSeconds;
+                ReturnLogErrorOnFailure(reader.Get(finalSyncIntervalSeconds));
+                PRETTY_PRINT("\tFinalSyncIntervalSeconds = 0x%" PRIx16 ",", finalSyncIntervalSeconds);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -80,7 +80,7 @@ CHIP_ERROR SubscribeResponse::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const uint16_t RequiredFields = (1 << kCsTag_SubscriptionId) | (1 << kCsTag_FinalSyncInterval);
+        const uint16_t RequiredFields = (1 << kCsTag_SubscriptionId) | (1 << kCsTag_FinalSyncIntervalSeconds);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -99,7 +99,7 @@ CHIP_ERROR SubscribeResponse::Parser::GetSubscriptionId(uint64_t * const apSubsc
 
 CHIP_ERROR SubscribeResponse::Parser::GetFinalSyncIntervalSeconds(uint16_t * const apFinalSyncIntervalSeconds) const
 {
-    return GetUnsignedInteger(kCsTag_FinalSyncInterval, apFinalSyncIntervalSeconds);
+    return GetUnsignedInteger(kCsTag_FinalSyncIntervalSeconds, apFinalSyncIntervalSeconds);
 }
 
 CHIP_ERROR SubscribeResponse::Builder::Init(chip::TLV::TLVWriter * const apWriter)
@@ -121,7 +121,7 @@ SubscribeResponse::Builder & SubscribeResponse::Builder::FinalSyncIntervalSecond
 {
     if (mError == CHIP_NO_ERROR)
     {
-        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FinalSyncInterval), aFinalSyncIntervalSeconds);
+        mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_FinalSyncIntervalSeconds), aFinalSyncIntervalSeconds);
         ChipLogFunctError(mError);
     }
     return *this;

--- a/src/app/MessageDef/SubscribeResponse.h
+++ b/src/app/MessageDef/SubscribeResponse.h
@@ -31,8 +31,8 @@ namespace app {
 namespace SubscribeResponse {
 enum
 {
-    kCsTag_SubscriptionId    = 0,
-    kCsTag_FinalSyncInterval = 1,
+    kCsTag_SubscriptionId           = 0,
+    kCsTag_FinalSyncIntervalSeconds = 1,
 };
 
 class Parser : public chip::app::Parser
@@ -66,7 +66,7 @@ public:
     CHIP_ERROR GetSubscriptionId(uint64_t * const apSubscriptionId) const;
 
     /**
-     *  @brief Get FinalSyncInterval. Next() must be called before accessing them.
+     *  @brief Get FinalSyncIntervalSeconds. Next() must be called before accessing them.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -908,10 +908,10 @@ void BuildSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter
     subscribeRequestBuilder.EventNumber(1);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
-    subscribeRequestBuilder.MinIntervalSeconds(1);
+    subscribeRequestBuilder.MinIntervalSeconds(2);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
-    subscribeRequestBuilder.MaxIntervalSeconds(1);
+    subscribeRequestBuilder.MaxIntervalSeconds(3);
     NL_TEST_ASSERT(apSuite, subscribeRequestBuilder.GetError() == CHIP_NO_ERROR);
 
     subscribeRequestBuilder.KeepExistingSubscriptions(true);
@@ -957,10 +957,10 @@ void ParseSubscribeRequest(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader
     NL_TEST_ASSERT(apSuite, eventNumber == 1 && err == CHIP_NO_ERROR);
 
     err = subscribeRequestParser.GetMinIntervalSeconds(&minIntervalSeconds);
-    NL_TEST_ASSERT(apSuite, minIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, minIntervalSeconds == 2 && err == CHIP_NO_ERROR);
 
     err = subscribeRequestParser.GetMaxIntervalSeconds(&maxIntervalSeconds);
-    NL_TEST_ASSERT(apSuite, maxIntervalSeconds == 1 && err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, maxIntervalSeconds == 3 && err == CHIP_NO_ERROR);
 
     err = subscribeRequestParser.GetKeepExistingSubscriptions(&keepExistingSubscription);
     NL_TEST_ASSERT(apSuite, keepExistingSubscription && err == CHIP_NO_ERROR);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
For IM subscribe min/max interval, it uses wrong tag inside

#### Change overview
Update the right tag for min/max internal in IM subscribe min/max interval

#### Testing
Previously the test use same value, 1 for event number, update test with different value so that it would catch this error.
