### PR TITLE
Updated IM Prototype

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -4903,7 +4903,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV

--- a/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
@@ -904,7 +904,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV

--- a/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
@@ -2447,7 +2447,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2683,6 +2683,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             }
             break;
         }
+
         case Clusters::NetworkCommissioning::Commands::Ids::EnableNetwork: {
             expectArgumentCount = 3;
             chip::ByteSpan networkID;

--- a/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
@@ -368,7 +368,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -2586,7 +2586,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV

--- a/examples/window-app/common/gen/IMClusterCommandHandler.cpp
+++ b/examples/window-app/common/gen/IMClusterCommandHandler.cpp
@@ -242,7 +242,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
+void __attribute__((weak)) DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aCommandId, EndpointId aEndpointId,
                            TLV::TLVReader & aDataTlv)
 {
     // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV

--- a/gen-v2/device/BUILD.gn
+++ b/gen-v2/device/BUILD.gn
@@ -1,0 +1,47 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("includes") {
+  include_dirs = [ "." ]
+}
+
+static_library("device") {
+  output_name = "libDeviceSchema"
+
+  sources = [
+    "TestCluster.cpp",
+    "TestCluster.h",
+    "TestCluster-Gen.h",
+
+    "NetworkCommissioningCluster.cpp",
+    "NetworkCommissioningCluster.h",
+    "NetworkCommissioningCluster-Gen.h"
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/app",
+    "${chip_root}/src/app/gen-utils:gen-utils-device"
+  ]
+
+  public_configs = [
+    "${chip_root}/src/app:app_config",
+    ":includes"
+  ]
+
+  defines = []
+}

--- a/gen-v2/device/NetworkCommissioningCluster-Gen.h
+++ b/gen-v2/device/NetworkCommissioningCluster-Gen.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include "NetworkCommissioningCluster.h"
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace NetworkCommissioningCluster {
+    namespace AddThreadNetworkCommand {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            chip::ByteSpan OperationalDataSet;
+            uint64_t Breadcrumb;
+            uint32_t TimeoutMs; 
+
+            chip::ClusterId GetClusterId() { return kClusterId; }
+            chip::CommandId GetCommandId() { return kAddThreadNetworkRequestCommandId; }
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+
+    namespace AddWifiNetworkCommand {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            chip::ByteSpan Ssid;
+            chip::ByteSpan Credentials;
+            uint64_t Breadcrumb;
+            uint32_t TimeoutMs; 
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+    
+    namespace EnableNetworkCommand {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            chip::ByteSpan NetworkId;
+            uint64_t Breadcrumb;
+            uint32_t TimeoutMs; 
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/device/NetworkCommissioningCluster.cpp
+++ b/gen-v2/device/NetworkCommissioningCluster.cpp
@@ -1,0 +1,83 @@
+#include "NetworkCommissioningCluster-Gen.h"
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace NetworkCommissioningCluster {
+    namespace AddThreadNetworkCommand {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, OperationalDataSet), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, Breadcrumb), sizeof(Type::Breadcrumb)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, TimeoutMs), sizeof(Type::TimeoutMs)};
+
+            return r;
+        }
+
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets)
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+
+    namespace AddWifiNetworkCommand {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, Ssid), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, Credentials), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, Breadcrumb), sizeof(Type::Breadcrumb)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, TimeoutMs), sizeof(Type::TimeoutMs)};
+
+            return r;
+        }
+
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets)
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+
+    namespace EnableNetworkCommand {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, NetworkId), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, Breadcrumb), sizeof(Type::Breadcrumb)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, TimeoutMs), sizeof(Type::TimeoutMs)};
+
+            return r;
+        }
+
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets)
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+}
+}
+}
+}

--- a/gen-v2/device/NetworkCommissioningCluster.h
+++ b/gen-v2/device/NetworkCommissioningCluster.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <type_traits>
+#include <array>
+#include <device/SchemaTypes.h>
+#include <basic-types.h>
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace NetworkCommissioningCluster {
+    constexpr chip::ClusterId kClusterId = 0x0031;
+
+    enum CommandId {
+        kScanNetworksRequestCommandId = 0,
+        kScanNetworksRespCommandId = 1,
+        kAddWifiNetworkRequestCommandId = 2,
+        kAddWifiNetworkResponseCommandId = 3,
+        kUpdateWifiNetworkRequestCommandId = 4,
+        kUpdateWifiNetworkResponseCommandId = 5,
+        kAddThreadNetworkRequestCommandId = 6,
+        kAddThreadNetworkResponseCommandId = 7,
+        kUpdateThreadNetworkRequestCommandId = 8,
+        kUpdateThreadNetworkResponseCommandId = 9,
+        kRemoveNetworkRequestCommandId = 10,
+        kRemoveNetworkResponseCommandId = 11,
+        kEnableNetworkRequestCommandId = 12,
+        kEnableNetworkResponseCommandId = 13,
+        kDisableNetworkRequestCommandId = 14,
+        kDisableNetworkResponseCommandId = 15,
+        kGetLastNetworkCommissioningResultRequestCommandId = 16
+    };
+
+    namespace AddThreadNetworkCommand {
+        enum FieldId {
+            kOperationalDatasetFieldId = 0,
+            kBreadcrumbFieldId = 1,
+            kTimeoutMsFieldId = 2
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kOperationalDatasetFieldId,    BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kBreadcrumbFieldId,            BitFlags<Type>(Type::TYPE_UINT64),      kNone,   0,       {}},
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+
+    namespace AddWifiNetworkCommand {
+        enum FieldId {
+            kSsidFieldId = 0,
+            kCredentialsFieldId = 1,
+            kBreadcrumbFieldId = 2,
+            kTimeoutMsFieldId = 3
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kSsidFieldId,                  BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kCredentialsFieldId,           BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kBreadcrumbFieldId,            BitFlags<Type>(Type::TYPE_UINT64),      kNone,   0,       {}},
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+
+    namespace DisableNetworkCommand {
+        enum FieldId {
+            kNetworkId = 0,
+            kBreadcrumbFieldId = 1,
+            kTimeoutMsFieldId = 2
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kNetworkId,                    BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kBreadcrumbFieldId,            BitFlags<Type>(Type::TYPE_UINT64),      kNone,   0,       {}},
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+
+    namespace EnableNetworkCommand {
+        enum FieldId {
+            kNetworkId = 0,
+            kBreadcrumbFieldId = 1,
+            kTimeoutMsFieldId = 2
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kNetworkId,                    BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kBreadcrumbFieldId,            BitFlags<Type>(Type::TYPE_UINT64),      kNone,   0,       {}},
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+
+    namespace RemoveNetworkCommand {
+        enum FieldId {
+            kNetworkId = 0,
+            kBreadcrumbFieldId = 1,
+            kTimeoutMsFieldId = 2
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kNetworkId,                    BitFlags<Type>(Type::TYPE_OCTSTR),      kNone,   0,       {}},
+            {kBreadcrumbFieldId,            BitFlags<Type>(Type::TYPE_UINT64),      kNone,   0,       {}},
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+    
+    
+    namespace GetLastNetworkCommissioningResultCommand {
+        enum FieldId {
+            kTimeoutMsFieldId = 0
+        };
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kTimeoutMsFieldId,             BitFlags<Type>(Type::TYPE_UINT32),      kNone,   0,       {}} 
+        };
+    };
+}
+}
+}
+}

--- a/gen-v2/device/TestCluster-Gen.h
+++ b/gen-v2/device/TestCluster-Gen.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include "TestCluster.h"
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster {
+    namespace StructA {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            uint8_t x;
+            uint8_t y;
+            chip::ByteSpan l;
+            chip::Span<char> m;
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+    
+    namespace StructB {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            uint8_t x;
+            uint8_t y;
+            StructA::Type z;
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+
+    namespace StructC {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            struct empty {};
+
+            uint8_t a;
+            uint8_t b;
+            StructA::Type c;
+            chip::Span<uint8_t> d;
+            chip::Span<StructA::Type> e;
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+
+    namespace CommandA {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            struct empty {};
+
+            uint8_t a;
+            uint8_t b;
+            StructA::Type c;
+            chip::Span<uint8_t> d;
+
+            static chip::ClusterId GetClusterId() { return kClusterId; }
+            static chip::CommandId GetCommandId() { return kCommandAId; }
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+    
+    namespace CommandB {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            struct empty {};
+
+            uint8_t a;
+            uint8_t b;
+            StructA::Type c;
+            chip::Span<uint8_t> d;
+            chip::Span<StructA::Type> e;
+
+            static chip::ClusterId GetClusterId() { return kClusterId; }
+            static chip::CommandId GetCommandId() { return kCommandBId; }
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+
+    namespace Attributes {
+        constexpr int NumImplementedFields = GetNumImplementedFields(_Schema);
+        extern const StructDescriptor<NumImplementedFields> Descriptor;
+        
+        struct Type {
+            struct empty {};
+
+            typedef typename std::conditional<IsImplemented(FieldC), uint32_t, empty>::type FieldCType;
+            typedef typename std::conditional<IsImplemented(FieldD), uint8_t, empty>::type FieldDType;
+
+            uint8_t a;
+            uint8_t b;
+            FieldCType c;
+            FieldDType d;
+            chip::Span<uint8_t> e;
+            StructB::Type f;
+
+            static const StructDescriptor<NumImplementedFields> &mDescriptor;
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/device/TestCluster.cpp
+++ b/gen-v2/device/TestCluster.cpp
@@ -1,0 +1,181 @@
+#include "TestCluster-Gen.h"
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster {
+    namespace StructA {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, x), sizeof(Type::x)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, y), sizeof(Type::y)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, l), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, m), sizeof(char)};
+
+            return r;
+        }
+
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets)
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+
+    namespace StructB {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, x), sizeof(Type::x)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, y), sizeof(Type::y)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, z), sizeof(Type::z)};
+
+            return r;
+        }
+        
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets,
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}))
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+    
+    namespace StructC {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, a), sizeof(Type::a)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, b), sizeof(Type::b)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, c), sizeof(Type::c)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, d), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, e), sizeof(StructA::Type)};
+
+            return r;
+        }
+        
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets,
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}),
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}))
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+
+    namespace CommandA {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, a), sizeof(Type::a)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, b), sizeof(Type::b)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, c), sizeof(Type::c)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, d), sizeof(uint8_t)};
+
+            return r;
+        }
+        
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets,
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}))
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+   
+    namespace CommandB {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, a), sizeof(Type::a)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, b), sizeof(Type::b)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, c), sizeof(Type::c)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, d), sizeof(uint8_t)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, e), sizeof(StructA::Type)};
+
+            return r;
+        }
+        
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+        
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets,
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}),
+                chip::Span<const CompactFieldDescriptor>({StructA::Descriptor.FieldList.data(), StructA::Descriptor.FieldList.size()}))
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+
+    namespace Attributes {
+        constexpr std::array<TypeOffsetInfo,NumImplementedFields> InitializeOffsets() {
+            using result_t = ::std::array<TypeOffsetInfo, NumImplementedFields>;
+            result_t r = {};
+            const result_t& const_r = r;
+
+            uint32_t i = 0;
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, a), sizeof(Type::a)};
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, b), sizeof(Type::b)};
+
+            if (IsImplemented(FieldC)) {
+                const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, c), sizeof(Type::c)};
+            }
+
+            if (IsImplemented(FieldD)) {
+                const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, d), sizeof(Type::d)};
+            }
+
+            if (IsImplemented(FieldE)) {
+                const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, e), sizeof(uint8_t)};
+            }
+
+            const_cast<typename result_t::reference>(const_r[i++]) = {offsetof(struct Type, f), sizeof(Type::f)};
+
+            return r;
+        }
+        
+        constexpr std::array<TypeOffsetInfo, NumImplementedFields> Offsets = InitializeOffsets();
+
+        const StructDescriptor<NumImplementedFields> Descriptor = {
+            .FieldList = PopulateFieldDescriptors<NumImplementedFields, ArraySize(_Schema)>(_Schema, Offsets,
+                chip::Span<const CompactFieldDescriptor>({StructB::Descriptor.FieldList.data(), StructB::Descriptor.FieldList.size()})
+            )
+        };
+
+        const StructDescriptor<NumImplementedFields>& Type::mDescriptor = Descriptor;
+    }
+}
+}
+}
+}

--- a/gen-v2/device/TestCluster.h
+++ b/gen-v2/device/TestCluster.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <type_traits>
+#include <array>
+#include <device/SchemaTypes.h>
+#include <basic-types.h>
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster {
+    constexpr chip::ClusterId kClusterId = 0x000000001;
+    
+    enum CommandId {
+        kCommandAId = 1,
+        kCommandBId = 2
+    };
+
+    namespace StructA {
+        enum FieldId {
+            kFieldIdJ = 0,
+            kFieldIdK = 1,
+            kFieldIdL = 2,
+            kFieldIdM = 3
+        };
+
+        constexpr uint64_t FieldJ = (0x00000001ULL << 32) | 0x0b;
+        constexpr uint64_t FieldK = (0x00000001ULL << 32) | 0x0c;
+        constexpr uint64_t FieldL = (0x00000001ULL << 32) | 0x20;
+        constexpr uint64_t FieldM = (0x00000001ULL << 32) | 0x21;
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdJ, Type::TYPE_UINT8,   kNone,                  FieldJ, {}},
+            {kFieldIdK, Type::TYPE_UINT8,   kNullable,              FieldK, {}},
+            {kFieldIdL, Type::TYPE_OCTSTR,  kNone,                  FieldL, {}},
+            {kFieldIdM, Type::TYPE_STRING,  kNone,                  FieldM, {}},
+        };
+    }
+    
+    namespace StructB {
+        enum FieldId {
+            kFieldIdX = 0,
+            kFieldIdY = 1,
+            kFieldIdZ = 2
+        };
+
+        constexpr uint64_t FieldX = (0x00000001ULL << 32) | 0x08;
+        constexpr uint64_t FieldY = (0x00000001ULL << 32) | 0x09;
+        constexpr uint64_t FieldZ = (0x00000001ULL << 32) | 0x0a;
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdX, Type::TYPE_UINT8, kNone,                  FieldX, {}},
+            {kFieldIdY, Type::TYPE_UINT8, kNullable,              FieldY, {}},
+            {kFieldIdZ, Type::TYPE_STRUCT, 0,                     FieldZ, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+        };
+    }
+
+    namespace StructC {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+
+        constexpr uint64_t FieldA = (0x00000001ULL << 32) | 0x0d;
+        constexpr uint64_t FieldB = (0x00000001ULL << 32) | 0x0e;
+        constexpr uint64_t FieldC = (0x00000001ULL << 32) | 0x0f;
+        constexpr uint64_t FieldD = (0x00000001ULL << 32) | 0x10;
+        constexpr uint64_t FieldE = (0x00000001ULL << 32) | 0x11;
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdA, Type::TYPE_UINT8,           kNone,                  FieldA, {}},
+            {kFieldIdB, Type::TYPE_UINT8,           kNullable,              FieldB, {}},
+            {kFieldIdC, Type::TYPE_STRUCT,          0,                      FieldC, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+            {kFieldIdD, BitFlags<Type>(Type::TYPE_ARRAY)
+                        .Set(Type::TYPE_UINT8),     0,                      FieldD, {}},
+            {kFieldIdE, BitFlags<Type>(Type::TYPE_ARRAY)
+                        .Set(Type::TYPE_STRUCT),    0,                      FieldE, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+        };
+    }
+
+    namespace CommandA {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+        };
+
+        constexpr uint64_t FieldA = (0x00000001ULL << 32) | 0x12;
+        constexpr uint64_t FieldB = (0x00000001ULL << 32) | 0x13;
+        constexpr uint64_t FieldC = (0x00000001ULL << 32) | 0x14;
+        constexpr uint64_t FieldD = (0x00000001ULL << 32) | 0x15;
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdA, Type::TYPE_UINT8,           kNone,                  FieldA, {}},
+            {kFieldIdB, Type::TYPE_UINT8,           kNullable,              FieldB, {}},
+            {kFieldIdC, Type::TYPE_STRUCT,          0,                      FieldC, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+            {kFieldIdD, BitFlags<Type>(Type::TYPE_ARRAY)
+                        .Set(Type::TYPE_UINT8),     0,                      FieldD, {}},
+        };
+    }
+
+    namespace CommandB {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+
+        constexpr uint64_t FieldA = (0x00000001ULL << 32) | 0x16;
+        constexpr uint64_t FieldB = (0x00000001ULL << 32) | 0x17;
+        constexpr uint64_t FieldC = (0x00000001ULL << 32) | 0x18;
+        constexpr uint64_t FieldD = (0x00000001ULL << 32) | 0x19;
+        constexpr uint64_t FieldE = (0x00000001ULL << 32) | 0x1a;
+
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdA, Type::TYPE_UINT8,           kNone,                  FieldA, {}},
+            {kFieldIdB, Type::TYPE_UINT8,           kNullable,              FieldB, {}},
+            {kFieldIdC, Type::TYPE_STRUCT,          0,                      FieldC, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+            {kFieldIdD, BitFlags<Type>(Type::TYPE_ARRAY)
+                        .Set(Type::TYPE_UINT8),     0,                      FieldD, {}},
+            {kFieldIdE, BitFlags<Type>(Type::TYPE_ARRAY)
+                        .Set(Type::TYPE_STRUCT),    0,                      FieldE, {StructA::_Schema, ArraySize(StructA::_Schema)}},
+        };
+    }
+
+    namespace Attributes {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+            kFieldIdF = 5
+        };
+
+        constexpr uint64_t FieldA = (0x00000001ULL << 32) | 0x01;
+        constexpr uint64_t FieldB = (0x00000001ULL << 32) | 0x02;
+        constexpr uint64_t FieldC = (0x00000001ULL << 32) | 0x04;
+        constexpr uint64_t FieldD = (0x00000001ULL << 32) | 0x05;
+        constexpr uint64_t FieldE = (0x00000001ULL << 32) | 0x06;
+        constexpr uint64_t FieldF = (0x00000001ULL << 32) | 0x07;
+        
+        constexpr FullFieldDescriptor _Schema[] = {
+            {kFieldIdA, Type::TYPE_UINT8,           kNone,                  FieldA,     {}},
+            {kFieldIdB, Type::TYPE_UINT8,           kNullable,              FieldB,     {}},
+            {kFieldIdC, Type::TYPE_UINT32,          kOptional | kNullable,  FieldC,     {}},
+            {kFieldIdD, Type::TYPE_UINT8,           kOptional | kNullable,  FieldD,     {}},
+            {kFieldIdE, BitFlags<Type>(Type::TYPE_ARRAY).Set(Type::TYPE_UINT8), kNone,                  FieldF,     {}},
+            {kFieldIdF, Type::TYPE_STRUCT,          kNone,                  FieldE,     {StructB::_Schema, ArraySize(StructB::_Schema)}},
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/device/TestCluster2-Gen.h
+++ b/gen-v2/device/TestCluster2-Gen.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <vector>
+#include <string>
+#include <basic-types.h>
+#include <IEncodableElement.h>
+#include <device/SchemaUtils.h>
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster2 {
+    constexpr chip::ClusterId kClusterId = 0x000000001;
+
+    enum CommandId {
+        kCommandAId = 1,
+        kCommandBId = 2
+    };
+    
+    namespace StructA {
+        enum FieldId {
+            kFieldIdJ = 0,
+            kFieldIdK = 1,
+            kFieldIdL = 2,
+            kFieldIdM = 3
+        };
+        
+        struct Type {
+                uint8_t x;
+                uint8_t y;
+                chip::ByteSpan l;
+                chip::Span<char> m;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag);
+                CHIP_ERROR Decode(TLV::TLVReader &reader);
+        };
+    }
+
+    namespace StructC {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+        
+        struct Type {
+            public:
+                struct empty {};
+
+            public:
+                uint8_t a;
+                uint8_t b;
+                StructA::Type c;
+                chip::Span<uint8_t> d;
+                chip::Span<StructA::Type> e;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag);
+                CHIP_ERROR Decode(TLV::TLVReader &reader);
+        };
+    }
+
+    namespace IteratableStructC {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+        
+        struct Type {
+            public:
+                struct empty {};
+
+            public:
+                uint8_t a;
+                uint8_t b;
+                StructA::Type c;
+                IteratableList<uint8_t> d;
+                IteratableList<StructA::Type> e;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag);
+                CHIP_ERROR Decode(TLV::TLVReader &reader);
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/device/TestCluster2.cpp
+++ b/gen-v2/device/TestCluster2.cpp
@@ -1,0 +1,181 @@
+#include "TestCluster2-Gen.h"
+#include "core/CHIPTLVTags.h"
+#include "core/CHIPTLVTypes.h"
+
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster2 {
+    namespace StructA {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdJ), x));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdK), y));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdL), l.data(), l.size()));
+            ReturnErrorOnFailure(writer.PutString(TLV::ContextTag(kFieldIdM), m.data(), m.size()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdJ)) {
+                    ReturnErrorOnFailure(reader.Get(x));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdK)) {
+                    ReturnErrorOnFailure(reader.Get(y));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdL)) {
+                   const uint8_t *p;
+                   ReturnErrorOnFailure(reader.GetDataPtr(p));
+                   l = chip::ByteSpan(p, reader.GetLength());
+                }
+                else if (tag == TLV::ContextTag(kFieldIdM)) {
+                   const uint8_t *p;
+                   ReturnErrorOnFailure(reader.GetDataPtr(p));
+                   m = chip::Span<char>((char *)p, reader.GetLength());
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace StructC {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdA), a));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdB), b));
+            ReturnErrorOnFailure(c.Encode(writer, TLV::ContextTag(kFieldIdC)));
+
+            {
+                TLV::TLVType outer1;
+                ReturnErrorOnFailure(writer.StartContainer(TLV::ContextTag(kFieldIdD), TLV::kTLVType_Array, outer1));
+                for (auto item : d) {
+                    ReturnErrorOnFailure(writer.Put(TLV::AnonymousTag, item));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(outer1));
+            }
+            
+            {
+                TLV::TLVType outer1;
+                ReturnErrorOnFailure(writer.StartContainer(TLV::ContextTag(kFieldIdE), TLV::kTLVType_Array, outer1));
+                for (auto item : e) {
+                    ReturnErrorOnFailure(item.Encode(writer, TLV::AnonymousTag));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(outer1));
+            }
+
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdA)) {
+                    ReturnErrorOnFailure(reader.Get(a));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdB)) {
+                    ReturnErrorOnFailure(reader.Get(b));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdC)) {
+                    ReturnErrorOnFailure(c.Decode(reader));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdD)) {
+                    TLV::TLVType outer1;
+                    size_t destBufSize = d.size();
+                    uint32_t i = 0;
+
+                    ReturnErrorOnFailure(reader.EnterContainer(outer1));
+
+                    while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                        VerifyOrReturnError(destBufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+                        ReturnErrorOnFailure(reader.Get(d.data()[i]));
+                    }
+
+                    ReturnErrorOnFailure(reader.ExitContainer(outer1));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdE)) {
+                    TLV::TLVType outer1;
+                    size_t destBufSize = e.size();
+                    uint32_t i = 0;
+
+                    ReturnErrorOnFailure(reader.EnterContainer(outer1));
+
+                    while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                        VerifyOrReturnError(destBufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+                        ReturnErrorOnFailure(e.data()[i].Decode(reader));
+                    }
+
+                    ReturnErrorOnFailure(reader.ExitContainer(outer1));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace IteratableStructC {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            return CHIP_ERROR_BAD_REQUEST;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdA)) {
+                    ReturnErrorOnFailure(reader.Get(a));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdB)) {
+                    ReturnErrorOnFailure(reader.Get(b));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdC)) {
+                    ReturnErrorOnFailure(c.Decode(reader));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdD)) {
+                    d.SetReader(reader);
+                }
+                else if (tag == TLV::ContextTag(kFieldIdE)) {
+                    e.SetReader(reader);
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+}
+}
+}
+}

--- a/gen-v2/stl/BUILD.gn
+++ b/gen-v2/stl/BUILD.gn
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("includes") {
+  include_dirs = [ "." ]
+}
+
+static_library("stl") {
+  output_name = "libStlSchema"
+
+  sources = [
+    "OperationalCredentialCluster.cpp",
+    "OperationalCredentialCluster-Gen.h",
+    "TestCluster.cpp",
+    "TestCluster-Gen.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/app"
+  ]
+
+  public_configs = [
+    "${chip_root}/src/app:app_config",
+    ":includes"
+  ]
+
+  defines = []
+}

--- a/gen-v2/stl/OperationalCredentialCluster-Gen.h
+++ b/gen-v2/stl/OperationalCredentialCluster-Gen.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <vector>
+#include <string>
+#include <basic-types.h>
+#include <IEncodableElement.h>
+
+namespace chip {
+namespace app {
+namespace Cluster {
+namespace OperationalCredentialCluster {
+    const chip::ClusterId kClusterId = 0x003E;
+    
+    namespace AddOpCert {
+        enum FieldId {
+            kFieldIdNoc = 0,
+            kFieldIdIpkValue = 1,
+            kFieldIdCaseAdminNode = 2,
+            kFieldIdAdminVendorId = 3
+        };
+        
+        struct Type : public IEncodableElement {
+                std::vector<uint8_t> noc;
+                std::vector<uint8_t> ipkValue;
+                chip::NodeId caseAdminNode;
+                int16_t adminVendorId;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+                static uint16_t GetCommandId() { return 0x06; }
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+    
+    namespace OpCertResponse {
+        enum FieldId {
+            kFieldIdStatusCode = 0,
+            kFieldIdFabricIndex = 1,
+            kFieldIdDebugText = 2
+        };
+        
+        struct Type : public IEncodableElement {
+                int8_t statusCode;
+                int64_t fabricIndex;
+                std::string debugText;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+
+                //
+                // TODO: This SHOULD be 0x08, but because the device side sends back a faulty status 
+                // response, we need to switch this back to 0x06.
+                //
+                static chip::CommandId GetCommandId() { return 0x06; }
+                
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+
+    namespace OpCsrRequest {
+        enum FieldID {
+            kFieldIdCsrNonce = 0
+        };
+        
+        struct Type : public IEncodableElement {
+                std::vector<uint8_t> csrNonce;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+                static chip::CommandId GetCommandId() { return 0x04; }
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+
+    namespace OpCsrResponse {
+        enum FieldID {
+            kFieldIdCsr = 0,
+            kFieldIdCsrNonce = 1,
+            kFieldIdVendorReserved1 = 2,
+            kFieldIdVendorReserved2 = 3,
+            kFieldIdVendorReserved3 = 4,
+            kFieldIdSignature = 5
+        };
+        
+        struct Type : public IEncodableElement {
+                std::vector<uint8_t> csr;
+                std::vector<uint8_t> csrNonce;
+                std::vector<uint8_t> vendorReserved1;
+                std::vector<uint8_t> vendorReserved2;
+                std::vector<uint8_t> vendorReserved3;
+                std::vector<uint8_t> signature;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+                static chip::CommandId GetCommandId() { return 0x05; }
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/stl/OperationalCredentialCluster.cpp
+++ b/gen-v2/stl/OperationalCredentialCluster.cpp
@@ -1,0 +1,187 @@
+#include "OperationalCredentialCluster-Gen.h"
+#include "core/CHIPTLVTags.h"
+#include "core/CHIPTLVTypes.h"
+
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace OperationalCredentialCluster {
+    namespace AddOpCert {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdNoc), &noc[0], noc.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdIpkValue), &ipkValue[0], ipkValue.size()));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdCaseAdminNode), caseAdminNode));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdAdminVendorId), adminVendorId));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdNoc)) {
+                   noc.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(noc.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdIpkValue)) {
+                   ipkValue.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(ipkValue.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdCaseAdminNode)) {
+                    ReturnErrorOnFailure(reader.Get(caseAdminNode));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdAdminVendorId)) {
+                    ReturnErrorOnFailure(reader.Get(adminVendorId));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace OpCertResponse {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdStatusCode), statusCode));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdFabricIndex), fabricIndex));
+            ReturnErrorOnFailure(writer.PutString(TLV::ContextTag(kFieldIdDebugText), debugText.c_str(), debugText.length()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+
+                if (tag == TLV::ContextTag(kFieldIdStatusCode)) {
+                    ReturnErrorOnFailure(reader.Get(statusCode));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdFabricIndex)) {
+                    ReturnErrorOnFailure(reader.Get(fabricIndex));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdDebugText)) {
+                   int len = reader.GetLength() + 1;
+                   char tmp[len];
+                   ReturnErrorOnFailure(reader.GetString(tmp, len + 1));
+                   debugText = std::string(tmp, len + 1);
+                   debugText.resize(len - 1);
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace OpCsrRequest {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdCsrNonce), &csrNonce[0], csrNonce.size()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdCsrNonce)) {
+                   csrNonce.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(csrNonce.data(), reader.GetLength()));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace OpCsrResponse {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdCsr), &csr[0], csr.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdCsrNonce), &csrNonce[0], csrNonce.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdVendorReserved1), &vendorReserved1[0], vendorReserved1.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdVendorReserved2), &vendorReserved2[0], vendorReserved2.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdVendorReserved3), &vendorReserved3[0], vendorReserved3.size()));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdSignature), &signature[0], signature.size()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdCsr)) {
+                   csr.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(csr.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdCsrNonce)) {
+                   csrNonce.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(csrNonce.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdVendorReserved1)) {
+                   vendorReserved1.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(vendorReserved1.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdVendorReserved2)) {
+                   vendorReserved2.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(vendorReserved2.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdVendorReserved3)) {
+                   vendorReserved3.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(vendorReserved3.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdSignature)) {
+                   signature.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(signature.data(), reader.GetLength()));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+}
+}
+}
+}

--- a/gen-v2/stl/TestCluster-Gen.h
+++ b/gen-v2/stl/TestCluster-Gen.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <array>
+#include <type_traits>
+#include <vector>
+#include <string>
+#include <basic-types.h>
+#include <IEncodableElement.h>
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster {
+    constexpr chip::ClusterId kClusterId = 0x000000001;
+
+    enum CommandId {
+        kCommandAId = 1,
+        kCommandBId = 2
+    };
+    
+    namespace StructA {
+        enum FieldId {
+            kFieldIdJ = 0,
+            kFieldIdK = 1,
+            kFieldIdL = 2,
+            kFieldIdM = 3
+        };
+        
+        struct Type : public IEncodableElement {
+                uint8_t x;
+                uint8_t y;
+                std::vector<uint8_t> l;
+                std::string m;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+    
+    namespace StructB {
+        enum FieldId {
+            kFieldIdX = 0,
+            kFieldIdY = 1,
+            kFieldIdZ = 2
+        };
+        
+        struct Type : public IEncodableElement {
+                uint8_t x;
+                uint8_t y;
+                StructA::Type z;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+
+    namespace StructC {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+        
+        struct Type : public IEncodableElement {
+            public:
+                struct empty {};
+
+            public:
+                uint8_t a;
+                uint8_t b;
+                StructA::Type c;
+                std::vector<uint8_t> d;
+                std::vector<StructA::Type> e;
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+
+    namespace CommandA {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+        };
+        
+        struct Type : public IEncodableElement {
+            public:
+                uint8_t a;
+                uint8_t b;
+                StructA::Type c;
+                std::vector<uint8_t> d;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+                static chip::CommandId GetCommandId() { return kCommandAId; }
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+    
+    namespace CommandB {
+        enum FieldId {
+            kFieldIdA = 0,
+            kFieldIdB = 1,
+            kFieldIdC = 2,
+            kFieldIdD = 3,
+            kFieldIdE = 4,
+        };
+        
+        struct Type : public IEncodableElement {
+                struct empty {};
+
+                uint8_t a;
+                uint8_t b;
+                StructA::Type c;
+                std::vector<uint8_t> d;
+                std::vector<StructA::Type> e;
+
+                static chip::ClusterId GetClusterId() { return kClusterId; }
+                static chip::CommandId GetCommandId() { return kCommandBId; }
+
+                CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) final; 
+                CHIP_ERROR Decode(TLV::TLVReader &reader) final;
+        };
+    }
+}
+}
+}
+}

--- a/gen-v2/stl/TestCluster.cpp
+++ b/gen-v2/stl/TestCluster.cpp
@@ -1,0 +1,283 @@
+#include "TestCluster-Gen.h"
+#include "core/CHIPTLVTags.h"
+#include "core/CHIPTLVTypes.h"
+
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
+namespace chip {
+namespace app {
+namespace Cluster { 
+namespace TestCluster {
+    namespace StructA {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdJ), x));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdK), y));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdL), &l[0], l.size()));
+            ReturnErrorOnFailure(writer.PutString(TLV::ContextTag(kFieldIdM), m.c_str(), m.length()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdJ)) {
+                    ReturnErrorOnFailure(reader.Get(x));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdK)) {
+                    ReturnErrorOnFailure(reader.Get(y));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdL)) {
+                   l.resize(reader.GetLength());
+                   ReturnErrorOnFailure(reader.GetBytes(l.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdM)) {
+                   int len = reader.GetLength() + 1;
+                   char tmp[len];
+                   ReturnErrorOnFailure(reader.GetString(tmp, len + 1));
+                   m = std::string(tmp, len + 1);
+                   m.resize(len - 1);
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    namespace StructB {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdX), x));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdY), y));
+            ReturnErrorOnFailure(z.Encode(writer, TLV::ContextTag(kFieldIdZ)));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdX)) {
+                    ReturnErrorOnFailure(reader.Get(x));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdY)) {
+                    ReturnErrorOnFailure(reader.Get(y));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdZ)) {
+                    ReturnErrorOnFailure(z.Decode(reader));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+  
+    namespace StructC {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdA), a));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdB), b));
+            ReturnErrorOnFailure(c.Encode(writer, TLV::ContextTag(kFieldIdC)));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdD), &d[0], d.size()));
+            
+            {
+                TLV::TLVType outer1;
+                ReturnErrorOnFailure(writer.StartContainer(TLV::ContextTag(kFieldIdE), TLV::kTLVType_Array, outer1));
+                for (auto item : e) {
+                    ReturnErrorOnFailure(item.Encode(writer, TLV::AnonymousTag));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(outer1));
+            }
+
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdA)) {
+                    ReturnErrorOnFailure(reader.Get(a));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdB)) {
+                    ReturnErrorOnFailure(reader.Get(b));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdC)) {
+                    ReturnErrorOnFailure(c.Decode(reader));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdD)) {
+                    d.resize(reader.GetLength());
+                    ReturnErrorOnFailure(reader.GetBytes(d.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdE)) {
+                    e.clear();
+
+                    {
+                        TLV::TLVType outer1;
+
+                        ReturnErrorOnFailure(reader.EnterContainer(outer1));
+
+                        while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                            StructA::Type tmp;
+
+                            ReturnErrorOnFailure(tmp.Decode(reader));
+                            e.push_back(tmp);
+                        }
+
+                        ReturnErrorOnFailure(reader.ExitContainer(outer1));
+                    }
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+    
+    namespace CommandA {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdA), a));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdB), b));
+            ReturnErrorOnFailure(c.Encode(writer, TLV::ContextTag(kFieldIdC)));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdD), &d[0], d.size()));
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdA)) {
+                    ReturnErrorOnFailure(reader.Get(a));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdB)) {
+                    ReturnErrorOnFailure(reader.Get(b));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdC)) {
+                    ReturnErrorOnFailure(c.Decode(reader));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdD)) {
+                    d.resize(reader.GetLength());
+                    ReturnErrorOnFailure(reader.GetBytes(d.data(), reader.GetLength()));
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+   
+    namespace CommandB {
+        CHIP_ERROR Type::Encode(TLV::TLVWriter &writer, uint64_t tag) {
+            TLV::TLVType outer;
+            ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdA), a));
+            ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kFieldIdB), b));
+            ReturnErrorOnFailure(c.Encode(writer, TLV::ContextTag(kFieldIdC)));
+            ReturnErrorOnFailure(writer.PutBytes(TLV::ContextTag(kFieldIdD), &d[0], d.size()));
+            
+            {
+                TLV::TLVType outer1;
+                ReturnErrorOnFailure(writer.StartContainer(TLV::ContextTag(kFieldIdE), TLV::kTLVType_Array, outer1));
+                for (auto item : e) {
+                    ReturnErrorOnFailure(item.Encode(writer, TLV::AnonymousTag));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(outer1));
+            }
+
+            ReturnErrorOnFailure(writer.EndContainer(outer));
+            ReturnErrorOnFailure(writer.Finalize());
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR Type::Decode(TLV::TLVReader &reader) {
+            CHIP_ERROR err;
+            TLV::TLVType outer;
+
+            err = reader.EnterContainer(outer);
+            ReturnErrorOnFailure(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                uint64_t tag = reader.GetTag();
+
+                if (tag == TLV::ContextTag(kFieldIdA)) {
+                    ReturnErrorOnFailure(reader.Get(a));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdB)) {
+                    ReturnErrorOnFailure(reader.Get(b));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdC)) {
+                    ReturnErrorOnFailure(c.Decode(reader));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdD)) {
+                    d.resize(reader.GetLength());
+                    ReturnErrorOnFailure(reader.GetBytes(d.data(), reader.GetLength()));
+                }
+                else if (tag == TLV::ContextTag(kFieldIdE)) {
+                    e.clear();
+
+                    {
+                        TLV::TLVType outer1;
+
+                        ReturnErrorOnFailure(reader.EnterContainer(outer1));
+
+                        while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                            StructA::Type tmp;
+
+                            ReturnErrorOnFailure(tmp.Decode(reader));
+                            e.push_back(tmp);
+                        }
+
+                        ReturnErrorOnFailure(reader.ExitContainer(outer1));
+                    }
+                }
+            }
+
+            ReturnErrorOnFailure(reader.ExitContainer(outer));
+            return CHIP_NO_ERROR;
+        }
+    }
+}
+}
+}
+}

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -31,6 +31,14 @@ buildconfig_header("app_buildconfig") {
   defines = [ "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=${chip_enable_schema_check}" ]
 }
 
+config("app_config") {
+  include_dirs = [
+    "util",
+    ".",
+    "${target_gen_dir}/include",
+  ]
+}
+
 static_library("app") {
   output_name = "libCHIPDataModel"
 
@@ -100,6 +108,10 @@ static_library("app") {
     "encoder-common.cpp",
     "reporting/Engine.cpp",
     "reporting/Engine.h",
+    "InvokeInteraction.cpp",
+    "InvokeInteraction.h",
+    "Cluster.cpp",
+    "Cluster.h"
   ]
 
   if (chip_ip_commissioning) {

--- a/src/app/Cluster.cpp
+++ b/src/app/Cluster.cpp
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#include "InvokeInteraction.h"
+#include "InteractionModelEngine.h"
+#include "system/SystemPacketBuffer.h"
+#include "system/TLVPacketBufferBackingStore.h"
+#include <core/CHIPTLVDebug.hpp>
+
+namespace chip {
+namespace app {
+
+ClusterServer::ClusterServer(ClusterId clusterId)
+{
+    mClusterId = clusterId;
+}
+
+}
+}

--- a/src/app/Cluster.h
+++ b/src/app/Cluster.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/BitFlags.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include "InvokeInteraction.h"
+#include <app/MessageDef/CommandDataElement.h>
+#include <app/MessageDef/CommandList.h>
+#include <app/MessageDef/InvokeCommand.h>
+
+#include "app/util/basic-types.h"
+#include <functional>
+
+namespace chip {
+namespace app {
+
+/*
+ * @brief
+ *
+ * Defines a base class that each cluster's implementation on the server is expected to extend to be
+ * deemed a valid, registered cluster instance on an endpoint.
+ *
+ * The virtual methods defined in this class revolve around command handling as well as attribute data gets and sets.
+ *
+ */
+class ClusterServer : public InvokeResponder::CommandHandler
+{
+public:
+    ClusterServer(chip::ClusterId clusterId);
+    virtual ~ClusterServer() = default;
+
+    void SetEndpoint(chip::EndpointId aEndpointId) { mEndpoint = aEndpointId; }
+
+    chip::ClusterId GetClusterId() { return mClusterId; }
+    chip::EndpointId GetEndpoint() { return mEndpoint; }
+
+private:
+    chip::ClusterId mClusterId;
+    chip::EndpointId mEndpoint = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/IEncodableElement.h
+++ b/src/app/IEncodableElement.h
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <support/CodeUtils.h>
+#include <core/CHIPConfig.h>
+#include <support/BitFlags.h>
+#include <array>
+
+namespace chip {
+namespace app {
+
+/*
+ * @brief
+ *
+ * Defines a standardized interface for encoding and decoding schema data to/from TLV.
+ *
+ * This interface is supported by the various interaction objects in the IM.
+ */
+class IEncodableElement {
+public:
+    virtual CHIP_ERROR Encode(TLV::TLVWriter &writer, uint64_t tag) = 0;
+    virtual CHIP_ERROR Decode(TLV::TLVReader &reader) = 0;
+    virtual ~IEncodableElement() {}
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -27,6 +27,7 @@
 #include "Command.h"
 #include "CommandHandler.h"
 #include "CommandSender.h"
+#include "InvokeInteraction.h"
 #include <cinttypes>
 
 namespace chip {
@@ -161,6 +162,30 @@ CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClien
     return err;
 }
 
+void InteractionModelEngine::FreeReleasedInvokeResponderObjects(intptr_t a)
+{
+    InteractionModelEngine *_this = reinterpret_cast<InteractionModelEngine *>(a);
+
+    _this->mInvokeResponders.ForEachActiveObject([&](InvokeResponder *apInteraction) {
+        if (apInteraction->mState == InvokeResponder::kStateReleased) {
+            _this->mInvokeResponders.ReleaseObject(apInteraction);
+        }
+
+        return true;
+    });
+}
+
+CHIP_ERROR InteractionModelEngine::RegisterServer(ClusterServer *apClusterServer)
+{
+    ClusterServer **server = mClusterServers.CreateObject();
+    if (server == nullptr) {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    *server = apClusterServer;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR InteractionModelEngine::NewWriteClient(WriteClient ** const apWriteClient)
 {
     *apWriteClient = nullptr;
@@ -209,26 +234,45 @@ CHIP_ERROR InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeCon
                                                           System::PacketBufferHandle && aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    InvokeResponder *responder = nullptr;
+    bool isLegacy = false;
+    
+    responder = mInvokeResponders.CreateObject();
+    assert(responder != nullptr);
 
-    for (auto & commandHandler : mCommandHandlerObjs)
-    {
-        if (commandHandler.IsFree())
+    //
+    // Since we're in a transition phase here to the new InvokeResponder approach, not all clusters have been ported over.
+    // So, first attempt to process the invoke command using the new InvokeResponder class, and if it returns a specific
+    // CHIP_ERROR_CLUSTER_NOT_FOUND error, then revert to the legacy approach.
+    //
+    err = responder->Init(apExchangeContext, aPayload.Retain());
+
+    if (err == CHIP_ERROR_CLUSTER_NOT_FOUND) {
+        err = CHIP_NO_ERROR;
+
+        isLegacy = true;
+
+        for (auto & commandHandler : mCommandHandlerObjs)
         {
-            err = commandHandler.Init(mpExchangeMgr, mpDelegate);
-            SuccessOrExit(err);
-            err = commandHandler.OnInvokeCommandRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
-            apExchangeContext = nullptr;
-            break;
+            if (commandHandler.IsFree())
+            {
+                err = commandHandler.Init(mpExchangeMgr, mpDelegate);
+                SuccessOrExit(err);
+                err = commandHandler.OnInvokeCommandRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+                apExchangeContext = nullptr;
+                break;
+            }
         }
     }
-
+    
 exit:
     ChipLogFunctError(err);
 
-    if (nullptr != apExchangeContext)
+    if (isLegacy && (nullptr != apExchangeContext))
     {
         apExchangeContext->Abort();
     }
+
     return err;
 }
 

--- a/src/app/InvokeInteraction.cpp
+++ b/src/app/InvokeInteraction.cpp
@@ -1,0 +1,660 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+#include <platform/CHIPDeviceLayer.h>
+#include "InvokeInteraction.h"
+#include "InteractionModelEngine.h"
+#include "MessageDef/CommandDataElement.h"
+#include "core/CHIPTLVTags.h"
+#include "messaging/ExchangeContext.h"
+#include "system/SystemPacketBuffer.h"
+#include "system/TLVPacketBufferBackingStore.h"
+#include <core/CHIPTLVDebug.hpp>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR InvokeResponder::Init(Messaging::ExchangeContext *apContext, System::PacketBufferHandle &&aBufferHandle)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferTLVReader reader;
+    TLV::TLVReader commandListReader;
+    InvokeCommand::Parser invokeCommandParser;
+    CommandList::Parser commandListParser;
+    
+    VerifyOrReturnError(apContext != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mpExchangeCtx = apContext;
+    mState = kStateReady;
+
+    //
+    // Increment the hold off to prevent transmission of any queued up responses till we've
+    // aggregated them all.
+    //
+    IncrementHoldOffRef();
+    
+    reader.Init(std::move(aBufferHandle));
+
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = invokeCommandParser.Init(reader);
+    SuccessOrExit(err);
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    err = invokeCommandParser.CheckSchemaValidity();
+    SuccessOrExit(err);
+#endif
+
+    err = invokeCommandParser.GetCommandList(&commandListParser);
+    SuccessOrExit(err);
+
+    commandListParser.GetReader(&commandListReader);
+
+    while (CHIP_NO_ERROR == (err = commandListReader.Next()))
+    {
+        CommandParams params;
+        CommandDataElement::Parser commandElement;
+        CommandPath::Parser commandPath;
+        TLV::TLVReader dataReader;
+        TLV::TLVReader *pReader = &dataReader;
+
+        VerifyOrExit(chip::TLV::AnonymousTag == commandListReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(chip::TLV::kTLVType_Structure == commandListReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
+
+        err = commandElement.Init(commandListReader);
+        SuccessOrExit(err);
+
+        SuccessOrExit(commandElement.GetCommandPath(&commandPath));
+        SuccessOrExit(commandPath.GetClusterId(&params.ClusterId));
+        SuccessOrExit(commandPath.GetCommandId(&params.CommandId));
+        SuccessOrExit(commandPath.GetEndpointId(&params.EndpointId));
+
+        err = commandElement.GetData(pReader);
+        if (err == CHIP_END_OF_TLV) {
+            err = CHIP_NO_ERROR;
+            pReader = NULL;
+        }
+
+        SuccessOrExit(err);
+
+        {
+            bool foundClusterInstance = false;
+
+            InteractionModelEngine::GetInstance()->GetClusterServerSet().ForEachActiveObject([&](ClusterServer **s) {
+                if ((*s)->GetClusterId() == params.ClusterId && (*s)->GetEndpoint() == params.EndpointId) {
+                    foundClusterInstance = true;
+
+                    err = (*s)->OnInvokeRequest(params, *this, pReader);
+                    SuccessOrExit(err);
+
+                    return false;
+                }
+
+            exit:
+                if (err != CHIP_NO_ERROR) {
+                    return true;
+                }
+
+                return true;
+            });
+
+            if (!foundClusterInstance) {
+                ChipLogProgress(DataManagement, "Could not find a matching server cluster for command! (ClusterId = %" PRIx32 ", Endpoint = %lu, Command = %lu)", 
+                                params.ClusterId, (unsigned long)params.EndpointId, (unsigned long)params.CommandId);
+
+                //
+                // To permit a gradual transition away from the legacy Ember approach of handling commands, we need a way to 'fall-back' to the legacy approach
+                // if we don't find a registered ClusterServer object. Returning a very specific error code here from this command signals to the caler to 
+                // switch back to the legacy call flow.
+                //
+                // TODO: Remove this once all legacy callers have moved over to the new model. In turn, re-enable the status report dispatch path below.
+                SuccessOrExit((err = CHIP_ERROR_CLUSTER_NOT_FOUND));
+
+                // err = AddStatusCode(params, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                //                     Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                // SuccessOrExit(err);
+            }
+        }
+    }
+
+    if (err == CHIP_END_OF_TLV) {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    //
+    // Decrement hold-off, and if zero, fire off any queued up responses and 
+    // shut outselves down.
+    //
+    DecrementHoldOffRef();
+    return err;
+}
+
+CHIP_ERROR InvokeResponder::AddResponse(CommandParams aParams, IEncodableElement *serializable)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = StartCommandHeader(aParams);
+    SuccessOrExit(err);
+
+    // 
+    // Invoke the passed in closure that will actually write out the command payload if any
+    //
+    err = serializable->Encode(*mInvokeCommandBuilder.GetWriter(), TLV::ContextTag(CommandDataElement::kCsTag_Data));
+    SuccessOrExit(err);
+
+    mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().EndOfCommandDataElement();
+    SuccessOrExit((err = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().GetError()));
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeResponder::AddStatusCode(const CommandParams &aParams, const StatusResponse &statusResponse)
+                             
+{
+    CHIP_ERROR err;
+    StatusElement::Builder statusBuilder;
+
+    // We don't need to sandwich this with Increment/Decrement calls, since this call to AddStatus
+    // can only happen as part of an existing 'HandleMessage' call flow, which in turn is already handling
+    // calling those two methods to correctly finalize a message if needed.
+
+    err = StartCommandHeader(aParams);
+    SuccessOrExit(err);
+
+    statusBuilder = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().CreateStatusElementBuilder();
+    statusBuilder.EncodeStatusElement(statusResponse.generalCode, statusResponse.protocolId.ToFullyQualifiedSpecForm(), statusResponse.protocolCode).EndOfStatusElement();
+
+    err = statusBuilder.GetError();
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeResponder::StartCommandHeader(const CommandParams &aParams)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferHandle txBuf;
+
+    //
+    // We only allocate the actual TX buffer once we have a command to add, which is now!
+    //
+    if (!mWriter.HasBuffer()) {
+        CommandList::Builder commandListBuilder;
+
+        txBuf = System::PacketBufferHandle::New(1024);
+        VerifyOrExit(!txBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+        mWriter.Init(std::move(txBuf));
+
+        err = mInvokeCommandBuilder.Init(&mWriter);
+        SuccessOrExit(err);
+
+        commandListBuilder = mInvokeCommandBuilder.CreateCommandListBuilder();
+        SuccessOrExit(commandListBuilder.GetError());
+    }
+
+    {
+        CommandDataElement::Builder commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+        CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
+
+        if (aParams.Flags.Has(CommandParams::TargetType::kTargetEndpoint))
+        {
+            commandPath.EndpointId(aParams.EndpointId);
+        }
+        else {
+            commandPath.GroupId(aParams.GroupId);
+        }
+
+        commandPath.ClusterId(aParams.ClusterId).CommandId(aParams.CommandId).EndOfCommandPath();
+        SuccessOrExit((err = commandPath.GetError()));
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeResponder::Shutdown()
+{
+    if (mpExchangeCtx) {
+#if 0
+        // TODO: Not sure why the ExchangeManager assumes that we shouldn't close this exchange ourselves...
+        mpExchangeCtx->Close();
+#endif
+        mpExchangeCtx = nullptr;
+    }
+
+    mState = kStateReleased;
+    
+    //DeviceLayer::PlatformMgr().ScheduleWork(InteractionModelEngine::FreeReleasedInvokeResponderObjects, (intptr_t)InteractionModelEngine::GetInstance());
+
+    //
+    // Call into our parent encapsulating entity to free ourselves up.
+    // This may seem contrived, but fundamentally, our parent does not have sufficient knowledge to knwo when this object can be destroyed,
+    // only because of the ability to support async. command responses. Otherwise, on completion of the call to Init, all work would have been
+    // done and the parent entity would have destroyed this object.
+    //
+    InteractionModelEngine::FreeReleasedInvokeResponderObjects((intptr_t)InteractionModelEngine::GetInstance());
+    return CHIP_NO_ERROR;
+}
+
+void InvokeResponder::IncrementHoldOffRef()
+{
+  assert(mHoldOffCount >= 0);
+  mHoldOffCount++;
+}
+
+void InvokeResponder::DecrementHoldOffRef()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+
+    assert(mHoldOffCount > 0);
+    mHoldOffCount--;
+
+    if (mHoldOffCount == 0) {
+        if (mWriter.HasBuffer()) {
+            System::PacketBufferHandle buf;
+
+            err = FinalizeMessage(buf);
+            SuccessOrExit(err);
+
+            err = SendMessage(std::move(buf));
+            SuccessOrExit(err);
+        }
+
+        Shutdown();
+    }
+
+exit:
+    return;
+}
+
+// Only get here if we have a valid buffer
+CHIP_ERROR InvokeResponder::FinalizeMessage(System::PacketBufferHandle &aBuf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+
+    {
+        System::PacketBufferHandle txBuf;
+        CommandList::Builder commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();
+        SuccessOrExit(commandListBuilder.GetError());
+
+        mInvokeCommandBuilder.EndOfInvokeCommand();
+
+        err = mInvokeCommandBuilder.GetError();
+        SuccessOrExit(err);
+
+        err = mWriter.Finalize(&txBuf);
+        SuccessOrExit(err);
+
+        VerifyOrExit(txBuf->EnsureReservedSize(System::PacketBuffer::kDefaultHeaderReserve),
+                     err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+        aBuf = std::move(txBuf);
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeResponder::SendMessage(System::PacketBufferHandle aBuf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(!aBuf.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandRequest, 
+                                     std::move(aBuf), Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+void InvokeInitiator::CloseExchange()
+{
+    if (mpExchangeCtx) {
+        mpExchangeCtx->Close();
+        mpExchangeCtx = nullptr;
+    }
+}
+
+CHIP_ERROR InvokeInitiator::Init(Messaging::ExchangeManager *apExchangeMgr, ICommandHandler *aHandler, NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(apExchangeMgr != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    mpExchangeMgr = apExchangeMgr;
+    mHandler = aHandler;
+
+    CloseExchange();
+
+    if (secureSession == nullptr) {
+        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+    }
+    else {
+        mpExchangeCtx = mpExchangeMgr->NewContext(*secureSession, this);
+    }
+
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+
+    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+
+    mState = kStateReady;
+
+exit:
+    if (err != CHIP_NO_ERROR) {
+        CloseExchange();
+    }
+
+    return err;
+}
+
+CHIP_ERROR InvokeInitiator::StartCommandHeader(const CommandParams &aParams)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferHandle txBuf;
+
+    VerifyOrExit(mState == kStateReady, err = CHIP_ERROR_INCORRECT_STATE);
+
+    //
+    // We only allocate the actual TX buffer once we have a command to add, which is now!
+    //
+    if (!mWriter.HasBuffer()) {
+        CommandList::Builder commandListBuilder;
+
+        txBuf = System::PacketBufferHandle::New(1024);
+        VerifyOrExit(!txBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+        mWriter.Init(std::move(txBuf));
+
+        err = mInvokeCommandBuilder.Init(&mWriter);
+        SuccessOrExit(err);
+
+        commandListBuilder = mInvokeCommandBuilder.CreateCommandListBuilder();
+        SuccessOrExit(commandListBuilder.GetError());
+    }
+
+    {
+        CommandDataElement::Builder commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+        CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
+
+        if (aParams.Flags.Has(CommandParams::TargetType::kTargetEndpoint))
+        {
+            commandPath.EndpointId(aParams.EndpointId);
+        }
+        else {
+            commandPath.GroupId(aParams.GroupId);
+        }
+
+        commandPath.ClusterId(aParams.ClusterId).CommandId(aParams.CommandId).EndOfCommandPath();
+        SuccessOrExit((err = commandPath.GetError()));
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeInitiator::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferTLVReader reader;
+    TLV::TLVReader commandListReader;
+    InvokeCommand::Parser invokeCommandParser;
+    CommandList::Parser commandListParser;
+    StatusElement::Parser statusElementParser;
+
+    VerifyOrExit(mState == kStateAwaitingResponse, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mHandler != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    // Now that we've received the response, move our state back to ready to permit adding commands
+    mState = kStateReady;
+    
+    reader.Init(std::move(aPayload));
+
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = invokeCommandParser.Init(reader);
+    SuccessOrExit(err);
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    err = invokeCommandParser.CheckSchemaValidity();
+    SuccessOrExit(err);
+#endif
+
+    err = invokeCommandParser.GetCommandList(&commandListParser);
+    SuccessOrExit(err);
+
+    commandListParser.GetReader(&commandListReader);
+
+    while (CHIP_NO_ERROR == (err = commandListReader.Next()))
+    {
+        CommandParams params;
+        CommandDataElement::Parser commandElement;
+        CommandPath::Parser commandPath;
+        TLV::TLVReader dataReader;
+        TLV::TLVReader *pReader = &dataReader;
+        //bool HasData = true;
+
+        VerifyOrExit(chip::TLV::AnonymousTag == commandListReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(chip::TLV::kTLVType_Structure == commandListReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
+
+        err = commandElement.Init(commandListReader);
+        SuccessOrExit(err);
+
+        SuccessOrExit(commandElement.GetCommandPath(&commandPath));
+        SuccessOrExit(commandPath.GetClusterId(&params.ClusterId));
+        SuccessOrExit(commandPath.GetCommandId(&params.CommandId));
+        SuccessOrExit(commandPath.GetEndpointId(&params.EndpointId));
+
+        err = commandElement.GetStatusElement(&statusElementParser);
+        if (err == CHIP_END_OF_TLV) {
+            err = commandElement.GetData(pReader);
+            SuccessOrExit(err);
+
+            mHandler->OnResponse(*this, params, pReader);
+        }
+        else {
+            StatusResponse statusResponse;
+            uint32_t protocolId;
+            
+            err = statusElementParser.DecodeStatusElement(&statusResponse.generalCode, &protocolId, &statusResponse.protocolCode);
+            SuccessOrExit(err);
+
+            statusResponse.protocolId = Protocols::Id((chip::VendorId)((protocolId & 0xff00) >> 16), protocolId & 0xffff);
+
+            if (!statusResponse.IsError()) {
+                mHandler->OnResponse(*this, params, nullptr);
+            }
+            else {
+                mHandler->OnError(*this, &params, CHIP_ERROR_STATUS_REPORT_RECEIVED, &statusResponse);
+            }
+        }
+
+        SuccessOrExit(err);
+
+        mState = kStateReady;
+    }
+
+    if (err == CHIP_END_OF_TLV) {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    CloseExchange();
+    
+   //
+   // We're done with this object now. Let's signal the application to indicate the completion
+   // of this interaction.
+   //
+   mHandler->OnEnd(*this);
+   mHandler = nullptr;
+
+   return err; 
+}
+
+void InvokeInitiator::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) 
+{
+    if (mHandler) {
+        mHandler->OnError(*this, NULL, CHIP_ERROR_TIMEOUT, nullptr);
+        mHandler->OnEnd(*this);
+        mHandler = nullptr;
+    }
+}
+
+CHIP_ERROR InvokeInitiator::AddRequest(CommandParams aParams, IEncodableElement *serializable) 
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    //
+    // Update our accumulated flag that tracks if any command going into this invoke
+    // expects responses
+    //
+    mExpectsResponses |= aParams.ExpectsResponses;
+
+    err = StartCommandHeader(aParams);
+    SuccessOrExit(err);
+
+    // 
+    // Invoke the passed in closure that will actually write out the command payload if any
+    //
+    err = serializable->Encode(*mInvokeCommandBuilder.GetWriter(), TLV::ContextTag(CommandDataElement::kCsTag_Data));
+    SuccessOrExit(err);
+
+    mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().EndOfCommandDataElement();
+    SuccessOrExit((err = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().GetError()));
+
+exit:
+    if (err != CHIP_NO_ERROR && mHandler) {
+        mHandler->OnEnd(*this);
+        mHandler = nullptr;
+    }
+
+    return err;
+}
+
+CHIP_ERROR InvokeInitiator::AddRequestAndSend(CommandParams aParams, IEncodableElement *serializable) 
+{
+    CHIP_ERROR err;
+
+    err = AddRequest(aParams, serializable);
+    SuccessOrExit(err);
+
+    err = Send();
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR && mHandler) {
+        mHandler->OnEnd(*this);
+        mHandler = nullptr;
+    }
+
+    return err;
+}
+
+CHIP_ERROR InvokeInitiator::Send()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mState == kStateReady, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mWriter.HasBuffer(), );
+   
+    { 
+        System::PacketBufferHandle buf;
+
+        err = FinalizeMessage(buf);
+        SuccessOrExit(err);
+
+        err = SendMessage(std::move(buf));
+        SuccessOrExit(err);
+
+        mState = kStateAwaitingResponse;
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR && mHandler) {
+        mHandler->OnEnd(*this);
+        mHandler = nullptr;
+    }
+    
+    return err;
+}
+
+// Only get here if we have a valid buffer
+CHIP_ERROR InvokeInitiator::FinalizeMessage(System::PacketBufferHandle &aBuf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mState != kStateAwaitingResponse, err = CHIP_ERROR_INCORRECT_STATE);
+
+    {
+        System::PacketBufferHandle txBuf;
+        CommandList::Builder commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();
+        SuccessOrExit(commandListBuilder.GetError());
+
+        mInvokeCommandBuilder.EndOfInvokeCommand();
+
+        err = mInvokeCommandBuilder.GetError();
+        SuccessOrExit(err);
+
+        err = mWriter.Finalize(&txBuf);
+        SuccessOrExit(err);
+
+        VerifyOrExit(txBuf->EnsureReservedSize(System::PacketBuffer::kDefaultHeaderReserve),
+                     err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+        aBuf = std::move(txBuf);
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR InvokeInitiator::SendMessage(System::PacketBufferHandle aBuf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(!aBuf.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandRequest, 
+                                     std::move(aBuf), Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+}
+}

--- a/src/app/InvokeInteraction.h
+++ b/src/app/InvokeInteraction.h
@@ -1,0 +1,438 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines a set of classes that applications can use to initiate and respond to
+ *      IM commands.
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/BitFlags.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include "IEncodableElement.h"
+#include <app/MessageDef/CommandDataElement.h>
+#include <app/MessageDef/CommandList.h>
+#include <app/MessageDef/InvokeCommand.h>
+#include <app/util/basic-types.h>
+#include "messaging/ExchangeDelegate.h"
+#include "protocols/secure_channel/Constants.h"
+#include <functional>
+
+namespace chip {
+namespace app {
+
+/*
+ * @brief
+ *
+ * This class encapsulates the data that goes into a status response message.
+ */
+struct StatusResponse {
+public:
+    bool IsError() { return generalCode != Protocols::SecureChannel::GeneralStatusCode::kSuccess; }
+    Protocols::SecureChannel::GeneralStatusCode generalCode = Protocols::SecureChannel::GeneralStatusCode::kSuccess;
+    Protocols::Id protocolId = Protocols::Id(Common, 0);
+    uint16_t protocolCode = 0;
+};
+
+/**
+ * @brief
+ *
+ * Encapsulates parameters that go into the header of an IM Invoke Request or Response message.
+ */
+struct CommandParams
+{
+    enum class TargetType : uint8_t
+    {
+        kTargetEndpoint     = 0x01, /**< Set when the EndpointId field is valid */
+        kTargetGroup        = 0x02, /**< Set when the GroupId field is valid */
+    };
+
+    template <class CodeGenType>
+    CommandParams(CodeGenType& t, chip::EndpointId endpointId, bool expectsResponses = true) {
+        ClusterId = (uint16_t)CodeGenType::GetClusterId();
+        CommandId = (uint8_t)CodeGenType::GetCommandId();
+        EndpointId = endpointId;
+        ExpectsResponses = expectsResponses;
+    }
+
+    CommandParams() { }
+
+    chip::EndpointId EndpointId = 0;
+    chip::GroupId GroupId = 0;
+    chip::ClusterId ClusterId = 0;
+    chip::CommandId CommandId = 0;
+    BitFlags<TargetType> Flags = TargetType::kTargetEndpoint;
+    bool ExpectsResponses = false;
+};
+
+/*
+ * @brief
+ *
+ * This class represents an invoke interaction from the initiating side (i.e on the client). An instance of this class maps to a specific
+ * invoke interaction over the wire. Consequently, the lifetime of this object is limited to a SINGLE interaction backed by a SINGLE exchange context.
+ *
+ * This object permits a single request + response. It does not permit multiple responses to be sequenced in order.
+ * 
+ * It provides a number of overloaded methods that permit adding multiple command payloads into the message.
+ *
+ * It also provides a means to register callbacks on receipt of responses or errors to the originating invoke request.
+ */
+class InvokeInitiator : chip::Messaging::ExchangeDelegate
+{
+public:
+    /*
+     * @brief
+     *
+     * An interface that applications implement to handle events that occur during the lifetime of an invoke interaction, including
+     * responses and errors.
+     */
+    class ICommandHandler
+    {
+    public:
+        /*
+         * @brief
+         *
+         * Called to handle a data element present within an Invoke Response message.
+         *
+         * @param invokeInteraction         A reference to the invoke interaction instance that corresponds to the invoke response being processed.
+         * @param commandParams             A reference to an object containing the parameters of the command response.
+         * @param payload                   If a data payload is present, a TLV reader positioned at that payload is provided. The reader 
+         *                                  shall not be assumed to exist past this call, so the application should save off the data if they desire to.
+         */
+        virtual void OnResponse(InvokeInitiator &invokeInteraction, CommandParams &commandParams, TLV::TLVReader *payload) = 0;
+
+        /*
+         * @brief
+         *
+         * Called to handle any asynchronously generated errors (exchange timeout, non-success status reports, etc) on the invoke interaction.
+         *
+         * @param invokeInteraction         A reference to the invoke interaction instance that corresponds to the invoke response being processed.
+         * @param commandParams             If the error is specific to a particular command, a pointer to a command parameter object shall be provided. Otherwise,
+         *                                  this SHALL be null.
+         * @param error                     A CHIP_ERROR containing the high-level error that occurred.
+         * @param statusResponse            If a status response was received, CHIP_ERROR shall be set to CHIP_ERROR_STATUS_RESPONSE_RECEIVED and this argument SHALL
+         *                                  be valid and non-null.
+         */
+        virtual void OnError(InvokeInitiator &invokeInteration, CommandParams *aPath, CHIP_ERROR error, StatusResponse *statusResponse) = 0;
+
+        /*
+         * @brief
+         *
+         * When the interaction has completed, this method is invoked to give the application the chance to reclaim this object if needed.
+         * This is invoked regardless of whether it was a successful completion or an erroneous one. In the latter case, the `OnError` method above will
+         * be invoked first before the below is invoked.
+         *
+         * This method will be invoked anytime after the Init() method has been called on this object.
+         *
+         *
+         * @param invokeInteraction         A reference to the invoke interaction instance that correponds to the invoke response being processed.
+         * @param commandParams             If the error is specific to a particular command, a pointer to a command parameter object shall be provided. Otherwise,
+         *                                  this SHALL be null.
+         * @param error                     A CHIP_ERROR containing the high-level error that occurred.
+         * @param statusResponse            If a status response was received, CHIP_ERROR shall be set to CHIP_ERROR_STATUS_RESPONSE_RECEIVED and this argument SHALL
+         *                                  be valid and non-null.
+         */
+        virtual void OnEnd(InvokeInitiator &invokeInteration) = 0;
+        virtual ~ICommandHandler() {}
+    };
+
+    /*
+     * @brief
+     *
+     * Initializes the object with a destination NodeId + AdminId pair OR a secure session handle.
+     *
+     */
+    CHIP_ERROR Init(Messaging::ExchangeManager *apExchangeMgr, ICommandHandler *aHandler, NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession);
+
+    /*
+     * @brief
+     *
+     * Encodes an invoke request into the larger invoke message. This method takes an encodable object and command parameters and
+     * writes that into an opened packet buffer.
+     *
+     */
+    CHIP_ERROR AddRequest(CommandParams aParams, IEncodableElement *serializable);
+   
+    /*
+     * @brief
+     *
+     * Encodes an invoke request into the larger invoke message. This method does so by accepting a generic lambda that is then
+     * invoked immediately with a TLVWriter + TLV tag passed in. The writer is positioned within the command's payload.
+     *
+     */
+    template <class F>
+    CHIP_ERROR AddRequest(CommandParams aParams, F f) {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        //
+        // Update our accumulated flag that tracks if any command going into this invoke
+        // expects responses
+        //
+        mExpectsResponses |= aParams.ExpectsResponses;
+
+        err = StartCommandHeader(aParams);
+        SuccessOrExit(err);
+
+        // 
+        // Invoke the passed in closure that will actually write out the command payload if any
+        //
+        err = f(*mInvokeCommandBuilder.GetWriter(), TLV::ContextTag(CommandDataElement::kCsTag_Data));
+        SuccessOrExit(err);
+
+        mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().EndOfCommandDataElement();
+        SuccessOrExit((err = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().GetError()));
+
+exit:
+        return err;
+    }
+
+    /*
+     * @brief
+     *
+     * In addition to encoding in the encodable object, this also immediately sends the message.
+     *
+     * This is equivalent to calling AddRequest and Send in succession.
+     *
+     */
+    CHIP_ERROR AddRequestAndSend(CommandParams aParams, IEncodableElement *serializable);
+   
+    /*
+     * @brief
+     *
+     * In addition to encoding in the invoke request by calling the provided lambda, this also immediately sends the message.
+     *
+     * This is equivalent to calling AddRequest and Send in succession.
+     *
+     */
+    template <class F>
+    CHIP_ERROR AddRequestAndSend(CommandParams aParams, F f) {
+        ReturnErrorOnFailure(AddRequest(aParams, f));
+        return Send();
+    }
+
+    /*
+     * @brief
+     *
+     * If any invokes have been written into the message, this closes up the packet buffer and sends the message.
+     * There-after, AddRequest and Send cannot be called again on this object.
+     *
+     */
+    CHIP_ERROR Send();
+
+    Messaging::ExchangeContext *GetExchange() { return mpExchangeCtx; }
+   
+private:
+    enum State
+    {
+        kStateReady = 0,           //< The invoke command message has been initialized and is ready
+        kStateAwaitingResponse = 1,
+    };
+
+    
+    CHIP_ERROR StartCommandHeader(const CommandParams &aParams);
+    void CloseExchange();
+
+    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+
+    Messaging::ExchangeContext *GetExchangeContext() { return mpExchangeCtx; }
+    friend class InteractionModelEngine;
+
+    CHIP_ERROR FinalizeMessage(System::PacketBufferHandle &aBuf);
+    CHIP_ERROR SendMessage(System::PacketBufferHandle aBuf);
+  
+private: 
+    enum Mode
+    {
+        kModeUnset = 0,
+        kModeClientInitiator = 1,
+        kModeServerResponder = 2
+    };
+
+    friend class TestInvokeInteraction;
+    bool mExpectsResponses = false;
+    State mState = kStateReady;
+    chip::System::PacketBufferTLVWriter mWriter;
+    app::InvokeCommand::Builder mInvokeCommandBuilder;
+    ICommandHandler *mHandler;
+    Messaging::ExchangeManager *mpExchangeMgr = nullptr;
+    Messaging::ExchangeContext *mpExchangeCtx = nullptr;
+};
+
+/*
+ * @brief
+ *
+ * This class represents an invoke interaction from the responding side (i.e on the server). An instance of this class maps to a specific
+ * invoke interaction over the wire. Consequently, the lifetime of this object is limited to a SINGLE interaction backed by a SINGLE exchange context.
+ *
+ * This object permits a single request + response. It does not permit multiple responses to be sequenced in order.
+ *
+ * This object comes into existence at the point that an invoke request has to be handled. Upon initialization of the object with the packet buffer, this
+ * object parses the various command data elements embedded in the message and dispatches them to ClusterServer objects registered with the 
+ * InteractionModel engine.
+ *
+ * Upon dispatch, the ClusterServer instance's OnInvokeRequest method is invoked. The cluster's OnInvokeRequest implementation has to follow one of the following
+ * calling conventions:
+ *      1. Handle the request and if a response needs to be generated, call AddResponse on the passed in InvokeResponder object.
+ *      2. Handle the request and if no responses needs to to be generated, do nothing.
+ *      3. Handle the request if a response needs to be generated asynchronously, call IncrementHoldOffRef() on the passed in InvokeResponder object. This
+ *         is a signal to the responder object to hold-off sending any queued up responoses till a matching DecrementHoldOffRef() call is made by that handler.
+ *
+ */
+class InvokeResponder
+{
+public:
+    /*
+     * @brief
+     *
+     * This interface defines the expectations for a handler of command requests.
+     *
+     */
+    class CommandHandler
+    {
+    public:
+        /*
+         * @brief
+         *
+         * Called to handle a data element present within an Invoke Request message.
+         *
+         * @param invokeInteraction         A reference to the invoke interaction instance that corresponds to the invoke request being processed.
+         * @param commandParams             A reference to an object containing the parameters of the command request.
+         * @param payload                   If a data payload is present, a TLV reader positioned at that payload is provided. The reader 
+         *                                  shall not be assumed to exist past this call, so the application should save off the data if they desire to.
+         */
+        virtual CHIP_ERROR OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload) = 0;
+
+        virtual ~CommandHandler() {} 
+    };
+
+    /*
+     * @brief
+     *
+     * Initializes the interaction object with the exchange context associated with the received message
+     * as well as a rvalue reference to the packet buffer containing the message.
+     *
+     */
+    CHIP_ERROR Init(Messaging::ExchangeContext *apContext, System::PacketBufferHandle &&aBufferHandle);
+   
+    /*
+     * @brief
+     *
+     * Encode a response to a request by providing command parameters as well as a pointer to an encodable object.
+     * The object's contents are immediately serialized into a response packet buffer. 
+     *
+     */
+    CHIP_ERROR AddResponse(CommandParams aParams, IEncodableElement *serializable);
+   
+    /*
+     * @brief
+     *
+     * Encode a response to a request by providing command parameters as well as a lambda that is in turn
+     * invoked with a TLVWriter passed in positioned at the appropriate offset into the packet buffer.
+     *
+     * This uses SFINAE to ensure selection of the right overload when a closure is passed in vs. a pointer to
+     * a serializable object.
+     *
+     */
+    template <typename F, typename std::enable_if<std::is_class<F>::value, int>::type = 0>
+    CHIP_ERROR AddResponse(CommandParams aParams, F f) {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        err = StartCommandHeader(aParams);
+        SuccessOrExit(err);
+
+        // 
+        // Invoke the passed in closure that will actually write out the command payload if any
+        //
+        err = f(*mInvokeCommandBuilder.GetWriter(), TLV::ContextTag(CommandDataElement::kCsTag_Data));
+        SuccessOrExit(err);
+
+        mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().EndOfCommandDataElement();
+        SuccessOrExit((err = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuidler().GetError()));
+
+exit:
+        return err;
+    }
+
+    /*
+     * @brief
+     *
+     * Encode a status response.
+     *
+     */
+    CHIP_ERROR AddStatusCode(const CommandParams &aParams, const StatusResponse &statusResponse);
+
+    /*
+     * @brief
+     *
+     * Increments the hold-off ref, signalling to the responder object that it should not dispatch any queued up responses till a 
+     * matching call to DecrementHoldOffRef() has been made. This also prevents the de-allocation of this object till the matching call
+     * has been made.
+     *
+     * If the caller of this method encounters any errors, it should call DecrementHoldOffRef() to safely permit the dispach of other responses
+     * on this object despite its own failure. Failure to do so will prevent futher work on this object.
+     */
+    void IncrementHoldOffRef();
+
+    /*
+     * @brief
+     *
+     * Decrements the hold-off ref. If it hits 0, any queued up responses that have been encoded into a response packet buffer are immediately
+     * transmitted, before this object is released/destructed.
+     */
+    void DecrementHoldOffRef();
+
+private:
+    enum State
+    {
+        kStateReady = 0,
+        kStateReleased = 1
+    };
+
+    CHIP_ERROR Shutdown();
+
+    Messaging::ExchangeContext *GetExchangeContext() { return mpExchangeCtx; }
+    CHIP_ERROR FinalizeMessage(System::PacketBufferHandle &aBuf);
+    CHIP_ERROR SendMessage(System::PacketBufferHandle aBuf);
+    friend class InteractionModelEngine;
+
+private:
+    int mHoldOffCount = 0;
+    State mState;
+    friend class TestInvokeInteraction;
+    CHIP_ERROR StartCommandHeader(const CommandParams &aParams);
+    app::InvokeCommand::Builder mInvokeCommandBuilder;
+    chip::System::PacketBufferTLVWriter mWriter;
+    Messaging::ExchangeContext *mpExchangeCtx = nullptr;
+};
+    
+
+} // namespace app
+} // namespace chip

--- a/src/app/MessageDef/CommandList.h
+++ b/src/app/MessageDef/CommandList.h
@@ -68,6 +68,8 @@ public:
      */
     CommandDataElement::Builder & CreateCommandDataElementBuilder();
 
+    CommandDataElement::Builder & GetCommandDataElementBuidler() { return mCommandDataElementBuilder; }
+
     /**
      *  @return A reference to CommandDataElement::Builder
      */

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -142,7 +142,6 @@ template("chip_data_model") {
       } else if (cluster == "network-commissioning") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}-ember.cpp",
-          "${_app_root}/clusters/${cluster}/${cluster}.cpp",
         ]
       } else {
         sources += [ "${_app_root}/clusters/${cluster}/${cluster}.cpp" ]
@@ -174,6 +173,7 @@ template("chip_data_model") {
     }
 
     public_deps += [
+      "${chip_root}/gen-v2/device",
       "${chip_root}/src/app",
       "${chip_root}/src/controller",
       "${chip_root}/src/lib/core",
@@ -192,7 +192,9 @@ template("chip_data_model") {
     cflags += [ "-Wconversion" ]
 
     if (!defined(public_configs)) {
-      public_configs = []
+      public_configs = [
+          "${chip_root}/gen-v2/device:includes"
+      ]
     }
 
     public_configs += [ ":${_data_model_name}_config" ]

--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -32,34 +32,25 @@
 
 using namespace chip;
 
+//
+// The following are now deprecated and implemented using the ClusterServer approach
+//
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan operationalDataset,
                                                                 uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), operationalDataset, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
-    return true;
+    return false;
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan ssid,
                                                               ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), ssid, credentials, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
-    return true;
+    return false;
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::CommandHandler * commandObj, ByteSpan networkID,
                                                              uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), networkID, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
-    return true;
+    return false;
 }
 
 // TODO: The following commands needed to be implemented.

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -220,7 +220,7 @@ CHIP_ERROR NetworkCommissioningServer::AddWifiNetwork(chip::app::Cluster::Networ
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddWiFiNetwork: %" PRId32, err);
+    ChipLogDetail(Zcl, "AddWiFiNetwork: %s", ErrorStr(err));
     return err;
 #else
     // The target does not supports WiFiNetwork.

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -17,10 +17,14 @@
  */
 
 #include "network-commissioning.h"
+#include "NetworkCommissioningCluster-Gen.h"
+#include "NetworkCommissioningCluster.h"
+#include "core/CHIPError.h"
+#include "protocols/secure_channel/Constants.h"
 
+#include <device/SchemaUtils.h>
 #include <cstring>
 #include <type_traits>
-
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/Span.h>
@@ -42,169 +46,181 @@
 #endif
 
 // TODO: Configuration should move to build-time configuration
-#ifndef CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS
-#define CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS 4
-#endif // CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS
 
-using namespace chip;
-using namespace chip::app;
-using namespace chip::app::clusters;
-using namespace chip::app::clusters::NetworkCommissioning;
+using namespace chip::app::Cluster;
 
 namespace chip {
 namespace app {
 namespace clusters {
 namespace NetworkCommissioning {
 
-constexpr uint8_t kMaxNetworkIDLen       = 32;
-constexpr uint8_t kMaxThreadDatasetLen   = 254; // As defined in Thread spec.
-constexpr uint8_t kMaxWiFiSSIDLen        = 32;
-constexpr uint8_t kMaxWiFiCredentialsLen = 64;
-constexpr uint8_t kMaxNetworks           = CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS;
-
-enum class NetworkType : uint8_t
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
-    kUndefined = 0,
-    kWiFi      = 1,
-    kThread    = 2,
-    kEthernet  = 3,
-};
+}
 
-struct ThreadNetworkInfo
-{
-    uint8_t mDataset[kMaxThreadDatasetLen];
-    uint8_t mDatasetLen;
-};
+}
+}
+}
+}
 
-struct WiFiNetworkInfo
+NetworkCommissioningServer::NetworkCommissioningServer()
+    : ClusterServer(NetworkCommissioningCluster::kClusterId)
 {
-    uint8_t mSSID[kMaxWiFiSSIDLen + 1];
-    uint8_t mSSIDLen;
-    uint8_t mCredentials[kMaxWiFiCredentialsLen];
-    uint8_t mCredentialsLen;
-};
+}
 
-struct NetworkInfo
+CHIP_ERROR NetworkCommissioningServer::OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload)
 {
-    uint8_t mNetworkID[kMaxNetworkIDLen];
-    uint8_t mNetworkIDLen;
-    uint8_t mEnabled;
-    NetworkType mNetworkType;
-    union NetworkData
-    {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    switch (commandParams.CommandId) {
+        case NetworkCommissioningCluster::kAddThreadNetworkRequestCommandId:
+            {
+                NetworkCommissioningCluster::AddThreadNetworkCommand::Type req;
+                uint8_t DataSet[200];
+
+                req.OperationalDataSet = chip::ByteSpan{DataSet};
+
+                err = DecodeSchemaElement(req, *payload);
+                SuccessOrExit(err);
+
+                err = AddThreadNetwork(req);
+                break;
+            }
+
+        case NetworkCommissioningCluster::kAddWifiNetworkRequestCommandId:
+            {
+                NetworkCommissioningCluster::AddWifiNetworkCommand::Type req;
+                uint8_t Ssid[200];
+                uint8_t Credentials[200];
+
+                req.Ssid = chip::ByteSpan{Ssid};
+                req.Credentials = chip::ByteSpan{Credentials};
+
+                err = DecodeSchemaElement(req, *payload);
+                SuccessOrExit(err);
+
+                err = AddWifiNetwork(req);
+                break;
+            }
+
+        case NetworkCommissioningCluster::kEnableNetworkRequestCommandId:
+            {
+                NetworkCommissioningCluster::EnableNetworkCommand::Type req;
+                uint8_t NetworkId[64];
+
+                req.NetworkId = chip::ByteSpan{NetworkId};
+
+                err = DecodeSchemaElement(req, *payload);
+                SuccessOrExit(err);
+
+                err = EnableNetwork(req);
+                break;
+            }
+    }
+
+exit:
+    //
+    // This is unfortunate that we're diluting errors returned down to a singular code. We should in-fact, be sending
+    // back either IM or Cluster status codes within each of the 'handlers' above.
+    //
+    err = invokeInteraction.AddStatusCode(commandParams, {Protocols::SecureChannel::GeneralStatusCode::kSuccess, Protocols::InteractionModel::Id, (uint16_t)err});
+    return err;
+}
+
+CHIP_ERROR NetworkCommissioningServer::AddThreadNetwork(NetworkCommissioningCluster::AddThreadNetworkCommand::Type &request)
+{
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        Thread::OperationalDataset mThread;
-#endif
-#if defined(CHIP_DEVICE_LAYER_TARGET)
-        WiFiNetworkInfo mWiFi;
-#endif
-    } mData;
-};
-
-namespace {
-// The internal network info containing credentials. Need to find some better place to save these info.
-NetworkInfo sNetworks[kMaxNetworks];
-} // namespace
-
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId,
-                                                                           ByteSpan operationalDataset, uint64_t breadcrumb,
-                                                                           uint32_t timeoutMs)
-{
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
     for (size_t i = 0; i < kMaxNetworks; i++)
     {
-        if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
+        if (mNetworks[i].mNetworkType == NetworkType::kUndefined)
         {
-            Thread::OperationalDataset & dataset = sNetworks[i].mData.mThread;
-            CHIP_ERROR error                     = dataset.Init(operationalDataset);
+            Thread::OperationalDataset & dataset = mNetworks[i].mData.mThread;
+            CHIP_ERROR error                     = dataset.Init(request.OperationalDataSet);
 
             if (error != CHIP_NO_ERROR)
             {
                 ChipLogDetail(Zcl, "Failed to parse Thread operational dataset: %s", ErrorStr(error));
-                err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+                err = CHIP_ERROR_INVALID_ARGUMENT;
                 break;
             }
 
             uint8_t extendedPanId[Thread::kSizeExtendedPanId];
 
-            static_assert(sizeof(sNetworks[i].mNetworkID) >= sizeof(extendedPanId),
+            static_assert(sizeof(mNetworks[i].mNetworkID) >= sizeof(extendedPanId),
                           "Network ID must be larger than Thread extended PAN ID!");
             SuccessOrExit(dataset.GetExtendedPanId(extendedPanId));
-            memcpy(sNetworks[i].mNetworkID, extendedPanId, sizeof(extendedPanId));
-            sNetworks[i].mNetworkIDLen = sizeof(extendedPanId);
+            memcpy(mNetworks[i].mNetworkID, extendedPanId, sizeof(extendedPanId));
+            mNetworks[i].mNetworkIDLen = sizeof(extendedPanId);
 
-            sNetworks[i].mNetworkType = NetworkType::kThread;
-            sNetworks[i].mEnabled     = false;
+            mNetworks[i].mNetworkType = NetworkType::kThread;
+            mNetworks[i].mEnabled     = false;
 
-            err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
+            err = CHIP_NO_ERROR;
             break;
         }
     }
 
 exit:
     // TODO: We should encode response command here.
-
-    ChipLogDetail(Zcl, "AddThreadNetwork: %" PRIu8, err);
+    ChipLogFunctError(err);
     return err;
 #else
     // The target does not supports ThreadNetwork. We should not add AddThreadNetwork command in that case then the upper layer will
     // return "Command not found" error.
-    return EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
 }
 
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan ssid,
-                                                                         ByteSpan credentials, uint64_t breadcrumb,
-                                                                         uint32_t timeoutMs)
+CHIP_ERROR NetworkCommissioningServer::AddWifiNetwork(chip::app::Cluster::NetworkCommissioningCluster::AddWifiNetworkCommand::Type &request)
 {
 #if defined(CHIP_DEVICE_LAYER_TARGET)
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
     for (size_t i = 0; i < kMaxNetworks; i++)
     {
-        if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
+        if (mNetworks[i].mNetworkType == NetworkType::kUndefined)
         {
-            VerifyOrExit(ssid.size() <= sizeof(sNetworks[i].mData.mWiFi.mSSID),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mData.mWiFi.mSSID, ssid.data(), ssid.size());
+            VerifyOrExit(request.Ssid.size() <= sizeof(mNetworks[i].mData.mWiFi.mSSID),
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
+            memcpy(mNetworks[i].mData.mWiFi.mSSID, request.Ssid.data(), request.Ssid.size());
 
-            using WiFiSSIDLenType = decltype(sNetworks[i].mData.mWiFi.mSSIDLen);
-            VerifyOrExit(chip::CanCastTo<WiFiSSIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mData.mWiFi.mSSIDLen = static_cast<WiFiSSIDLenType>(ssid.size());
+            using WiFiSSIDLenType = decltype(mNetworks[i].mData.mWiFi.mSSIDLen);
+            VerifyOrExit(chip::CanCastTo<WiFiSSIDLenType>(request.Ssid.size()), err = CHIP_ERROR_INVALID_ARGUMENT);
+            mNetworks[i].mData.mWiFi.mSSIDLen = static_cast<WiFiSSIDLenType>(request.Ssid.size());
 
-            VerifyOrExit(credentials.size() <= sizeof(sNetworks[i].mData.mWiFi.mCredentials),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mData.mWiFi.mCredentials, credentials.data(), credentials.size());
+            VerifyOrExit(request.Credentials.size() <= sizeof(mNetworks[i].mData.mWiFi.mCredentials),
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
+            memcpy(mNetworks[i].mData.mWiFi.mCredentials, request.Credentials.data(), request.Credentials.size());
 
-            using WiFiCredentialsLenType = decltype(sNetworks[i].mData.mWiFi.mCredentialsLen);
-            VerifyOrExit(chip::CanCastTo<WiFiCredentialsLenType>(ssid.size()),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mData.mWiFi.mCredentialsLen = static_cast<WiFiCredentialsLenType>(credentials.size());
+            using WiFiCredentialsLenType = decltype(mNetworks[i].mData.mWiFi.mCredentialsLen);
+            VerifyOrExit(chip::CanCastTo<WiFiCredentialsLenType>(request.Ssid.size()),
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
+            mNetworks[i].mData.mWiFi.mCredentialsLen = static_cast<WiFiCredentialsLenType>(request.Credentials.size());
 
-            VerifyOrExit(ssid.size() <= sizeof(sNetworks[i].mNetworkID), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mNetworkID, sNetworks[i].mData.mWiFi.mSSID, ssid.size());
+            VerifyOrExit(request.Ssid.size() <= sizeof(mNetworks[i].mNetworkID), err = CHIP_ERROR_INVALID_ARGUMENT);
+            memcpy(mNetworks[i].mNetworkID, mNetworks[i].mData.mWiFi.mSSID, request.Ssid.size());
 
-            using NetworkIDLenType = decltype(sNetworks[i].mNetworkIDLen);
-            VerifyOrExit(chip::CanCastTo<NetworkIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mNetworkIDLen = static_cast<NetworkIDLenType>(ssid.size());
+            using NetworkIDLenType = decltype(mNetworks[i].mNetworkIDLen);
+            VerifyOrExit(chip::CanCastTo<NetworkIDLenType>(request.Ssid.size()), err = CHIP_ERROR_INVALID_ARGUMENT);
+            mNetworks[i].mNetworkIDLen = static_cast<NetworkIDLenType>(request.Ssid.size());
 
-            sNetworks[i].mNetworkType = NetworkType::kWiFi;
-            sNetworks[i].mEnabled     = false;
+            mNetworks[i].mNetworkType = NetworkType::kWiFi;
+            mNetworks[i].mEnabled     = false;
 
-            err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
+            err = CHIP_NO_ERROR;
             break;
         }
     }
 
-    VerifyOrExit(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS, );
+    VerifyOrExit(err == CHIP_NO_ERROR, );
 
-    ChipLogDetail(Zcl, "WiFi provisioning data: SSID: %.*s", static_cast<int>(ssid.size()), ssid.data());
+    ChipLogDetail(Zcl, "WiFi provisioning data: SSID: %.*s", static_cast<int>(request.Ssid.size()), request.Ssid.data());
 exit:
     // TODO: We should encode response command here.
 
-    ChipLogDetail(Zcl, "AddWiFiNetwork: %" PRIu8, err);
+    ChipLogDetail(Zcl, "AddWiFiNetwork: %" PRId32, err);
     return err;
 #else
     // The target does not supports WiFiNetwork.
@@ -213,12 +229,11 @@ exit:
 #endif
 }
 
-namespace {
-CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
+CHIP_ERROR NetworkCommissioningServer::DoEnableNetwork(NetworkInfo * network)
 {
     switch (network->mNetworkType)
     {
-    case NetworkType::kThread:
+        case NetworkType::kThread:
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 // TODO: On linux, we are using Reset() instead of Detach() to disable thread network, which is not expected.
 // Upstream issue: https://github.com/openthread/ot-br-posix/issues/755
@@ -233,65 +248,61 @@ CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
         break;
     case NetworkType::kWiFi:
 #if defined(CHIP_DEVICE_LAYER_TARGET)
-    {
-        // TODO: Currently, DeviceNetworkProvisioningDelegateImpl assumes that ssid and credentials are null terminated strings,
-        // which is not correct, this should be changed once we have better method for commissioning wifi networks.
-        DeviceLayer::DeviceNetworkProvisioningDelegateImpl deviceDelegate;
-        ReturnErrorOnFailure(deviceDelegate.ProvisionWiFi(reinterpret_cast<const char *>(network->mData.mWiFi.mSSID),
-                                                          reinterpret_cast<const char *>(network->mData.mWiFi.mCredentials)));
-        break;
-    }
+        {
+            // TODO: Currently, DeviceNetworkProvisioningDelegateImpl assumes that ssid and credentials are null terminated strings,
+            // which is not correct, this should be changed once we have better method for commissioning wifi networks.
+            DeviceLayer::DeviceNetworkProvisioningDelegateImpl deviceDelegate;
+            ReturnErrorOnFailure(deviceDelegate.ProvisionWiFi(reinterpret_cast<const char *>(network->mData.mWiFi.mSSID),
+                                                              reinterpret_cast<const char *>(network->mData.mWiFi.mCredentials)));
+            break;
+        }
 #else
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
-    break;
+        break;
     case NetworkType::kEthernet:
     case NetworkType::kUndefined:
     default:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     network->mEnabled = true;
+
     return CHIP_NO_ERROR;
 }
-} // namespace
 
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan networkID,
-                                                                        uint64_t breadcrumb, uint32_t timeoutMs)
+CHIP_ERROR NetworkCommissioningServer::EnableNetwork(NetworkCommissioningCluster::EnableNetworkCommand::Type &request)
 {
     size_t networkSeq;
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_NETWORK_ID_NOT_FOUND;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+	
     // TODO(cecille): This is very dangerous - need to check against real netif name, ensure no password.
     constexpr char ethernetNetifMagicCode[] = "ETH0";
-    if (networkID.size() == sizeof(ethernetNetifMagicCode) &&
-        memcmp(networkID.data(), ethernetNetifMagicCode, networkID.size()) == 0)
+    if (request.NetworkId.size() == sizeof(ethernetNetifMagicCode) &&
+        memcmp(request.NetworkId.data(), ethernetNetifMagicCode, request.NetworkId.size()) == 0)
     {
         ChipLogProgress(Zcl, "Wired network enabling requested. Assuming success.");
-        ExitNow(err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS);
+        ExitNow(err = CHIP_NO_ERROR);
     }
 
     for (networkSeq = 0; networkSeq < kMaxNetworks; networkSeq++)
     {
-        if (sNetworks[networkSeq].mNetworkIDLen == networkID.size() &&
-            sNetworks[networkSeq].mNetworkType != NetworkType::kUndefined &&
-            memcmp(sNetworks[networkSeq].mNetworkID, networkID.data(), networkID.size()) == 0)
+        if (mNetworks[networkSeq].mNetworkIDLen == request.NetworkId.size() &&
+            mNetworks[networkSeq].mNetworkType != NetworkType::kUndefined &&
+            memcmp(mNetworks[networkSeq].mNetworkID, request.NetworkId.data(), request.NetworkId.size()) == 0)
         {
             // TODO: Currently, we cannot figure out the detailed error from network provisioning on DeviceLayer, we should
             // implement this in device layer.
-            VerifyOrExit(DoEnableNetwork(&sNetworks[networkSeq]) == CHIP_NO_ERROR,
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR);
-            ExitNow(err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS);
+            VerifyOrExit(DoEnableNetwork(&mNetworks[networkSeq]) == CHIP_NO_ERROR,
+                         err = CHIP_ERROR_INVALID_ARGUMENT);
+            ExitNow(err = CHIP_NO_ERROR);
         }
     }
+
     // TODO: We should encode response command here.
 exit:
-    if (err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS)
+    if (err == CHIP_NO_ERROR)
     {
-        DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().EnableNetworkForOperational(networkID);
+        DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().EnableNetworkForOperational(request.NetworkId);
     }
     return err;
 }
-
-} // namespace NetworkCommissioning
-} // namespace clusters
-} // namespace app
-} // namespace chip

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -22,20 +22,81 @@
 #include <app/common/gen/enums.h>
 #include <lib/core/CHIPCore.h>
 #include <platform/internal/DeviceNetworkProvisioning.h>
+#include <Cluster.h>
+#include <NetworkCommissioningCluster-Gen.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <lib/support/ThreadOperationalDataset.h>
 
 namespace chip {
 namespace app {
-namespace clusters {
-namespace NetworkCommissioning {
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId,
-                                                                           ByteSpan operationalDataset, uint64_t breadcrumb,
-                                                                           uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan ssid,
-                                                                         ByteSpan credentials, uint64_t breadcrumb,
-                                                                         uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::CommandHandler *, EndpointId, ByteSpan networkID,
-                                                                        uint64_t breadcrumb, uint32_t timeoutMs);
-} // namespace NetworkCommissioning
+namespace Cluster {
+
+#ifndef CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS
+#define CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS 4
+#endif // CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS
+    
+class NetworkCommissioningServer : public ClusterServer {
+public:
+    NetworkCommissioningServer();
+
+private:
+    CHIP_ERROR OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload) override;
+    CHIP_ERROR AddThreadNetwork(chip::app::Cluster::NetworkCommissioningCluster::AddThreadNetworkCommand::Type &request);
+    CHIP_ERROR AddWifiNetwork(chip::app::Cluster::NetworkCommissioningCluster::AddWifiNetworkCommand::Type &request);
+    CHIP_ERROR EnableNetwork(chip::app::Cluster::NetworkCommissioningCluster::EnableNetworkCommand::Type &request);
+
+private:
+    constexpr static uint8_t kMaxNetworkIDLen       = 32;
+    constexpr static uint8_t kMaxThreadDatasetLen   = 254; // As defined in Thread spec.
+    constexpr static uint8_t kMaxWiFiSSIDLen        = 32;
+    constexpr static uint8_t kMaxWiFiCredentialsLen = 64;
+    constexpr static uint8_t kMaxNetworks           = CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS;
+
+    enum class NetworkType : uint8_t
+    {
+        kUndefined = 0,
+        kWiFi      = 1,
+        kThread    = 2,
+        kEthernet  = 3,
+    };
+
+    struct ThreadNetworkInfo
+    {
+        uint8_t mDataset[kMaxThreadDatasetLen];
+        uint8_t mDatasetLen;
+    };
+
+    struct WiFiNetworkInfo
+    {
+        uint8_t mSSID[kMaxWiFiSSIDLen + 1];
+        uint8_t mSSIDLen;
+        uint8_t mCredentials[kMaxWiFiCredentialsLen];
+        uint8_t mCredentialsLen;
+    };
+
+    struct NetworkInfo
+    {
+        uint8_t mNetworkID[kMaxNetworkIDLen];
+        uint8_t mNetworkIDLen;
+        uint8_t mEnabled;
+        NetworkType mNetworkType;
+        union NetworkData
+        {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+            Thread::OperationalDataset mThread;
+#endif
+#if defined(CHIP_DEVICE_LAYER_TARGET)
+            WiFiNetworkInfo mWiFi;
+#endif
+        } mData;
+    };
+
+    CHIP_ERROR DoEnableNetwork(NetworkInfo *network);
+
+private:    
+    NetworkInfo mNetworks[kMaxNetworks];
+
+};
 
 } // namespace clusters
 } // namespace app

--- a/src/app/gen-utils/BUILD.gn
+++ b/src/app/gen-utils/BUILD.gn
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("includes") {
+  include_dirs = [ "." ]
+}
+
+static_library("gen-utils-device") {
+  output_name = "libGenUtilsDevice"
+
+  sources = [
+    "device/SchemaUtils.cpp",
+    "device/SchemaTypes.h"
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/app"
+  ]
+
+  public_configs = [
+    "${chip_root}/src/app:app_config",
+    ":includes"
+  ]
+
+  defines = []
+}
+
+static_library("gen-utils-stl") {
+  output_name = "libGenUtilsStl"
+
+  sources = [
+    "stl/DemuxedInvokeInitiator.cpp",
+    "stl/DemuxedInvokeInitiator.h"
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/app"
+  ]
+
+  public_configs = [
+    "${chip_root}/src/app:app_config",
+    ":includes"
+  ]
+
+  defines = []
+}
+

--- a/src/app/gen-utils/device/SchemaTypes.h
+++ b/src/app/gen-utils/device/SchemaTypes.h
@@ -1,0 +1,195 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Contains various types and methods used in the generated code for constrained devices.
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <support/CodeUtils.h>
+#include <core/CHIPConfig.h>
+#include <support/BitFlags.h>
+#include <array>
+#include <basic-types.h>
+
+namespace chip {
+namespace app {
+
+/*
+ * @brief
+ *
+ * Type of a field in a schema element (attributes, commands, events)
+ */
+enum class Type: uint8_t
+{
+    TYPE_UINT8 = (1 << 0),
+    TYPE_UINT32 = (1 << 1),
+    TYPE_ARRAY = (1 << 2),
+    TYPE_STRUCT = (1 << 3),
+    TYPE_UINT64 = (1 << 4),
+    TYPE_OCTSTR = (1 << 5),
+    TYPE_STRING = (1 << 6)
+};
+
+/*
+ * @brief
+ *
+ * Qualities of a field in a cluster definition.
+ */
+enum QualityMasks {
+    kNone = 0,
+    kOptional = (1 << 0),
+    kNullable = (1 << 1),
+};
+
+/*
+ * @brief
+ *
+ * This descriptor contains schema information describing a particular field in a schema element.
+ *
+ * This is emited in generated cluster definitions.
+ */
+struct FullFieldDescriptor {
+    chip::FieldId FieldId;
+    BitFlags<Type> FieldType;
+    uint32_t Qualities;
+    uint64_t FieldGenTag;
+    chip::Span<const FullFieldDescriptor> FieldList;
+};
+
+/*
+ * @brief
+ *
+ * This descriptor contains schema information describing a particular field in a schema element.
+ *
+ * This is generated using constexpr functions at compile time from generated descriptor tables of 
+ * type FullFieldDescriptor
+ */
+struct CompactFieldDescriptor {
+    chip::FieldId FieldId;
+    BitFlags<Type> FieldType;
+    uint32_t Qualities;
+    uint32_t Offset;
+    uint32_t TypeSize;
+    chip::Span<const CompactFieldDescriptor> StructDef;
+};
+
+/*
+ * @brief
+ *
+ * For every field in a generated type definition, this structure contains the offset of those fields
+ */
+struct TypeOffsetInfo {
+    uint32_t Offset;
+    uint32_t TypeSize;
+};
+
+
+template <size_t N>
+struct BaseType {
+    std::array<uint32_t,N> mOffsets;
+};
+
+template <size_t N>
+struct StructDescriptor {
+    std::array<CompactFieldDescriptor, N> FieldList;
+};
+
+constexpr bool IsImplemented(uint64_t FieldId)
+{
+#ifdef ImplementedFields
+    for (size_t i = 0; i < ImplementedFields.size(); i++) {
+        if (ImplementedFields[i] == FieldId) {
+            return true;
+        }
+    }
+#endif
+
+    return true;
+}
+
+/*
+ * @brief
+ *
+ * A function that computes the number of implemented fields in a given full field descriptor
+ * based on what the product configuration file has defined as being implemented.
+ *
+ * This macro is helpful for compile-time sizing the compact field descriptors, as well as a number of
+ * other constexpr arrays.
+ */
+template <size_t N>
+constexpr int GetNumImplementedFields(const FullFieldDescriptor (&structDescriptor)[N])
+{
+    int count = 0;
+
+    for (size_t i = 0; i < N; i++) {
+        if (structDescriptor[i].Qualities & kOptional) {
+            count += !!IsImplemented(structDescriptor[i].FieldGenTag);
+        }
+        else {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+/*
+ * @brief
+ *
+ * The main function that generates the compact field descriptors from the full field descriptor using
+ * product configuration information about implemented fields/features, as well as other product configuration defines (in the future)
+ */
+template <size_t N, size_t M, class ...Args>
+constexpr std::array<CompactFieldDescriptor, N> PopulateFieldDescriptors(const FullFieldDescriptor (&schema)[M], 
+                                                                  std::array<TypeOffsetInfo,N> offsets, const Args& ...args) {
+    int index = 0;
+    int structIndex = 0;
+
+    using result_t = ::std::array<CompactFieldDescriptor, N>;
+    result_t r = {};
+    std::array<chip::Span<const CompactFieldDescriptor>, sizeof...(args)> structArgs = {{ args... }};
+    const result_t& const_r = r;
+
+    for (size_t i = 0; i < M; i++) {
+        if (((schema[i].Qualities & kOptional) && IsImplemented(schema[i].FieldGenTag)) ||
+            !(schema[i].Qualities & kOptional)) {
+            const_cast<decltype(CompactFieldDescriptor::Offset)&>(const_r[index].Offset) = offsets[index].Offset;
+            const_cast<decltype(CompactFieldDescriptor::TypeSize)&>(const_r[index].TypeSize) = offsets[index].TypeSize;
+            const_cast<decltype(CompactFieldDescriptor::FieldId)&>(const_r[index].FieldId) = schema[i].FieldId;
+            const_cast<decltype(CompactFieldDescriptor::FieldType)&>(const_r[index].FieldType) = schema[i].FieldType;
+            const_cast<decltype(CompactFieldDescriptor::Qualities)&>(const_r[index].Qualities) = schema[i].Qualities;
+
+            if (schema[i].FieldType.Has(Type::TYPE_STRUCT)) {
+                const_cast<decltype(CompactFieldDescriptor::StructDef)&>(const_r[index].StructDef) = structArgs[structIndex++];
+            }
+
+            index++;
+        }
+    }
+
+    return r;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/gen-utils/device/SchemaUtils.cpp
+++ b/src/app/gen-utils/device/SchemaUtils.cpp
@@ -1,0 +1,253 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#include "SchemaTypes.h"
+#include "core/CHIPError.h"
+#include "core/CHIPTLVTags.h"
+#include "core/CHIPTLVTypes.h"
+#include <core/CHIPTLVDebug.hpp>
+
+struct Test {
+};
+
+static_assert(sizeof(chip::Span<uint8_t>) == sizeof(chip::Span<Test>), "Chip::Span cannot be type erasured");
+
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR EncodeSchemaElement(chip::Span<const CompactFieldDescriptor> pDescriptor, void *buf, uint64_t tag, TLV::TLVWriter &writer, bool inArray)
+{
+    CHIP_ERROR err;
+    TLV::TLVType outerContainerType;
+
+    if (!inArray) {
+        err = writer.StartContainer(tag, TLV::kTLVType_Structure, outerContainerType);
+        SuccessOrExit(err);
+    }
+
+    for (auto schemaIter = pDescriptor.data(); schemaIter != (pDescriptor.data() + pDescriptor.size()); schemaIter++) {
+        uint64_t fieldTag = inArray ? TLV::AnonymousTag : TLV::ContextTag((uint8_t)schemaIter->FieldId);
+
+        if (schemaIter->FieldType.Has(Type::TYPE_ARRAY)) {
+            TLV::TLVType outerContainerType2;
+            chip::ByteSpan &p = *(reinterpret_cast<chip::ByteSpan *>((uintptr_t)(buf) + schemaIter->Offset));
+            CompactFieldDescriptor tmpDescriptor = *schemaIter;
+            chip::Span<const CompactFieldDescriptor> tmpDescriptorList = {&tmpDescriptor, 1};
+
+            if (p.data() && p.size()) {
+                tmpDescriptor.FieldType.Clear(Type::TYPE_ARRAY);
+                tmpDescriptor.Offset = 0;
+
+                err = writer.StartContainer(TLV::ContextTag((uint8_t)(schemaIter->FieldId)), TLV::kTLVType_Array, outerContainerType2);
+                SuccessOrExit(err);
+
+                for (const uint8_t *ptr = p.data(); ptr < (p.data() + p.size() * schemaIter->TypeSize); ptr += schemaIter->TypeSize) {
+                    err = EncodeSchemaElement(tmpDescriptorList, (void *)ptr, 0, writer, true);
+                    SuccessOrExit(err);
+                }
+
+                err = writer.EndContainer(outerContainerType2);
+                SuccessOrExit(err);
+            }
+        }
+        else if (schemaIter->FieldType.Has(Type::TYPE_STRUCT)) {
+            err = EncodeSchemaElement(schemaIter->StructDef, (void *)((uintptr_t)(buf) + schemaIter->Offset), 
+                                      fieldTag, writer, false);
+            SuccessOrExit(err);
+        }
+        
+        else if (schemaIter->FieldType.Has(Type::TYPE_UINT8)) {
+            uint8_t *v = (uint8_t *)((uintptr_t)(buf) + schemaIter->Offset);
+            err = writer.Put(fieldTag, *v);
+            SuccessOrExit(err);
+        }
+        else if (schemaIter->FieldType.Has(Type::TYPE_UINT32)) {
+            uint32_t *v = (uint32_t *)((uintptr_t)(buf) + schemaIter->Offset);
+            err = writer.Put(fieldTag, *v);
+            SuccessOrExit(err);
+        }
+        else if (schemaIter->FieldType.Has(Type::TYPE_OCTSTR)) {
+            chip::ByteSpan &p = *(reinterpret_cast<chip::ByteSpan *>((uintptr_t)(buf) + schemaIter->Offset));
+
+            if (p.data() && p.size()) {
+                err = writer.PutBytes(TLV::ContextTag((uint8_t)(schemaIter->FieldId)), p.data(), (uint32_t)p.size());
+                SuccessOrExit(err);
+            }
+        }
+        else if (schemaIter->FieldType.Has(Type::TYPE_STRING)) {
+            chip::Span<char> &p = *(reinterpret_cast<chip::Span<char>*>((uintptr_t)(buf) + schemaIter->Offset));
+
+            if (p.data() && p.size()) {
+                err = writer.PutString(TLV::ContextTag((uint8_t)(schemaIter->FieldId)), p.data(), (uint32_t)p.size());
+                SuccessOrExit(err);
+            }
+        }
+    }
+
+    if (!inArray) {
+        err = writer.EndContainer(outerContainerType);
+        SuccessOrExit(err);
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR DecodeSchemaElement(chip::Span<const CompactFieldDescriptor> pDescriptor, void *buf, TLV::TLVReader &reader, bool inArray)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outerContainerType;
+
+    if (!inArray) {
+        err = reader.EnterContainer(outerContainerType);
+        SuccessOrExit(err);
+    }
+
+    while ((err = reader.Next()) == CHIP_NO_ERROR) {
+        uint64_t tag = reader.GetTag();
+
+        if (!inArray) {
+            VerifyOrExit(TLV::IsContextTag(tag), err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+        }
+
+        if (!buf) {
+            return CHIP_ERROR_NULL_BUF_ARG;
+        }
+
+        for (auto schemaIter = pDescriptor.data(); schemaIter != (pDescriptor.data() + pDescriptor.size()); schemaIter++) {
+            if (inArray || (!inArray && (schemaIter->FieldId == TLV::TagNumFromTag(tag)))) {
+                if (schemaIter->FieldType.Has(Type::TYPE_ARRAY)) {
+                    TLV::TLVType outerContainerType2;
+                    chip::ByteSpan &p = *(reinterpret_cast<chip::ByteSpan *>((uintptr_t)(buf) + schemaIter->Offset));
+                    CompactFieldDescriptor tmpDescriptor = *schemaIter;
+                    chip::Span<const CompactFieldDescriptor> tmpDescriptorList = {&tmpDescriptor, 1};
+
+                    tmpDescriptor.FieldType.Clear(Type::TYPE_ARRAY);
+                    tmpDescriptor.Offset = 0;
+
+                    err = reader.EnterContainer(outerContainerType2);
+                    SuccessOrExit(err);
+
+                    {
+                        const uint8_t *ptr = p.data();
+                        int size = (int)p.size();
+
+                        VerifyOrExit(size, err = CHIP_ERROR_NULL_BUF_ARG);
+
+                        while ((err = DecodeSchemaElement(tmpDescriptorList, (void *)ptr, reader, true) == CHIP_NO_ERROR)) {
+                            size--;
+
+                            if (size == 0) {
+                                ptr = nullptr;
+                            }
+                            else {
+                                ptr += schemaIter->TypeSize;
+                            }
+                        }
+
+                    }
+
+                    if (err == CHIP_END_OF_TLV) {
+                        err = CHIP_NO_ERROR;
+                    }
+
+                    SuccessOrExit(err);
+
+                    err = reader.ExitContainer(outerContainerType2);
+                    SuccessOrExit(err);
+                    break;
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_STRUCT)) {
+                    err = DecodeSchemaElement(schemaIter->StructDef, (void *)((uintptr_t)(buf) + schemaIter->Offset), reader, false);
+                    SuccessOrExit(err);
+                    break;
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_UINT8)) {
+                    uint8_t *v = (uint8_t *)((uintptr_t)buf + schemaIter->Offset);
+                    err = reader.Get(*v);
+                    SuccessOrExit(err);
+                    break;
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_UINT32)) {
+                    uint32_t *v = (uint32_t *)((uintptr_t)buf + schemaIter->Offset);
+                    err = reader.Get(*v);
+                    SuccessOrExit(err);
+                    break;
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_UINT64)) {
+                    uint64_t *v = (uint64_t *)((uintptr_t)buf + schemaIter->Offset);
+                    err = reader.Get(*v);
+                    SuccessOrExit(err);
+                    break;
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_OCTSTR)) {
+                    chip::ByteSpan &p = *(reinterpret_cast<chip::ByteSpan *>((uintptr_t)(buf) + schemaIter->Offset));
+                    uint32_t sz = reader.GetLength();
+
+                    VerifyOrExit(p.data() && p.size() >= sz, err = CHIP_ERROR_NULL_BUF_ARG);
+
+                    err = reader.GetBytes((uint8_t *)p.data(), (uint32_t)p.size());
+                    SuccessOrExit(err);
+
+                    chip::ByteSpan *p1 = (reinterpret_cast<chip::ByteSpan *>((uintptr_t)(buf) + schemaIter->Offset));
+                    *p1 = chip::ByteSpan(p.data(), sz);
+                }
+                else if (schemaIter->FieldType.Has(Type::TYPE_STRING)) {
+                    chip::Span<char> &p = *(reinterpret_cast<chip::Span<char> *>((uintptr_t)(buf) + schemaIter->Offset));
+                    uint32_t sz = reader.GetLength();
+
+                    VerifyOrExit(p.data() && p.size() >= sz, err = CHIP_ERROR_NULL_BUF_ARG);
+
+                    err = reader.GetString((char *)p.data(), (uint32_t)p.size());
+                    SuccessOrExit(err);
+
+                    chip::Span<char> *p1 = (reinterpret_cast<chip::Span<char> *>((uintptr_t)(buf) + schemaIter->Offset));
+                    *p1 = chip::Span<char>(p.data(), sz);
+                }
+            }
+        }
+
+        if (inArray) {
+            break;
+        }
+    }
+
+    if (!inArray) {
+        err = reader.ExitContainer(outerContainerType);
+        SuccessOrExit(err);
+
+        if (err == CHIP_END_OF_TLV) {
+            err = CHIP_NO_ERROR;
+        }
+    }
+
+exit:
+    return err;
+}
+
+
+} // namespace app
+} // namespace chip

--- a/src/app/gen-utils/device/SchemaUtils.h
+++ b/src/app/gen-utils/device/SchemaUtils.h
@@ -31,6 +31,7 @@
 #include <array>
 #include <basic-types.h>
 #include "SchemaTypes.h"
+#include "core/CHIPTLVTypes.h"
 #include "system/SystemPacketBuffer.h"
 #include <support/PrivateHeap.h>
 #include <Cluster.h>

--- a/src/app/gen-utils/device/SchemaUtils.h
+++ b/src/app/gen-utils/device/SchemaUtils.h
@@ -1,0 +1,64 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <support/CodeUtils.h>
+#include <core/CHIPConfig.h>
+#include <support/BitFlags.h>
+#include <array>
+#include <basic-types.h>
+#include "SchemaTypes.h"
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR EncodeSchemaElement(chip::Span<const CompactFieldDescriptor> pDescriptor, void *buf, uint64_t tag, TLV::TLVWriter &writer, bool inArray = false);
+CHIP_ERROR DecodeSchemaElement(chip::Span<const CompactFieldDescriptor> pDescriptor, void *buf, TLV::TLVReader &reader, bool inArray = false);
+
+template <typename GenType_t>
+CHIP_ERROR EncodeSchemaElement(GenType_t &v, TLV::TLVWriter &writer, uint64_t tag)
+{
+    CHIP_ERROR err = EncodeSchemaElement({v.mDescriptor.FieldList.data(), v.mDescriptor.FieldList.size()}, &v, tag, writer);    
+    SuccessOrExit(err);
+
+    err = writer.Finalize(); 
+
+exit:
+    return err;
+}
+
+template <typename GenType_t>
+CHIP_ERROR DecodeSchemaElement(GenType_t &v, TLV::TLVReader &reader)
+{
+    CHIP_ERROR err = DecodeSchemaElement({v.mDescriptor.FieldList.data(), v.mDescriptor.FieldList.size()}, &v, reader);    
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/gen-utils/stl/DemuxedInvokeInitiator.cpp
+++ b/src/app/gen-utils/stl/DemuxedInvokeInitiator.cpp
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#include "DemuxedInvokeInitiator.h"
+
+namespace chip {
+namespace app {
+
+DemuxedInvokeInitiator::DemuxedInvokeInitiator(onDoneFuncDef onDoneFunc)
+   : mOnDoneFunc(onDoneFunc)
+{
+}
+
+CHIP_ERROR DemuxedInvokeInitiator::AddCommand(IEncodableElement *request, CommandParams params,
+                  std::function<void (DemuxedInvokeInitiator& invokeInitiator, CommandParams&)> onDataFunc,
+                  std::function<void (DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, StatusResponse *response)> onErrorFunc)
+{
+    auto onDataClosure = [onDataFunc](DemuxedInvokeInitiator& initiator, CommandParams &pparams, TLV::TLVReader *reader) {
+        onDataFunc(initiator, pparams);
+    };
+
+    mHandlers.push_back({onDataClosure, onErrorFunc, params.ClusterId, params.CommandId});
+    return mInitiator.AddRequest(params, request);
+}
+
+void DemuxedInvokeInitiator::OnResponse(InvokeInitiator &initiator, CommandParams &params, TLV::TLVReader *payload) 
+{
+    bool foundMatch = false;
+
+    for (auto iter : mHandlers) {
+        if (iter.clusterId == params.ClusterId && iter.commandId == params.CommandId) {
+            iter.onDataClosure(*this, params, payload);
+            return;
+        }
+    }
+
+    if (!foundMatch) {
+        ChipLogProgress(DataManagement, "Could not find a matching demuxed handler for command! (ClusterId = %" PRIx32 ", Endpoint = %lu, Command = %lu)", 
+                        params.ClusterId, (unsigned long)params.EndpointId, (unsigned long)params.CommandId);
+    }           
+}
+
+void DemuxedInvokeInitiator::OnError(InvokeInitiator &initiator, CommandParams *params, CHIP_ERROR error, StatusResponse *statusResponse) 
+{
+    for (auto iter : mHandlers) {
+        if ((params && (iter.clusterId == params->ClusterId && iter.commandId == params->CommandId)) || (!params)) {
+            iter.onErrorFunc(*this, error, statusResponse);
+            return;
+        }
+    }
+}
+
+void DemuxedInvokeInitiator::OnEnd(InvokeInitiator &initiator) 
+{
+    mOnDoneFunc(*this);
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/gen-utils/stl/DemuxedInvokeInitiator.h
+++ b/src/app/gen-utils/stl/DemuxedInvokeInitiator.h
@@ -1,0 +1,158 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/BitFlags.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+
+#include <app/MessageDef/CommandDataElement.h>
+#include <app/MessageDef/CommandList.h>
+#include <app/MessageDef/InvokeCommand.h>
+#include <InvokeInteraction.h>
+#include <basic-types.h>
+#include <protocols/secure_channel/Constants.h>
+#include <functional>
+#include <vector>
+
+namespace chip {
+namespace app {
+
+/*
+ * @brief
+ *
+ * This class provides syntactic glue to make it easier for command initiators to register handlers for responses and errors
+ * for the commands they send by handling the demuxing of received command responses and routing it to the right registered handler
+ * based on the cluster and command id. This class wraps the InvokeInitiator class and provides pass-through calls to the underlying object as needed
+ * to maintain the same public API as that of the InvokeInitiator class.
+ *
+ * At the time a command request is added, handlers for the success and error cases are passed in as well.
+ *
+ * To achieve a hands-free allocation model of the ensuing response object, the method to add a request is templated against the type of the response,
+ * which is then allocated on stack inside an embedded closure before being passed up to the application. This avoids the application having to
+ * manage the allocation of the response object and the subsequent destruction of it.
+ *
+ * This class can only be used with cluster objects that support the IEncodableElement interface!
+ *
+ * The logic below leverages std::function to provide a flexible means to express the handler callbacks, which can be used along with std::bind to achieve
+ * a flexible scheme for expressing callbacks. As such, the class below is not suitable for embedded platforms.
+ *
+ */
+class DemuxedInvokeInitiator : public InvokeInitiator::ICommandHandler {
+public :
+   typedef std::function<void (DemuxedInvokeInitiator& demuxedInitiator)> onDoneFuncDef;
+
+   /*
+    * @brief
+    *
+    * Constructor that expects to be passed an onDoneFunc that will be called when the invoke has completed
+    * and the object is safe for destruction.
+    */
+   DemuxedInvokeInitiator(onDoneFuncDef onDoneFunc);
+
+   /*
+    * @brief
+    *
+    * Initializes the object by calling down to the invokeInitiator's method and passing self as the command handler
+    *
+    */
+   CHIP_ERROR Init(Messaging::ExchangeManager *apExchangeMgr, NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle *secureSession) {
+       return mInitiator.Init(apExchangeMgr, this, aNodeId, aAdminId, secureSession);
+   }
+
+   /*
+    * @brief
+    *
+    * Add a command request along with a response and error functions. This is a templated method with the type of the response object is used as the specialization.
+    * The response object is allocated on stack through a small closure that is invoked when the ensuing response is parsed by the OnResponse method.
+    *
+    */
+   template <typename T>
+   CHIP_ERROR AddCommand(IEncodableElement *request, CommandParams params,
+                  std::function<void (DemuxedInvokeInitiator &invokeInitiator, CommandParams&, T* t1)> onDataFunc, 
+                  std::function<void (DemuxedInvokeInitiator &invokeInitiator, CHIP_ERROR error, StatusResponse *response)> onErrorFunc = {}) {
+        auto onDataClosure = [onDataFunc](DemuxedInvokeInitiator& initiator, CommandParams &param, TLV::TLVReader *reader) {
+            if (reader) {
+                T t1;
+                t1.Decode(*reader);
+                onDataFunc(initiator, param, &t1);
+            }
+            else {
+                onDataFunc(initiator, param, NULL);
+            }
+        };
+
+        mHandlers.push_back({onDataClosure, onErrorFunc, T::GetClusterId(), T::GetCommandId()});
+        return mInitiator.AddRequest(params, request);
+   }
+
+   /*
+    * @brief
+    *
+    * Add a command request along with a response and error functions. Unlike the above, this does not expect a data response and as such, the signature
+    * of the onDataFunc callback does not contain the response object passed in.
+    *
+    */
+   CHIP_ERROR AddCommand(IEncodableElement *request, CommandParams params,
+                  std::function<void (DemuxedInvokeInitiator& invokeInitiator, CommandParams&)> onDataFunc = {}, 
+                  std::function<void (DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, StatusResponse *response)> onErrorFunc = {});
+
+   CHIP_ERROR Send() {
+       return mInitiator.Send();
+   }
+
+   InvokeInitiator &GetInitiator() { return mInitiator; }
+   
+   ~DemuxedInvokeInitiator() {}
+
+private:
+   void OnResponse(InvokeInitiator &initiator, CommandParams &params, TLV::TLVReader *payload) final;
+
+   void OnError(InvokeInitiator &initiator, CommandParams *params, CHIP_ERROR error, StatusResponse *statusResponse) final;
+
+   void OnEnd(InvokeInitiator &initiator) final;
+
+   struct Handler {
+       std::function<void (DemuxedInvokeInitiator& invokeInitiator, CommandParams &params, TLV::TLVReader *reader)> onDataClosure; 
+       std::function<void (DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, StatusResponse *response)> onErrorFunc;
+       chip::ClusterId clusterId;
+       chip::CommandId commandId;
+   };
+
+   InvokeInitiator mInitiator;
+   std::vector<Handler> mHandlers;
+   onDoneFuncDef mOnDoneFunc;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -39,13 +39,19 @@ static_library("server") {
     "Server.h",
     "StorablePeerConnection.cpp",
     "StorablePeerConnection.h",
+    "../clusters/network-commissioning/network-commissioning.cpp",
+    "../clusters/network-commissioning/network-commissioning.h"
   ]
 
-  public_configs = [ ":server_config" ]
+  public_configs = [ 
+    ":server_config",
+    "${chip_root}/gen-v2/device:includes"
+  ]
 
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/gen-v2/device",
     "${chip_root}/src/app",
     "${chip_root}/src/lib/mdns",
     "${chip_root}/src/messaging",

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -44,6 +44,8 @@
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/SecureSessionMgr.h>
 
+#include "../clusters/network-commissioning/network-commissioning.h"
+
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 #include <app/server/Mdns.h>
 #endif
@@ -451,6 +453,21 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindow
     return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, adminInfo);
 }
 
+chip::app::Cluster::NetworkCommissioningServer gNetworkCommissioningServer;
+
+CHIP_ERROR AddCoreServerClusters()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    gNetworkCommissioningServer.SetEndpoint(0);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&gNetworkCommissioningServer);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
 // The function will initialize datamodel handler and then start the server
 // The server assumes the platform's networking has been setup already
 void InitServer(AppDelegate * delegate)
@@ -551,6 +568,9 @@ void InitServer(AppDelegate * delegate)
 
     err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable(),
                                                     &gSessionIDAllocator);
+    SuccessOrExit(err);
+
+    err = AddCoreServerClusters();
     SuccessOrExit(err);
 
 exit:

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -77,11 +77,11 @@ chip_test_suite("tests") {
     "TestReadInteraction.cpp",
     "TestReportingEngine.cpp",
     "TestWriteInteraction.cpp",
-    "TestInvokeInteraction-STL.cpp",
-    "TestSchemaUtils-STL.cpp",
+    #"TestInvokeInteraction-STL.cpp",
+    #"TestSchemaUtils-STL.cpp",
     # TODO: Figure out how to compile the bottom set too...
-    #"TestInvokeInteraction-Device.cpp",
-    #"TestSchemaUtils-Device.cpp",
+    "TestInvokeInteraction-Device.cpp",
+    "TestSchemaUtils-Device.cpp",
   ]
 
   cflags = [ "-Wconversion" ]
@@ -89,10 +89,10 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app",
-    "${chip_root}/src/app/gen-utils:gen-utils-stl",
-    "${chip_root}/gen-v2/stl",
-    #"${chip_root}/src/app/gen-utils:gen-utils-device",
-    #"${chip_root}/gen-v2/device",
+    #"${chip_root}/src/app/gen-utils:gen-utils-stl",
+    #"${chip_root}/gen-v2/stl",
+    "${chip_root}/src/app/gen-utils:gen-utils-device",
+    "${chip_root}/gen-v2/device",
     "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/messaging/tests:helpers",

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -80,9 +80,8 @@ chip_test_suite("tests") {
     "TestInvokeInteraction-STL.cpp",
     "TestSchemaUtils-STL.cpp",
     # TODO: Figure out how to compile the bottom set too...
-    # "TestInvokeInteraction-Device.cpp",
-    # "TestSchemaUtils-Device.cpp",
-    
+    #"TestInvokeInteraction-Device.cpp",
+    #"TestSchemaUtils-Device.cpp",
   ]
 
   cflags = [ "-Wconversion" ]
@@ -92,6 +91,8 @@ chip_test_suite("tests") {
     "${chip_root}/src/app",
     "${chip_root}/src/app/gen-utils:gen-utils-stl",
     "${chip_root}/gen-v2/stl",
+    #"${chip_root}/src/app/gen-utils:gen-utils-device",
+    #"${chip_root}/gen-v2/device",
     "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/messaging/tests:helpers",

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -17,9 +17,53 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("${chip_root}/build/chip/chip_test_group.gni")
+
+#chip_test_suite("tests_stl") {
+#  output_name = "libAppTestsStl"
+#
+#  test_sources = [
+#    "TestSchemaUtils-STL.cpp"
+#  ]
+#
+#  cflags = [ "-Wconversion" ]
+#
+#  public_configs = [
+#    "${chip_root}/gen-v2/stl:includes"
+#  ]
+#
+#  public_deps = [
+#    "${chip_root}/src/app",
+#    "${chip_root}/gen-v2/stl",
+#    "${chip_root}/src/lib/core",
+#    "${chip_root}/src/protocols",
+#    "${nlunit_test_root}:nlunit-test",
+#  ]
+#}
+#
+#chip_test_suite("tests_device") {
+#  test_sources = [
+#    "TestSchemaUtils.cpp"
+#  ]
+#
+#  cflags = [ "-Wconversion" ]
+#
+#  public_configs = [
+#    "${chip_root}/gen-v2/device:includes"
+#  ]
+#
+#  public_deps = [
+#    "${chip_root}/src/app",
+#    "${chip_root}/gen-v2/device",
+#    "${chip_root}/src/lib/core",
+#    "${chip_root}/src/protocols",
+#    "${nlunit_test_root}:nlunit-test",
+#  ]
+#}
 
 chip_test_suite("tests") {
   output_name = "libAppTests"
+
 
   test_sources = [
     "TestCHIPDeviceCallbacksMgr.cpp",
@@ -33,12 +77,21 @@ chip_test_suite("tests") {
     "TestReadInteraction.cpp",
     "TestReportingEngine.cpp",
     "TestWriteInteraction.cpp",
+    "TestInvokeInteraction-STL.cpp",
+    "TestSchemaUtils-STL.cpp",
+    # TODO: Figure out how to compile the bottom set too...
+    # "TestInvokeInteraction-Device.cpp",
+    # "TestSchemaUtils-Device.cpp",
+    
   ]
 
   cflags = [ "-Wconversion" ]
 
+
   public_deps = [
     "${chip_root}/src/app",
+    "${chip_root}/src/app/gen-utils:gen-utils-stl",
+    "${chip_root}/gen-v2/stl",
     "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/messaging/tests:helpers",

--- a/src/app/tests/TestInvokeInteraction-Device.cpp
+++ b/src/app/tests/TestInvokeInteraction-Device.cpp
@@ -1,0 +1,383 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Command Interaction
+ *
+ */
+
+#include "TestCluster.h"
+#include "messaging/ExchangeDelegate.h"
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVText.hpp>
+#include <core/CHIPTLVData.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+
+#include <nlunit-test.h>
+
+#include <device/SchemaUtils.h>
+#include <TestCluster-Gen.h>
+#include <NetworkCommissioningCluster-Gen.h>
+
+namespace chip {
+static System::Layer gSystemLayer;
+static SecureSessionMgr gSessionManager;
+static Messaging::ExchangeManager gExchangeManager;
+static secure_channel::MessageCounterManager gMessageCounterManager;
+static TransportMgr<Transport::UDP> gTransportManager;
+static Transport::AdminId gAdminId = 0;
+
+namespace app {
+
+nlTestSuite *gpSuite = nullptr;
+InvokeResponder *gServerInvoke = nullptr;
+Messaging::ExchangeContext *gClientEc = nullptr;
+
+class TestServerCluster : public ClusterServer
+{
+public:
+    TestServerCluster();
+    CHIP_ERROR OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload) final;
+
+    bool mGotCommandA = false;
+};
+
+TestServerCluster::TestServerCluster()
+    : ClusterServer(chip::app::Cluster::TestCluster::kClusterId)
+{
+}
+
+CHIP_ERROR 
+TestServerCluster::OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::Cluster::TestCluster::CommandA::Type req;
+    uint8_t d[5];
+
+    req.d = chip::Span<uint8_t>{d};
+
+    if (commandParams.CommandId == chip::app::Cluster::TestCluster::kCommandAId) {
+        printf("Received CommandA\n");
+
+        gServerInvoke = &invokeInteraction;
+
+        NL_TEST_ASSERT(gpSuite, payload != nullptr); 
+
+        err = DecodeSchemaElement(req, *payload);
+        NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+
+        NL_TEST_ASSERT(gpSuite, req.a == 10);
+        NL_TEST_ASSERT(gpSuite, req.b == 20);
+        NL_TEST_ASSERT(gpSuite, req.c.x == 13);
+        NL_TEST_ASSERT(gpSuite, req.c.y == 99);
+
+        for (size_t i = 0; i < ArraySize(d); i++) {
+            NL_TEST_ASSERT(gpSuite, d[i] == i);
+        }
+
+        //
+        // Send response synchronously
+        //
+        
+        {
+            chip::app::Cluster::TestCluster::CommandB::Type resp;
+            chip::app::Cluster::TestCluster::StructA::Type e[5];
+
+            resp.a = 21;
+            resp.b = 49;
+            resp.c.x = 19;
+            resp.c.y = 233;
+            resp.d = chip::Span<uint8_t>{d};
+            resp.e = chip::Span<chip::app::Cluster::TestCluster::StructA::Type>{e};
+    
+            for (size_t i = 0; i < ArraySize(d); i++) {
+                d[i] = (uint8_t)(255 - i);
+            }
+
+            for (size_t i = 0; i < ArraySize(e); i++) {
+                e[i].x = (uint8_t)(255 - i);
+                e[i].y = (uint8_t)(255 - i);
+            }
+
+            commandParams.CommandId = chip::app::Cluster::TestCluster::kCommandBId;
+            err = invokeInteraction.AddResponse(commandParams, [&](chip::TLV::TLVWriter &writer, uint64_t tag) {
+                return EncodeSchemaElement(resp, writer, tag);
+            });
+
+            NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+        }
+
+        mGotCommandA = true;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+class TestInvokeInteraction : public Messaging::ExchangeContextUnitTestDelegate, public InvokeInitiator::ICommandHandler
+{
+public:
+    static void TestInvokeInteractionSimple(nlTestSuite * apSuite, void * apContext);
+    void InterceptMessage(System::PacketBufferHandle buf);
+    int GetNumActiveInvokes();
+
+protected:
+    void OnResponse(InvokeInitiator &invokeInteraction, CommandParams &commandParams, TLV::TLVReader *payload) final;
+    void OnError(InvokeInitiator &invokeInteration, CommandParams *aPath, CHIP_ERROR error, StatusResponse *statusResponse) final {}
+    void OnEnd(InvokeInitiator &invokeInteraction) final {}
+
+    System::PacketBufferHandle mBuf;
+    bool mGotCommandB = false;
+};
+
+using namespace chip::TLV;
+
+void TestInvokeInteraction::InterceptMessage(System::PacketBufferHandle buf)
+{
+    mBuf = std::move(buf);
+}
+
+void
+TestInvokeInteraction::OnResponse(InvokeInitiator &invokeInteraction, CommandParams &commandParams, TLV::TLVReader *payload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::Cluster::TestCluster::CommandB::Type resp;
+    uint8_t d[5];
+    chip::app::Cluster::TestCluster::StructA::Type e[5];
+
+    resp.d = chip::Span<uint8_t>{d};
+    resp.e = chip::Span<chip::app::Cluster::TestCluster::StructA::Type>{e};
+
+    if (commandParams.CommandId == chip::app::Cluster::TestCluster::kCommandBId) {
+        printf("Received CommandB\n");
+
+        // 
+        // To prevent the stack from actually sending this message
+        //
+        //invokeInteraction.IncrementHoldoffRef();
+
+        NL_TEST_ASSERT(gpSuite, payload != nullptr); 
+
+        err = DecodeSchemaElement(resp, *payload);
+        NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+
+        NL_TEST_ASSERT(gpSuite, resp.a == 21);
+        NL_TEST_ASSERT(gpSuite, resp.b == 49);
+        NL_TEST_ASSERT(gpSuite, resp.c.x == 19);
+        NL_TEST_ASSERT(gpSuite, resp.c.y == 233);
+
+        for (size_t i = 0; i < ArraySize(d); i++) {
+            NL_TEST_ASSERT(gpSuite, d[i] == (uint8_t)(255 - i));
+        }
+
+        for (size_t i = 0; i < ArraySize(e); i++) {
+            NL_TEST_ASSERT(gpSuite, e[i].x == (uint8_t)(255 - i));
+            NL_TEST_ASSERT(gpSuite, e[i].y == (uint8_t)(255 - i));
+        }
+
+        mGotCommandB = true;
+    }
+
+    return;
+}
+
+TestInvokeInteraction gTestInvoke;
+
+int TestInvokeInteraction::GetNumActiveInvokes()
+{
+    int count = 0;
+
+    InteractionModelEngine::GetInstance()->mInvokeResponders.ForEachActiveObject([&](InvokeResponder *apInteraction) {
+        count++;
+        return true;
+    });
+
+    return count;
+}
+
+/*
+ * @brief
+ *
+ * This test tries to achieve an 'end-to-end' test between a client and a server.
+ * Specifically, it has a client sending an invoke action to a server containing two commands targeting
+ * two different endpoints, with the server responding back syncronously with a response containing two response
+ * payloads.
+ *
+ * To achieve 'end-to-endness' within a single stack, the message is created and intercepted before it is sent out,
+ * and then 'looped back in' to the IM for it to make its way back up the stack to the application.
+ */
+void TestInvokeInteraction::TestInvokeInteractionSimple(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle buf;
+    Messaging::ExchangeContext *pRxEc;
+    PacketHeader packetHdr;
+    PayloadHeader payloadHdr;
+    TestServerCluster serverEp0;
+    TestServerCluster serverEp1;
+    InvokeInitiator invokeInitiator;
+
+    serverEp0.SetEndpoint(0);
+    serverEp1.SetEndpoint(1);
+    
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp0);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    invokeInitiator.Init(&chip::gExchangeManager, &gTestInvoke, 0, 0, NULL);
+
+    {
+        chip::app::Cluster::TestCluster::CommandA::Type req;
+        uint8_t d[5];
+
+        req.a = 10;
+        req.b = 20;
+        req.c.x = 13;
+        req.c.y = 99;
+        req.d = chip::Span<uint8_t>{d};
+
+        for (size_t i = 0; i < ArraySize(d); i++) {
+            d[i] = (uint8_t)i;
+        }
+    
+        err = invokeInitiator.AddRequest(CommandParams(req, 0, true), [&req](auto &writer, auto tag) {
+            return EncodeSchemaElement(req, writer, tag);
+        });
+        
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator.AddRequest(CommandParams(req, 1, true), [&req](auto &writer, auto tag) {
+            return EncodeSchemaElement(req, writer, tag);
+        });
+
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator.Send();
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    }
+
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+
+    gServerInvoke = nullptr;
+
+    pRxEc = chip::gExchangeManager.NewContext({0, 0, 0}, NULL);
+    NL_TEST_ASSERT(apSuite, pRxEc != nullptr);
+    
+    chip::app::InteractionModelEngine::GetInstance()->OnInvokeCommandRequest(pRxEc, packetHdr, payloadHdr, std::move(buf));
+    NL_TEST_ASSERT(apSuite, gServerInvoke != nullptr);
+    NL_TEST_ASSERT(apSuite, serverEp0.mGotCommandA);
+    NL_TEST_ASSERT(apSuite, serverEp1.mGotCommandA);
+
+    NL_TEST_ASSERT(apSuite, gTestInvoke.GetNumActiveInvokes() == 0);
+    
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+
+    invokeInitiator.OnMessageReceived(invokeInitiator.GetExchange(), PacketHeader(), PayloadHeader(), std::move(buf));
+    NL_TEST_ASSERT(apSuite, gTestInvoke.mGotCommandB);
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    chip::app::gpSuite = apSuite;
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::gSystemLayer.Init(nullptr);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins, &chip::gMessageCounterManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::Messaging::ExchangeContext::SetUnitTestDelegate(&chip::app::gTestInvoke);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestInvokeInteractionSimple", chip::app::TestInvokeInteraction::TestInvokeInteractionSimple),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestInvokeInteraction()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "InvokeInteraction",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestInvokeInteraction)

--- a/src/app/tests/TestInvokeInteraction-STL.cpp
+++ b/src/app/tests/TestInvokeInteraction-STL.cpp
@@ -1,0 +1,510 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Command Interaction
+ *
+ */
+
+#include <messaging/ExchangeDelegate.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVText.hpp>
+#include <core/CHIPTLVData.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <stl/DemuxedInvokeInitiator.h>
+#include <nlunit-test.h>
+#include <memory>
+#include <TestCluster-Gen.h>
+
+using namespace std::placeholders;
+
+namespace chip {
+static System::Layer gSystemLayer;
+static SecureSessionMgr gSessionManager;
+static Messaging::ExchangeManager gExchangeManager;
+static secure_channel::MessageCounterManager gMessageCounterManager;
+static TransportMgr<Transport::UDP> gTransportManager;
+static Transport::AdminId gAdminId = 0;
+
+namespace app {
+
+nlTestSuite *gpSuite = nullptr;
+InvokeResponder *gServerInvoke = nullptr;
+Messaging::ExchangeContext *gClientEc = nullptr;
+
+class TestServerCluster : public ClusterServer
+{
+public:
+    TestServerCluster();
+    CHIP_ERROR OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload) override;
+
+    void SetAsyncResp() { mDoAsyncResp = true; }
+
+    CHIP_ERROR SendAsyncResp();
+
+    bool mGotCommandA = false;
+    bool mDoAsyncResp = false;
+    InvokeResponder *mStashedInvokeResponder = nullptr;
+    CommandParams mStashedCommandParams;
+};
+
+TestServerCluster::TestServerCluster()
+    : ClusterServer(chip::app::Cluster::TestCluster::kClusterId)
+{
+}
+
+CHIP_ERROR
+TestServerCluster::SendAsyncResp()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::Cluster::TestCluster::CommandB::Type resp;
+
+    resp.a = 21;
+    resp.b = 49;
+    resp.c.x = 19;
+    resp.c.y = 233;
+
+    for (size_t i = 0; i < 5; i++) {
+        resp.d.insert(resp.d.begin() + (long)i, (uint8_t)(255 - i));
+    }
+
+    for (size_t i = 0; i < 5; i++) {
+        resp.e.insert(resp.e.begin() + (long)i, chip::app::Cluster::TestCluster::StructA::Type());
+        resp.e[i].x = (uint8_t)(255 - i);
+        resp.e[i].y = (uint8_t)(255 - i);
+    }
+
+    mStashedCommandParams.CommandId = chip::app::Cluster::TestCluster::kCommandBId;
+
+    err = mStashedInvokeResponder->AddResponse(mStashedCommandParams, &resp);
+    NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+
+    mStashedInvokeResponder->DecrementHoldOffRef();
+    return err;
+}
+
+CHIP_ERROR 
+TestServerCluster::OnInvokeRequest(CommandParams &commandParams, InvokeResponder &invokeInteraction, TLV::TLVReader *payload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::Cluster::TestCluster::CommandA::Type req;
+
+    if (commandParams.CommandId == chip::app::Cluster::TestCluster::kCommandAId) {
+        printf("Received CommandA\n");
+
+        gServerInvoke = &invokeInteraction;
+
+        NL_TEST_ASSERT(gpSuite, payload != nullptr); 
+
+        err = req.Decode(*payload);
+        NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+
+        NL_TEST_ASSERT(gpSuite, req.a == 10);
+        NL_TEST_ASSERT(gpSuite, req.b == 20);
+        NL_TEST_ASSERT(gpSuite, req.c.x == 13);
+        NL_TEST_ASSERT(gpSuite, req.c.y == 99);
+
+        for (size_t i = 0; i < req.d.size(); i++) {
+            NL_TEST_ASSERT(gpSuite, req.d[i] == i);
+        }
+
+        //
+        // Send response synchronously
+        //
+      
+        if (!mDoAsyncResp) { 
+            chip::app::Cluster::TestCluster::CommandB::Type resp;
+
+            resp.a = 21;
+            resp.b = 49;
+            resp.c.x = 19;
+            resp.c.y = 233;
+    
+            for (size_t i = 0; i < 5; i++) {
+                resp.d.insert(resp.d.begin() + (long)i, (uint8_t)(255 - i));
+            }
+
+            for (size_t i = 0; i < 5; i++) {
+                resp.e.insert(resp.e.begin() + (long)i, chip::app::Cluster::TestCluster::StructA::Type());
+                resp.e[i].x = (uint8_t)(255 - i);
+                resp.e[i].y = (uint8_t)(255 - i);
+            }
+
+            commandParams.CommandId = chip::app::Cluster::TestCluster::kCommandBId;
+
+            err = invokeInteraction.AddResponse(commandParams, &resp);
+            NL_TEST_ASSERT(gpSuite, err == CHIP_NO_ERROR);
+        }
+        else {
+            invokeInteraction.IncrementHoldOffRef();
+            mStashedInvokeResponder = &invokeInteraction;
+            mStashedCommandParams = commandParams;
+        }
+
+        mGotCommandA = true;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+class TestInvokeInteraction : public Messaging::ExchangeContextUnitTestDelegate
+{
+public:
+    static void TestInvokeInteractionSimple(nlTestSuite * apSuite, void * apContext);
+    static void TestInvokeInteractionAsyncResponder(nlTestSuite * apSuite, void * apContext);
+    void InterceptMessage(System::PacketBufferHandle buf);
+    int GetNumActiveInvokes();
+
+    void OnCommandBResponse(DemuxedInvokeInitiator &invokeInteraction, CommandParams &commandParams, chip::app::Cluster::TestCluster::CommandB::Type *response);
+    
+protected:
+    System::PacketBufferHandle mBuf;
+    int mGotCommandB = 0;
+    bool mGotMessage = false;
+};
+
+using namespace chip::TLV;
+
+void TestInvokeInteraction::InterceptMessage(System::PacketBufferHandle buf)
+{
+    mBuf = std::move(buf);
+    mGotMessage = true;
+}
+
+void
+TestInvokeInteraction::OnCommandBResponse(DemuxedInvokeInitiator &invokeInteraction, CommandParams &commandParams, chip::app::Cluster::TestCluster::CommandB::Type *response)
+{
+    NL_TEST_ASSERT(gpSuite, response);
+
+    printf("Received CommandB on EP%d\n", commandParams.EndpointId);
+
+    NL_TEST_ASSERT(gpSuite, response->a == 21);
+    NL_TEST_ASSERT(gpSuite, response->b == 49);
+    NL_TEST_ASSERT(gpSuite, response->c.x == 19);
+    NL_TEST_ASSERT(gpSuite, response->c.y == 233);
+
+    for (size_t i = 0; i < response->d.size(); i++) {
+        NL_TEST_ASSERT(gpSuite, response->d[i] == (uint8_t)(255 - i));
+    }
+
+    for (size_t i = 0; i < response->e.size(); i++) {
+        NL_TEST_ASSERT(gpSuite, response->e[i].x == (uint8_t)(255 - i));
+        NL_TEST_ASSERT(gpSuite, response->e[i].y == (uint8_t)(255 - i));
+    }
+
+    mGotCommandB++;
+
+    return;
+}
+
+TestInvokeInteraction gTestInvoke;
+
+int TestInvokeInteraction::GetNumActiveInvokes()
+{
+    int count = 0;
+
+    InteractionModelEngine::GetInstance()->mInvokeResponders.ForEachActiveObject([&](InvokeResponder *apInteraction) {
+        count++;
+        return true;
+    });
+
+    return count;
+}
+
+/*
+ * @brief
+ *
+ * This test tries to achieve an 'end-to-end' test between a client and a server.
+ * Specifically, it has a client sending an invoke action to a server containing two commands targeting
+ * two different endpoints, with the server responding back syncronously with a response containing two response
+ * payloads.
+ *
+ * To achieve 'end-to-endness' within a single stack, the message is created and intercepted before it is sent out,
+ * and then 'looped back in' to the IM for it to make its way back up the stack to the application.
+ */
+void TestInvokeInteraction::TestInvokeInteractionSimple(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle buf;
+    Messaging::ExchangeContext *pRxEc;
+    PacketHeader packetHdr;
+    PayloadHeader payloadHdr;
+    TestServerCluster serverEp0;
+    TestServerCluster serverEp1;
+    std::unique_ptr<DemuxedInvokeInitiator> invokeInitiator;
+    
+    auto onDoneFunc = [apSuite, &invokeInitiator] (DemuxedInvokeInitiator &initiator) {
+        printf("OnDone!\n");
+        NL_TEST_ASSERT(apSuite, &initiator == invokeInitiator.get());
+        (void)invokeInitiator.release();
+    };
+
+    // Re-init it.
+    gTestInvoke = TestInvokeInteraction();
+
+    serverEp0.SetEndpoint(0);
+    serverEp1.SetEndpoint(1);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp0);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    invokeInitiator = std::make_unique<DemuxedInvokeInitiator>(onDoneFunc);
+
+    err = invokeInitiator->Init(&chip::gExchangeManager, 0, 0, NULL);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    {
+        chip::app::Cluster::TestCluster::CommandA::Type req;
+        auto onSuccessFunc = std::bind(&TestInvokeInteraction::OnCommandBResponse, &gTestInvoke, _1, _2, _3);
+
+        req.a = 10;
+        req.b = 20;
+        req.c.x = 13;
+        req.c.y = 99;
+        req.d = {0, 1, 2, 3, 4};
+
+        err = invokeInitiator->AddCommand<chip::app::Cluster::TestCluster::CommandB::Type>(&req, CommandParams(req, 0, true),  onSuccessFunc);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator->AddCommand<chip::app::Cluster::TestCluster::CommandB::Type>(&req, CommandParams(req, 1, true),  onSuccessFunc);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator->Send();
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    }
+
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+
+    gServerInvoke = nullptr;
+
+    pRxEc = chip::gExchangeManager.NewContext({0, 0, 0}, NULL);
+    NL_TEST_ASSERT(apSuite, pRxEc != nullptr);
+    
+    chip::app::InteractionModelEngine::GetInstance()->OnInvokeCommandRequest(pRxEc, packetHdr, payloadHdr, std::move(buf));
+    NL_TEST_ASSERT(apSuite, gServerInvoke != nullptr);
+    NL_TEST_ASSERT(apSuite, serverEp0.mGotCommandA);
+    NL_TEST_ASSERT(apSuite, serverEp1.mGotCommandA);
+
+    NL_TEST_ASSERT(apSuite, gTestInvoke.GetNumActiveInvokes() == 0);
+    
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+    
+    invokeInitiator->GetInitiator().OnMessageReceived(invokeInitiator->GetInitiator().GetExchange(), PacketHeader(), PayloadHeader(), std::move(buf));
+    NL_TEST_ASSERT(apSuite, gTestInvoke.mGotCommandB == 2);
+}
+
+/*
+ * @brief
+ *
+ * This test tries to achieve an 'end-to-end' test between a client and a server.
+ * Specifically, it has a client sending an invoke action to a server containing two commands targeting
+ * two different endpoints, with the server responding back with a response containing two response
+ * payloads.
+ *
+ * The key distinction between this and the previous test is that one of the responses emitted by a cluster handler
+ * is done asyncronously.
+ */
+void TestInvokeInteraction::TestInvokeInteractionAsyncResponder(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle buf;
+    Messaging::ExchangeContext *pRxEc;
+    PacketHeader packetHdr;
+    PayloadHeader payloadHdr;
+    TestServerCluster serverEp0;
+    TestServerCluster serverEp1;
+    std::unique_ptr<DemuxedInvokeInitiator> invokeInitiator;
+    
+    auto onDoneFunc = [apSuite, &invokeInitiator] (DemuxedInvokeInitiator &initiator) {
+        NL_TEST_ASSERT(apSuite, &initiator == invokeInitiator.get());
+        (void)invokeInitiator.release();
+    };
+
+    // Re-init it.
+    gTestInvoke = TestInvokeInteraction();
+
+    serverEp0.SetEndpoint(0);
+    serverEp1.SetEndpoint(1);
+
+    // Set the server EP1 test logic to not respond syncronously.
+    serverEp1.SetAsyncResp();
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp0);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->RegisterServer(&serverEp1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    invokeInitiator = std::make_unique<DemuxedInvokeInitiator>(onDoneFunc);
+
+    err = invokeInitiator->Init(&chip::gExchangeManager, 0, 0, NULL);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    {
+        chip::app::Cluster::TestCluster::CommandA::Type req;
+        auto onSuccessFunc = std::bind(&TestInvokeInteraction::OnCommandBResponse, &gTestInvoke, _1, _2, _3);
+
+        req.a = 10;
+        req.b = 20;
+        req.c.x = 13;
+        req.c.y = 99;
+        req.d = {0, 1, 2, 3, 4};
+
+        err = invokeInitiator->AddCommand<chip::app::Cluster::TestCluster::CommandB::Type>(&req, CommandParams(req, 0, true),  onSuccessFunc);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator->AddCommand<chip::app::Cluster::TestCluster::CommandB::Type>(&req, CommandParams(req, 1, true),  onSuccessFunc);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = invokeInitiator->Send();
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    }
+
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+
+    gServerInvoke = nullptr;
+
+    pRxEc = chip::gExchangeManager.NewContext({0, 0, 0}, NULL);
+    NL_TEST_ASSERT(apSuite, pRxEc != nullptr);
+    
+    chip::app::InteractionModelEngine::GetInstance()->OnInvokeCommandRequest(pRxEc, packetHdr, payloadHdr, std::move(buf));
+    NL_TEST_ASSERT(apSuite, gServerInvoke != nullptr);
+    NL_TEST_ASSERT(apSuite, serverEp0.mGotCommandA);
+    NL_TEST_ASSERT(apSuite, serverEp1.mGotCommandA);
+
+    // Make sure it's got the invoke responder stashed away since it's doing async.
+    NL_TEST_ASSERT(apSuite, serverEp1.mStashedInvokeResponder != nullptr);
+
+    // Make sure the invoke responder object has not been auto free'ed.
+    NL_TEST_ASSERT(apSuite, gTestInvoke.GetNumActiveInvokes() == 1);
+   
+    err = serverEp1.SendAsyncResp();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    // Now, make sure it's been freed.
+    NL_TEST_ASSERT(apSuite, gTestInvoke.GetNumActiveInvokes() == 0);
+    
+    {
+        chip::System::PacketBufferTLVReader reader;
+        reader.Init(std::move(gTestInvoke.mBuf));
+        chip::TLV::Utilities::Print(reader);
+        buf = reader.GetBackingStore().Release();
+    }
+
+    invokeInitiator->GetInitiator().OnMessageReceived(invokeInitiator->GetInitiator().GetExchange(), PacketHeader(), PayloadHeader(), std::move(buf));
+    NL_TEST_ASSERT(apSuite, gTestInvoke.mGotCommandB == 2);
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    chip::app::gpSuite = apSuite;
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::gSystemLayer.Init();
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins, &chip::gMessageCounterManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::Messaging::ExchangeContext::SetUnitTestDelegate(&chip::app::gTestInvoke);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestInvokeInteractionSimple", chip::app::TestInvokeInteraction::TestInvokeInteractionSimple),
+    NL_TEST_DEF("TestInvokeInteractionAsyncResponder", chip::app::TestInvokeInteraction::TestInvokeInteractionAsyncResponder),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestInvokeInteraction()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "InvokeInteraction",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestInvokeInteraction)

--- a/src/app/tests/TestSchemaUtils-Device.cpp
+++ b/src/app/tests/TestSchemaUtils-Device.cpp
@@ -140,12 +140,11 @@ void TestSchemaUtils::TestSchemaUtilsEncAndDecSimplePrivateHeap(nlTestSuite * ap
     sa = chip::app::Cluster::TestCluster::StructA::Type();
 
     {
-        chip::System::PacketBufferHandle buf = System::PacketBufferHandle::New(1024);
-        SchemaAllocator allocator(buf->Start(), buf->AvailableDataLength());
+        SchemaAllocator schemaAllocator;
 
         _this->SetupReader();
 
-        err = chip::app::DecodeSchemaElement(sa, _this->mReader, &allocator);
+        err = chip::app::DecodeSchemaElement(sa, _this->mReader, &schemaAllocator);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         NL_TEST_ASSERT(apSuite, sa.x == 20);

--- a/src/app/tests/TestSchemaUtils-Device.cpp
+++ b/src/app/tests/TestSchemaUtils-Device.cpp
@@ -1,0 +1,308 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Command Interaction
+ *
+ */
+
+#include <device/SchemaTypes.h>
+#include <device/SchemaUtils.h>
+#include "core/CHIPTLVTags.h"
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVText.hpp>
+#include <core/CHIPTLVData.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+
+#include <nlunit-test.h>
+
+#include <TestCluster-Gen.h>
+
+namespace chip {
+static System::Layer gSystemLayer;
+static SecureSessionMgr gSessionManager;
+static Messaging::ExchangeManager gExchangeManager;
+static secure_channel::MessageCounterManager gMessageCounterManager;
+static TransportMgr<Transport::UDP> gTransportManager;
+static Transport::AdminId gAdminId = 0;
+
+namespace app {
+
+class TestSchemaUtils
+{
+public:
+    static void TestSchemaUtilsEncAndDecSimple(nlTestSuite * apSuite, void * apContext);
+    static void TestSchemaUtilsEncAndDecNestedStruct(nlTestSuite * apSuite, void * apContext);
+    static void TestSchemaUtilsEncAndDecList(nlTestSuite * apSuite, void * apContext);
+
+private:
+    void SetupBuf();
+    void DumpBuf();
+    void SetupReader();
+
+    chip::System::TLVPacketBufferBackingStore mStore;
+    chip::TLV::TLVWriter mWriter;
+    chip::TLV::TLVReader mReader;
+    nlTestSuite *mpSuite;
+};
+
+using namespace chip::TLV;
+
+TestSchemaUtils gTestSchemaUtils;
+
+void TestSchemaUtils::SetupBuf()
+{
+    chip::System::PacketBufferHandle buf;
+   
+    buf = System::PacketBufferHandle::New(1024);
+    mStore.Init(std::move(buf));
+
+    mWriter.Init(mStore);
+    mReader.Init(mStore);
+}
+
+void TestSchemaUtils::DumpBuf()
+{
+    TLV::TLVReader reader;
+    reader.Init(mStore);
+    chip::TLV::Utilities::Print(reader);
+}
+
+void TestSchemaUtils::SetupReader()
+{
+    CHIP_ERROR err;
+
+    mReader.Init(mStore);
+    err = mReader.Next();
+
+    NL_TEST_ASSERT(mpSuite, err == CHIP_NO_ERROR);
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecSimple(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructA::Type sa;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+    uint8_t buf[4] = {0, 1, 2, 3};
+    char strbuf[10] = "chip";
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    sa.x = 20;
+    sa.y = 30;
+    sa.l = chip::ByteSpan{buf};
+
+    // TODO: Bug in CHIPTLVWriter/Reader that don't quite deal with the null-terminator correctly.
+    sa.m = chip::Span<char>(strbuf, strlen(strbuf));
+    
+    err = chip::app::EncodeSchemaElement(sa, _this->mWriter, TLV::AnonymousTag);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    memset(&sa, 0, sizeof(sa));
+    memset(buf, 0, ArraySize(buf));
+    memset(strbuf, 0, ArraySize(strbuf));
+
+    sa.l = chip::ByteSpan{buf};
+    sa.m = chip::Span<char>{strbuf};
+
+    _this->SetupReader();
+
+    err = chip::app::DecodeSchemaElement(sa, _this->mReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, sa.x == 20);
+    NL_TEST_ASSERT(apSuite, sa.y == 30);
+
+    for (uint32_t i = 0; i < ArraySize(buf); i++) {
+        NL_TEST_ASSERT(apSuite, buf[i] == i);
+    }
+
+    NL_TEST_ASSERT(apSuite, strncmp(strbuf, "chip", ArraySize("chip")) == 0);
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecNestedStruct(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructB::Type sb;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    sb.x = 20;
+    sb.y = 30;
+    sb.z.x = 99;
+    sb.z.y = 17;
+    
+    err = chip::app::EncodeSchemaElement(sb, _this->mWriter, TLV::AnonymousTag);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    memset(&sb, 0, sizeof(sb));
+
+    _this->SetupReader();
+
+    err = chip::app::DecodeSchemaElement(sb, _this->mReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, sb.x == 20);
+    NL_TEST_ASSERT(apSuite, sb.y == 30);
+    NL_TEST_ASSERT(apSuite, sb.z.x == 99);
+    NL_TEST_ASSERT(apSuite, sb.z.y == 17);
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecList(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructC::Type sc;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+    uint8_t d[5];
+    chip::app::Cluster::TestCluster::StructA::Type e[5];
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    for (size_t i = 0; i < ArraySize(d); i++) {
+        d[i] = (uint8_t)i;
+    }
+
+    sc.a = 20;
+    sc.b = 30;
+    sc.c.x = 99;
+    sc.c.y = 17;
+    sc.d = chip::Span<uint8_t>{d};
+    sc.e = chip::Span<chip::app::Cluster::TestCluster::StructA::Type>{e};
+
+    for (size_t i = 0; i < ArraySize(e); i++) {
+        e[i].x = (uint8_t)i;
+        e[i].y = (uint8_t)i;
+    }
+    
+    err = chip::app::EncodeSchemaElement(sc, _this->mWriter, TLV::AnonymousTag);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    memset(&sc, 0, sizeof(sc));
+    memset(d, 0, sizeof(d));
+    memset(e, 0, sizeof(e));
+
+    sc.d = chip::Span<uint8_t>{d};
+    sc.e = chip::Span<chip::app::Cluster::TestCluster::StructA::Type>{e};
+
+    _this->SetupReader();
+
+    err = chip::app::DecodeSchemaElement(sc, _this->mReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, sc.a == 20);
+    NL_TEST_ASSERT(apSuite, sc.b == 30);
+    NL_TEST_ASSERT(apSuite, sc.c.x == 99);
+    NL_TEST_ASSERT(apSuite, sc.c.y == 17);
+
+    for (size_t i = 0; i < ArraySize(d); i++) {
+        NL_TEST_ASSERT(apSuite, d[i] == i);
+    }
+
+    for (size_t i = 0; i < ArraySize(e); i++) {
+        NL_TEST_ASSERT(apSuite, e[i].x == i);
+        NL_TEST_ASSERT(apSuite, e[i].y == i);
+    }
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::gSystemLayer.Init(nullptr);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins, &chip::gMessageCounterManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecSimple", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecSimple),
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecNestedStruct", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecNestedStruct),
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecList", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecList),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestSchemaUtils()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "TestSchemaUtils",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, &chip::app::gTestSchemaUtils);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestSchemaUtils)

--- a/src/app/tests/TestSchemaUtils-STL.cpp
+++ b/src/app/tests/TestSchemaUtils-STL.cpp
@@ -1,0 +1,293 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Command Interaction
+ *
+ */
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <support/CodeUtils.h>
+#include <core/CHIPTLVTags.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVText.hpp>
+#include <core/CHIPTLVData.hpp>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <memory>
+#include <nlunit-test.h>
+
+#include <TestCluster-Gen.h>
+
+namespace chip {
+static System::Layer gSystemLayer;
+static SecureSessionMgr gSessionManager;
+static Messaging::ExchangeManager gExchangeManager;
+static secure_channel::MessageCounterManager gMessageCounterManager;
+static TransportMgr<Transport::UDP> gTransportManager;
+static Transport::AdminId gAdminId = 0;
+
+namespace app {
+
+class TestSchemaUtils
+{
+public:
+    static void TestSchemaUtilsEncAndDecSimple(nlTestSuite * apSuite, void * apContext);
+    static void TestSchemaUtilsEncAndDecNestedStruct(nlTestSuite * apSuite, void * apContext);
+    static void TestSchemaUtilsEncAndDecList(nlTestSuite * apSuite, void * apContext);
+
+private:
+    void SetupBuf();
+    void DumpBuf();
+    void SetupReader();
+
+    chip::System::TLVPacketBufferBackingStore mStore;
+    chip::TLV::TLVWriter mWriter;
+    chip::TLV::TLVReader mReader;
+    nlTestSuite *mpSuite;
+};
+
+using namespace chip::TLV;
+
+TestSchemaUtils gTestSchemaUtils;
+
+void TestSchemaUtils::SetupBuf()
+{
+    chip::System::PacketBufferHandle buf;
+   
+    buf = System::PacketBufferHandle::New(1024);
+    mStore.Init(std::move(buf));
+
+    mWriter.Init(mStore);
+    mReader.Init(mStore);
+}
+
+void TestSchemaUtils::DumpBuf()
+{
+    TLV::TLVReader reader;
+    reader.Init(mStore);
+    chip::TLV::Utilities::Print(reader);
+}
+
+void TestSchemaUtils::SetupReader()
+{
+    CHIP_ERROR err;
+
+    mReader.Init(mStore);
+    err = mReader.Next();
+
+    NL_TEST_ASSERT(mpSuite, err == CHIP_NO_ERROR);
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecSimple(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructA::Type sa;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    sa.x = 20;
+    sa.y = 30;
+    sa.l = {0, 1, 2, 3};
+    sa.m = "chip";
+
+    err = sa.Encode(_this->mWriter, TLV::AnonymousTag);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    sa = chip::app::Cluster::TestCluster::StructA::Type();
+
+    _this->SetupReader();
+
+    err = sa.Decode(_this->mReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, sa.x == 20);
+    NL_TEST_ASSERT(apSuite, sa.y == 30);
+
+    for (size_t i = 0; i < sa.l.size(); i++) {
+        NL_TEST_ASSERT(apSuite, sa.l[i] == i);
+    }
+
+    NL_TEST_ASSERT(apSuite, !sa.m.compare("chip"));
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecNestedStruct(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructB::Type sb;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    sb.x = 20;
+    sb.y = 30;
+    sb.z.x = 99;
+    sb.z.y = 17;
+
+    err = sb.Encode(_this->mWriter, TLV::AnonymousTag);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    sb = chip::app::Cluster::TestCluster::StructB::Type();
+
+    _this->SetupReader();
+
+    err = sb.Decode(_this->mReader);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, sb.x == 20);
+    NL_TEST_ASSERT(apSuite, sb.y == 30);
+    NL_TEST_ASSERT(apSuite, sb.z.x == 99);
+    NL_TEST_ASSERT(apSuite, sb.z.y == 17);
+}
+
+void TestSchemaUtils::TestSchemaUtilsEncAndDecList(nlTestSuite * apSuite, void * apContext)
+{
+    chip::app::Cluster::TestCluster::StructC::Type sc;
+    CHIP_ERROR err;
+    chip::app::TestSchemaUtils *_this = static_cast<chip::app::TestSchemaUtils *>(apContext);
+
+    _this->mpSuite = apSuite;
+    _this->SetupBuf();
+
+    for (size_t i = 0; i < 5; i++) {
+        sc.d.insert(sc.d.begin() + (long)i, (uint8_t)i);
+    }
+
+    sc.a = 20;
+    sc.b = 30;
+    sc.c.x = 99;
+    sc.c.y = 17;
+
+    for (size_t i = 0; i < 7; i++) {
+        chip::app::Cluster::TestCluster::StructA::Type t;
+
+        t.x = (uint8_t)i;
+        t.y = (uint8_t)i;
+
+        sc.e.insert(sc.e.begin() + (long)i, t);
+    }
+   
+    err = sc.Encode(_this->mWriter, TLV::AnonymousTag); 
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    _this->DumpBuf();
+
+    sc = chip::app::Cluster::TestCluster::StructC::Type();
+
+    _this->SetupReader();
+
+    err = sc.Decode(_this->mReader);
+
+    NL_TEST_ASSERT(apSuite, sc.a == 20);
+    NL_TEST_ASSERT(apSuite, sc.b == 30);
+    NL_TEST_ASSERT(apSuite, sc.c.x == 99);
+    NL_TEST_ASSERT(apSuite, sc.c.y == 17);
+
+    for (size_t i = 0; i < 5; i++) {
+        NL_TEST_ASSERT(apSuite, sc.d[i] == i);
+    }
+
+    for (size_t i = 0; i < 7; i++) {
+        NL_TEST_ASSERT(apSuite, sc.e[i].x == i);
+        NL_TEST_ASSERT(apSuite, sc.e[i].y == i);
+    }
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    chip::gSystemLayer.Init();
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins, &chip::gMessageCounterManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&chip::gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecSimple", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecSimple),
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecNestedStruct", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecNestedStruct),
+    NL_TEST_DEF("TestSchemaUtilsEncAndDecList", chip::app::TestSchemaUtils::TestSchemaUtilsEncAndDecList),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestSchemaUtils()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "TestSchemaUtils",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, &chip::app::gTestSchemaUtils);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestSchemaUtils)

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -57,7 +57,7 @@ EmberAfInterpanHeader imCompatibilityInterpanHeader;
 Command * currentCommandObject;
 
 // BasicType maps the type to basic int(8|16|32|64)(s|u) types.
-EmberAfAttributeType BaseType(EmberAfAttributeType type)
+EmberAfAttributeType BaseAttributeType(EmberAfAttributeType type)
 {
     switch (type)
     {
@@ -212,7 +212,7 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     }
 
     // TODO: ZCL_STRUCT_ATTRIBUTE_TYPE is not included in this switch case currently, should add support for structures.
-    switch (BaseType(attributeType))
+    switch (BaseAttributeType(attributeType))
     {
     case ZCL_NO_DATA_ATTRIBUTE_TYPE: // No data
         ReturnErrorOnFailure(apWriter->PutNull(TLV::ContextTag(AttributeDataElement::kCsTag_Data)));

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster-revised.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster-revised.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="CHIP"/>
+
+   <struct name="StructA">
+     <item name="x" type="UINT8U", optional="false"/>
+     <item name="y" type="UINT8U", optional="false"/>
+     <item name="l" type="OCTET_STRING", optional="false"/>
+     <item name="m" type="CHAR_STRING", optional="false"/>
+   </struct>
+
+   <struct name="StructB">
+     <item name="x" type="UINT8U", optional="false"/>
+     <item name="y" type="UINT8U", optional="false"/>
+     <item name="z" type="StructA", optional="false"/>
+   </struct>
+
+   <struct name="StructC">
+     <item name="a" type="UINT8U", optional="false"/>
+     <item name="b" type="UINT8U", optional="false"/>
+     <item name="c" type="StructA", optional="false"/>
+     <item name="d" type="OCTET_STRING", optional="false"/>
+     <item name="e" type="StructA", array="true", optional="false"/>
+   </struct>
+   
+  <cluster>
+    <domain>CHIP</domain>
+    <name>Test Cluster</name>
+    <code>0x0510</code>
+    <define>TEST_CLUSTER_REVISED</define>
+    <description>The Test Cluster is meant to validate the updated code-generation strategy</description>
+
+    <!-- Test Commands -->
+    <command source="client" code="0x01" name="CommandA" optional="false">
+        <description>
+            A rich command with complex types in it.
+        </description>
+        
+        <arg name="a" type="UINT8U", optional="false"/>
+        <arg name="b" type="UINT8U", optional="false"/>
+        <arg name="c" type="StructA", optional="false"/>
+        <arg name="d" type="OCTET_STRING", optional="false"/>
+    </command>
+
+    <command source="server" code="0x02" name="TestSpecificResponse" optional="false" disableDefaultResponse="true">
+      <description>
+          Rich response back to CommandA
+      </description>
+
+        <arg name="a" type="UINT8U", optional="false"/>
+        <arg name="b" type="UINT8U", optional="false"/>
+        <arg name="c" type="StructA", optional="false"/>
+        <arg name="d" type="OCTET_STRING", optional="false"/>
+        <arg name="e" type="StructA", array="true", optional="false"/>
+    </command>
+
+  </cluster>
+</configurator>

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -33,10 +33,16 @@ static_library("controller") {
     "data_model/gen/chip-zcl-zpro-codec-api.h",
   ]
 
+  public_configs = [
+    "${chip_root}/gen-v2/stl:includes"
+  ]
+  
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/gen-v2/stl",
     "${chip_root}/src/app",
+    "${chip_root}/src/app/gen-utils:gen-utils-stl",
     "${chip_root}/src/app/util:device_callbacks_manager",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/mdns",

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -328,6 +328,7 @@ public:
     NodeId GetDeviceId() const { return mDeviceId; }
 
     bool MatchesSession(SecureSessionHandle session) const { return mSecureSession == session; }
+    SecureSessionHandle GetSessionHandle() const { return mSecureSession; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -63,6 +63,8 @@
 #include <support/TimeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <OperationalCredentialCluster-Gen.h>
+
 #if CONFIG_NETWORK_LAYER_BLE
 #include <ble/BleLayer.h>
 #include <transport/raw/BLE.h>
@@ -80,6 +82,7 @@
 using namespace chip::Inet;
 using namespace chip::System;
 using namespace chip::Credentials;
+using namespace std::placeholders;
 
 // For some applications those does not implement IMDelegate, the DeviceControllerInteractionModelDelegate will dispatch the
 // response to IMDefaultResponseCallback CHIPClientCallbacks, for the applications those implemented IMDelegate, this function will
@@ -805,9 +808,7 @@ ControllerDeviceInitParams DeviceController::GetControllerDeviceInitParams()
 
 DeviceCommissioner::DeviceCommissioner() :
     mSuccess(BasicSuccess, this), mFailure(BasicFailure, this),
-    mOpCSRResponseCallback(OnOperationalCertificateSigningRequest, this),
-    mOpCertResponseCallback(OnOperationalCertificateAddResponse, this), mRootCertResponseCallback(OnRootCertSuccessResponse, this),
-    mOnCSRFailureCallback(OnCSRFailureResponse, this), mOnCertFailureCallback(OnAddOpCertFailureResponse, this),
+    mRootCertResponseCallback(OnRootCertSuccessResponse, this),
     mOnRootCertFailureCallback(OnRootCertFailureResponse, this), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
     mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this), mDeviceNOCCallback(OnDeviceNOCGenerated, this)
 {
@@ -1181,45 +1182,55 @@ void DeviceCommissioner::OnSessionEstablished()
 
 CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(Device * device)
 {
+    chip::app::Cluster::OperationalCredentialCluster::OpCsrRequest::Type req;
+
     ChipLogDetail(Controller, "Sending OpCSR request to %p device", device);
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, 0);
+    
+    auto pInitiator = CreateInitiator(device);
+    VerifyOrReturnError(pInitiator != nullptr, CHIP_ERROR_INTERNAL);
 
-    Callback::Cancelable * successCallback = mOpCSRResponseCallback.Cancel();
-    Callback::Cancelable * failureCallback = mOnCSRFailureCallback.Cancel();
+    chip::ByteSpan nonce = device->GetCSRNonce();
+    req.csrNonce.assign(nonce.data(), nonce.data() + nonce.size());
 
-    ReturnErrorOnFailure(cluster.OpCSRRequest(successCallback, failureCallback, device->GetCSRNonce()));
+    auto onSuccess = std::bind(&DeviceCommissioner::OnOperationalCertificateSigningRequest, this, _1, _2, _3);
+    auto onError = std::bind(&DeviceCommissioner::OnCSRFailureResponse, this, _1, _2, _3);
+
+    ReturnErrorOnFailure(pInitiator->AddCommand<chip::app::Cluster::OperationalCredentialCluster::OpCsrResponse::Type>(&req, app::CommandParams(req, 0), onSuccess, onError));
+    ReturnErrorOnFailure(pInitiator->Send());
+
+    //
+    // Move it into the invoke to be tracked for eventual deletion and release
+    // when the invoke is done
+    //
+    mDemuxedInvokeInitiatorList.push_back(std::move(pInitiator));
+
     ChipLogDetail(Controller, "Sent OpCSR request, waiting for the CSR");
     return CHIP_NO_ERROR;
 }
 
-void DeviceCommissioner::OnCSRFailureResponse(void * context, uint8_t status)
+void DeviceCommissioner::OnCSRFailureResponse(app::DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, chip::app::StatusResponse *response)
 {
-    ChipLogProgress(Controller, "Device failed to receive the CSR request Response: 0x%02x", status);
-    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
-    commissioner->mOpCSRResponseCallback.Cancel();
-    commissioner->mOnCSRFailureCallback.Cancel();
-    // TODO: Map error status to correct error code
-    commissioner->OnSessionEstablishmentError(CHIP_ERROR_INTERNAL);
+    ChipLogProgress(Controller, "Device failed to receive the CSR request Response: %s", ErrorStr(error));
+    OnSessionEstablishmentError(error);
 }
 
-void DeviceCommissioner::OnOperationalCertificateSigningRequest(void * context, ByteSpan CSR, ByteSpan CSRNonce,
-                                                                ByteSpan VendorReserved1, ByteSpan VendorReserved2,
-                                                                ByteSpan VendorReserved3, ByteSpan Signature)
+void DeviceCommissioner::OnOperationalCertificateSigningRequest(app::DemuxedInvokeInitiator& invokeInitiator, app::CommandParams &params, 
+                                                       chip::app::Cluster::OperationalCredentialCluster::OpCsrResponse::Type *resp)
 {
     ChipLogProgress(Controller, "Received certificate signing request from the device");
-    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
 
-    commissioner->mOpCSRResponseCallback.Cancel();
-    commissioner->mOnCSRFailureCallback.Cancel();
+    if (resp == nullptr) {
+        ChipLogError(Controller, "Got back an empty OpCertSigningRequest!");
+    }
+    else {
+        if (ProcessOpCSR(*resp))
+        {
+            // Handle error, and notify session failure to the commissioner application.
+            ChipLogError(Controller, "Failed to process the certificate signing request");
 
-    if (commissioner->ProcessOpCSR(CSR, CSRNonce, VendorReserved1, VendorReserved2, VendorReserved3, Signature) != CHIP_NO_ERROR)
-    {
-        // Handle error, and notify session failure to the commissioner application.
-        ChipLogError(Controller, "Failed to process the certificate signing request");
-        // TODO: Map error status to correct error code
-        commissioner->OnSessionEstablishmentError(CHIP_ERROR_INTERNAL);
+            // TODO: Map error status to correct error code
+            OnSessionEstablishmentError(CHIP_ERROR_INTERNAL);
+        }
     }
 }
 
@@ -1260,9 +1271,7 @@ exit:
     }
 }
 
-CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & CSR, const ByteSpan & CSRNonce, const ByteSpan & VendorReserved1,
-                                            const ByteSpan & VendorReserved2, const ByteSpan & VendorReserved3,
-                                            const ByteSpan & Signature)
+CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const chip::app::Cluster::OperationalCredentialCluster::OpCsrResponse::Type& resp)
 {
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mDeviceBeingPaired < kNumMaxActiveDevices, CHIP_ERROR_INCORRECT_STATE);
@@ -1271,8 +1280,8 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & CSR, const ByteSpan
 
     // Verify that Nonce matches with what we sent
     const ByteSpan nonce = device->GetCSRNonce();
-    VerifyOrReturnError(CSRNonce.size() == nonce.size(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(memcmp(CSRNonce.data(), nonce.data(), CSRNonce.size()) == 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(resp.csrNonce.size() == nonce.size(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(memcmp(resp.csrNonce.data(), nonce.data(), resp.csrNonce.size()) == 0, CHIP_ERROR_INVALID_ARGUMENT);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipOpCert;
     ReturnErrorCodeIf(!chipOpCert.Alloc(kMaxCHIPCertLength * 2), CHIP_ERROR_NO_MEMORY);
@@ -1280,61 +1289,91 @@ CHIP_ERROR DeviceCommissioner::ProcessOpCSR(const ByteSpan & CSR, const ByteSpan
     // TODO: Send DAC as input parameter to GenerateNodeOperationalCertificate()
     //       This will be done when device attestation is implemented.
     ReturnErrorOnFailure(mOperationalCredentialsDelegate->GenerateNodeOperationalCertificate(
-        Optional<NodeId>(device->GetDeviceId()), 0, CSR, ByteSpan(), &mDeviceNOCCallback));
-
+            Optional<NodeId>(device->GetDeviceId()), 0, chip::ByteSpan{resp.csr.data(), resp.csr.size()}, ByteSpan(), &mDeviceNOCCallback));
+    
     return CHIP_NO_ERROR;
+}
+
+void DeviceCommissioner::OnInvokeDone(app::DemuxedInvokeInitiator &demuxedInitiator)
+{
+    //
+    // This method gets invoked when all work has completed on the invoke object, at which point, we can free up the object.
+    // Track it down in our list, and approriately release it.
+    //
+    auto it = find_if(mDemuxedInvokeInitiatorList.begin(), mDemuxedInvokeInitiatorList.end(), [&](std::unique_ptr<app::DemuxedInvokeInitiator> &obj) { 
+        return (obj.get() == &demuxedInitiator);
+    });
+
+    if (it != mDemuxedInvokeInitiatorList.end()) {
+        mDemuxedInvokeInitiatorList.erase(it); 
+    }
+}
+
+std::unique_ptr<app::DemuxedInvokeInitiator> DeviceCommissioner::CreateInitiator(Device *device)
+{
+    std::unique_ptr<app::DemuxedInvokeInitiator> pInitiator;
+
+    if (device == nullptr) {
+        return pInitiator;
+    }
+
+    SecureSessionHandle handle = device->GetSessionHandle();
+    auto onDone = std::bind(&DeviceCommissioner::OnInvokeDone, this, _1);
+    pInitiator = std::make_unique<app::DemuxedInvokeInitiator>(onDone);
+
+    if (pInitiator->Init(mExchangeMgr, device->GetDeviceId(), 0, &handle) != CHIP_NO_ERROR) {
+        (void)pInitiator.release();
+    }
+
+    return pInitiator;
 }
 
 CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(Device * device, const ByteSpan & opCertBuf)
 {
-    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, 0);
+    chip::app::Cluster::OperationalCredentialCluster::AddOpCert::Type req;
 
-    Callback::Cancelable * successCallback = mOpCertResponseCallback.Cancel();
-    Callback::Cancelable * failureCallback = mOnCertFailureCallback.Cancel();
+    auto pInitiator = CreateInitiator(device);
+    VerifyOrReturnError(pInitiator.get() != nullptr, CHIP_ERROR_INTERNAL);
 
-    ReturnErrorOnFailure(cluster.AddOpCert(successCallback, failureCallback, opCertBuf, ByteSpan(nullptr, 0), mLocalDeviceId, 0));
+    req.noc.assign(opCertBuf.data(), opCertBuf.data() + opCertBuf.size());
+    req.caseAdminNode = mLocalDeviceId;
+    req.adminVendorId = 0;
 
-    ChipLogProgress(Controller, "Sent operational certificate to the device");
+    auto onSuccess = std::bind(&DeviceCommissioner::OnOperationalCertificateAddResponse, this, _1, _2);
+    auto onError = std::bind(&DeviceCommissioner::OnAddOpCertFailureResponse, this, _1, _2, _3);
+
+    ReturnErrorOnFailure(pInitiator->AddCommand(&req, app::CommandParams(req, 0), onSuccess, onError));
+    ReturnErrorOnFailure(pInitiator->Send());
+
+    mDemuxedInvokeInitiatorList.push_back(std::move(pInitiator));
 
     return CHIP_NO_ERROR;
 }
 
-void DeviceCommissioner::OnAddOpCertFailureResponse(void * context, uint8_t status)
+void DeviceCommissioner::OnAddOpCertFailureResponse(app::DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, chip::app::StatusResponse *response)
 {
-    ChipLogProgress(Controller, "Device failed to receive the operational certificate Response: 0x%02x", status);
-    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
-    commissioner->mOpCSRResponseCallback.Cancel();
-    commissioner->mOnCertFailureCallback.Cancel();
-    // TODO: Map error status to correct error code
-    commissioner->OnSessionEstablishmentError(CHIP_ERROR_INTERNAL);
+    ChipLogProgress(Controller, "Device failed to receive the operational certificate Response: %s", ErrorStr(error));
+    OnSessionEstablishmentError(error);
 }
 
-void DeviceCommissioner::OnOperationalCertificateAddResponse(void * context, uint8_t StatusCode, uint64_t FabricIndex,
-                                                             uint8_t * DebugText)
+void DeviceCommissioner::OnOperationalCertificateAddResponse(app::DemuxedInvokeInitiator& invokeInitiator, app::CommandParams &params)
 {
     ChipLogProgress(Controller, "Device confirmed that it has received the operational certificate");
-    DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
 
     CHIP_ERROR err  = CHIP_NO_ERROR;
     Device * device = nullptr;
 
-    VerifyOrExit(commissioner->mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
 
-    commissioner->mOpCSRResponseCallback.Cancel();
-    commissioner->mOnCertFailureCallback.Cancel();
+    device = &mActiveDevices[mDeviceBeingPaired];
 
-    VerifyOrExit(commissioner->mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
-
-    device = &commissioner->mActiveDevices[commissioner->mDeviceBeingPaired];
-
-    err = commissioner->OnOperationalCredentialsProvisioningCompletion(device);
+    err = OnOperationalCredentialsProvisioningCompletion(device);
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        commissioner->OnSessionEstablishmentError(err);
+        OnSessionEstablishmentError(err);
     }
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -48,6 +48,9 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
+#include <stl/DemuxedInvokeInitiator.h>
+#include <OperationalCredentialCluster-Gen.h>
+#include <memory>
 
 #if CONFIG_DEVICE_LAYER
 #include <platform/CHIPDeviceLayer.h>
@@ -342,6 +345,7 @@ protected:
     Credentials::OperationalCredentialSet mCredentials;
     Credentials::CertificateKeyId mRootKeyId;
 
+
     SessionIDAllocator mIDAllocator;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
@@ -525,7 +529,11 @@ public:
 
     void RegisterPairingDelegate(DevicePairingDelegate * pairingDelegate) { mPairingDelegate = pairingDelegate; }
 
+    void OnInvokeDone(app::DemuxedInvokeInitiator &demuxedInitiator);
+    
 private:
+    std::vector<std::unique_ptr<app::DemuxedInvokeInitiator>> mDemuxedInvokeInitiatorList;
+    
     DevicePairingDelegate * mPairingDelegate;
 
     /* This field is an index in mActiveDevices list. The object at this index in the list
@@ -548,6 +556,8 @@ private:
 
     DeviceCommissionerRendezvousAdvertisementDelegate mRendezvousAdvDelegate;
 
+    std::unique_ptr<app::DemuxedInvokeInitiator> CreateInitiator(Device *device);
+    
     void PersistDeviceList();
 
     void FreeRendezvousSession();
@@ -578,7 +588,7 @@ private:
     CHIP_ERROR OnOperationalCredentialsProvisioningCompletion(Device * device);
 
     /* Callback when the previously sent CSR request results in failure */
-    static void OnCSRFailureResponse(void * context, uint8_t status);
+    void OnCSRFailureResponse(app::DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, chip::app::StatusResponse *response);
 
     /**
      * @brief
@@ -593,13 +603,16 @@ private:
      * @param[in] VendorReserved3 vendor-specific information that may aid in device commissioning.
      * @param[in] Signature       Cryptographic signature generated for the fields in the response message.
      */
-    static void OnOperationalCertificateSigningRequest(void * context, ByteSpan CSR, ByteSpan CSRNonce, ByteSpan VendorReserved1,
-                                                       ByteSpan VendorReserved2, ByteSpan VendorReserved3, ByteSpan Signature);
+    void OnOperationalCertificateSigningRequest(app::DemuxedInvokeInitiator& invokeInitiator, app::CommandParams &params, 
+                                                       chip::app::Cluster::OperationalCredentialCluster::OpCsrResponse::Type *resp);
+                                                       
 
     /* Callback when adding operational certs to device results in failure */
-    static void OnAddOpCertFailureResponse(void * context, uint8_t status);
+    void OnAddOpCertFailureResponse(app::DemuxedInvokeInitiator& invokeInitiator, CHIP_ERROR error, chip::app::StatusResponse *response);
+
     /* Callback when the device confirms that it has added the operational certificates */
-    static void OnOperationalCertificateAddResponse(void * context, uint8_t StatusCode, uint64_t FabricIndex, uint8_t * DebugText);
+    void OnOperationalCertificateAddResponse(app::DemuxedInvokeInitiator& invokeInitiator, app::CommandParams &params);
+
 
     /* Callback when the device confirms that it has added the root certificate */
     static void OnRootCertSuccessResponse(void * context);
@@ -623,8 +636,7 @@ private:
      * @param[in] VendorReserved3 vendor-specific information that may aid in device commissioning.
      * @param[in] Signature       Cryptographic signature generated for all the above fields.
      */
-    CHIP_ERROR ProcessOpCSR(const ByteSpan & CSR, const ByteSpan & CSRNonce, const ByteSpan & VendorReserved1,
-                            const ByteSpan & VendorReserved2, const ByteSpan & VendorReserved3, const ByteSpan & Signature);
+    CHIP_ERROR ProcessOpCSR(const chip::app::Cluster::OperationalCredentialCluster::OpCsrResponse::Type& resp);
 
     // Cluster callbacks for advancing commissioning flows
     Callback::Callback<BasicSuccessCallback> mSuccess;
@@ -632,11 +644,7 @@ private:
 
     CommissioningStage GetNextCommissioningStage();
 
-    Callback::Callback<OperationalCredentialsClusterOpCSRResponseCallback> mOpCSRResponseCallback;
-    Callback::Callback<OperationalCredentialsClusterOpCertResponseCallback> mOpCertResponseCallback;
     Callback::Callback<DefaultSuccessCallback> mRootCertResponseCallback;
-    Callback::Callback<DefaultFailureCallback> mOnCSRFailureCallback;
-    Callback::Callback<DefaultFailureCallback> mOnCertFailureCallback;
     Callback::Callback<DefaultFailureCallback> mOnRootCertFailureCallback;
 
     Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -70,7 +70,6 @@ static const BitFlags<KeyPurposeFlags> sCA(KeyPurposeFlags::kClientAuth);
 static const BitFlags<KeyPurposeFlags> sCS(KeyPurposeFlags::kCodeSigning);
 static const BitFlags<KeyPurposeFlags> sEP(KeyPurposeFlags::kEmailProtection);
 static const BitFlags<KeyPurposeFlags> sTS(KeyPurposeFlags::kTimeStamping);
-static const BitFlags<KeyPurposeFlags> sOS(KeyPurposeFlags::kOCSPSigning);
 static const BitFlags<KeyPurposeFlags> sSAandCA(sSA, sCA);
 static const BitFlags<KeyPurposeFlags> sSAandCS(sSA, sCS);
 static const BitFlags<KeyPurposeFlags> sSAandEP(sSA, sEP);

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -100,6 +100,7 @@ static_library("core") {
     "CHIPTLVTypes.h",
     "CHIPTLVUpdater.cpp",
     "CHIPTLVUtilities.cpp",
+    "CHIPTLVText.cpp",
     "CHIPTLVWriter.cpp",
     "PeerId.h",
   ]

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2014,6 +2014,31 @@ using CHIP_ERROR = ::chip::ChipError::ErrorType;
  */
 #define CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED                  CHIP_CORE_ERROR(0xc4)
 
+
+/**
+ * @def CHIP_ERROR_NULL_BUF_ARG
+ *
+ * @brief
+ *  A buffer that was passed in is unexpectedly null.
+ */ 
+#define CHIP_ERROR_NULL_BUF_ARG                                CHIP_CORE_ERROR(197)
+
+
+/**
+ * @def CHIP_ERROR_CLUSTER_NOT_FOUND
+ *
+ * @brief
+ *  Requested cluster with a specific Cluster ID was not found
+ */ 
+#define CHIP_ERROR_CLUSTER_NOT_FOUND                            CHIP_CORE_ERROR(198)
+
+/**
+ * @def CHIP_ERROR_STATUS_RESPONSE_RECEIVED
+ *
+ * @brief
+ *  A status response containing an error was received.
+ */ 
+#define CHIP_ERROR_STATUS_RESPONSE_RECEIVED                     CHIP_CORE_ERROR(199)
 /**
  *  @}
  */

--- a/src/lib/core/CHIPTLVText.cpp
+++ b/src/lib/core/CHIPTLVText.cpp
@@ -1,0 +1,189 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements utility interfaces for managing and
+ *      working with CHIP TLV.
+ *
+ */
+
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <support/CodeUtils.h>
+#include <core/CHIPTLVTypes.h>
+#include <cstdint>
+
+namespace chip {
+
+namespace TLV {
+
+namespace Utilities {
+
+void PrintTabs(int tabLevel) 
+{
+    for (int i = 0; i < tabLevel; i++) {
+        printf("\t");
+    }
+}
+
+void PrintTag(uint64_t tag, int tabLevel)
+{
+    PrintTabs(tabLevel);
+
+    if (IsContextTag(tag)) {
+        printf("%" PRIu32 " = ", TagNumFromTag(tag));
+    }
+    else if (IsProfileTag(tag)) {
+        printf("0x%" PRIx16 "::0x%" PRIx16 ":0x%" PRIu32 " = ", VendorIdFromTag(tag), ProfileNumFromTag(tag), TagNumFromTag(tag));
+    }
+}
+
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
+CHIP_ERROR Print(TLV::TLVReader &reader, int tabLevel)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    PrintTag(reader.GetTag(), tabLevel);
+
+    if (tabLevel == 0) {
+        err = reader.Next();
+        SuccessOrExit(err);
+    }
+
+    switch (reader.GetType()) {
+        case kTLVType_Structure:
+        case kTLVType_Array:
+        case kTLVType_List:
+        {
+            TLVType containerType;
+            const char *openingBrace, *closingBrace;
+
+            if (reader.GetType() == kTLVType_Structure) {
+                openingBrace = "{";
+                closingBrace = "}";
+            }
+            else if (reader.GetType() == kTLVType_Array) {
+                openingBrace = "[";
+                closingBrace = "]";
+            }
+            else {
+                openingBrace = "[[";
+                closingBrace = "]]";
+            }
+
+            printf("\n");
+            PrintTabs(tabLevel);
+            printf("%s\n", openingBrace);
+
+            err = reader.EnterContainer(containerType);
+            SuccessOrExit(err);
+
+            while ((err = reader.Next()) == CHIP_NO_ERROR) {
+                err = Print(reader, tabLevel + 1);
+                SuccessOrExit(err);
+            }
+
+            err = reader.ExitContainer(containerType);
+            SuccessOrExit(err);
+
+            PrintTabs(tabLevel);
+            printf("%s\n", closingBrace);
+            break;
+        }
+
+        case kTLVType_Boolean:
+        {
+            bool v;
+
+            err = reader.Get(v);
+            SuccessOrExit(err);
+
+            printf("%s,\n", (v) ? "true" : "false");
+            break;
+        }
+
+        case kTLVType_SignedInteger:
+        {
+            int64_t v;
+
+            err = reader.Get(v);
+            SuccessOrExit(err);
+
+            printf("%" PRId64 ",\n", v);
+            break;
+        }
+
+        case kTLVType_UnsignedInteger:
+        {
+            uint64_t v;
+
+            err = reader.Get(v);
+            SuccessOrExit(err);
+
+            printf("%" PRIu64 ",\n", v);
+            break;
+        }
+
+        case kTLVType_ByteString:
+        {
+            uint32_t sz = reader.GetLength();
+            uint8_t buf[sz];
+
+            err = reader.GetBytes(buf, sz);
+            SuccessOrExit(err);
+
+            for (uint32_t i = 0; i < sz; i++) {
+                printf("%" PRIu8 " ", buf[i]);
+            }
+
+            printf("\n");
+            break;
+        }
+
+        case kTLVType_UTF8String:
+        {
+            uint32_t sz = reader.GetLength();
+            char buf[sz + 1];
+
+            err = reader.GetString(buf, sz + 1);
+            SuccessOrExit(err);
+
+            buf[sz] = '\0';
+            printf("\"%s\"\n", buf);
+            break;
+        }
+
+        default:
+        {
+            printf("?,\n");
+            break;
+        }
+    }
+
+exit:
+    return err;
+}
+
+
+} // namespace Utilities
+
+} // namespace TLV
+
+} // namespace chip

--- a/src/lib/core/CHIPTLVText.hpp
+++ b/src/lib/core/CHIPTLVText.hpp
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file specifies types and utility interfaces for managing and
+ *      working with CHIP TLV.
+ *
+ */
+
+#ifndef CHIPTLVTEXT_HPP
+#define CHIPTLVTEXT_HPP
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <core/CHIPError.h>
+#include <core/CHIPTLV.h>
+
+namespace chip {
+
+namespace TLV {
+
+/**
+ *   @namespace chip::TLV::Utilities
+ *
+ *   @brief
+ *     This namespace includes types and utility interfaces for managing and
+ *     working with CHIP TLV.
+ *
+ */
+namespace Utilities {
+
+CHIP_ERROR Print(TLV::TLVReader &reader, int tabLevel = 0);
+
+} // namespace Utilities
+
+} // namespace TLV
+
+} // namespace chip
+
+#endif // CHIPTLVUTILITIES_HPP

--- a/src/lib/support/BitFlags.h
+++ b/src/lib/support/BitFlags.h
@@ -47,22 +47,22 @@ public:
     using IntegerType = StorageType;
 
     constexpr BitFlags() : mValue(0) {}
-    BitFlags(const BitFlags & other) = default;
-    BitFlags & operator=(const BitFlags &) = default;
+    constexpr BitFlags(const BitFlags & other) = default;
+    constexpr BitFlags & operator=(const BitFlags &) = default;
 
-    explicit BitFlags(FlagsEnum value) : mValue(static_cast<IntegerType>(value)) {}
-    explicit BitFlags(IntegerType value) : mValue(value) {}
+    constexpr explicit BitFlags(FlagsEnum value) : mValue(static_cast<IntegerType>(value)) {}
+    constexpr explicit BitFlags(IntegerType value) : mValue(value) {}
 
     template <typename... Args>
-    BitFlags(FlagsEnum flag, Args &&... args) : mValue(Or(flag, std::forward<Args>(args)...))
+    constexpr BitFlags(FlagsEnum flag, Args &&... args) : mValue(Or(flag, std::forward<Args>(args)...))
     {}
 
     template <typename... Args>
-    BitFlags(const BitFlags<FlagsEnum> & flags, Args &&... args) : mValue(Or(flags, std::forward<Args>(args)...))
+    constexpr BitFlags(const BitFlags<FlagsEnum> & flags, Args &&... args) : mValue(Or(flags, std::forward<Args>(args)...))
     {}
 
     template <typename... Args>
-    BitFlags(IntegerType value, Args &&... args) : mValue(value | Or(std::forward<Args>(args)...))
+    constexpr BitFlags(IntegerType value, Args &&... args) : mValue(value | Or(std::forward<Args>(args)...))
     {}
 
     /**

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -57,6 +57,10 @@ static void DefaultOnMessageReceived(ExchangeContext * ec, const PacketHeader & 
                  protocolId.ToFullyQualifiedSpecForm(), msgType, ec->GetExchangeId(), packetHeader.GetMessageId());
 }
 
+#if CHIP_CONFIG_TEST
+ExchangeContextUnitTestDelegate *ExchangeContext::sUnitTestDelegate = nullptr;
+#endif
+
 bool ExchangeContext::IsInitiator() const
 {
     return mFlags.Has(Flags::kFlagInitiator);
@@ -90,6 +94,13 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 
     CHIP_ERROR err                         = CHIP_NO_ERROR;
     Transport::PeerConnectionState * state = nullptr;
+
+#if CHIP_CONFIG_TEST
+    if (sUnitTestDelegate) {
+       sUnitTestDelegate->InterceptMessage(std::move(msgBuf));
+       return CHIP_NO_ERROR;
+    }
+#endif
 
     VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INTERNAL);
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -49,6 +49,13 @@ public:
     static void Release(ExchangeContext * obj);
 };
 
+class ExchangeContextUnitTestDelegate
+{
+public:
+    virtual void InterceptMessage(System::PacketBufferHandle handle) = 0;
+    virtual ~ExchangeContextUnitTestDelegate() {}
+};
+
 /**
  *  @brief
  *    This class represents an ongoing conversation (ExchangeContext) between two or more nodes.
@@ -173,6 +180,12 @@ public:
     void Abort();
 
     void SetResponseTimeout(Timeout timeout);
+
+#if CHIP_CONFIG_TEST
+public:
+    static ExchangeContextUnitTestDelegate *sUnitTestDelegate;
+    static void SetUnitTestDelegate(ExchangeContextUnitTestDelegate *delegate) { sUnitTestDelegate = delegate; }
+#endif
 
 private:
     Timeout mResponseTimeout; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.

--- a/src/system/TLVPacketBufferBackingStore.h
+++ b/src/system/TLVPacketBufferBackingStore.h
@@ -61,6 +61,7 @@ public:
         mCurrentBuffer     = mHeadBuffer.Retain();
         mUseChainedBuffers = useChainedBuffers;
     }
+
     void Adopt(chip::System::PacketBufferHandle && buffer) { Init(std::move(buffer), mUseChainedBuffers); }
 
     /**
@@ -73,6 +74,8 @@ public:
         mCurrentBuffer = nullptr;
         return std::move(mHeadBuffer);
     }
+
+    chip::System::PacketBufferHandle& GetCurrentBuffer() { return mCurrentBuffer; }
 
     // TLVBackingStore overrides:
     CHIP_ERROR OnInit(chip::TLV::TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) override;
@@ -104,6 +107,8 @@ public:
         chip::TLV::TLVReader::Init(mBackingStore);
     }
 
+    TLVPacketBufferBackingStore& GetBackingStore() {return mBackingStore;}
+
 private:
     TLVPacketBufferBackingStore mBackingStore;
 };
@@ -125,6 +130,7 @@ public:
         mBackingStore.Init(std::move(buffer), useChainedBuffers);
         chip::TLV::TLVWriter::Init(mBackingStore);
     }
+
     /**
      * Finish the writing of a TLV encoding and release ownership of the underlying PacketBuffer.
      *
@@ -145,6 +151,9 @@ public:
         *outBuffer     = mBackingStore.Release();
         return err;
     }
+
+    bool HasBuffer() { return !mBackingStore.GetCurrentBuffer().IsNull(); }
+    
     /**
      * Free the underlying PacketBuffer.
      *

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -280,7 +280,7 @@ public:
     const AdminPairingInfo & operator*() const { return mStart[mIndex]; }
     const AdminPairingInfo * operator->() const { return mStart + mIndex; }
 
-    bool operator==(const ConstAdminIterator & other)
+    bool operator==(const ConstAdminIterator & other) const
     {
         if (IsAtEnd())
         {


### PR DESCRIPTION
This is a prototype of an evolved approached to the IM that addresses some key deficiencies in the current implementation with the following key features:

* A code-generation scheme that generates objects instead of code for the various cluster elements (events, attributes, commands).
     * Supports complex types (structs, lists, lists of structs) as well as pervasive optionality/nullability (not implemented yet).
* Flexible code-generation scheme that permits generating different types of cluster objects for different targets with differing capabilities.
     * Two have been provided in this PR: One that uses STL for platforms that support STL + heap, and another that uses chip::Span for non-heap based products.
     * Generated code for devices is agnostic to products, and leverages product-specified configurations to 'alter' the generated code at compile-time using `constexpr` functions.
* New `InvokeInitiator`/`InvokeResponder` classes that are evolutions of the current `CommandSender` and `CommandHandler` classes respectively, with a revamped API that is much more application friendly. This includes an improved callback mechanism to facilitate registration of application handlers for responses and errors.
    * Does away with all of the CallbackMgr routing logic and simplifies it down significantly.
    * Support for async sending of responses on the server
    * Supports batching multiple commands in the same request.
 * Unit tests that try to emulate 'end-to-end' testing of commands, as well as the code-generation.
 * Show-cases the transition strategy that permits co-existence of both old and new approaches, permitting a gradated shift to the new scheme incrementally, cluster-by-cluster.

So far, the prototype only mocks up how Commands would work in this new scheme. To show-case real changes, the PR also modifies the [network commissioning cluster](https://github.com/project-chip/connectedhomeip/pull/8313/files#diff-8447f09e1df8ba9b0ef5528fd94c7dc3501bf1516f9afd5352fc9a4262f119aa) implementation on the server side, as well as a number of commissioning commands on the [CHIP controller](https://github.com/project-chip/connectedhomeip/pull/8313/files#diff-30c3779ffb95f404ea48b1ed6319a810a1f5639a9b035002f11a44193b4cddbe) side. Those as well as the TestInvokeInteraction-* unit tests should be looked at to see a complete, top-down view of how all of this is stitched together.

For more details, see this [doc](https://docs.google.com/document/d/1fwF2fhKv-ZH1nt6uzFqqCEBwAF56xyGBUmpEULaWMjs/edit?userstoinvite=kianoosh.karami@smartthings.com&ts=60f05a9f&resourcekey=0-VHx9KlQ7QoY7rPlA6YPOzQ).