### PR TITLE
Turn off the non-tsan "tests" jobs.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
 
         strategy:
           matrix:
-            type: [debug, tsan]
+            type: [tsan]
             eventloop: [eventloop_same, eventloop_separate]
         env:
             USE_SEPARATE_EVENTLOOP: ${{ matrix.eventloop == 'eventloop_separate' }}
@@ -106,7 +106,7 @@ jobs:
 
         strategy:
           matrix:
-            type: [debug, tsan]
+            type: [tsan]
             eventloop: [eventloop_same, eventloop_separate]
         env:
             USE_SEPARATE_EVENTLOOP: ${{ matrix.eventloop == 'eventloop_separate' }}


### PR DESCRIPTION
The tsan jobs should be doing everything the non-tsan jobs do, and
this will save us a bit of CI compute....

#### Problem
Running jobs we might not need to.

#### Change overview
Don't run the non-Tsan "tests" jobs.

#### Testing
Ran CI.