### PR TITLE
ESP32: Minor fix in lock-app RPC lock status

### DIFF
--- a/examples/lock-app/esp32/main/Rpc.cpp
+++ b/examples/lock-app/esp32/main/Rpc.cpp
@@ -55,7 +55,7 @@ public:
 
     pw::Status Get(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_LockingState & response)
     {
-        response.locked = BoltLockMgr().IsUnlocked();
+        response.locked = !BoltLockMgr().IsUnlocked();
         return pw::OkStatus();
     }
 };


### PR DESCRIPTION
#### Problem
* Locking RPC shows inappropriate locked value.
* Set locked = false, means perform unlock action
* Set locked =  true, means perform lock action
```
In [1]: rpcs.chip.rpc.Locking.Set(locked=False)
Out[1]: (Status.OK, chip.rpc.Empty())

In [2]: a,b = rpcs.chip.rpc.Locking.Get()

In [3]: b.locked
Out[3]: True

In [4]: rpcs.chip.rpc.Locking.Set(locked=True)
Out[4]: (Status.OK, chip.rpc.Empty())

In [5]: a,b = rpcs.chip.rpc.Locking.Get()

In [6]: b.locked
Out[6]: False
```

#### Change overview
Fixed the resultant value.

#### Testing
* Build, compiled the lock-app, and performed the RPC communication
```
In [1]: rpcs.chip.rpc.Locking.Set(locked=False)
Out[1]: (Status.OK, chip.rpc.Empty())

In [2]: a,b = rpcs.chip.rpc.Locking.Get()

In [3]: b.locked
Out[3]: False

In [4]: rpcs.chip.rpc.Locking.Set(locked=True)
Out[4]: (Status.OK, chip.rpc.Empty())

In [5]: a,b = rpcs.chip.rpc.Locking.Get()

In [6]: b.locked
Out[6]: True
```