### PR TITLE
Generate Clusters/Commands/Attributes ids using MEI encoding

### DIFF
--- a/src/app/common/gen/ids/Attributes.h
+++ b/src/app/common/gen/ids/Attributes.h
@@ -26,8 +26,8 @@ namespace Clusters {
 namespace Globals {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId FeatureMap      = 0xFFFC;
-static constexpr AttributeId ClusterRevision = 0xFFFD;
+static constexpr AttributeId FeatureMap      = 0x0000FFFC;
+static constexpr AttributeId ClusterRevision = 0x0000FFFD;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Globals
@@ -35,63 +35,63 @@ static constexpr AttributeId ClusterRevision = 0xFFFD;
 namespace PowerConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MainsVoltage                   = 0x0000;
-static constexpr AttributeId MainsFrequency                 = 0x0001;
-static constexpr AttributeId MainsAlarmMask                 = 0x0010;
-static constexpr AttributeId MainsVoltageMinThreshold       = 0x0011;
-static constexpr AttributeId MainsVoltageMaxThreshold       = 0x0012;
-static constexpr AttributeId MainsVoltageDwellTrip          = 0x0013;
-static constexpr AttributeId BatteryVoltage                 = 0x0020;
-static constexpr AttributeId BatteryPercentageRemaining     = 0x0021;
-static constexpr AttributeId BatteryManufacturer            = 0x0030;
-static constexpr AttributeId BatterySize                    = 0x0031;
-static constexpr AttributeId BatteryAhrRating               = 0x0032;
-static constexpr AttributeId BatteryQuantity                = 0x0033;
-static constexpr AttributeId BatteryRatedVoltage            = 0x0034;
-static constexpr AttributeId BatteryAlarmMask               = 0x0035;
-static constexpr AttributeId BatteryVoltageMinThreshold     = 0x0036;
-static constexpr AttributeId BatteryVoltageThreshold1       = 0x0037;
-static constexpr AttributeId BatteryVoltageThreshold2       = 0x0038;
-static constexpr AttributeId BatteryVoltageThreshold3       = 0x0039;
-static constexpr AttributeId BatteryPercentageMinThreshold  = 0x003A;
-static constexpr AttributeId BatteryPercentageThreshold1    = 0x003B;
-static constexpr AttributeId BatteryPercentageThreshold2    = 0x003C;
-static constexpr AttributeId BatteryPercentageThreshold3    = 0x003D;
-static constexpr AttributeId BatteryAlarmState              = 0x003E;
-static constexpr AttributeId Battery2Voltage                = 0x0040;
-static constexpr AttributeId Battery2PercentageRemaining    = 0x0041;
-static constexpr AttributeId Battery2Manufacturer           = 0x0050;
-static constexpr AttributeId Battery2Size                   = 0x0051;
-static constexpr AttributeId Battery2AhrRating              = 0x0052;
-static constexpr AttributeId Battery2Quantity               = 0x0053;
-static constexpr AttributeId Battery2RatedVoltage           = 0x0054;
-static constexpr AttributeId Battery2AlarmMask              = 0x0055;
-static constexpr AttributeId Battery2VoltageMinThreshold    = 0x0056;
-static constexpr AttributeId Battery2VoltageThreshold1      = 0x0057;
-static constexpr AttributeId Battery2VoltageThreshold2      = 0x0058;
-static constexpr AttributeId Battery2VoltageThreshold3      = 0x0059;
-static constexpr AttributeId Battery2PercentageMinThreshold = 0x005A;
-static constexpr AttributeId Battery2PercentageThreshold1   = 0x005B;
-static constexpr AttributeId Battery2PercentageThreshold2   = 0x005C;
-static constexpr AttributeId Battery2PercentageThreshold3   = 0x005D;
-static constexpr AttributeId Battery2AlarmState             = 0x005E;
-static constexpr AttributeId Battery3Voltage                = 0x0060;
-static constexpr AttributeId Battery3PercentageRemaining    = 0x0061;
-static constexpr AttributeId Battery3Manufacturer           = 0x0070;
-static constexpr AttributeId Battery3Size                   = 0x0071;
-static constexpr AttributeId Battery3AhrRating              = 0x0072;
-static constexpr AttributeId Battery3Quantity               = 0x0073;
-static constexpr AttributeId Battery3RatedVoltage           = 0x0074;
-static constexpr AttributeId Battery3AlarmMask              = 0x0075;
-static constexpr AttributeId Battery3VoltageMinThreshold    = 0x0076;
-static constexpr AttributeId Battery3VoltageThreshold1      = 0x0077;
-static constexpr AttributeId Battery3VoltageThreshold2      = 0x0078;
-static constexpr AttributeId Battery3VoltageThreshold3      = 0x0079;
-static constexpr AttributeId Battery3PercentageMinThreshold = 0x007A;
-static constexpr AttributeId Battery3PercentageThreshold1   = 0x007B;
-static constexpr AttributeId Battery3PercentageThreshold2   = 0x007C;
-static constexpr AttributeId Battery3PercentageThreshold3   = 0x007D;
-static constexpr AttributeId Battery3AlarmState             = 0x007E;
+static constexpr AttributeId MainsVoltage                   = 0x00000000;
+static constexpr AttributeId MainsFrequency                 = 0x00000001;
+static constexpr AttributeId MainsAlarmMask                 = 0x00000010;
+static constexpr AttributeId MainsVoltageMinThreshold       = 0x00000011;
+static constexpr AttributeId MainsVoltageMaxThreshold       = 0x00000012;
+static constexpr AttributeId MainsVoltageDwellTrip          = 0x00000013;
+static constexpr AttributeId BatteryVoltage                 = 0x00000020;
+static constexpr AttributeId BatteryPercentageRemaining     = 0x00000021;
+static constexpr AttributeId BatteryManufacturer            = 0x00000030;
+static constexpr AttributeId BatterySize                    = 0x00000031;
+static constexpr AttributeId BatteryAhrRating               = 0x00000032;
+static constexpr AttributeId BatteryQuantity                = 0x00000033;
+static constexpr AttributeId BatteryRatedVoltage            = 0x00000034;
+static constexpr AttributeId BatteryAlarmMask               = 0x00000035;
+static constexpr AttributeId BatteryVoltageMinThreshold     = 0x00000036;
+static constexpr AttributeId BatteryVoltageThreshold1       = 0x00000037;
+static constexpr AttributeId BatteryVoltageThreshold2       = 0x00000038;
+static constexpr AttributeId BatteryVoltageThreshold3       = 0x00000039;
+static constexpr AttributeId BatteryPercentageMinThreshold  = 0x0000003A;
+static constexpr AttributeId BatteryPercentageThreshold1    = 0x0000003B;
+static constexpr AttributeId BatteryPercentageThreshold2    = 0x0000003C;
+static constexpr AttributeId BatteryPercentageThreshold3    = 0x0000003D;
+static constexpr AttributeId BatteryAlarmState              = 0x0000003E;
+static constexpr AttributeId Battery2Voltage                = 0x00000040;
+static constexpr AttributeId Battery2PercentageRemaining    = 0x00000041;
+static constexpr AttributeId Battery2Manufacturer           = 0x00000050;
+static constexpr AttributeId Battery2Size                   = 0x00000051;
+static constexpr AttributeId Battery2AhrRating              = 0x00000052;
+static constexpr AttributeId Battery2Quantity               = 0x00000053;
+static constexpr AttributeId Battery2RatedVoltage           = 0x00000054;
+static constexpr AttributeId Battery2AlarmMask              = 0x00000055;
+static constexpr AttributeId Battery2VoltageMinThreshold    = 0x00000056;
+static constexpr AttributeId Battery2VoltageThreshold1      = 0x00000057;
+static constexpr AttributeId Battery2VoltageThreshold2      = 0x00000058;
+static constexpr AttributeId Battery2VoltageThreshold3      = 0x00000059;
+static constexpr AttributeId Battery2PercentageMinThreshold = 0x0000005A;
+static constexpr AttributeId Battery2PercentageThreshold1   = 0x0000005B;
+static constexpr AttributeId Battery2PercentageThreshold2   = 0x0000005C;
+static constexpr AttributeId Battery2PercentageThreshold3   = 0x0000005D;
+static constexpr AttributeId Battery2AlarmState             = 0x0000005E;
+static constexpr AttributeId Battery3Voltage                = 0x00000060;
+static constexpr AttributeId Battery3PercentageRemaining    = 0x00000061;
+static constexpr AttributeId Battery3Manufacturer           = 0x00000070;
+static constexpr AttributeId Battery3Size                   = 0x00000071;
+static constexpr AttributeId Battery3AhrRating              = 0x00000072;
+static constexpr AttributeId Battery3Quantity               = 0x00000073;
+static constexpr AttributeId Battery3RatedVoltage           = 0x00000074;
+static constexpr AttributeId Battery3AlarmMask              = 0x00000075;
+static constexpr AttributeId Battery3VoltageMinThreshold    = 0x00000076;
+static constexpr AttributeId Battery3VoltageThreshold1      = 0x00000077;
+static constexpr AttributeId Battery3VoltageThreshold2      = 0x00000078;
+static constexpr AttributeId Battery3VoltageThreshold3      = 0x00000079;
+static constexpr AttributeId Battery3PercentageMinThreshold = 0x0000007A;
+static constexpr AttributeId Battery3PercentageThreshold1   = 0x0000007B;
+static constexpr AttributeId Battery3PercentageThreshold2   = 0x0000007C;
+static constexpr AttributeId Battery3PercentageThreshold3   = 0x0000007D;
+static constexpr AttributeId Battery3AlarmState             = 0x0000007E;
 } // namespace Ids
 } // namespace Attributes
 } // namespace PowerConfiguration
@@ -99,15 +99,15 @@ static constexpr AttributeId Battery3AlarmState             = 0x007E;
 namespace DeviceTemperatureConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId CurrentTemperature     = 0x0000;
-static constexpr AttributeId MinTempExperienced     = 0x0001;
-static constexpr AttributeId MaxTempExperienced     = 0x0002;
-static constexpr AttributeId OverTempTotalDwell     = 0x0003;
-static constexpr AttributeId DeviceTempAlarmMask    = 0x0010;
-static constexpr AttributeId LowTempThreshold       = 0x0011;
-static constexpr AttributeId HighTempThreshold      = 0x0012;
-static constexpr AttributeId LowTempDwellTripPoint  = 0x0013;
-static constexpr AttributeId HighTempDwellTripPoint = 0x0014;
+static constexpr AttributeId CurrentTemperature     = 0x00000000;
+static constexpr AttributeId MinTempExperienced     = 0x00000001;
+static constexpr AttributeId MaxTempExperienced     = 0x00000002;
+static constexpr AttributeId OverTempTotalDwell     = 0x00000003;
+static constexpr AttributeId DeviceTempAlarmMask    = 0x00000010;
+static constexpr AttributeId LowTempThreshold       = 0x00000011;
+static constexpr AttributeId HighTempThreshold      = 0x00000012;
+static constexpr AttributeId LowTempDwellTripPoint  = 0x00000013;
+static constexpr AttributeId HighTempDwellTripPoint = 0x00000014;
 } // namespace Ids
 } // namespace Attributes
 } // namespace DeviceTemperatureConfiguration
@@ -115,8 +115,8 @@ static constexpr AttributeId HighTempDwellTripPoint = 0x0014;
 namespace Identify {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId IdentifyTime    = 0x0000;
-static constexpr AttributeId CommissionState = 0x0001;
+static constexpr AttributeId IdentifyTime    = 0x00000000;
+static constexpr AttributeId CommissionState = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Identify
@@ -124,7 +124,7 @@ static constexpr AttributeId CommissionState = 0x0001;
 namespace Groups {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId NameSupport = 0x0000;
+static constexpr AttributeId NameSupport = 0x00000000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Groups
@@ -132,12 +132,12 @@ static constexpr AttributeId NameSupport = 0x0000;
 namespace Scenes {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId SceneCount       = 0x0000;
-static constexpr AttributeId CurrentScene     = 0x0001;
-static constexpr AttributeId CurrentGroup     = 0x0002;
-static constexpr AttributeId SceneValid       = 0x0003;
-static constexpr AttributeId NameSupport      = 0x0004;
-static constexpr AttributeId LastConfiguredBy = 0x0005;
+static constexpr AttributeId SceneCount       = 0x00000000;
+static constexpr AttributeId CurrentScene     = 0x00000001;
+static constexpr AttributeId CurrentGroup     = 0x00000002;
+static constexpr AttributeId SceneValid       = 0x00000003;
+static constexpr AttributeId NameSupport      = 0x00000004;
+static constexpr AttributeId LastConfiguredBy = 0x00000005;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Scenes
@@ -145,15 +145,15 @@ static constexpr AttributeId LastConfiguredBy = 0x0005;
 namespace OnOff {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId OnOff                                  = 0x0000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1002 = 0x0000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1049 = 0x0000;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1002 = 0x0001;
-static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1040 = 0x0001;
-static constexpr AttributeId GlobalSceneControl                     = 0x4000;
-static constexpr AttributeId OnTime                                 = 0x4001;
-static constexpr AttributeId OffWaitTime                            = 0x4002;
-static constexpr AttributeId StartUpOnOff                           = 0x4003;
+static constexpr AttributeId OnOff                                  = 0x00000000;
+static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1002 = 0x10020000;
+static constexpr AttributeId SampleMfgSpecificAttribute0x00000x1049 = 0x10490000;
+static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1002 = 0x10020001;
+static constexpr AttributeId SampleMfgSpecificAttribute0x00010x1040 = 0x10490001;
+static constexpr AttributeId GlobalSceneControl                     = 0x00004000;
+static constexpr AttributeId OnTime                                 = 0x00004001;
+static constexpr AttributeId OffWaitTime                            = 0x00004002;
+static constexpr AttributeId StartUpOnOff                           = 0x00004003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OnOff
@@ -161,8 +161,8 @@ static constexpr AttributeId StartUpOnOff                           = 0x4003;
 namespace OnOffSwitchConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId SwitchType    = 0x0000;
-static constexpr AttributeId SwitchActions = 0x0010;
+static constexpr AttributeId SwitchType    = 0x00000000;
+static constexpr AttributeId SwitchActions = 0x00000010;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OnOffSwitchConfiguration
@@ -170,15 +170,15 @@ static constexpr AttributeId SwitchActions = 0x0010;
 namespace LevelControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId CurrentLevel        = 0x0000;
-static constexpr AttributeId RemainingTime       = 0x0001;
-static constexpr AttributeId Options             = 0x000F;
-static constexpr AttributeId OnOffTransitionTime = 0x0010;
-static constexpr AttributeId OnLevel             = 0x0011;
-static constexpr AttributeId OnTransitionTime    = 0x0012;
-static constexpr AttributeId OffTransitionTime   = 0x0013;
-static constexpr AttributeId DefaultMoveRate     = 0x0014;
-static constexpr AttributeId StartUpCurrentLevel = 0x4000;
+static constexpr AttributeId CurrentLevel        = 0x00000000;
+static constexpr AttributeId RemainingTime       = 0x00000001;
+static constexpr AttributeId Options             = 0x0000000F;
+static constexpr AttributeId OnOffTransitionTime = 0x00000010;
+static constexpr AttributeId OnLevel             = 0x00000011;
+static constexpr AttributeId OnTransitionTime    = 0x00000012;
+static constexpr AttributeId OffTransitionTime   = 0x00000013;
+static constexpr AttributeId DefaultMoveRate     = 0x00000014;
+static constexpr AttributeId StartUpCurrentLevel = 0x00004000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace LevelControl
@@ -186,7 +186,7 @@ static constexpr AttributeId StartUpCurrentLevel = 0x4000;
 namespace Alarms {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId AlarmCount = 0x0000;
+static constexpr AttributeId AlarmCount = 0x00000000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Alarms
@@ -194,16 +194,16 @@ static constexpr AttributeId AlarmCount = 0x0000;
 namespace Time {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Time           = 0x0000;
-static constexpr AttributeId TimeStatus     = 0x0001;
-static constexpr AttributeId TimeZone       = 0x0002;
-static constexpr AttributeId DstStart       = 0x0003;
-static constexpr AttributeId DstEnd         = 0x0004;
-static constexpr AttributeId DstShift       = 0x0005;
-static constexpr AttributeId StandardTime   = 0x0006;
-static constexpr AttributeId LocalTime      = 0x0007;
-static constexpr AttributeId LastSetTime    = 0x0008;
-static constexpr AttributeId ValidUntilTime = 0x0009;
+static constexpr AttributeId Time           = 0x00000000;
+static constexpr AttributeId TimeStatus     = 0x00000001;
+static constexpr AttributeId TimeZone       = 0x00000002;
+static constexpr AttributeId DstStart       = 0x00000003;
+static constexpr AttributeId DstEnd         = 0x00000004;
+static constexpr AttributeId DstShift       = 0x00000005;
+static constexpr AttributeId StandardTime   = 0x00000006;
+static constexpr AttributeId LocalTime      = 0x00000007;
+static constexpr AttributeId LastSetTime    = 0x00000008;
+static constexpr AttributeId ValidUntilTime = 0x00000009;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Time
@@ -211,15 +211,15 @@ static constexpr AttributeId ValidUntilTime = 0x0009;
 namespace BinaryInputBasic {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId ActiveText      = 0x0004;
-static constexpr AttributeId Description     = 0x001C;
-static constexpr AttributeId InactiveText    = 0x002E;
-static constexpr AttributeId OutOfService    = 0x0051;
-static constexpr AttributeId Polarity        = 0x0054;
-static constexpr AttributeId PresentValue    = 0x0055;
-static constexpr AttributeId Reliability     = 0x0067;
-static constexpr AttributeId StatusFlags     = 0x006F;
-static constexpr AttributeId ApplicationType = 0x0100;
+static constexpr AttributeId ActiveText      = 0x00000004;
+static constexpr AttributeId Description     = 0x0000001C;
+static constexpr AttributeId InactiveText    = 0x0000002E;
+static constexpr AttributeId OutOfService    = 0x00000051;
+static constexpr AttributeId Polarity        = 0x00000054;
+static constexpr AttributeId PresentValue    = 0x00000055;
+static constexpr AttributeId Reliability     = 0x00000067;
+static constexpr AttributeId StatusFlags     = 0x0000006F;
+static constexpr AttributeId ApplicationType = 0x00000100;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BinaryInputBasic
@@ -227,11 +227,11 @@ static constexpr AttributeId ApplicationType = 0x0100;
 namespace PowerProfile {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId TotalProfileNum    = 0x0000;
-static constexpr AttributeId MultipleScheduling = 0x0001;
-static constexpr AttributeId EnergyFormatting   = 0x0002;
-static constexpr AttributeId EnergyRemote       = 0x0003;
-static constexpr AttributeId ScheduleMode       = 0x0004;
+static constexpr AttributeId TotalProfileNum    = 0x00000000;
+static constexpr AttributeId MultipleScheduling = 0x00000001;
+static constexpr AttributeId EnergyFormatting   = 0x00000002;
+static constexpr AttributeId EnergyRemote       = 0x00000003;
+static constexpr AttributeId ScheduleMode       = 0x00000004;
 } // namespace Ids
 } // namespace Attributes
 } // namespace PowerProfile
@@ -239,9 +239,9 @@ static constexpr AttributeId ScheduleMode       = 0x0004;
 namespace ApplianceControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId StartTime     = 0x0000;
-static constexpr AttributeId FinishTime    = 0x0001;
-static constexpr AttributeId RemainingTime = 0x0002;
+static constexpr AttributeId StartTime     = 0x00000000;
+static constexpr AttributeId FinishTime    = 0x00000001;
+static constexpr AttributeId RemainingTime = 0x00000002;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ApplianceControl
@@ -249,10 +249,10 @@ static constexpr AttributeId RemainingTime = 0x0002;
 namespace Descriptor {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId DeviceList = 0x0000;
-static constexpr AttributeId ServerList = 0x0001;
-static constexpr AttributeId ClientList = 0x0002;
-static constexpr AttributeId PartsList  = 0x0003;
+static constexpr AttributeId DeviceList = 0x00000000;
+static constexpr AttributeId ServerList = 0x00000001;
+static constexpr AttributeId ClientList = 0x00000002;
+static constexpr AttributeId PartsList  = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Descriptor
@@ -260,13 +260,13 @@ static constexpr AttributeId PartsList  = 0x0003;
 namespace PollControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId CheckInInterval     = 0x0000;
-static constexpr AttributeId LongPollInterval    = 0x0001;
-static constexpr AttributeId ShortPollInterval   = 0x0002;
-static constexpr AttributeId FastPollTimeout     = 0x0003;
-static constexpr AttributeId CheckInIntervalMin  = 0x0004;
-static constexpr AttributeId LongPollIntervalMin = 0x0005;
-static constexpr AttributeId FastPollTimeoutMax  = 0x0006;
+static constexpr AttributeId CheckInInterval     = 0x00000000;
+static constexpr AttributeId LongPollInterval    = 0x00000001;
+static constexpr AttributeId ShortPollInterval   = 0x00000002;
+static constexpr AttributeId FastPollTimeout     = 0x00000003;
+static constexpr AttributeId CheckInIntervalMin  = 0x00000004;
+static constexpr AttributeId LongPollIntervalMin = 0x00000005;
+static constexpr AttributeId FastPollTimeoutMax  = 0x00000006;
 } // namespace Ids
 } // namespace Attributes
 } // namespace PollControl
@@ -274,24 +274,24 @@ static constexpr AttributeId FastPollTimeoutMax  = 0x0006;
 namespace Basic {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId InteractionModelVersion = 0x0000;
-static constexpr AttributeId VendorName              = 0x0001;
-static constexpr AttributeId VendorID                = 0x0002;
-static constexpr AttributeId ProductName             = 0x0003;
-static constexpr AttributeId ProductID               = 0x0004;
-static constexpr AttributeId UserLabel               = 0x0005;
-static constexpr AttributeId Location                = 0x0006;
-static constexpr AttributeId HardwareVersion         = 0x0007;
-static constexpr AttributeId HardwareVersionString   = 0x0008;
-static constexpr AttributeId SoftwareVersion         = 0x0009;
-static constexpr AttributeId SoftwareVersionString   = 0x000A;
-static constexpr AttributeId ManufacturingDate       = 0x000B;
-static constexpr AttributeId PartNumber              = 0x000C;
-static constexpr AttributeId ProductURL              = 0x000D;
-static constexpr AttributeId ProductLabel            = 0x000E;
-static constexpr AttributeId SerialNumber            = 0x000F;
-static constexpr AttributeId LocalConfigDisabled     = 0x0010;
-static constexpr AttributeId Reachable               = 0x0011;
+static constexpr AttributeId InteractionModelVersion = 0x00000000;
+static constexpr AttributeId VendorName              = 0x00000001;
+static constexpr AttributeId VendorID                = 0x00000002;
+static constexpr AttributeId ProductName             = 0x00000003;
+static constexpr AttributeId ProductID               = 0x00000004;
+static constexpr AttributeId UserLabel               = 0x00000005;
+static constexpr AttributeId Location                = 0x00000006;
+static constexpr AttributeId HardwareVersion         = 0x00000007;
+static constexpr AttributeId HardwareVersionString   = 0x00000008;
+static constexpr AttributeId SoftwareVersion         = 0x00000009;
+static constexpr AttributeId SoftwareVersionString   = 0x0000000A;
+static constexpr AttributeId ManufacturingDate       = 0x0000000B;
+static constexpr AttributeId PartNumber              = 0x0000000C;
+static constexpr AttributeId ProductURL              = 0x0000000D;
+static constexpr AttributeId ProductLabel            = 0x0000000E;
+static constexpr AttributeId SerialNumber            = 0x0000000F;
+static constexpr AttributeId LocalConfigDisabled     = 0x00000010;
+static constexpr AttributeId Reachable               = 0x00000011;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Basic
@@ -299,8 +299,8 @@ static constexpr AttributeId Reachable               = 0x0011;
 namespace GeneralCommissioning {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId FabricId   = 0x0000;
-static constexpr AttributeId Breadcrumb = 0x0001;
+static constexpr AttributeId FabricId   = 0x00000000;
+static constexpr AttributeId Breadcrumb = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace GeneralCommissioning
@@ -308,14 +308,14 @@ static constexpr AttributeId Breadcrumb = 0x0001;
 namespace GeneralDiagnostics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId NetworkInterfaces     = 0x0000;
-static constexpr AttributeId RebootCount           = 0x0001;
-static constexpr AttributeId UpTime                = 0x0002;
-static constexpr AttributeId TotalOperationalHours = 0x0003;
-static constexpr AttributeId BootReasons           = 0x0004;
-static constexpr AttributeId ActiveHardwareFaults  = 0x0005;
-static constexpr AttributeId ActiveRadioFaults     = 0x0006;
-static constexpr AttributeId ActiveNetworkFaults   = 0x0007;
+static constexpr AttributeId NetworkInterfaces     = 0x00000000;
+static constexpr AttributeId RebootCount           = 0x00000001;
+static constexpr AttributeId UpTime                = 0x00000002;
+static constexpr AttributeId TotalOperationalHours = 0x00000003;
+static constexpr AttributeId BootReasons           = 0x00000004;
+static constexpr AttributeId ActiveHardwareFaults  = 0x00000005;
+static constexpr AttributeId ActiveRadioFaults     = 0x00000006;
+static constexpr AttributeId ActiveNetworkFaults   = 0x00000007;
 } // namespace Ids
 } // namespace Attributes
 } // namespace GeneralDiagnostics
@@ -323,10 +323,10 @@ static constexpr AttributeId ActiveNetworkFaults   = 0x0007;
 namespace SoftwareDiagnostics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId ThreadMetrics            = 0x0000;
-static constexpr AttributeId CurrentHeapFree          = 0x0001;
-static constexpr AttributeId CurrentHeapUsed          = 0x0002;
-static constexpr AttributeId CurrentHeapHighWatermark = 0x0003;
+static constexpr AttributeId ThreadMetrics            = 0x00000000;
+static constexpr AttributeId CurrentHeapFree          = 0x00000001;
+static constexpr AttributeId CurrentHeapUsed          = 0x00000002;
+static constexpr AttributeId CurrentHeapHighWatermark = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SoftwareDiagnostics
@@ -334,69 +334,69 @@ static constexpr AttributeId CurrentHeapHighWatermark = 0x0003;
 namespace ThreadNetworkDiagnostics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Channel                           = 0x0000;
-static constexpr AttributeId RoutingRole                       = 0x0001;
-static constexpr AttributeId NetworkName                       = 0x0002;
-static constexpr AttributeId PanId                             = 0x0003;
-static constexpr AttributeId ExtendedPanId                     = 0x0004;
-static constexpr AttributeId MeshLocalPrefix                   = 0x0005;
-static constexpr AttributeId OverrunCount                      = 0x0006;
-static constexpr AttributeId NeighborTableList                 = 0x0007;
-static constexpr AttributeId RouteTableList                    = 0x0008;
-static constexpr AttributeId PartitionId                       = 0x0009;
-static constexpr AttributeId Weighting                         = 0x000A;
-static constexpr AttributeId DataVersion                       = 0x000B;
-static constexpr AttributeId StableDataVersion                 = 0x000C;
-static constexpr AttributeId LeaderRouterId                    = 0x000D;
-static constexpr AttributeId DetachedRoleCount                 = 0x000E;
-static constexpr AttributeId ChildRoleCount                    = 0x000F;
-static constexpr AttributeId RouterRoleCount                   = 0x0010;
-static constexpr AttributeId LeaderRoleCount                   = 0x0011;
-static constexpr AttributeId AttachAttemptCount                = 0x0012;
-static constexpr AttributeId PartitionIdChangeCount            = 0x0013;
-static constexpr AttributeId BetterPartitionAttachAttemptCount = 0x0014;
-static constexpr AttributeId ParentChangeCount                 = 0x0015;
-static constexpr AttributeId TxTotalCount                      = 0x0016;
-static constexpr AttributeId TxUnicastCount                    = 0x0017;
-static constexpr AttributeId TxBroadcastCount                  = 0x0018;
-static constexpr AttributeId TxAckRequestedCount               = 0x0019;
-static constexpr AttributeId TxAckedCount                      = 0x001A;
-static constexpr AttributeId TxNoAckRequestedCount             = 0x001B;
-static constexpr AttributeId TxDataCount                       = 0x001C;
-static constexpr AttributeId TxDataPollCount                   = 0x001D;
-static constexpr AttributeId TxBeaconCount                     = 0x001E;
-static constexpr AttributeId TxBeaconRequestCount              = 0x001F;
-static constexpr AttributeId TxOtherCount                      = 0x0020;
-static constexpr AttributeId TxRetryCount                      = 0x0021;
-static constexpr AttributeId TxDirectMaxRetryExpiryCount       = 0x0022;
-static constexpr AttributeId TxIndirectMaxRetryExpiryCount     = 0x0023;
-static constexpr AttributeId TxErrCcaCount                     = 0x0024;
-static constexpr AttributeId TxErrAbortCount                   = 0x0025;
-static constexpr AttributeId TxErrBusyChannelCount             = 0x0026;
-static constexpr AttributeId RxTotalCount                      = 0x0027;
-static constexpr AttributeId RxUnicastCount                    = 0x0028;
-static constexpr AttributeId RxBroadcastCount                  = 0x0029;
-static constexpr AttributeId RxDataCount                       = 0x002A;
-static constexpr AttributeId RxDataPollCount                   = 0x002B;
-static constexpr AttributeId RxBeaconCount                     = 0x002C;
-static constexpr AttributeId RxBeaconRequestCount              = 0x002D;
-static constexpr AttributeId RxOtherCount                      = 0x002E;
-static constexpr AttributeId RxAddressFilteredCount            = 0x002F;
-static constexpr AttributeId RxDestAddrFilteredCount           = 0x0030;
-static constexpr AttributeId RxDuplicatedCount                 = 0x0031;
-static constexpr AttributeId RxErrNoFrameCount                 = 0x0032;
-static constexpr AttributeId RxErrUnknownNeighborCount         = 0x0033;
-static constexpr AttributeId RxErrInvalidSrcAddrCount          = 0x0034;
-static constexpr AttributeId RxErrSecCount                     = 0x0035;
-static constexpr AttributeId RxErrFcsCount                     = 0x0036;
-static constexpr AttributeId RxErrOtherCount                   = 0x0037;
-static constexpr AttributeId ActiveTimestamp                   = 0x0038;
-static constexpr AttributeId PendingTimestamp                  = 0x0039;
-static constexpr AttributeId Delay                             = 0x003A;
-static constexpr AttributeId SecurityPolicy                    = 0x003B;
-static constexpr AttributeId ChannelMask                       = 0x003C;
-static constexpr AttributeId OperationalDatasetComponents      = 0x003D;
-static constexpr AttributeId ActiveNetworkFaultsList           = 0x003E;
+static constexpr AttributeId Channel                           = 0x00000000;
+static constexpr AttributeId RoutingRole                       = 0x00000001;
+static constexpr AttributeId NetworkName                       = 0x00000002;
+static constexpr AttributeId PanId                             = 0x00000003;
+static constexpr AttributeId ExtendedPanId                     = 0x00000004;
+static constexpr AttributeId MeshLocalPrefix                   = 0x00000005;
+static constexpr AttributeId OverrunCount                      = 0x00000006;
+static constexpr AttributeId NeighborTableList                 = 0x00000007;
+static constexpr AttributeId RouteTableList                    = 0x00000008;
+static constexpr AttributeId PartitionId                       = 0x00000009;
+static constexpr AttributeId Weighting                         = 0x0000000A;
+static constexpr AttributeId DataVersion                       = 0x0000000B;
+static constexpr AttributeId StableDataVersion                 = 0x0000000C;
+static constexpr AttributeId LeaderRouterId                    = 0x0000000D;
+static constexpr AttributeId DetachedRoleCount                 = 0x0000000E;
+static constexpr AttributeId ChildRoleCount                    = 0x0000000F;
+static constexpr AttributeId RouterRoleCount                   = 0x00000010;
+static constexpr AttributeId LeaderRoleCount                   = 0x00000011;
+static constexpr AttributeId AttachAttemptCount                = 0x00000012;
+static constexpr AttributeId PartitionIdChangeCount            = 0x00000013;
+static constexpr AttributeId BetterPartitionAttachAttemptCount = 0x00000014;
+static constexpr AttributeId ParentChangeCount                 = 0x00000015;
+static constexpr AttributeId TxTotalCount                      = 0x00000016;
+static constexpr AttributeId TxUnicastCount                    = 0x00000017;
+static constexpr AttributeId TxBroadcastCount                  = 0x00000018;
+static constexpr AttributeId TxAckRequestedCount               = 0x00000019;
+static constexpr AttributeId TxAckedCount                      = 0x0000001A;
+static constexpr AttributeId TxNoAckRequestedCount             = 0x0000001B;
+static constexpr AttributeId TxDataCount                       = 0x0000001C;
+static constexpr AttributeId TxDataPollCount                   = 0x0000001D;
+static constexpr AttributeId TxBeaconCount                     = 0x0000001E;
+static constexpr AttributeId TxBeaconRequestCount              = 0x0000001F;
+static constexpr AttributeId TxOtherCount                      = 0x00000020;
+static constexpr AttributeId TxRetryCount                      = 0x00000021;
+static constexpr AttributeId TxDirectMaxRetryExpiryCount       = 0x00000022;
+static constexpr AttributeId TxIndirectMaxRetryExpiryCount     = 0x00000023;
+static constexpr AttributeId TxErrCcaCount                     = 0x00000024;
+static constexpr AttributeId TxErrAbortCount                   = 0x00000025;
+static constexpr AttributeId TxErrBusyChannelCount             = 0x00000026;
+static constexpr AttributeId RxTotalCount                      = 0x00000027;
+static constexpr AttributeId RxUnicastCount                    = 0x00000028;
+static constexpr AttributeId RxBroadcastCount                  = 0x00000029;
+static constexpr AttributeId RxDataCount                       = 0x0000002A;
+static constexpr AttributeId RxDataPollCount                   = 0x0000002B;
+static constexpr AttributeId RxBeaconCount                     = 0x0000002C;
+static constexpr AttributeId RxBeaconRequestCount              = 0x0000002D;
+static constexpr AttributeId RxOtherCount                      = 0x0000002E;
+static constexpr AttributeId RxAddressFilteredCount            = 0x0000002F;
+static constexpr AttributeId RxDestAddrFilteredCount           = 0x00000030;
+static constexpr AttributeId RxDuplicatedCount                 = 0x00000031;
+static constexpr AttributeId RxErrNoFrameCount                 = 0x00000032;
+static constexpr AttributeId RxErrUnknownNeighborCount         = 0x00000033;
+static constexpr AttributeId RxErrInvalidSrcAddrCount          = 0x00000034;
+static constexpr AttributeId RxErrSecCount                     = 0x00000035;
+static constexpr AttributeId RxErrFcsCount                     = 0x00000036;
+static constexpr AttributeId RxErrOtherCount                   = 0x00000037;
+static constexpr AttributeId ActiveTimestamp                   = 0x00000038;
+static constexpr AttributeId PendingTimestamp                  = 0x00000039;
+static constexpr AttributeId Delay                             = 0x0000003A;
+static constexpr AttributeId SecurityPolicy                    = 0x0000003B;
+static constexpr AttributeId ChannelMask                       = 0x0000003C;
+static constexpr AttributeId OperationalDatasetComponents      = 0x0000003D;
+static constexpr AttributeId ActiveNetworkFaultsList           = 0x0000003E;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ThreadNetworkDiagnostics
@@ -404,19 +404,19 @@ static constexpr AttributeId ActiveNetworkFaultsList           = 0x003E;
 namespace WiFiNetworkDiagnostics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Bssid                  = 0x0000;
-static constexpr AttributeId SecurityType           = 0x0001;
-static constexpr AttributeId WiFiVersion            = 0x0002;
-static constexpr AttributeId ChannelNumber          = 0x0003;
-static constexpr AttributeId Rssi                   = 0x0004;
-static constexpr AttributeId BeaconLostCount        = 0x0005;
-static constexpr AttributeId BeaconRxCount          = 0x0006;
-static constexpr AttributeId PacketMulticastRxCount = 0x0007;
-static constexpr AttributeId PacketMulticastTxCount = 0x0008;
-static constexpr AttributeId PacketUnicastRxCount   = 0x0009;
-static constexpr AttributeId PacketUnicastTxCount   = 0x000A;
-static constexpr AttributeId CurrentMaxRate         = 0x000B;
-static constexpr AttributeId OverrunCount           = 0x000C;
+static constexpr AttributeId Bssid                  = 0x00000000;
+static constexpr AttributeId SecurityType           = 0x00000001;
+static constexpr AttributeId WiFiVersion            = 0x00000002;
+static constexpr AttributeId ChannelNumber          = 0x00000003;
+static constexpr AttributeId Rssi                   = 0x00000004;
+static constexpr AttributeId BeaconLostCount        = 0x00000005;
+static constexpr AttributeId BeaconRxCount          = 0x00000006;
+static constexpr AttributeId PacketMulticastRxCount = 0x00000007;
+static constexpr AttributeId PacketMulticastTxCount = 0x00000008;
+static constexpr AttributeId PacketUnicastRxCount   = 0x00000009;
+static constexpr AttributeId PacketUnicastTxCount   = 0x0000000A;
+static constexpr AttributeId CurrentMaxRate         = 0x0000000B;
+static constexpr AttributeId OverrunCount           = 0x0000000C;
 } // namespace Ids
 } // namespace Attributes
 } // namespace WiFiNetworkDiagnostics
@@ -424,15 +424,15 @@ static constexpr AttributeId OverrunCount           = 0x000C;
 namespace EthernetNetworkDiagnostics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId PHYRate        = 0x0000;
-static constexpr AttributeId FullDuplex     = 0x0001;
-static constexpr AttributeId PacketRxCount  = 0x0002;
-static constexpr AttributeId PacketTxCount  = 0x0003;
-static constexpr AttributeId TxErrCount     = 0x0004;
-static constexpr AttributeId CollisionCount = 0x0005;
-static constexpr AttributeId OverrunCount   = 0x0006;
-static constexpr AttributeId CarrierDetect  = 0x0007;
-static constexpr AttributeId TimeSinceReset = 0x0008;
+static constexpr AttributeId PHYRate        = 0x00000000;
+static constexpr AttributeId FullDuplex     = 0x00000001;
+static constexpr AttributeId PacketRxCount  = 0x00000002;
+static constexpr AttributeId PacketTxCount  = 0x00000003;
+static constexpr AttributeId TxErrCount     = 0x00000004;
+static constexpr AttributeId CollisionCount = 0x00000005;
+static constexpr AttributeId OverrunCount   = 0x00000006;
+static constexpr AttributeId CarrierDetect  = 0x00000007;
+static constexpr AttributeId TimeSinceReset = 0x00000008;
 } // namespace Ids
 } // namespace Attributes
 } // namespace EthernetNetworkDiagnostics
@@ -440,20 +440,20 @@ static constexpr AttributeId TimeSinceReset = 0x0008;
 namespace BridgedDeviceBasic {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId VendorName            = 0x0001;
-static constexpr AttributeId VendorID              = 0x0002;
-static constexpr AttributeId ProductName           = 0x0003;
-static constexpr AttributeId UserLabel             = 0x0005;
-static constexpr AttributeId HardwareVersion       = 0x0007;
-static constexpr AttributeId HardwareVersionString = 0x0008;
-static constexpr AttributeId SoftwareVersion       = 0x0009;
-static constexpr AttributeId SoftwareVersionString = 0x000A;
-static constexpr AttributeId ManufacturingDate     = 0x000B;
-static constexpr AttributeId PartNumber            = 0x000C;
-static constexpr AttributeId ProductURL            = 0x000D;
-static constexpr AttributeId ProductLabel          = 0x000E;
-static constexpr AttributeId SerialNumber          = 0x000F;
-static constexpr AttributeId Reachable             = 0x0011;
+static constexpr AttributeId VendorName            = 0x00000001;
+static constexpr AttributeId VendorID              = 0x00000002;
+static constexpr AttributeId ProductName           = 0x00000003;
+static constexpr AttributeId UserLabel             = 0x00000005;
+static constexpr AttributeId HardwareVersion       = 0x00000007;
+static constexpr AttributeId HardwareVersionString = 0x00000008;
+static constexpr AttributeId SoftwareVersion       = 0x00000009;
+static constexpr AttributeId SoftwareVersionString = 0x0000000A;
+static constexpr AttributeId ManufacturingDate     = 0x0000000B;
+static constexpr AttributeId PartNumber            = 0x0000000C;
+static constexpr AttributeId ProductURL            = 0x0000000D;
+static constexpr AttributeId ProductLabel          = 0x0000000E;
+static constexpr AttributeId SerialNumber          = 0x0000000F;
+static constexpr AttributeId Reachable             = 0x00000011;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BridgedDeviceBasic
@@ -461,9 +461,9 @@ static constexpr AttributeId Reachable             = 0x0011;
 namespace Switch {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId NumberOfPositions = 0x0000;
-static constexpr AttributeId CurrentPosition   = 0x0001;
-static constexpr AttributeId MultiPressMax     = 0x0002;
+static constexpr AttributeId NumberOfPositions = 0x00000000;
+static constexpr AttributeId CurrentPosition   = 0x00000001;
+static constexpr AttributeId MultiPressMax     = 0x00000002;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Switch
@@ -471,7 +471,7 @@ static constexpr AttributeId MultiPressMax     = 0x0002;
 namespace OperationalCredentials {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId FabricsList = 0x0001;
+static constexpr AttributeId FabricsList = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OperationalCredentials
@@ -479,7 +479,7 @@ static constexpr AttributeId FabricsList = 0x0001;
 namespace FixedLabel {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId LabelList = 0x0000;
+static constexpr AttributeId LabelList = 0x00000000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace FixedLabel
@@ -487,11 +487,11 @@ static constexpr AttributeId LabelList = 0x0000;
 namespace ShadeConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId PhysicalClosedLimit = 0x0000;
-static constexpr AttributeId MotorStepSize       = 0x0001;
-static constexpr AttributeId Status              = 0x0002;
-static constexpr AttributeId ClosedLimit         = 0x0010;
-static constexpr AttributeId Mode                = 0x0011;
+static constexpr AttributeId PhysicalClosedLimit = 0x00000000;
+static constexpr AttributeId MotorStepSize       = 0x00000001;
+static constexpr AttributeId Status              = 0x00000002;
+static constexpr AttributeId ClosedLimit         = 0x00000010;
+static constexpr AttributeId Mode                = 0x00000011;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ShadeConfiguration
@@ -499,49 +499,49 @@ static constexpr AttributeId Mode                = 0x0011;
 namespace DoorLock {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId LockState                           = 0x0000;
-static constexpr AttributeId LockType                            = 0x0001;
-static constexpr AttributeId ActuatorEnabled                     = 0x0002;
-static constexpr AttributeId DoorState                           = 0x0003;
-static constexpr AttributeId DoorOpenEvents                      = 0x0004;
-static constexpr AttributeId DoorClosedEvents                    = 0x0005;
-static constexpr AttributeId OpenPeriod                          = 0x0006;
-static constexpr AttributeId NumLockRecordsSupported             = 0x0010;
-static constexpr AttributeId NumTotalUsersSupported              = 0x0011;
-static constexpr AttributeId NumPinUsersSupported                = 0x0012;
-static constexpr AttributeId NumRfidUsersSupported               = 0x0013;
-static constexpr AttributeId NumWeekdaySchedulesSupportedPerUser = 0x0014;
-static constexpr AttributeId NumYeardaySchedulesSupportedPerUser = 0x0015;
-static constexpr AttributeId NumHolidaySchedulesSupportedPerUser = 0x0016;
-static constexpr AttributeId MaxPinLength                        = 0x0017;
-static constexpr AttributeId MinPinLength                        = 0x0018;
-static constexpr AttributeId MaxRfidCodeLength                   = 0x0019;
-static constexpr AttributeId MinRfidCodeLength                   = 0x001A;
-static constexpr AttributeId EnableLogging                       = 0x0020;
-static constexpr AttributeId Language                            = 0x0021;
-static constexpr AttributeId LedSettings                         = 0x0022;
-static constexpr AttributeId AutoRelockTime                      = 0x0023;
-static constexpr AttributeId SoundVolume                         = 0x0024;
-static constexpr AttributeId OperatingMode                       = 0x0025;
-static constexpr AttributeId SupportedOperatingModes             = 0x0026;
-static constexpr AttributeId DefaultConfigurationRegister        = 0x0027;
-static constexpr AttributeId EnableLocalProgramming              = 0x0028;
-static constexpr AttributeId EnableOneTouchLocking               = 0x0029;
-static constexpr AttributeId EnableInsideStatusLed               = 0x002A;
-static constexpr AttributeId EnablePrivacyModeButton             = 0x002B;
-static constexpr AttributeId WrongCodeEntryLimit                 = 0x0030;
-static constexpr AttributeId UserCodeTemporaryDisableTime        = 0x0031;
-static constexpr AttributeId SendPinOverTheAir                   = 0x0032;
-static constexpr AttributeId RequirePinForRfOperation            = 0x0033;
-static constexpr AttributeId ZigbeeSecurityLevel                 = 0x0034;
-static constexpr AttributeId AlarmMask                           = 0x0040;
-static constexpr AttributeId KeypadOperationEventMask            = 0x0041;
-static constexpr AttributeId RfOperationEventMask                = 0x0042;
-static constexpr AttributeId ManualOperationEventMask            = 0x0043;
-static constexpr AttributeId RfidOperationEventMask              = 0x0044;
-static constexpr AttributeId KeypadProgrammingEventMask          = 0x0045;
-static constexpr AttributeId RfProgrammingEventMask              = 0x0046;
-static constexpr AttributeId RfidProgrammingEventMask            = 0x0047;
+static constexpr AttributeId LockState                           = 0x00000000;
+static constexpr AttributeId LockType                            = 0x00000001;
+static constexpr AttributeId ActuatorEnabled                     = 0x00000002;
+static constexpr AttributeId DoorState                           = 0x00000003;
+static constexpr AttributeId DoorOpenEvents                      = 0x00000004;
+static constexpr AttributeId DoorClosedEvents                    = 0x00000005;
+static constexpr AttributeId OpenPeriod                          = 0x00000006;
+static constexpr AttributeId NumLockRecordsSupported             = 0x00000010;
+static constexpr AttributeId NumTotalUsersSupported              = 0x00000011;
+static constexpr AttributeId NumPinUsersSupported                = 0x00000012;
+static constexpr AttributeId NumRfidUsersSupported               = 0x00000013;
+static constexpr AttributeId NumWeekdaySchedulesSupportedPerUser = 0x00000014;
+static constexpr AttributeId NumYeardaySchedulesSupportedPerUser = 0x00000015;
+static constexpr AttributeId NumHolidaySchedulesSupportedPerUser = 0x00000016;
+static constexpr AttributeId MaxPinLength                        = 0x00000017;
+static constexpr AttributeId MinPinLength                        = 0x00000018;
+static constexpr AttributeId MaxRfidCodeLength                   = 0x00000019;
+static constexpr AttributeId MinRfidCodeLength                   = 0x0000001A;
+static constexpr AttributeId EnableLogging                       = 0x00000020;
+static constexpr AttributeId Language                            = 0x00000021;
+static constexpr AttributeId LedSettings                         = 0x00000022;
+static constexpr AttributeId AutoRelockTime                      = 0x00000023;
+static constexpr AttributeId SoundVolume                         = 0x00000024;
+static constexpr AttributeId OperatingMode                       = 0x00000025;
+static constexpr AttributeId SupportedOperatingModes             = 0x00000026;
+static constexpr AttributeId DefaultConfigurationRegister        = 0x00000027;
+static constexpr AttributeId EnableLocalProgramming              = 0x00000028;
+static constexpr AttributeId EnableOneTouchLocking               = 0x00000029;
+static constexpr AttributeId EnableInsideStatusLed               = 0x0000002A;
+static constexpr AttributeId EnablePrivacyModeButton             = 0x0000002B;
+static constexpr AttributeId WrongCodeEntryLimit                 = 0x00000030;
+static constexpr AttributeId UserCodeTemporaryDisableTime        = 0x00000031;
+static constexpr AttributeId SendPinOverTheAir                   = 0x00000032;
+static constexpr AttributeId RequirePinForRfOperation            = 0x00000033;
+static constexpr AttributeId ZigbeeSecurityLevel                 = 0x00000034;
+static constexpr AttributeId AlarmMask                           = 0x00000040;
+static constexpr AttributeId KeypadOperationEventMask            = 0x00000041;
+static constexpr AttributeId RfOperationEventMask                = 0x00000042;
+static constexpr AttributeId ManualOperationEventMask            = 0x00000043;
+static constexpr AttributeId RfidOperationEventMask              = 0x00000044;
+static constexpr AttributeId KeypadProgrammingEventMask          = 0x00000045;
+static constexpr AttributeId RfProgrammingEventMask              = 0x00000046;
+static constexpr AttributeId RfidProgrammingEventMask            = 0x00000047;
 } // namespace Ids
 } // namespace Attributes
 } // namespace DoorLock
@@ -549,33 +549,33 @@ static constexpr AttributeId RfidProgrammingEventMask            = 0x0047;
 namespace WindowCovering {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Type                             = 0x0000;
-static constexpr AttributeId PhysicalClosedLimitLift          = 0x0001;
-static constexpr AttributeId PhysicalClosedLimitTilt          = 0x0002;
-static constexpr AttributeId CurrentPositionLift              = 0x0003;
-static constexpr AttributeId CurrentPositionTilt              = 0x0004;
-static constexpr AttributeId NumberOfActuationsLift           = 0x0005;
-static constexpr AttributeId NumberOfActuationsTilt           = 0x0006;
-static constexpr AttributeId ConfigStatus                     = 0x0007;
-static constexpr AttributeId CurrentPositionLiftPercentage    = 0x0008;
-static constexpr AttributeId CurrentPositionTiltPercentage    = 0x0009;
-static constexpr AttributeId OperationalStatus                = 0x000A;
-static constexpr AttributeId TargetPositionLiftPercent100ths  = 0x000B;
-static constexpr AttributeId TargetPositionTiltPercent100ths  = 0x000C;
-static constexpr AttributeId EndProductType                   = 0x000D;
-static constexpr AttributeId CurrentPositionLiftPercent100ths = 0x000E;
-static constexpr AttributeId CurrentPositionTiltPercent100ths = 0x000F;
-static constexpr AttributeId InstalledOpenLimitLift           = 0x0010;
-static constexpr AttributeId InstalledClosedLimitLift         = 0x0011;
-static constexpr AttributeId InstalledOpenLimitTilt           = 0x0012;
-static constexpr AttributeId InstalledClosedLimitTilt         = 0x0013;
-static constexpr AttributeId VelocityLift                     = 0x0014;
-static constexpr AttributeId AccelerationTimeLift             = 0x0015;
-static constexpr AttributeId DecelerationTimeLift             = 0x0016;
-static constexpr AttributeId Mode                             = 0x0017;
-static constexpr AttributeId IntermediateSetpointsLift        = 0x0018;
-static constexpr AttributeId IntermediateSetpointsTilt        = 0x0019;
-static constexpr AttributeId SafetyStatus                     = 0x001A;
+static constexpr AttributeId Type                             = 0x00000000;
+static constexpr AttributeId PhysicalClosedLimitLift          = 0x00000001;
+static constexpr AttributeId PhysicalClosedLimitTilt          = 0x00000002;
+static constexpr AttributeId CurrentPositionLift              = 0x00000003;
+static constexpr AttributeId CurrentPositionTilt              = 0x00000004;
+static constexpr AttributeId NumberOfActuationsLift           = 0x00000005;
+static constexpr AttributeId NumberOfActuationsTilt           = 0x00000006;
+static constexpr AttributeId ConfigStatus                     = 0x00000007;
+static constexpr AttributeId CurrentPositionLiftPercentage    = 0x00000008;
+static constexpr AttributeId CurrentPositionTiltPercentage    = 0x00000009;
+static constexpr AttributeId OperationalStatus                = 0x0000000A;
+static constexpr AttributeId TargetPositionLiftPercent100ths  = 0x0000000B;
+static constexpr AttributeId TargetPositionTiltPercent100ths  = 0x0000000C;
+static constexpr AttributeId EndProductType                   = 0x0000000D;
+static constexpr AttributeId CurrentPositionLiftPercent100ths = 0x0000000E;
+static constexpr AttributeId CurrentPositionTiltPercent100ths = 0x0000000F;
+static constexpr AttributeId InstalledOpenLimitLift           = 0x00000010;
+static constexpr AttributeId InstalledClosedLimitLift         = 0x00000011;
+static constexpr AttributeId InstalledOpenLimitTilt           = 0x00000012;
+static constexpr AttributeId InstalledClosedLimitTilt         = 0x00000013;
+static constexpr AttributeId VelocityLift                     = 0x00000014;
+static constexpr AttributeId AccelerationTimeLift             = 0x00000015;
+static constexpr AttributeId DecelerationTimeLift             = 0x00000016;
+static constexpr AttributeId Mode                             = 0x00000017;
+static constexpr AttributeId IntermediateSetpointsLift        = 0x00000018;
+static constexpr AttributeId IntermediateSetpointsTilt        = 0x00000019;
+static constexpr AttributeId SafetyStatus                     = 0x0000001A;
 } // namespace Ids
 } // namespace Attributes
 } // namespace WindowCovering
@@ -583,16 +583,16 @@ static constexpr AttributeId SafetyStatus                     = 0x001A;
 namespace BarrierControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId BarrierMovingState        = 0x0001;
-static constexpr AttributeId BarrierSafetyStatus       = 0x0002;
-static constexpr AttributeId BarrierCapabilities       = 0x0003;
-static constexpr AttributeId BarrierOpenEvents         = 0x0004;
-static constexpr AttributeId BarrierCloseEvents        = 0x0005;
-static constexpr AttributeId BarrierCommandOpenEvents  = 0x0006;
-static constexpr AttributeId BarrierCommandCloseEvents = 0x0007;
-static constexpr AttributeId BarrierOpenPeriod         = 0x0008;
-static constexpr AttributeId BarrierClosePeriod        = 0x0009;
-static constexpr AttributeId BarrierPosition           = 0x000A;
+static constexpr AttributeId BarrierMovingState        = 0x00000001;
+static constexpr AttributeId BarrierSafetyStatus       = 0x00000002;
+static constexpr AttributeId BarrierCapabilities       = 0x00000003;
+static constexpr AttributeId BarrierOpenEvents         = 0x00000004;
+static constexpr AttributeId BarrierCloseEvents        = 0x00000005;
+static constexpr AttributeId BarrierCommandOpenEvents  = 0x00000006;
+static constexpr AttributeId BarrierCommandCloseEvents = 0x00000007;
+static constexpr AttributeId BarrierOpenPeriod         = 0x00000008;
+static constexpr AttributeId BarrierClosePeriod        = 0x00000009;
+static constexpr AttributeId BarrierPosition           = 0x0000000A;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BarrierControl
@@ -600,30 +600,30 @@ static constexpr AttributeId BarrierPosition           = 0x000A;
 namespace PumpConfigurationAndControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MaxPressure            = 0x0000;
-static constexpr AttributeId MaxSpeed               = 0x0001;
-static constexpr AttributeId MaxFlow                = 0x0002;
-static constexpr AttributeId MinConstPressure       = 0x0003;
-static constexpr AttributeId MaxConstPressure       = 0x0004;
-static constexpr AttributeId MinCompPressure        = 0x0005;
-static constexpr AttributeId MaxCompPressure        = 0x0006;
-static constexpr AttributeId MinConstSpeed          = 0x0007;
-static constexpr AttributeId MaxConstSpeed          = 0x0008;
-static constexpr AttributeId MinConstFlow           = 0x0009;
-static constexpr AttributeId MaxConstFlow           = 0x000A;
-static constexpr AttributeId MinConstTemp           = 0x000B;
-static constexpr AttributeId MaxConstTemp           = 0x000C;
-static constexpr AttributeId PumpStatus             = 0x0010;
-static constexpr AttributeId EffectiveOperationMode = 0x0011;
-static constexpr AttributeId EffectiveControlMode   = 0x0012;
-static constexpr AttributeId Capacity               = 0x0013;
-static constexpr AttributeId Speed                  = 0x0014;
-static constexpr AttributeId LifetimeRunningHours   = 0x0015;
-static constexpr AttributeId Power                  = 0x0016;
-static constexpr AttributeId LifetimeEnergyConsumed = 0x0017;
-static constexpr AttributeId OperationMode          = 0x0020;
-static constexpr AttributeId ControlMode            = 0x0021;
-static constexpr AttributeId AlarmMask              = 0x0022;
+static constexpr AttributeId MaxPressure            = 0x00000000;
+static constexpr AttributeId MaxSpeed               = 0x00000001;
+static constexpr AttributeId MaxFlow                = 0x00000002;
+static constexpr AttributeId MinConstPressure       = 0x00000003;
+static constexpr AttributeId MaxConstPressure       = 0x00000004;
+static constexpr AttributeId MinCompPressure        = 0x00000005;
+static constexpr AttributeId MaxCompPressure        = 0x00000006;
+static constexpr AttributeId MinConstSpeed          = 0x00000007;
+static constexpr AttributeId MaxConstSpeed          = 0x00000008;
+static constexpr AttributeId MinConstFlow           = 0x00000009;
+static constexpr AttributeId MaxConstFlow           = 0x0000000A;
+static constexpr AttributeId MinConstTemp           = 0x0000000B;
+static constexpr AttributeId MaxConstTemp           = 0x0000000C;
+static constexpr AttributeId PumpStatus             = 0x00000010;
+static constexpr AttributeId EffectiveOperationMode = 0x00000011;
+static constexpr AttributeId EffectiveControlMode   = 0x00000012;
+static constexpr AttributeId Capacity               = 0x00000013;
+static constexpr AttributeId Speed                  = 0x00000014;
+static constexpr AttributeId LifetimeRunningHours   = 0x00000015;
+static constexpr AttributeId Power                  = 0x00000016;
+static constexpr AttributeId LifetimeEnergyConsumed = 0x00000017;
+static constexpr AttributeId OperationMode          = 0x00000020;
+static constexpr AttributeId ControlMode            = 0x00000021;
+static constexpr AttributeId AlarmMask              = 0x00000022;
 } // namespace Ids
 } // namespace Attributes
 } // namespace PumpConfigurationAndControl
@@ -631,49 +631,49 @@ static constexpr AttributeId AlarmMask              = 0x0022;
 namespace Thermostat {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId LocalTemperature                   = 0x0000;
-static constexpr AttributeId OutdoorTemperature                 = 0x0001;
-static constexpr AttributeId Occupancy                          = 0x0002;
-static constexpr AttributeId AbsMinHeatSetpointLimit            = 0x0003;
-static constexpr AttributeId AbsMaxHeatSetpointLimit            = 0x0004;
-static constexpr AttributeId AbsMinCoolSetpointLimit            = 0x0005;
-static constexpr AttributeId AbsMaxCoolSetpointLimit            = 0x0006;
-static constexpr AttributeId PiCoolingDemand                    = 0x0007;
-static constexpr AttributeId PiHeatingDemand                    = 0x0008;
-static constexpr AttributeId HvacSystemTypeConfiguration        = 0x0009;
-static constexpr AttributeId LocalTemperatureCalibration        = 0x0010;
-static constexpr AttributeId OccupiedCoolingSetpoint            = 0x0011;
-static constexpr AttributeId OccupiedHeatingSetpoint            = 0x0012;
-static constexpr AttributeId UnoccupiedCoolingSetpoint          = 0x0013;
-static constexpr AttributeId UnoccupiedHeatingSetpoint          = 0x0014;
-static constexpr AttributeId MinHeatSetpointLimit               = 0x0015;
-static constexpr AttributeId MaxHeatSetpointLimit               = 0x0016;
-static constexpr AttributeId MinCoolSetpointLimit               = 0x0017;
-static constexpr AttributeId MaxCoolSetpointLimit               = 0x0018;
-static constexpr AttributeId MinSetpointDeadBand                = 0x0019;
-static constexpr AttributeId RemoteSensing                      = 0x001A;
-static constexpr AttributeId ControlSequenceOfOperation         = 0x001B;
-static constexpr AttributeId SystemMode                         = 0x001C;
-static constexpr AttributeId AlarmMask                          = 0x001D;
-static constexpr AttributeId ThermostatRunningMode              = 0x001E;
-static constexpr AttributeId StartOfWeek                        = 0x0020;
-static constexpr AttributeId NumberOfWeeklyTransitions          = 0x0021;
-static constexpr AttributeId NumberOfDailyTransitions           = 0x0022;
-static constexpr AttributeId TemperatureSetpointHold            = 0x0023;
-static constexpr AttributeId TemperatureSetpointHoldDuration    = 0x0024;
-static constexpr AttributeId ThermostatProgrammingOperationMode = 0x0025;
-static constexpr AttributeId HvacRelayState                     = 0x0029;
-static constexpr AttributeId SetpointChangeSource               = 0x0030;
-static constexpr AttributeId SetpointChangeAmount               = 0x0031;
-static constexpr AttributeId SetpointChangeSourceTimestamp      = 0x0032;
-static constexpr AttributeId AcType                             = 0x0040;
-static constexpr AttributeId AcCapacity                         = 0x0041;
-static constexpr AttributeId AcRefrigerantType                  = 0x0042;
-static constexpr AttributeId AcCompressor                       = 0x0043;
-static constexpr AttributeId AcErrorCode                        = 0x0044;
-static constexpr AttributeId AcLouverPosition                   = 0x0045;
-static constexpr AttributeId AcCoilTemperature                  = 0x0046;
-static constexpr AttributeId AcCapacityFormat                   = 0x0047;
+static constexpr AttributeId LocalTemperature                   = 0x00000000;
+static constexpr AttributeId OutdoorTemperature                 = 0x00000001;
+static constexpr AttributeId Occupancy                          = 0x00000002;
+static constexpr AttributeId AbsMinHeatSetpointLimit            = 0x00000003;
+static constexpr AttributeId AbsMaxHeatSetpointLimit            = 0x00000004;
+static constexpr AttributeId AbsMinCoolSetpointLimit            = 0x00000005;
+static constexpr AttributeId AbsMaxCoolSetpointLimit            = 0x00000006;
+static constexpr AttributeId PiCoolingDemand                    = 0x00000007;
+static constexpr AttributeId PiHeatingDemand                    = 0x00000008;
+static constexpr AttributeId HvacSystemTypeConfiguration        = 0x00000009;
+static constexpr AttributeId LocalTemperatureCalibration        = 0x00000010;
+static constexpr AttributeId OccupiedCoolingSetpoint            = 0x00000011;
+static constexpr AttributeId OccupiedHeatingSetpoint            = 0x00000012;
+static constexpr AttributeId UnoccupiedCoolingSetpoint          = 0x00000013;
+static constexpr AttributeId UnoccupiedHeatingSetpoint          = 0x00000014;
+static constexpr AttributeId MinHeatSetpointLimit               = 0x00000015;
+static constexpr AttributeId MaxHeatSetpointLimit               = 0x00000016;
+static constexpr AttributeId MinCoolSetpointLimit               = 0x00000017;
+static constexpr AttributeId MaxCoolSetpointLimit               = 0x00000018;
+static constexpr AttributeId MinSetpointDeadBand                = 0x00000019;
+static constexpr AttributeId RemoteSensing                      = 0x0000001A;
+static constexpr AttributeId ControlSequenceOfOperation         = 0x0000001B;
+static constexpr AttributeId SystemMode                         = 0x0000001C;
+static constexpr AttributeId AlarmMask                          = 0x0000001D;
+static constexpr AttributeId ThermostatRunningMode              = 0x0000001E;
+static constexpr AttributeId StartOfWeek                        = 0x00000020;
+static constexpr AttributeId NumberOfWeeklyTransitions          = 0x00000021;
+static constexpr AttributeId NumberOfDailyTransitions           = 0x00000022;
+static constexpr AttributeId TemperatureSetpointHold            = 0x00000023;
+static constexpr AttributeId TemperatureSetpointHoldDuration    = 0x00000024;
+static constexpr AttributeId ThermostatProgrammingOperationMode = 0x00000025;
+static constexpr AttributeId HvacRelayState                     = 0x00000029;
+static constexpr AttributeId SetpointChangeSource               = 0x00000030;
+static constexpr AttributeId SetpointChangeAmount               = 0x00000031;
+static constexpr AttributeId SetpointChangeSourceTimestamp      = 0x00000032;
+static constexpr AttributeId AcType                             = 0x00000040;
+static constexpr AttributeId AcCapacity                         = 0x00000041;
+static constexpr AttributeId AcRefrigerantType                  = 0x00000042;
+static constexpr AttributeId AcCompressor                       = 0x00000043;
+static constexpr AttributeId AcErrorCode                        = 0x00000044;
+static constexpr AttributeId AcLouverPosition                   = 0x00000045;
+static constexpr AttributeId AcCoilTemperature                  = 0x00000046;
+static constexpr AttributeId AcCapacityFormat                   = 0x00000047;
 } // namespace Ids
 } // namespace Attributes
 } // namespace Thermostat
@@ -681,8 +681,8 @@ static constexpr AttributeId AcCapacityFormat                   = 0x0047;
 namespace FanControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId FanMode         = 0x0000;
-static constexpr AttributeId FanModeSequence = 0x0001;
+static constexpr AttributeId FanMode         = 0x00000000;
+static constexpr AttributeId FanModeSequence = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace FanControl
@@ -690,14 +690,14 @@ static constexpr AttributeId FanModeSequence = 0x0001;
 namespace DehumidificationControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId RelativeHumidity           = 0x0000;
-static constexpr AttributeId DehumidificationCooling    = 0x0001;
-static constexpr AttributeId RhDehumidificationSetpoint = 0x0010;
-static constexpr AttributeId RelativeHumidityMode       = 0x0011;
-static constexpr AttributeId DehumidificationLockout    = 0x0012;
-static constexpr AttributeId DehumidificationHysteresis = 0x0013;
-static constexpr AttributeId DehumidificationMaxCool    = 0x0014;
-static constexpr AttributeId RelativeHumidityDisplay    = 0x0015;
+static constexpr AttributeId RelativeHumidity           = 0x00000000;
+static constexpr AttributeId DehumidificationCooling    = 0x00000001;
+static constexpr AttributeId RhDehumidificationSetpoint = 0x00000010;
+static constexpr AttributeId RelativeHumidityMode       = 0x00000011;
+static constexpr AttributeId DehumidificationLockout    = 0x00000012;
+static constexpr AttributeId DehumidificationHysteresis = 0x00000013;
+static constexpr AttributeId DehumidificationMaxCool    = 0x00000014;
+static constexpr AttributeId RelativeHumidityDisplay    = 0x00000015;
 } // namespace Ids
 } // namespace Attributes
 } // namespace DehumidificationControl
@@ -705,9 +705,9 @@ static constexpr AttributeId RelativeHumidityDisplay    = 0x0015;
 namespace ThermostatUserInterfaceConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId TemperatureDisplayMode        = 0x0000;
-static constexpr AttributeId KeypadLockout                 = 0x0001;
-static constexpr AttributeId ScheduleProgrammingVisibility = 0x0002;
+static constexpr AttributeId TemperatureDisplayMode        = 0x00000000;
+static constexpr AttributeId KeypadLockout                 = 0x00000001;
+static constexpr AttributeId ScheduleProgrammingVisibility = 0x00000002;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ThermostatUserInterfaceConfiguration
@@ -715,58 +715,58 @@ static constexpr AttributeId ScheduleProgrammingVisibility = 0x0002;
 namespace ColorControl {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId CurrentHue                      = 0x0000;
-static constexpr AttributeId CurrentSaturation               = 0x0001;
-static constexpr AttributeId RemainingTime                   = 0x0002;
-static constexpr AttributeId CurrentX                        = 0x0003;
-static constexpr AttributeId CurrentY                        = 0x0004;
-static constexpr AttributeId DriftCompensation               = 0x0005;
-static constexpr AttributeId CompensationText                = 0x0006;
-static constexpr AttributeId ColorTemperature                = 0x0007;
-static constexpr AttributeId ColorMode                       = 0x0008;
-static constexpr AttributeId ColorControlOptions             = 0x000F;
-static constexpr AttributeId NumberOfPrimaries               = 0x0010;
-static constexpr AttributeId Primary1X                       = 0x0011;
-static constexpr AttributeId Primary1Y                       = 0x0012;
-static constexpr AttributeId Primary1Intensity               = 0x0013;
-static constexpr AttributeId Primary2X                       = 0x0015;
-static constexpr AttributeId Primary2Y                       = 0x0016;
-static constexpr AttributeId Primary2Intensity               = 0x0017;
-static constexpr AttributeId Primary3X                       = 0x0019;
-static constexpr AttributeId Primary3Y                       = 0x001A;
-static constexpr AttributeId Primary3Intensity               = 0x001B;
-static constexpr AttributeId Primary4X                       = 0x0020;
-static constexpr AttributeId Primary4Y                       = 0x0021;
-static constexpr AttributeId Primary4Intensity               = 0x0022;
-static constexpr AttributeId Primary5X                       = 0x0024;
-static constexpr AttributeId Primary5Y                       = 0x0025;
-static constexpr AttributeId Primary5Intensity               = 0x0026;
-static constexpr AttributeId Primary6X                       = 0x0028;
-static constexpr AttributeId Primary6Y                       = 0x0029;
-static constexpr AttributeId Primary6Intensity               = 0x002A;
-static constexpr AttributeId WhitePointX                     = 0x0030;
-static constexpr AttributeId WhitePointY                     = 0x0031;
-static constexpr AttributeId ColorPointRX                    = 0x0032;
-static constexpr AttributeId ColorPointRY                    = 0x0033;
-static constexpr AttributeId ColorPointRIntensity            = 0x0034;
-static constexpr AttributeId ColorPointGX                    = 0x0036;
-static constexpr AttributeId ColorPointGY                    = 0x0037;
-static constexpr AttributeId ColorPointGIntensity            = 0x0038;
-static constexpr AttributeId ColorPointBX                    = 0x003A;
-static constexpr AttributeId ColorPointBY                    = 0x003B;
-static constexpr AttributeId ColorPointBIntensity            = 0x003C;
-static constexpr AttributeId EnhancedCurrentHue              = 0x4000;
-static constexpr AttributeId EnhancedColorMode               = 0x4001;
-static constexpr AttributeId ColorLoopActive                 = 0x4002;
-static constexpr AttributeId ColorLoopDirection              = 0x4003;
-static constexpr AttributeId ColorLoopTime                   = 0x4004;
-static constexpr AttributeId ColorLoopStartEnhancedHue       = 0x4005;
-static constexpr AttributeId ColorLoopStoredEnhancedHue      = 0x4006;
-static constexpr AttributeId ColorCapabilities               = 0x400A;
-static constexpr AttributeId ColorTempPhysicalMin            = 0x400B;
-static constexpr AttributeId ColorTempPhysicalMax            = 0x400C;
-static constexpr AttributeId CoupleColorTempToLevelMinMireds = 0x400D;
-static constexpr AttributeId StartUpColorTemperatureMireds   = 0x4010;
+static constexpr AttributeId CurrentHue                      = 0x00000000;
+static constexpr AttributeId CurrentSaturation               = 0x00000001;
+static constexpr AttributeId RemainingTime                   = 0x00000002;
+static constexpr AttributeId CurrentX                        = 0x00000003;
+static constexpr AttributeId CurrentY                        = 0x00000004;
+static constexpr AttributeId DriftCompensation               = 0x00000005;
+static constexpr AttributeId CompensationText                = 0x00000006;
+static constexpr AttributeId ColorTemperature                = 0x00000007;
+static constexpr AttributeId ColorMode                       = 0x00000008;
+static constexpr AttributeId ColorControlOptions             = 0x0000000F;
+static constexpr AttributeId NumberOfPrimaries               = 0x00000010;
+static constexpr AttributeId Primary1X                       = 0x00000011;
+static constexpr AttributeId Primary1Y                       = 0x00000012;
+static constexpr AttributeId Primary1Intensity               = 0x00000013;
+static constexpr AttributeId Primary2X                       = 0x00000015;
+static constexpr AttributeId Primary2Y                       = 0x00000016;
+static constexpr AttributeId Primary2Intensity               = 0x00000017;
+static constexpr AttributeId Primary3X                       = 0x00000019;
+static constexpr AttributeId Primary3Y                       = 0x0000001A;
+static constexpr AttributeId Primary3Intensity               = 0x0000001B;
+static constexpr AttributeId Primary4X                       = 0x00000020;
+static constexpr AttributeId Primary4Y                       = 0x00000021;
+static constexpr AttributeId Primary4Intensity               = 0x00000022;
+static constexpr AttributeId Primary5X                       = 0x00000024;
+static constexpr AttributeId Primary5Y                       = 0x00000025;
+static constexpr AttributeId Primary5Intensity               = 0x00000026;
+static constexpr AttributeId Primary6X                       = 0x00000028;
+static constexpr AttributeId Primary6Y                       = 0x00000029;
+static constexpr AttributeId Primary6Intensity               = 0x0000002A;
+static constexpr AttributeId WhitePointX                     = 0x00000030;
+static constexpr AttributeId WhitePointY                     = 0x00000031;
+static constexpr AttributeId ColorPointRX                    = 0x00000032;
+static constexpr AttributeId ColorPointRY                    = 0x00000033;
+static constexpr AttributeId ColorPointRIntensity            = 0x00000034;
+static constexpr AttributeId ColorPointGX                    = 0x00000036;
+static constexpr AttributeId ColorPointGY                    = 0x00000037;
+static constexpr AttributeId ColorPointGIntensity            = 0x00000038;
+static constexpr AttributeId ColorPointBX                    = 0x0000003A;
+static constexpr AttributeId ColorPointBY                    = 0x0000003B;
+static constexpr AttributeId ColorPointBIntensity            = 0x0000003C;
+static constexpr AttributeId EnhancedCurrentHue              = 0x00004000;
+static constexpr AttributeId EnhancedColorMode               = 0x00004001;
+static constexpr AttributeId ColorLoopActive                 = 0x00004002;
+static constexpr AttributeId ColorLoopDirection              = 0x00004003;
+static constexpr AttributeId ColorLoopTime                   = 0x00004004;
+static constexpr AttributeId ColorLoopStartEnhancedHue       = 0x00004005;
+static constexpr AttributeId ColorLoopStoredEnhancedHue      = 0x00004006;
+static constexpr AttributeId ColorCapabilities               = 0x0000400A;
+static constexpr AttributeId ColorTempPhysicalMin            = 0x0000400B;
+static constexpr AttributeId ColorTempPhysicalMax            = 0x0000400C;
+static constexpr AttributeId CoupleColorTempToLevelMinMireds = 0x0000400D;
+static constexpr AttributeId StartUpColorTemperatureMireds   = 0x00004010;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ColorControl
@@ -774,22 +774,22 @@ static constexpr AttributeId StartUpColorTemperatureMireds   = 0x4010;
 namespace BallastConfiguration {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId PhysicalMinLevel        = 0x0000;
-static constexpr AttributeId PhysicalMaxLevel        = 0x0001;
-static constexpr AttributeId BallastStatus           = 0x0002;
-static constexpr AttributeId MinLevel                = 0x0010;
-static constexpr AttributeId MaxLevel                = 0x0011;
-static constexpr AttributeId PowerOnLevel            = 0x0012;
-static constexpr AttributeId PowerOnFadeTime         = 0x0013;
-static constexpr AttributeId IntrinsicBallastFactor  = 0x0014;
-static constexpr AttributeId BallastFactorAdjustment = 0x0015;
-static constexpr AttributeId LampQuality             = 0x0020;
-static constexpr AttributeId LampType                = 0x0030;
-static constexpr AttributeId LampManufacturer        = 0x0031;
-static constexpr AttributeId LampRatedHours          = 0x0032;
-static constexpr AttributeId LampBurnHours           = 0x0033;
-static constexpr AttributeId LampAlarmMode           = 0x0034;
-static constexpr AttributeId LampBurnHoursTripPoint  = 0x0035;
+static constexpr AttributeId PhysicalMinLevel        = 0x00000000;
+static constexpr AttributeId PhysicalMaxLevel        = 0x00000001;
+static constexpr AttributeId BallastStatus           = 0x00000002;
+static constexpr AttributeId MinLevel                = 0x00000010;
+static constexpr AttributeId MaxLevel                = 0x00000011;
+static constexpr AttributeId PowerOnLevel            = 0x00000012;
+static constexpr AttributeId PowerOnFadeTime         = 0x00000013;
+static constexpr AttributeId IntrinsicBallastFactor  = 0x00000014;
+static constexpr AttributeId BallastFactorAdjustment = 0x00000015;
+static constexpr AttributeId LampQuality             = 0x00000020;
+static constexpr AttributeId LampType                = 0x00000030;
+static constexpr AttributeId LampManufacturer        = 0x00000031;
+static constexpr AttributeId LampRatedHours          = 0x00000032;
+static constexpr AttributeId LampBurnHours           = 0x00000033;
+static constexpr AttributeId LampAlarmMode           = 0x00000034;
+static constexpr AttributeId LampBurnHoursTripPoint  = 0x00000035;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BallastConfiguration
@@ -797,11 +797,11 @@ static constexpr AttributeId LampBurnHoursTripPoint  = 0x0035;
 namespace IlluminanceMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
-static constexpr AttributeId LightSensorType  = 0x0004;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
+static constexpr AttributeId LightSensorType  = 0x00000004;
 } // namespace Ids
 } // namespace Attributes
 } // namespace IlluminanceMeasurement
@@ -809,9 +809,9 @@ static constexpr AttributeId LightSensorType  = 0x0004;
 namespace IlluminanceLevelSensing {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId LevelStatus            = 0x0000;
-static constexpr AttributeId LightSensorType        = 0x0001;
-static constexpr AttributeId IlluminanceLevelTarget = 0x0010;
+static constexpr AttributeId LevelStatus            = 0x00000000;
+static constexpr AttributeId LightSensorType        = 0x00000001;
+static constexpr AttributeId IlluminanceLevelTarget = 0x00000010;
 } // namespace Ids
 } // namespace Attributes
 } // namespace IlluminanceLevelSensing
@@ -819,10 +819,10 @@ static constexpr AttributeId IlluminanceLevelTarget = 0x0010;
 namespace TemperatureMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TemperatureMeasurement
@@ -830,15 +830,15 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace PressureMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
-static constexpr AttributeId ScaledValue      = 0x0010;
-static constexpr AttributeId MinScaledValue   = 0x0011;
-static constexpr AttributeId MaxScaledValue   = 0x0012;
-static constexpr AttributeId ScaledTolerance  = 0x0013;
-static constexpr AttributeId Scale            = 0x0014;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
+static constexpr AttributeId ScaledValue      = 0x00000010;
+static constexpr AttributeId MinScaledValue   = 0x00000011;
+static constexpr AttributeId MaxScaledValue   = 0x00000012;
+static constexpr AttributeId ScaledTolerance  = 0x00000013;
+static constexpr AttributeId Scale            = 0x00000014;
 } // namespace Ids
 } // namespace Attributes
 } // namespace PressureMeasurement
@@ -846,10 +846,10 @@ static constexpr AttributeId Scale            = 0x0014;
 namespace FlowMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace FlowMeasurement
@@ -857,10 +857,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace RelativeHumidityMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace RelativeHumidityMeasurement
@@ -868,18 +868,18 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace OccupancySensing {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Occupancy                                    = 0x0000;
-static constexpr AttributeId OccupancySensorType                          = 0x0001;
-static constexpr AttributeId OccupancySensorTypeBitmap                    = 0x0002;
-static constexpr AttributeId PirOccupiedToUnoccupiedDelay                 = 0x0010;
-static constexpr AttributeId PirUnoccupiedToOccupiedDelay                 = 0x0011;
-static constexpr AttributeId PirUnoccupiedToOccupiedThreshold             = 0x0012;
-static constexpr AttributeId UltrasonicOccupiedToUnoccupiedDelay          = 0x0020;
-static constexpr AttributeId UltrasonicUnoccupiedToOccupiedDelay          = 0x0021;
-static constexpr AttributeId UltrasonicUnoccupiedToOccupiedThreshold      = 0x0022;
-static constexpr AttributeId PhysicalContactOccupiedToUnoccupiedDelay     = 0x0030;
-static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedDelay     = 0x0031;
-static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedThreshold = 0x0032;
+static constexpr AttributeId Occupancy                                    = 0x00000000;
+static constexpr AttributeId OccupancySensorType                          = 0x00000001;
+static constexpr AttributeId OccupancySensorTypeBitmap                    = 0x00000002;
+static constexpr AttributeId PirOccupiedToUnoccupiedDelay                 = 0x00000010;
+static constexpr AttributeId PirUnoccupiedToOccupiedDelay                 = 0x00000011;
+static constexpr AttributeId PirUnoccupiedToOccupiedThreshold             = 0x00000012;
+static constexpr AttributeId UltrasonicOccupiedToUnoccupiedDelay          = 0x00000020;
+static constexpr AttributeId UltrasonicUnoccupiedToOccupiedDelay          = 0x00000021;
+static constexpr AttributeId UltrasonicUnoccupiedToOccupiedThreshold      = 0x00000022;
+static constexpr AttributeId PhysicalContactOccupiedToUnoccupiedDelay     = 0x00000030;
+static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedDelay     = 0x00000031;
+static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedThreshold = 0x00000032;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OccupancySensing
@@ -887,10 +887,10 @@ static constexpr AttributeId PhysicalContactUnoccupiedToOccupiedThreshold = 0x00
 namespace CarbonMonoxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace CarbonMonoxideConcentrationMeasurement
@@ -898,10 +898,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace CarbonDioxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace CarbonDioxideConcentrationMeasurement
@@ -909,10 +909,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace EthyleneConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace EthyleneConcentrationMeasurement
@@ -920,10 +920,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace EthyleneOxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace EthyleneOxideConcentrationMeasurement
@@ -931,10 +931,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace HydrogenConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace HydrogenConcentrationMeasurement
@@ -942,10 +942,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace HydrogenSulphideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace HydrogenSulphideConcentrationMeasurement
@@ -953,10 +953,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace NitricOxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace NitricOxideConcentrationMeasurement
@@ -964,10 +964,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace NitrogenDioxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace NitrogenDioxideConcentrationMeasurement
@@ -975,10 +975,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace OxygenConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OxygenConcentrationMeasurement
@@ -986,10 +986,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace OzoneConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace OzoneConcentrationMeasurement
@@ -997,10 +997,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace SulfurDioxideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SulfurDioxideConcentrationMeasurement
@@ -1008,10 +1008,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace DissolvedOxygenConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace DissolvedOxygenConcentrationMeasurement
@@ -1019,10 +1019,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace BromateConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BromateConcentrationMeasurement
@@ -1030,10 +1030,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace ChloraminesConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ChloraminesConcentrationMeasurement
@@ -1041,10 +1041,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace ChlorineConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ChlorineConcentrationMeasurement
@@ -1052,10 +1052,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace FecalColiformAndEColiConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace FecalColiformAndEColiConcentrationMeasurement
@@ -1063,10 +1063,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace FluorideConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace FluorideConcentrationMeasurement
@@ -1074,10 +1074,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace HaloaceticAcidsConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace HaloaceticAcidsConcentrationMeasurement
@@ -1085,10 +1085,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace TotalTrihalomethanesConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TotalTrihalomethanesConcentrationMeasurement
@@ -1096,10 +1096,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace TotalColiformBacteriaConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TotalColiformBacteriaConcentrationMeasurement
@@ -1107,10 +1107,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace TurbidityConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TurbidityConcentrationMeasurement
@@ -1118,10 +1118,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace CopperConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace CopperConcentrationMeasurement
@@ -1129,10 +1129,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace LeadConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace LeadConcentrationMeasurement
@@ -1140,10 +1140,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace ManganeseConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ManganeseConcentrationMeasurement
@@ -1151,10 +1151,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace SulfateConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SulfateConcentrationMeasurement
@@ -1162,10 +1162,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace BromodichloromethaneConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BromodichloromethaneConcentrationMeasurement
@@ -1173,10 +1173,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace BromoformConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace BromoformConcentrationMeasurement
@@ -1184,10 +1184,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace ChlorodibromomethaneConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ChlorodibromomethaneConcentrationMeasurement
@@ -1195,10 +1195,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace ChloroformConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ChloroformConcentrationMeasurement
@@ -1206,10 +1206,10 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace SodiumConcentrationMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasuredValue    = 0x0000;
-static constexpr AttributeId MinMeasuredValue = 0x0001;
-static constexpr AttributeId MaxMeasuredValue = 0x0002;
-static constexpr AttributeId Tolerance        = 0x0003;
+static constexpr AttributeId MeasuredValue    = 0x00000000;
+static constexpr AttributeId MinMeasuredValue = 0x00000001;
+static constexpr AttributeId MaxMeasuredValue = 0x00000002;
+static constexpr AttributeId Tolerance        = 0x00000003;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SodiumConcentrationMeasurement
@@ -1217,13 +1217,13 @@ static constexpr AttributeId Tolerance        = 0x0003;
 namespace IasZone {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId ZoneState                              = 0x0000;
-static constexpr AttributeId ZoneType                               = 0x0001;
-static constexpr AttributeId ZoneStatus                             = 0x0002;
-static constexpr AttributeId IasCieAddress                          = 0x0010;
-static constexpr AttributeId ZoneId                                 = 0x0011;
-static constexpr AttributeId NumberOfZoneSensitivityLevelsSupported = 0x0012;
-static constexpr AttributeId CurrentZoneSensitivityLevel            = 0x0013;
+static constexpr AttributeId ZoneState                              = 0x00000000;
+static constexpr AttributeId ZoneType                               = 0x00000001;
+static constexpr AttributeId ZoneStatus                             = 0x00000002;
+static constexpr AttributeId IasCieAddress                          = 0x00000010;
+static constexpr AttributeId ZoneId                                 = 0x00000011;
+static constexpr AttributeId NumberOfZoneSensitivityLevelsSupported = 0x00000012;
+static constexpr AttributeId CurrentZoneSensitivityLevel            = 0x00000013;
 } // namespace Ids
 } // namespace Attributes
 } // namespace IasZone
@@ -1231,7 +1231,7 @@ static constexpr AttributeId CurrentZoneSensitivityLevel            = 0x0013;
 namespace IasWd {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MaxDuration = 0x0000;
+static constexpr AttributeId MaxDuration = 0x00000000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace IasWd
@@ -1239,7 +1239,7 @@ static constexpr AttributeId MaxDuration = 0x0000;
 namespace WakeOnLan {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId WakeOnLanMacAddress = 0x0000;
+static constexpr AttributeId WakeOnLanMacAddress = 0x00000000;
 } // namespace Ids
 } // namespace Attributes
 } // namespace WakeOnLan
@@ -1247,9 +1247,9 @@ static constexpr AttributeId WakeOnLanMacAddress = 0x0000;
 namespace TvChannel {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId TvChannelList    = 0x0000;
-static constexpr AttributeId TvChannelLineup  = 0x0001;
-static constexpr AttributeId CurrentTvChannel = 0x0002;
+static constexpr AttributeId TvChannelList    = 0x00000000;
+static constexpr AttributeId TvChannelLineup  = 0x00000001;
+static constexpr AttributeId CurrentTvChannel = 0x00000002;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TvChannel
@@ -1257,8 +1257,8 @@ static constexpr AttributeId CurrentTvChannel = 0x0002;
 namespace TargetNavigator {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId TargetNavigatorList    = 0x0000;
-static constexpr AttributeId CurrentNavigatorTarget = 0x0001;
+static constexpr AttributeId TargetNavigatorList    = 0x00000000;
+static constexpr AttributeId CurrentNavigatorTarget = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TargetNavigator
@@ -1266,14 +1266,14 @@ static constexpr AttributeId CurrentNavigatorTarget = 0x0001;
 namespace MediaPlayback {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId PlaybackState  = 0x0000;
-static constexpr AttributeId StartTime      = 0x0001;
-static constexpr AttributeId Duration       = 0x0002;
-static constexpr AttributeId UpdatedAt      = 0x0003;
-static constexpr AttributeId Posistion      = 0x0004;
-static constexpr AttributeId PlaybackSpeed  = 0x0005;
-static constexpr AttributeId SeekRangeEnd   = 0x0006;
-static constexpr AttributeId SeekRangeStart = 0x0007;
+static constexpr AttributeId PlaybackState  = 0x00000000;
+static constexpr AttributeId StartTime      = 0x00000001;
+static constexpr AttributeId Duration       = 0x00000002;
+static constexpr AttributeId UpdatedAt      = 0x00000003;
+static constexpr AttributeId Posistion      = 0x00000004;
+static constexpr AttributeId PlaybackSpeed  = 0x00000005;
+static constexpr AttributeId SeekRangeEnd   = 0x00000006;
+static constexpr AttributeId SeekRangeStart = 0x00000007;
 } // namespace Ids
 } // namespace Attributes
 } // namespace MediaPlayback
@@ -1281,8 +1281,8 @@ static constexpr AttributeId SeekRangeStart = 0x0007;
 namespace MediaInput {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MediaInputList    = 0x0000;
-static constexpr AttributeId CurrentMediaInput = 0x0001;
+static constexpr AttributeId MediaInputList    = 0x00000000;
+static constexpr AttributeId CurrentMediaInput = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace MediaInput
@@ -1290,8 +1290,8 @@ static constexpr AttributeId CurrentMediaInput = 0x0001;
 namespace ContentLauncher {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId AcceptsHeaderList       = 0x0000;
-static constexpr AttributeId SupportedStreamingTypes = 0x0001;
+static constexpr AttributeId AcceptsHeaderList       = 0x00000000;
+static constexpr AttributeId SupportedStreamingTypes = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ContentLauncher
@@ -1299,8 +1299,8 @@ static constexpr AttributeId SupportedStreamingTypes = 0x0001;
 namespace AudioOutput {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId AudioOutputList    = 0x0000;
-static constexpr AttributeId CurrentAudioOutput = 0x0001;
+static constexpr AttributeId AudioOutputList    = 0x00000000;
+static constexpr AttributeId CurrentAudioOutput = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace AudioOutput
@@ -1308,9 +1308,9 @@ static constexpr AttributeId CurrentAudioOutput = 0x0001;
 namespace ApplicationLauncher {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId ApplicationLauncherList = 0x0000;
-static constexpr AttributeId CatalogVendorId         = 0x0001;
-static constexpr AttributeId ApplicationId           = 0x0002;
+static constexpr AttributeId ApplicationLauncherList = 0x00000000;
+static constexpr AttributeId CatalogVendorId         = 0x00000001;
+static constexpr AttributeId ApplicationId           = 0x00000002;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ApplicationLauncher
@@ -1318,13 +1318,13 @@ static constexpr AttributeId ApplicationId           = 0x0002;
 namespace ApplicationBasic {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId VendorName        = 0x0000;
-static constexpr AttributeId VendorId          = 0x0001;
-static constexpr AttributeId ApplicationName   = 0x0002;
-static constexpr AttributeId ProductId         = 0x0003;
-static constexpr AttributeId ApplicationId     = 0x0005;
-static constexpr AttributeId CatalogVendorId   = 0x0006;
-static constexpr AttributeId ApplicationStatus = 0x0007;
+static constexpr AttributeId VendorName        = 0x00000000;
+static constexpr AttributeId VendorId          = 0x00000001;
+static constexpr AttributeId ApplicationName   = 0x00000002;
+static constexpr AttributeId ProductId         = 0x00000003;
+static constexpr AttributeId ApplicationId     = 0x00000005;
+static constexpr AttributeId CatalogVendorId   = 0x00000006;
+static constexpr AttributeId ApplicationStatus = 0x00000007;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ApplicationBasic
@@ -1332,29 +1332,29 @@ static constexpr AttributeId ApplicationStatus = 0x0007;
 namespace TestCluster {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Boolean               = 0x0000;
-static constexpr AttributeId Bitmap8               = 0x0001;
-static constexpr AttributeId Bitmap16              = 0x0002;
-static constexpr AttributeId Bitmap32              = 0x0003;
-static constexpr AttributeId Bitmap64              = 0x0004;
-static constexpr AttributeId Int8u                 = 0x0005;
-static constexpr AttributeId Int16u                = 0x0006;
-static constexpr AttributeId Int32u                = 0x0008;
-static constexpr AttributeId Int64u                = 0x000C;
-static constexpr AttributeId Int8s                 = 0x000D;
-static constexpr AttributeId Int16s                = 0x000E;
-static constexpr AttributeId Int32s                = 0x0010;
-static constexpr AttributeId Int64s                = 0x0014;
-static constexpr AttributeId Enum8                 = 0x0015;
-static constexpr AttributeId Enum16                = 0x0016;
-static constexpr AttributeId OctetString           = 0x0019;
-static constexpr AttributeId ListInt8u             = 0x001A;
-static constexpr AttributeId ListOctetString       = 0x001B;
-static constexpr AttributeId ListStructOctetString = 0x001C;
-static constexpr AttributeId LongOctetString       = 0x001D;
-static constexpr AttributeId CharString            = 0x001E;
-static constexpr AttributeId LongCharString        = 0x001F;
-static constexpr AttributeId Unsupported           = 0x00FF;
+static constexpr AttributeId Boolean               = 0x00000000;
+static constexpr AttributeId Bitmap8               = 0x00000001;
+static constexpr AttributeId Bitmap16              = 0x00000002;
+static constexpr AttributeId Bitmap32              = 0x00000003;
+static constexpr AttributeId Bitmap64              = 0x00000004;
+static constexpr AttributeId Int8u                 = 0x00000005;
+static constexpr AttributeId Int16u                = 0x00000006;
+static constexpr AttributeId Int32u                = 0x00000008;
+static constexpr AttributeId Int64u                = 0x0000000C;
+static constexpr AttributeId Int8s                 = 0x0000000D;
+static constexpr AttributeId Int16s                = 0x0000000E;
+static constexpr AttributeId Int32s                = 0x00000010;
+static constexpr AttributeId Int64s                = 0x00000014;
+static constexpr AttributeId Enum8                 = 0x00000015;
+static constexpr AttributeId Enum16                = 0x00000016;
+static constexpr AttributeId OctetString           = 0x00000019;
+static constexpr AttributeId ListInt8u             = 0x0000001A;
+static constexpr AttributeId ListOctetString       = 0x0000001B;
+static constexpr AttributeId ListStructOctetString = 0x0000001C;
+static constexpr AttributeId LongOctetString       = 0x0000001D;
+static constexpr AttributeId CharString            = 0x0000001E;
+static constexpr AttributeId LongCharString        = 0x0000001F;
+static constexpr AttributeId Unsupported           = 0x000000FF;
 } // namespace Ids
 } // namespace Attributes
 } // namespace TestCluster
@@ -1362,18 +1362,18 @@ static constexpr AttributeId Unsupported           = 0x00FF;
 namespace ApplianceIdentification {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId BasicIdentification       = 0x0000;
-static constexpr AttributeId CompanyName               = 0x0010;
-static constexpr AttributeId CompanyId                 = 0x0011;
-static constexpr AttributeId BrandName                 = 0x0012;
-static constexpr AttributeId BrandId                   = 0x0013;
-static constexpr AttributeId Model                     = 0x0014;
-static constexpr AttributeId PartNumber                = 0x0015;
-static constexpr AttributeId ProductRevision           = 0x0016;
-static constexpr AttributeId SoftwareRevision          = 0x0017;
-static constexpr AttributeId ProductTypeName           = 0x0018;
-static constexpr AttributeId ProductTypeId             = 0x0019;
-static constexpr AttributeId CecedSpecificationVersion = 0x001A;
+static constexpr AttributeId BasicIdentification       = 0x00000000;
+static constexpr AttributeId CompanyName               = 0x00000010;
+static constexpr AttributeId CompanyId                 = 0x00000011;
+static constexpr AttributeId BrandName                 = 0x00000012;
+static constexpr AttributeId BrandId                   = 0x00000013;
+static constexpr AttributeId Model                     = 0x00000014;
+static constexpr AttributeId PartNumber                = 0x00000015;
+static constexpr AttributeId ProductRevision           = 0x00000016;
+static constexpr AttributeId SoftwareRevision          = 0x00000017;
+static constexpr AttributeId ProductTypeName           = 0x00000018;
+static constexpr AttributeId ProductTypeId             = 0x00000019;
+static constexpr AttributeId CecedSpecificationVersion = 0x0000001A;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ApplianceIdentification
@@ -1381,18 +1381,18 @@ static constexpr AttributeId CecedSpecificationVersion = 0x001A;
 namespace MeterIdentification {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId CompanyName      = 0x0000;
-static constexpr AttributeId MeterTypeId      = 0x0001;
-static constexpr AttributeId DataQualityId    = 0x0004;
-static constexpr AttributeId CustomerName     = 0x0005;
-static constexpr AttributeId Model            = 0x0006;
-static constexpr AttributeId PartNumber       = 0x0007;
-static constexpr AttributeId ProductRevision  = 0x0008;
-static constexpr AttributeId SoftwareRevision = 0x000A;
-static constexpr AttributeId UtilityName      = 0x000B;
-static constexpr AttributeId Pod              = 0x000C;
-static constexpr AttributeId AvailablePower   = 0x000D;
-static constexpr AttributeId PowerThreshold   = 0x000E;
+static constexpr AttributeId CompanyName      = 0x00000000;
+static constexpr AttributeId MeterTypeId      = 0x00000001;
+static constexpr AttributeId DataQualityId    = 0x00000004;
+static constexpr AttributeId CustomerName     = 0x00000005;
+static constexpr AttributeId Model            = 0x00000006;
+static constexpr AttributeId PartNumber       = 0x00000007;
+static constexpr AttributeId ProductRevision  = 0x00000008;
+static constexpr AttributeId SoftwareRevision = 0x0000000A;
+static constexpr AttributeId UtilityName      = 0x0000000B;
+static constexpr AttributeId Pod              = 0x0000000C;
+static constexpr AttributeId AvailablePower   = 0x0000000D;
+static constexpr AttributeId PowerThreshold   = 0x0000000E;
 } // namespace Ids
 } // namespace Attributes
 } // namespace MeterIdentification
@@ -1400,8 +1400,8 @@ static constexpr AttributeId PowerThreshold   = 0x000E;
 namespace ApplianceStatistics {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId LogMaxSize      = 0x0000;
-static constexpr AttributeId LogQueueMaxSize = 0x0001;
+static constexpr AttributeId LogMaxSize      = 0x00000000;
+static constexpr AttributeId LogQueueMaxSize = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ApplianceStatistics
@@ -1409,134 +1409,134 @@ static constexpr AttributeId LogQueueMaxSize = 0x0001;
 namespace ElectricalMeasurement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId MeasurementType                          = 0x0000;
-static constexpr AttributeId DcVoltage                                = 0x0100;
-static constexpr AttributeId DcVoltageMin                             = 0x0101;
-static constexpr AttributeId DcVoltageMax                             = 0x0102;
-static constexpr AttributeId DcCurrent                                = 0x0103;
-static constexpr AttributeId DcCurrentMin                             = 0x0104;
-static constexpr AttributeId DcCurrentMax                             = 0x0105;
-static constexpr AttributeId DcPower                                  = 0x0106;
-static constexpr AttributeId DcPowerMin                               = 0x0107;
-static constexpr AttributeId DcPowerMax                               = 0x0108;
-static constexpr AttributeId DcVoltageMultiplier                      = 0x0200;
-static constexpr AttributeId DcVoltageDivisor                         = 0x0201;
-static constexpr AttributeId DcCurrentMultiplier                      = 0x0202;
-static constexpr AttributeId DcCurrentDivisor                         = 0x0203;
-static constexpr AttributeId DcPowerMultiplier                        = 0x0204;
-static constexpr AttributeId DcPowerDivisor                           = 0x0205;
-static constexpr AttributeId AcFrequency                              = 0x0300;
-static constexpr AttributeId AcFrequencyMin                           = 0x0301;
-static constexpr AttributeId AcFrequencyMax                           = 0x0302;
-static constexpr AttributeId NeutralCurrent                           = 0x0303;
-static constexpr AttributeId TotalActivePower                         = 0x0304;
-static constexpr AttributeId TotalReactivePower                       = 0x0305;
-static constexpr AttributeId TotalApparentPower                       = 0x0306;
-static constexpr AttributeId Measured1stHarmonicCurrent               = 0x0307;
-static constexpr AttributeId Measured3rdHarmonicCurrent               = 0x0308;
-static constexpr AttributeId Measured5thHarmonicCurrent               = 0x0309;
-static constexpr AttributeId Measured7thHarmonicCurrent               = 0x030A;
-static constexpr AttributeId Measured9thHarmonicCurrent               = 0x030B;
-static constexpr AttributeId Measured11thHarmonicCurrent              = 0x030C;
-static constexpr AttributeId MeasuredPhase1stHarmonicCurrent          = 0x030D;
-static constexpr AttributeId MeasuredPhase3rdHarmonicCurrent          = 0x030E;
-static constexpr AttributeId MeasuredPhase5thHarmonicCurrent          = 0x030F;
-static constexpr AttributeId MeasuredPhase7thHarmonicCurrent          = 0x0310;
-static constexpr AttributeId MeasuredPhase9thHarmonicCurrent          = 0x0311;
-static constexpr AttributeId MeasuredPhase11thHarmonicCurrent         = 0x0312;
-static constexpr AttributeId AcFrequencyMultiplier                    = 0x0400;
-static constexpr AttributeId AcFrequencyDivisor                       = 0x0401;
-static constexpr AttributeId PowerMultiplier                          = 0x0402;
-static constexpr AttributeId PowerDivisor                             = 0x0403;
-static constexpr AttributeId HarmonicCurrentMultiplier                = 0x0404;
-static constexpr AttributeId PhaseHarmonicCurrentMultiplier           = 0x0405;
-static constexpr AttributeId InstantaneousVoltage                     = 0x0500;
-static constexpr AttributeId InstantaneousLineCurrent                 = 0x0501;
-static constexpr AttributeId InstantaneousActiveCurrent               = 0x0502;
-static constexpr AttributeId InstantaneousReactiveCurrent             = 0x0503;
-static constexpr AttributeId InstantaneousPower                       = 0x0504;
-static constexpr AttributeId RmsVoltage                               = 0x0505;
-static constexpr AttributeId RmsVoltageMin                            = 0x0506;
-static constexpr AttributeId RmsVoltageMax                            = 0x0507;
-static constexpr AttributeId RmsCurrent                               = 0x0508;
-static constexpr AttributeId RmsCurrentMin                            = 0x0509;
-static constexpr AttributeId RmsCurrentMax                            = 0x050A;
-static constexpr AttributeId ActivePower                              = 0x050B;
-static constexpr AttributeId ActivePowerMin                           = 0x050C;
-static constexpr AttributeId ActivePowerMax                           = 0x050D;
-static constexpr AttributeId ReactivePower                            = 0x050E;
-static constexpr AttributeId ApparentPower                            = 0x050F;
-static constexpr AttributeId PowerFactor                              = 0x0510;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriod       = 0x0511;
-static constexpr AttributeId AverageRmsUnderVoltageCounter            = 0x0513;
-static constexpr AttributeId RmsExtremeOverVoltagePeriod              = 0x0514;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriod             = 0x0515;
-static constexpr AttributeId RmsVoltageSagPeriod                      = 0x0516;
-static constexpr AttributeId RmsVoltageSwellPeriod                    = 0x0517;
-static constexpr AttributeId AcVoltageMultiplier                      = 0x0600;
-static constexpr AttributeId AcVoltageDivisor                         = 0x0601;
-static constexpr AttributeId AcCurrentMultiplier                      = 0x0602;
-static constexpr AttributeId AcCurrentDivisor                         = 0x0603;
-static constexpr AttributeId AcPowerMultiplier                        = 0x0604;
-static constexpr AttributeId AcPowerDivisor                           = 0x0605;
-static constexpr AttributeId OverloadAlarmsMask                       = 0x0700;
-static constexpr AttributeId VoltageOverload                          = 0x0701;
-static constexpr AttributeId CurrentOverload                          = 0x0702;
-static constexpr AttributeId AcOverloadAlarmsMask                     = 0x0800;
-static constexpr AttributeId AcVoltageOverload                        = 0x0801;
-static constexpr AttributeId AcCurrentOverload                        = 0x0802;
-static constexpr AttributeId AcActivePowerOverload                    = 0x0803;
-static constexpr AttributeId AcReactivePowerOverload                  = 0x0804;
-static constexpr AttributeId AverageRmsOverVoltage                    = 0x0805;
-static constexpr AttributeId AverageRmsUnderVoltage                   = 0x0806;
-static constexpr AttributeId RmsExtremeOverVoltage                    = 0x0807;
-static constexpr AttributeId RmsExtremeUnderVoltage                   = 0x0808;
-static constexpr AttributeId RmsVoltageSag                            = 0x0809;
-static constexpr AttributeId RmsVoltageSwell                          = 0x080A;
-static constexpr AttributeId LineCurrentPhaseB                        = 0x0901;
-static constexpr AttributeId ActiveCurrentPhaseB                      = 0x0902;
-static constexpr AttributeId ReactiveCurrentPhaseB                    = 0x0903;
-static constexpr AttributeId RmsVoltagePhaseB                         = 0x0905;
-static constexpr AttributeId RmsVoltageMinPhaseB                      = 0x0906;
-static constexpr AttributeId RmsVoltageMaxPhaseB                      = 0x0907;
-static constexpr AttributeId RmsCurrentPhaseB                         = 0x0908;
-static constexpr AttributeId RmsCurrentMinPhaseB                      = 0x0909;
-static constexpr AttributeId RmsCurrentMaxPhaseB                      = 0x090A;
-static constexpr AttributeId ActivePowerPhaseB                        = 0x090B;
-static constexpr AttributeId ActivePowerMinPhaseB                     = 0x090C;
-static constexpr AttributeId ActivePowerMaxPhaseB                     = 0x090D;
-static constexpr AttributeId ReactivePowerPhaseB                      = 0x090E;
-static constexpr AttributeId ApparentPowerPhaseB                      = 0x090F;
-static constexpr AttributeId PowerFactorPhaseB                        = 0x0910;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseB = 0x0911;
-static constexpr AttributeId AverageRmsOverVoltageCounterPhaseB       = 0x0912;
-static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseB      = 0x0913;
-static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseB        = 0x0914;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseB       = 0x0915;
-static constexpr AttributeId RmsVoltageSagPeriodPhaseB                = 0x0916;
-static constexpr AttributeId RmsVoltageSwellPeriodPhaseB              = 0x0917;
-static constexpr AttributeId LineCurrentPhaseC                        = 0x0A01;
-static constexpr AttributeId ActiveCurrentPhaseC                      = 0x0A02;
-static constexpr AttributeId ReactiveCurrentPhaseC                    = 0x0A03;
-static constexpr AttributeId RmsVoltagePhaseC                         = 0x0A05;
-static constexpr AttributeId RmsVoltageMinPhaseC                      = 0x0A06;
-static constexpr AttributeId RmsVoltageMaxPhaseC                      = 0x0A07;
-static constexpr AttributeId RmsCurrentPhaseC                         = 0x0A08;
-static constexpr AttributeId RmsCurrentMinPhaseC                      = 0x0A09;
-static constexpr AttributeId RmsCurrentMaxPhaseC                      = 0x0A0A;
-static constexpr AttributeId ActivePowerPhaseC                        = 0x0A0B;
-static constexpr AttributeId ActivePowerMinPhaseC                     = 0x0A0C;
-static constexpr AttributeId ActivePowerMaxPhaseC                     = 0x0A0D;
-static constexpr AttributeId ReactivePowerPhaseC                      = 0x0A0E;
-static constexpr AttributeId ApparentPowerPhaseC                      = 0x0A0F;
-static constexpr AttributeId PowerFactorPhaseC                        = 0x0A10;
-static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseC = 0x0A11;
-static constexpr AttributeId AverageRmsOverVoltageCounterPhaseC       = 0x0A12;
-static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseC      = 0x0A13;
-static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseC        = 0x0A14;
-static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseC       = 0x0A15;
-static constexpr AttributeId RmsVoltageSagPeriodPhaseC                = 0x0A16;
-static constexpr AttributeId RmsVoltageSwellPeriodPhaseC              = 0x0A17;
+static constexpr AttributeId MeasurementType                          = 0x00000000;
+static constexpr AttributeId DcVoltage                                = 0x00000100;
+static constexpr AttributeId DcVoltageMin                             = 0x00000101;
+static constexpr AttributeId DcVoltageMax                             = 0x00000102;
+static constexpr AttributeId DcCurrent                                = 0x00000103;
+static constexpr AttributeId DcCurrentMin                             = 0x00000104;
+static constexpr AttributeId DcCurrentMax                             = 0x00000105;
+static constexpr AttributeId DcPower                                  = 0x00000106;
+static constexpr AttributeId DcPowerMin                               = 0x00000107;
+static constexpr AttributeId DcPowerMax                               = 0x00000108;
+static constexpr AttributeId DcVoltageMultiplier                      = 0x00000200;
+static constexpr AttributeId DcVoltageDivisor                         = 0x00000201;
+static constexpr AttributeId DcCurrentMultiplier                      = 0x00000202;
+static constexpr AttributeId DcCurrentDivisor                         = 0x00000203;
+static constexpr AttributeId DcPowerMultiplier                        = 0x00000204;
+static constexpr AttributeId DcPowerDivisor                           = 0x00000205;
+static constexpr AttributeId AcFrequency                              = 0x00000300;
+static constexpr AttributeId AcFrequencyMin                           = 0x00000301;
+static constexpr AttributeId AcFrequencyMax                           = 0x00000302;
+static constexpr AttributeId NeutralCurrent                           = 0x00000303;
+static constexpr AttributeId TotalActivePower                         = 0x00000304;
+static constexpr AttributeId TotalReactivePower                       = 0x00000305;
+static constexpr AttributeId TotalApparentPower                       = 0x00000306;
+static constexpr AttributeId Measured1stHarmonicCurrent               = 0x00000307;
+static constexpr AttributeId Measured3rdHarmonicCurrent               = 0x00000308;
+static constexpr AttributeId Measured5thHarmonicCurrent               = 0x00000309;
+static constexpr AttributeId Measured7thHarmonicCurrent               = 0x0000030A;
+static constexpr AttributeId Measured9thHarmonicCurrent               = 0x0000030B;
+static constexpr AttributeId Measured11thHarmonicCurrent              = 0x0000030C;
+static constexpr AttributeId MeasuredPhase1stHarmonicCurrent          = 0x0000030D;
+static constexpr AttributeId MeasuredPhase3rdHarmonicCurrent          = 0x0000030E;
+static constexpr AttributeId MeasuredPhase5thHarmonicCurrent          = 0x0000030F;
+static constexpr AttributeId MeasuredPhase7thHarmonicCurrent          = 0x00000310;
+static constexpr AttributeId MeasuredPhase9thHarmonicCurrent          = 0x00000311;
+static constexpr AttributeId MeasuredPhase11thHarmonicCurrent         = 0x00000312;
+static constexpr AttributeId AcFrequencyMultiplier                    = 0x00000400;
+static constexpr AttributeId AcFrequencyDivisor                       = 0x00000401;
+static constexpr AttributeId PowerMultiplier                          = 0x00000402;
+static constexpr AttributeId PowerDivisor                             = 0x00000403;
+static constexpr AttributeId HarmonicCurrentMultiplier                = 0x00000404;
+static constexpr AttributeId PhaseHarmonicCurrentMultiplier           = 0x00000405;
+static constexpr AttributeId InstantaneousVoltage                     = 0x00000500;
+static constexpr AttributeId InstantaneousLineCurrent                 = 0x00000501;
+static constexpr AttributeId InstantaneousActiveCurrent               = 0x00000502;
+static constexpr AttributeId InstantaneousReactiveCurrent             = 0x00000503;
+static constexpr AttributeId InstantaneousPower                       = 0x00000504;
+static constexpr AttributeId RmsVoltage                               = 0x00000505;
+static constexpr AttributeId RmsVoltageMin                            = 0x00000506;
+static constexpr AttributeId RmsVoltageMax                            = 0x00000507;
+static constexpr AttributeId RmsCurrent                               = 0x00000508;
+static constexpr AttributeId RmsCurrentMin                            = 0x00000509;
+static constexpr AttributeId RmsCurrentMax                            = 0x0000050A;
+static constexpr AttributeId ActivePower                              = 0x0000050B;
+static constexpr AttributeId ActivePowerMin                           = 0x0000050C;
+static constexpr AttributeId ActivePowerMax                           = 0x0000050D;
+static constexpr AttributeId ReactivePower                            = 0x0000050E;
+static constexpr AttributeId ApparentPower                            = 0x0000050F;
+static constexpr AttributeId PowerFactor                              = 0x00000510;
+static constexpr AttributeId AverageRmsVoltageMeasurementPeriod       = 0x00000511;
+static constexpr AttributeId AverageRmsUnderVoltageCounter            = 0x00000513;
+static constexpr AttributeId RmsExtremeOverVoltagePeriod              = 0x00000514;
+static constexpr AttributeId RmsExtremeUnderVoltagePeriod             = 0x00000515;
+static constexpr AttributeId RmsVoltageSagPeriod                      = 0x00000516;
+static constexpr AttributeId RmsVoltageSwellPeriod                    = 0x00000517;
+static constexpr AttributeId AcVoltageMultiplier                      = 0x00000600;
+static constexpr AttributeId AcVoltageDivisor                         = 0x00000601;
+static constexpr AttributeId AcCurrentMultiplier                      = 0x00000602;
+static constexpr AttributeId AcCurrentDivisor                         = 0x00000603;
+static constexpr AttributeId AcPowerMultiplier                        = 0x00000604;
+static constexpr AttributeId AcPowerDivisor                           = 0x00000605;
+static constexpr AttributeId OverloadAlarmsMask                       = 0x00000700;
+static constexpr AttributeId VoltageOverload                          = 0x00000701;
+static constexpr AttributeId CurrentOverload                          = 0x00000702;
+static constexpr AttributeId AcOverloadAlarmsMask                     = 0x00000800;
+static constexpr AttributeId AcVoltageOverload                        = 0x00000801;
+static constexpr AttributeId AcCurrentOverload                        = 0x00000802;
+static constexpr AttributeId AcActivePowerOverload                    = 0x00000803;
+static constexpr AttributeId AcReactivePowerOverload                  = 0x00000804;
+static constexpr AttributeId AverageRmsOverVoltage                    = 0x00000805;
+static constexpr AttributeId AverageRmsUnderVoltage                   = 0x00000806;
+static constexpr AttributeId RmsExtremeOverVoltage                    = 0x00000807;
+static constexpr AttributeId RmsExtremeUnderVoltage                   = 0x00000808;
+static constexpr AttributeId RmsVoltageSag                            = 0x00000809;
+static constexpr AttributeId RmsVoltageSwell                          = 0x0000080A;
+static constexpr AttributeId LineCurrentPhaseB                        = 0x00000901;
+static constexpr AttributeId ActiveCurrentPhaseB                      = 0x00000902;
+static constexpr AttributeId ReactiveCurrentPhaseB                    = 0x00000903;
+static constexpr AttributeId RmsVoltagePhaseB                         = 0x00000905;
+static constexpr AttributeId RmsVoltageMinPhaseB                      = 0x00000906;
+static constexpr AttributeId RmsVoltageMaxPhaseB                      = 0x00000907;
+static constexpr AttributeId RmsCurrentPhaseB                         = 0x00000908;
+static constexpr AttributeId RmsCurrentMinPhaseB                      = 0x00000909;
+static constexpr AttributeId RmsCurrentMaxPhaseB                      = 0x0000090A;
+static constexpr AttributeId ActivePowerPhaseB                        = 0x0000090B;
+static constexpr AttributeId ActivePowerMinPhaseB                     = 0x0000090C;
+static constexpr AttributeId ActivePowerMaxPhaseB                     = 0x0000090D;
+static constexpr AttributeId ReactivePowerPhaseB                      = 0x0000090E;
+static constexpr AttributeId ApparentPowerPhaseB                      = 0x0000090F;
+static constexpr AttributeId PowerFactorPhaseB                        = 0x00000910;
+static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseB = 0x00000911;
+static constexpr AttributeId AverageRmsOverVoltageCounterPhaseB       = 0x00000912;
+static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseB      = 0x00000913;
+static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseB        = 0x00000914;
+static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseB       = 0x00000915;
+static constexpr AttributeId RmsVoltageSagPeriodPhaseB                = 0x00000916;
+static constexpr AttributeId RmsVoltageSwellPeriodPhaseB              = 0x00000917;
+static constexpr AttributeId LineCurrentPhaseC                        = 0x00000A01;
+static constexpr AttributeId ActiveCurrentPhaseC                      = 0x00000A02;
+static constexpr AttributeId ReactiveCurrentPhaseC                    = 0x00000A03;
+static constexpr AttributeId RmsVoltagePhaseC                         = 0x00000A05;
+static constexpr AttributeId RmsVoltageMinPhaseC                      = 0x00000A06;
+static constexpr AttributeId RmsVoltageMaxPhaseC                      = 0x00000A07;
+static constexpr AttributeId RmsCurrentPhaseC                         = 0x00000A08;
+static constexpr AttributeId RmsCurrentMinPhaseC                      = 0x00000A09;
+static constexpr AttributeId RmsCurrentMaxPhaseC                      = 0x00000A0A;
+static constexpr AttributeId ActivePowerPhaseC                        = 0x00000A0B;
+static constexpr AttributeId ActivePowerMinPhaseC                     = 0x00000A0C;
+static constexpr AttributeId ActivePowerMaxPhaseC                     = 0x00000A0D;
+static constexpr AttributeId ReactivePowerPhaseC                      = 0x00000A0E;
+static constexpr AttributeId ApparentPowerPhaseC                      = 0x00000A0F;
+static constexpr AttributeId PowerFactorPhaseC                        = 0x00000A10;
+static constexpr AttributeId AverageRmsVoltageMeasurementPeriodPhaseC = 0x00000A11;
+static constexpr AttributeId AverageRmsOverVoltageCounterPhaseC       = 0x00000A12;
+static constexpr AttributeId AverageRmsUnderVoltageCounterPhaseC      = 0x00000A13;
+static constexpr AttributeId RmsExtremeOverVoltagePeriodPhaseC        = 0x00000A14;
+static constexpr AttributeId RmsExtremeUnderVoltagePeriodPhaseC       = 0x00000A15;
+static constexpr AttributeId RmsVoltageSagPeriodPhaseC                = 0x00000A16;
+static constexpr AttributeId RmsVoltageSwellPeriodPhaseC              = 0x00000A17;
 } // namespace Ids
 } // namespace Attributes
 } // namespace ElectricalMeasurement
@@ -1544,8 +1544,8 @@ static constexpr AttributeId RmsVoltageSwellPeriodPhaseC              = 0x0A17;
 namespace GroupKeyManagement {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId Groups    = 0x0000;
-static constexpr AttributeId GroupKeys = 0x0001;
+static constexpr AttributeId Groups    = 0x00000000;
+static constexpr AttributeId GroupKeys = 0x00000001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace GroupKeyManagement
@@ -1553,8 +1553,8 @@ static constexpr AttributeId GroupKeys = 0x0001;
 namespace SampleMfgSpecificCluster {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId EmberSampleAttribute  = 0x0000;
-static constexpr AttributeId EmberSampleAttribute2 = 0x0001;
+static constexpr AttributeId EmberSampleAttribute  = 0x10020000;
+static constexpr AttributeId EmberSampleAttribute2 = 0x10020001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster
@@ -1562,8 +1562,8 @@ static constexpr AttributeId EmberSampleAttribute2 = 0x0001;
 namespace SampleMfgSpecificCluster2 {
 namespace Attributes {
 namespace Ids {
-static constexpr AttributeId EmberSampleAttribute3 = 0x0000;
-static constexpr AttributeId EmberSampleAttribute4 = 0x0001;
+static constexpr AttributeId EmberSampleAttribute3 = 0x10490000;
+static constexpr AttributeId EmberSampleAttribute4 = 0x10490001;
 } // namespace Ids
 } // namespace Attributes
 } // namespace SampleMfgSpecificCluster2

--- a/src/app/common/gen/ids/Clusters.h
+++ b/src/app/common/gen/ids/Clusters.h
@@ -26,316 +26,316 @@ namespace app {
 namespace Clusters {
 
 namespace PowerConfiguration {
-static constexpr ClusterId Id = 0x0001;
+static constexpr ClusterId Id = 0x00000001;
 } // namespace PowerConfiguration
 namespace DeviceTemperatureConfiguration {
-static constexpr ClusterId Id = 0x0002;
+static constexpr ClusterId Id = 0x00000002;
 } // namespace DeviceTemperatureConfiguration
 namespace Identify {
-static constexpr ClusterId Id = 0x0003;
+static constexpr ClusterId Id = 0x00000003;
 } // namespace Identify
 namespace Groups {
-static constexpr ClusterId Id = 0x0004;
+static constexpr ClusterId Id = 0x00000004;
 } // namespace Groups
 namespace Scenes {
-static constexpr ClusterId Id = 0x0005;
+static constexpr ClusterId Id = 0x00000005;
 } // namespace Scenes
 namespace OnOff {
-static constexpr ClusterId Id = 0x0006;
+static constexpr ClusterId Id = 0x00000006;
 } // namespace OnOff
 namespace OnOffSwitchConfiguration {
-static constexpr ClusterId Id = 0x0007;
+static constexpr ClusterId Id = 0x00000007;
 } // namespace OnOffSwitchConfiguration
 namespace LevelControl {
-static constexpr ClusterId Id = 0x0008;
+static constexpr ClusterId Id = 0x00000008;
 } // namespace LevelControl
 namespace Alarms {
-static constexpr ClusterId Id = 0x0009;
+static constexpr ClusterId Id = 0x00000009;
 } // namespace Alarms
 namespace Time {
-static constexpr ClusterId Id = 0x000A;
+static constexpr ClusterId Id = 0x0000000A;
 } // namespace Time
 namespace BinaryInputBasic {
-static constexpr ClusterId Id = 0x000F;
+static constexpr ClusterId Id = 0x0000000F;
 } // namespace BinaryInputBasic
 namespace PowerProfile {
-static constexpr ClusterId Id = 0x001A;
+static constexpr ClusterId Id = 0x0000001A;
 } // namespace PowerProfile
 namespace ApplianceControl {
-static constexpr ClusterId Id = 0x001B;
+static constexpr ClusterId Id = 0x0000001B;
 } // namespace ApplianceControl
 namespace Descriptor {
-static constexpr ClusterId Id = 0x001D;
+static constexpr ClusterId Id = 0x0000001D;
 } // namespace Descriptor
 namespace PollControl {
-static constexpr ClusterId Id = 0x0020;
+static constexpr ClusterId Id = 0x00000020;
 } // namespace PollControl
 namespace Basic {
-static constexpr ClusterId Id = 0x0028;
+static constexpr ClusterId Id = 0x00000028;
 } // namespace Basic
 namespace OtaSoftwareUpdateProvider {
-static constexpr ClusterId Id = 0x0029;
+static constexpr ClusterId Id = 0x00000029;
 } // namespace OtaSoftwareUpdateProvider
 namespace OtaSoftwareUpdateRequestor {
-static constexpr ClusterId Id = 0x002A;
+static constexpr ClusterId Id = 0x0000002A;
 } // namespace OtaSoftwareUpdateRequestor
 namespace GeneralCommissioning {
-static constexpr ClusterId Id = 0x0030;
+static constexpr ClusterId Id = 0x00000030;
 } // namespace GeneralCommissioning
 namespace NetworkCommissioning {
-static constexpr ClusterId Id = 0x0031;
+static constexpr ClusterId Id = 0x00000031;
 } // namespace NetworkCommissioning
 namespace DiagnosticLogs {
-static constexpr ClusterId Id = 0x0032;
+static constexpr ClusterId Id = 0x00000032;
 } // namespace DiagnosticLogs
 namespace GeneralDiagnostics {
-static constexpr ClusterId Id = 0x0033;
+static constexpr ClusterId Id = 0x00000033;
 } // namespace GeneralDiagnostics
 namespace SoftwareDiagnostics {
-static constexpr ClusterId Id = 0x0034;
+static constexpr ClusterId Id = 0x00000034;
 } // namespace SoftwareDiagnostics
 namespace ThreadNetworkDiagnostics {
-static constexpr ClusterId Id = 0x0035;
+static constexpr ClusterId Id = 0x00000035;
 } // namespace ThreadNetworkDiagnostics
 namespace WiFiNetworkDiagnostics {
-static constexpr ClusterId Id = 0x0036;
+static constexpr ClusterId Id = 0x00000036;
 } // namespace WiFiNetworkDiagnostics
 namespace EthernetNetworkDiagnostics {
-static constexpr ClusterId Id = 0x0037;
+static constexpr ClusterId Id = 0x00000037;
 } // namespace EthernetNetworkDiagnostics
 namespace BridgedDeviceBasic {
-static constexpr ClusterId Id = 0x0039;
+static constexpr ClusterId Id = 0x00000039;
 } // namespace BridgedDeviceBasic
 namespace Switch {
-static constexpr ClusterId Id = 0x003B;
+static constexpr ClusterId Id = 0x0000003B;
 } // namespace Switch
 namespace OperationalCredentials {
-static constexpr ClusterId Id = 0x003E;
+static constexpr ClusterId Id = 0x0000003E;
 } // namespace OperationalCredentials
 namespace FixedLabel {
-static constexpr ClusterId Id = 0x0040;
+static constexpr ClusterId Id = 0x00000040;
 } // namespace FixedLabel
 namespace ShadeConfiguration {
-static constexpr ClusterId Id = 0x0100;
+static constexpr ClusterId Id = 0x00000100;
 } // namespace ShadeConfiguration
 namespace DoorLock {
-static constexpr ClusterId Id = 0x0101;
+static constexpr ClusterId Id = 0x00000101;
 } // namespace DoorLock
 namespace WindowCovering {
-static constexpr ClusterId Id = 0x0102;
+static constexpr ClusterId Id = 0x00000102;
 } // namespace WindowCovering
 namespace BarrierControl {
-static constexpr ClusterId Id = 0x0103;
+static constexpr ClusterId Id = 0x00000103;
 } // namespace BarrierControl
 namespace PumpConfigurationAndControl {
-static constexpr ClusterId Id = 0x0200;
+static constexpr ClusterId Id = 0x00000200;
 } // namespace PumpConfigurationAndControl
 namespace Thermostat {
-static constexpr ClusterId Id = 0x0201;
+static constexpr ClusterId Id = 0x00000201;
 } // namespace Thermostat
 namespace FanControl {
-static constexpr ClusterId Id = 0x0202;
+static constexpr ClusterId Id = 0x00000202;
 } // namespace FanControl
 namespace DehumidificationControl {
-static constexpr ClusterId Id = 0x0203;
+static constexpr ClusterId Id = 0x00000203;
 } // namespace DehumidificationControl
 namespace ThermostatUserInterfaceConfiguration {
-static constexpr ClusterId Id = 0x0204;
+static constexpr ClusterId Id = 0x00000204;
 } // namespace ThermostatUserInterfaceConfiguration
 namespace ColorControl {
-static constexpr ClusterId Id = 0x0300;
+static constexpr ClusterId Id = 0x00000300;
 } // namespace ColorControl
 namespace BallastConfiguration {
-static constexpr ClusterId Id = 0x0301;
+static constexpr ClusterId Id = 0x00000301;
 } // namespace BallastConfiguration
 namespace IlluminanceMeasurement {
-static constexpr ClusterId Id = 0x0400;
+static constexpr ClusterId Id = 0x00000400;
 } // namespace IlluminanceMeasurement
 namespace IlluminanceLevelSensing {
-static constexpr ClusterId Id = 0x0401;
+static constexpr ClusterId Id = 0x00000401;
 } // namespace IlluminanceLevelSensing
 namespace TemperatureMeasurement {
-static constexpr ClusterId Id = 0x0402;
+static constexpr ClusterId Id = 0x00000402;
 } // namespace TemperatureMeasurement
 namespace PressureMeasurement {
-static constexpr ClusterId Id = 0x0403;
+static constexpr ClusterId Id = 0x00000403;
 } // namespace PressureMeasurement
 namespace FlowMeasurement {
-static constexpr ClusterId Id = 0x0404;
+static constexpr ClusterId Id = 0x00000404;
 } // namespace FlowMeasurement
 namespace RelativeHumidityMeasurement {
-static constexpr ClusterId Id = 0x0405;
+static constexpr ClusterId Id = 0x00000405;
 } // namespace RelativeHumidityMeasurement
 namespace OccupancySensing {
-static constexpr ClusterId Id = 0x0406;
+static constexpr ClusterId Id = 0x00000406;
 } // namespace OccupancySensing
 namespace CarbonMonoxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x040C;
+static constexpr ClusterId Id = 0x0000040C;
 } // namespace CarbonMonoxideConcentrationMeasurement
 namespace CarbonDioxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x040D;
+static constexpr ClusterId Id = 0x0000040D;
 } // namespace CarbonDioxideConcentrationMeasurement
 namespace EthyleneConcentrationMeasurement {
-static constexpr ClusterId Id = 0x040E;
+static constexpr ClusterId Id = 0x0000040E;
 } // namespace EthyleneConcentrationMeasurement
 namespace EthyleneOxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x040F;
+static constexpr ClusterId Id = 0x0000040F;
 } // namespace EthyleneOxideConcentrationMeasurement
 namespace HydrogenConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0410;
+static constexpr ClusterId Id = 0x00000410;
 } // namespace HydrogenConcentrationMeasurement
 namespace HydrogenSulphideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0411;
+static constexpr ClusterId Id = 0x00000411;
 } // namespace HydrogenSulphideConcentrationMeasurement
 namespace NitricOxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0412;
+static constexpr ClusterId Id = 0x00000412;
 } // namespace NitricOxideConcentrationMeasurement
 namespace NitrogenDioxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0413;
+static constexpr ClusterId Id = 0x00000413;
 } // namespace NitrogenDioxideConcentrationMeasurement
 namespace OxygenConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0414;
+static constexpr ClusterId Id = 0x00000414;
 } // namespace OxygenConcentrationMeasurement
 namespace OzoneConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0415;
+static constexpr ClusterId Id = 0x00000415;
 } // namespace OzoneConcentrationMeasurement
 namespace SulfurDioxideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0416;
+static constexpr ClusterId Id = 0x00000416;
 } // namespace SulfurDioxideConcentrationMeasurement
 namespace DissolvedOxygenConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0417;
+static constexpr ClusterId Id = 0x00000417;
 } // namespace DissolvedOxygenConcentrationMeasurement
 namespace BromateConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0418;
+static constexpr ClusterId Id = 0x00000418;
 } // namespace BromateConcentrationMeasurement
 namespace ChloraminesConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0419;
+static constexpr ClusterId Id = 0x00000419;
 } // namespace ChloraminesConcentrationMeasurement
 namespace ChlorineConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041A;
+static constexpr ClusterId Id = 0x0000041A;
 } // namespace ChlorineConcentrationMeasurement
 namespace FecalColiformAndEColiConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041B;
+static constexpr ClusterId Id = 0x0000041B;
 } // namespace FecalColiformAndEColiConcentrationMeasurement
 namespace FluorideConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041C;
+static constexpr ClusterId Id = 0x0000041C;
 } // namespace FluorideConcentrationMeasurement
 namespace HaloaceticAcidsConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041D;
+static constexpr ClusterId Id = 0x0000041D;
 } // namespace HaloaceticAcidsConcentrationMeasurement
 namespace TotalTrihalomethanesConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041E;
+static constexpr ClusterId Id = 0x0000041E;
 } // namespace TotalTrihalomethanesConcentrationMeasurement
 namespace TotalColiformBacteriaConcentrationMeasurement {
-static constexpr ClusterId Id = 0x041F;
+static constexpr ClusterId Id = 0x0000041F;
 } // namespace TotalColiformBacteriaConcentrationMeasurement
 namespace TurbidityConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0420;
+static constexpr ClusterId Id = 0x00000420;
 } // namespace TurbidityConcentrationMeasurement
 namespace CopperConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0421;
+static constexpr ClusterId Id = 0x00000421;
 } // namespace CopperConcentrationMeasurement
 namespace LeadConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0422;
+static constexpr ClusterId Id = 0x00000422;
 } // namespace LeadConcentrationMeasurement
 namespace ManganeseConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0423;
+static constexpr ClusterId Id = 0x00000423;
 } // namespace ManganeseConcentrationMeasurement
 namespace SulfateConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0424;
+static constexpr ClusterId Id = 0x00000424;
 } // namespace SulfateConcentrationMeasurement
 namespace BromodichloromethaneConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0425;
+static constexpr ClusterId Id = 0x00000425;
 } // namespace BromodichloromethaneConcentrationMeasurement
 namespace BromoformConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0426;
+static constexpr ClusterId Id = 0x00000426;
 } // namespace BromoformConcentrationMeasurement
 namespace ChlorodibromomethaneConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0427;
+static constexpr ClusterId Id = 0x00000427;
 } // namespace ChlorodibromomethaneConcentrationMeasurement
 namespace ChloroformConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0428;
+static constexpr ClusterId Id = 0x00000428;
 } // namespace ChloroformConcentrationMeasurement
 namespace SodiumConcentrationMeasurement {
-static constexpr ClusterId Id = 0x0429;
+static constexpr ClusterId Id = 0x00000429;
 } // namespace SodiumConcentrationMeasurement
 namespace IasZone {
-static constexpr ClusterId Id = 0x0500;
+static constexpr ClusterId Id = 0x00000500;
 } // namespace IasZone
 namespace IasAce {
-static constexpr ClusterId Id = 0x0501;
+static constexpr ClusterId Id = 0x00000501;
 } // namespace IasAce
 namespace IasWd {
-static constexpr ClusterId Id = 0x0502;
+static constexpr ClusterId Id = 0x00000502;
 } // namespace IasWd
 namespace WakeOnLan {
-static constexpr ClusterId Id = 0x0503;
+static constexpr ClusterId Id = 0x00000503;
 } // namespace WakeOnLan
 namespace TvChannel {
-static constexpr ClusterId Id = 0x0504;
+static constexpr ClusterId Id = 0x00000504;
 } // namespace TvChannel
 namespace TargetNavigator {
-static constexpr ClusterId Id = 0x0505;
+static constexpr ClusterId Id = 0x00000505;
 } // namespace TargetNavigator
 namespace MediaPlayback {
-static constexpr ClusterId Id = 0x0506;
+static constexpr ClusterId Id = 0x00000506;
 } // namespace MediaPlayback
 namespace MediaInput {
-static constexpr ClusterId Id = 0x0507;
+static constexpr ClusterId Id = 0x00000507;
 } // namespace MediaInput
 namespace LowPower {
-static constexpr ClusterId Id = 0x0508;
+static constexpr ClusterId Id = 0x00000508;
 } // namespace LowPower
 namespace KeypadInput {
-static constexpr ClusterId Id = 0x0509;
+static constexpr ClusterId Id = 0x00000509;
 } // namespace KeypadInput
 namespace ContentLauncher {
-static constexpr ClusterId Id = 0x050A;
+static constexpr ClusterId Id = 0x0000050A;
 } // namespace ContentLauncher
 namespace AudioOutput {
-static constexpr ClusterId Id = 0x050B;
+static constexpr ClusterId Id = 0x0000050B;
 } // namespace AudioOutput
 namespace ApplicationLauncher {
-static constexpr ClusterId Id = 0x050C;
+static constexpr ClusterId Id = 0x0000050C;
 } // namespace ApplicationLauncher
 namespace ApplicationBasic {
-static constexpr ClusterId Id = 0x050D;
+static constexpr ClusterId Id = 0x0000050D;
 } // namespace ApplicationBasic
 namespace AccountLogin {
-static constexpr ClusterId Id = 0x050E;
+static constexpr ClusterId Id = 0x0000050E;
 } // namespace AccountLogin
 namespace TestCluster {
-static constexpr ClusterId Id = 0x050F;
+static constexpr ClusterId Id = 0x0000050F;
 } // namespace TestCluster
 namespace Messaging {
-static constexpr ClusterId Id = 0x0703;
+static constexpr ClusterId Id = 0x00000703;
 } // namespace Messaging
 namespace ApplianceIdentification {
-static constexpr ClusterId Id = 0x0B00;
+static constexpr ClusterId Id = 0x00000B00;
 } // namespace ApplianceIdentification
 namespace MeterIdentification {
-static constexpr ClusterId Id = 0x0B01;
+static constexpr ClusterId Id = 0x00000B01;
 } // namespace MeterIdentification
 namespace ApplianceEventsAndAlert {
-static constexpr ClusterId Id = 0x0B02;
+static constexpr ClusterId Id = 0x00000B02;
 } // namespace ApplianceEventsAndAlert
 namespace ApplianceStatistics {
-static constexpr ClusterId Id = 0x0B03;
+static constexpr ClusterId Id = 0x00000B03;
 } // namespace ApplianceStatistics
 namespace ElectricalMeasurement {
-static constexpr ClusterId Id = 0x0B04;
+static constexpr ClusterId Id = 0x00000B04;
 } // namespace ElectricalMeasurement
 namespace Binding {
-static constexpr ClusterId Id = 0xF000;
+static constexpr ClusterId Id = 0x0000F000;
 } // namespace Binding
 namespace GroupKeyManagement {
-static constexpr ClusterId Id = 0xF004;
+static constexpr ClusterId Id = 0x0000F004;
 } // namespace GroupKeyManagement
 namespace SampleMfgSpecificCluster {
-static constexpr ClusterId Id = 0xFC00;
+static constexpr ClusterId Id = 0x1002FC00;
 } // namespace SampleMfgSpecificCluster
 namespace SampleMfgSpecificCluster2 {
-static constexpr ClusterId Id = 0xFC00;
+static constexpr ClusterId Id = 0x1049FC00;
 } // namespace SampleMfgSpecificCluster2
 
 } // namespace Clusters

--- a/src/app/common/gen/ids/Commands.h
+++ b/src/app/common/gen/ids/Commands.h
@@ -28,29 +28,29 @@ namespace Clusters {
 namespace Globals {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ReadAttributes                     = 0x00;
-static constexpr CommandId ReadAttributesResponse             = 0x01;
-static constexpr CommandId WriteAttributes                    = 0x02;
-static constexpr CommandId WriteAttributesUndivided           = 0x03;
-static constexpr CommandId WriteAttributesResponse            = 0x04;
-static constexpr CommandId WriteAttributesNoResponse          = 0x05;
-static constexpr CommandId ConfigureReporting                 = 0x06;
-static constexpr CommandId ConfigureReportingResponse         = 0x07;
-static constexpr CommandId ReadReportingConfiguration         = 0x08;
-static constexpr CommandId ReadReportingConfigurationResponse = 0x09;
-static constexpr CommandId ReportAttributes                   = 0x0A;
-static constexpr CommandId DefaultResponse                    = 0x0B;
-static constexpr CommandId DiscoverAttributes                 = 0x0C;
-static constexpr CommandId DiscoverAttributesResponse         = 0x0D;
-static constexpr CommandId ReadAttributesStructured           = 0x0E;
-static constexpr CommandId WriteAttributesStructured          = 0x0F;
-static constexpr CommandId WriteAttributesStructuredResponse  = 0x10;
-static constexpr CommandId DiscoverCommandsReceived           = 0x11;
-static constexpr CommandId DiscoverCommandsReceivedResponse   = 0x12;
-static constexpr CommandId DiscoverCommandsGenerated          = 0x13;
-static constexpr CommandId DiscoverCommandsGeneratedResponse  = 0x14;
-static constexpr CommandId DiscoverAttributesExtended         = 0x15;
-static constexpr CommandId DiscoverAttributesExtendedResponse = 0x16;
+static constexpr CommandId ReadAttributes                     = 0x00000000;
+static constexpr CommandId ReadAttributesResponse             = 0x00000001;
+static constexpr CommandId WriteAttributes                    = 0x00000002;
+static constexpr CommandId WriteAttributesUndivided           = 0x00000003;
+static constexpr CommandId WriteAttributesResponse            = 0x00000004;
+static constexpr CommandId WriteAttributesNoResponse          = 0x00000005;
+static constexpr CommandId ConfigureReporting                 = 0x00000006;
+static constexpr CommandId ConfigureReportingResponse         = 0x00000007;
+static constexpr CommandId ReadReportingConfiguration         = 0x00000008;
+static constexpr CommandId ReadReportingConfigurationResponse = 0x00000009;
+static constexpr CommandId ReportAttributes                   = 0x0000000A;
+static constexpr CommandId DefaultResponse                    = 0x0000000B;
+static constexpr CommandId DiscoverAttributes                 = 0x0000000C;
+static constexpr CommandId DiscoverAttributesResponse         = 0x0000000D;
+static constexpr CommandId ReadAttributesStructured           = 0x0000000E;
+static constexpr CommandId WriteAttributesStructured          = 0x0000000F;
+static constexpr CommandId WriteAttributesStructuredResponse  = 0x00000010;
+static constexpr CommandId DiscoverCommandsReceived           = 0x00000011;
+static constexpr CommandId DiscoverCommandsReceivedResponse   = 0x00000012;
+static constexpr CommandId DiscoverCommandsGenerated          = 0x00000013;
+static constexpr CommandId DiscoverCommandsGeneratedResponse  = 0x00000014;
+static constexpr CommandId DiscoverAttributesExtended         = 0x00000015;
+static constexpr CommandId DiscoverAttributesExtendedResponse = 0x00000016;
 } // namespace Ids
 } // namespace Commands
 } // namespace Globals
@@ -58,12 +58,12 @@ static constexpr CommandId DiscoverAttributesExtendedResponse = 0x16;
 namespace Identify {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Identify              = 0x00;
-static constexpr CommandId IdentifyQueryResponse = 0x00;
-static constexpr CommandId IdentifyQuery         = 0x01;
-static constexpr CommandId EZModeInvoke          = 0x02;
-static constexpr CommandId UpdateCommissionState = 0x03;
-static constexpr CommandId TriggerEffect         = 0x40;
+static constexpr CommandId Identify              = 0x00000000;
+static constexpr CommandId IdentifyQueryResponse = 0x00000000;
+static constexpr CommandId IdentifyQuery         = 0x00000001;
+static constexpr CommandId EZModeInvoke          = 0x00000002;
+static constexpr CommandId UpdateCommissionState = 0x00000003;
+static constexpr CommandId TriggerEffect         = 0x00000040;
 } // namespace Ids
 } // namespace Commands
 } // namespace Identify
@@ -71,16 +71,16 @@ static constexpr CommandId TriggerEffect         = 0x40;
 namespace Groups {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId AddGroup                   = 0x00;
-static constexpr CommandId AddGroupResponse           = 0x00;
-static constexpr CommandId ViewGroup                  = 0x01;
-static constexpr CommandId ViewGroupResponse          = 0x01;
-static constexpr CommandId GetGroupMembership         = 0x02;
-static constexpr CommandId GetGroupMembershipResponse = 0x02;
-static constexpr CommandId RemoveGroup                = 0x03;
-static constexpr CommandId RemoveGroupResponse        = 0x03;
-static constexpr CommandId RemoveAllGroups            = 0x04;
-static constexpr CommandId AddGroupIfIdentifying      = 0x05;
+static constexpr CommandId AddGroup                   = 0x00000000;
+static constexpr CommandId AddGroupResponse           = 0x00000000;
+static constexpr CommandId ViewGroup                  = 0x00000001;
+static constexpr CommandId ViewGroupResponse          = 0x00000001;
+static constexpr CommandId GetGroupMembership         = 0x00000002;
+static constexpr CommandId GetGroupMembershipResponse = 0x00000002;
+static constexpr CommandId RemoveGroup                = 0x00000003;
+static constexpr CommandId RemoveGroupResponse        = 0x00000003;
+static constexpr CommandId RemoveAllGroups            = 0x00000004;
+static constexpr CommandId AddGroupIfIdentifying      = 0x00000005;
 } // namespace Ids
 } // namespace Commands
 } // namespace Groups
@@ -88,25 +88,25 @@ static constexpr CommandId AddGroupIfIdentifying      = 0x05;
 namespace Scenes {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId AddScene                   = 0x00;
-static constexpr CommandId AddSceneResponse           = 0x00;
-static constexpr CommandId ViewScene                  = 0x01;
-static constexpr CommandId ViewSceneResponse          = 0x01;
-static constexpr CommandId RemoveScene                = 0x02;
-static constexpr CommandId RemoveSceneResponse        = 0x02;
-static constexpr CommandId RemoveAllScenes            = 0x03;
-static constexpr CommandId RemoveAllScenesResponse    = 0x03;
-static constexpr CommandId StoreScene                 = 0x04;
-static constexpr CommandId StoreSceneResponse         = 0x04;
-static constexpr CommandId RecallScene                = 0x05;
-static constexpr CommandId GetSceneMembership         = 0x06;
-static constexpr CommandId GetSceneMembershipResponse = 0x06;
-static constexpr CommandId EnhancedAddScene           = 0x40;
-static constexpr CommandId EnhancedAddSceneResponse   = 0x40;
-static constexpr CommandId EnhancedViewScene          = 0x41;
-static constexpr CommandId EnhancedViewSceneResponse  = 0x41;
-static constexpr CommandId CopyScene                  = 0x42;
-static constexpr CommandId CopySceneResponse          = 0x42;
+static constexpr CommandId AddScene                   = 0x00000000;
+static constexpr CommandId AddSceneResponse           = 0x00000000;
+static constexpr CommandId ViewScene                  = 0x00000001;
+static constexpr CommandId ViewSceneResponse          = 0x00000001;
+static constexpr CommandId RemoveScene                = 0x00000002;
+static constexpr CommandId RemoveSceneResponse        = 0x00000002;
+static constexpr CommandId RemoveAllScenes            = 0x00000003;
+static constexpr CommandId RemoveAllScenesResponse    = 0x00000003;
+static constexpr CommandId StoreScene                 = 0x00000004;
+static constexpr CommandId StoreSceneResponse         = 0x00000004;
+static constexpr CommandId RecallScene                = 0x00000005;
+static constexpr CommandId GetSceneMembership         = 0x00000006;
+static constexpr CommandId GetSceneMembershipResponse = 0x00000006;
+static constexpr CommandId EnhancedAddScene           = 0x00000040;
+static constexpr CommandId EnhancedAddSceneResponse   = 0x00000040;
+static constexpr CommandId EnhancedViewScene          = 0x00000041;
+static constexpr CommandId EnhancedViewSceneResponse  = 0x00000041;
+static constexpr CommandId CopyScene                  = 0x00000042;
+static constexpr CommandId CopySceneResponse          = 0x00000042;
 } // namespace Ids
 } // namespace Commands
 } // namespace Scenes
@@ -114,17 +114,17 @@ static constexpr CommandId CopySceneResponse          = 0x42;
 namespace OnOff {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Off                                    = 0x00;
-static constexpr CommandId SampleMfgSpecificOffWithTransition     = 0x00;
-static constexpr CommandId On                                     = 0x01;
-static constexpr CommandId SampleMfgSpecificOnWithTransition      = 0x01;
-static constexpr CommandId SampleMfgSpecificOnWithTransition2     = 0x01;
-static constexpr CommandId Toggle                                 = 0x02;
-static constexpr CommandId SampleMfgSpecificToggleWithTransition  = 0x02;
-static constexpr CommandId SampleMfgSpecificToggleWithTransition2 = 0x02;
-static constexpr CommandId OffWithEffect                          = 0x40;
-static constexpr CommandId OnWithRecallGlobalScene                = 0x41;
-static constexpr CommandId OnWithTimedOff                         = 0x42;
+static constexpr CommandId Off                                    = 0x00000000;
+static constexpr CommandId SampleMfgSpecificOffWithTransition     = 0x10020000;
+static constexpr CommandId On                                     = 0x00000001;
+static constexpr CommandId SampleMfgSpecificOnWithTransition      = 0x10020001;
+static constexpr CommandId SampleMfgSpecificOnWithTransition2     = 0x10490001;
+static constexpr CommandId Toggle                                 = 0x00000002;
+static constexpr CommandId SampleMfgSpecificToggleWithTransition  = 0x10020002;
+static constexpr CommandId SampleMfgSpecificToggleWithTransition2 = 0x10490002;
+static constexpr CommandId OffWithEffect                          = 0x00000040;
+static constexpr CommandId OnWithRecallGlobalScene                = 0x00000041;
+static constexpr CommandId OnWithTimedOff                         = 0x00000042;
 } // namespace Ids
 } // namespace Commands
 } // namespace OnOff
@@ -132,14 +132,14 @@ static constexpr CommandId OnWithTimedOff                         = 0x42;
 namespace LevelControl {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId MoveToLevel          = 0x00;
-static constexpr CommandId Move                 = 0x01;
-static constexpr CommandId Step                 = 0x02;
-static constexpr CommandId Stop                 = 0x03;
-static constexpr CommandId MoveToLevelWithOnOff = 0x04;
-static constexpr CommandId MoveWithOnOff        = 0x05;
-static constexpr CommandId StepWithOnOff        = 0x06;
-static constexpr CommandId StopWithOnOff        = 0x07;
+static constexpr CommandId MoveToLevel          = 0x00000000;
+static constexpr CommandId Move                 = 0x00000001;
+static constexpr CommandId Step                 = 0x00000002;
+static constexpr CommandId Stop                 = 0x00000003;
+static constexpr CommandId MoveToLevelWithOnOff = 0x00000004;
+static constexpr CommandId MoveWithOnOff        = 0x00000005;
+static constexpr CommandId StepWithOnOff        = 0x00000006;
+static constexpr CommandId StopWithOnOff        = 0x00000007;
 } // namespace Ids
 } // namespace Commands
 } // namespace LevelControl
@@ -147,12 +147,12 @@ static constexpr CommandId StopWithOnOff        = 0x07;
 namespace Alarms {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ResetAlarm       = 0x00;
-static constexpr CommandId Alarm            = 0x00;
-static constexpr CommandId ResetAllAlarms   = 0x01;
-static constexpr CommandId GetAlarmResponse = 0x01;
-static constexpr CommandId GetAlarm         = 0x02;
-static constexpr CommandId ResetAlarmLog    = 0x03;
+static constexpr CommandId ResetAlarm       = 0x00000000;
+static constexpr CommandId Alarm            = 0x00000000;
+static constexpr CommandId ResetAllAlarms   = 0x00000001;
+static constexpr CommandId GetAlarmResponse = 0x00000001;
+static constexpr CommandId GetAlarm         = 0x00000002;
+static constexpr CommandId ResetAlarmLog    = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace Alarms
@@ -160,27 +160,27 @@ static constexpr CommandId ResetAlarmLog    = 0x03;
 namespace PowerProfile {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId PowerProfileRequest                         = 0x00;
-static constexpr CommandId PowerProfileNotification                    = 0x00;
-static constexpr CommandId PowerProfileStateRequest                    = 0x01;
-static constexpr CommandId PowerProfileResponse                        = 0x01;
-static constexpr CommandId GetPowerProfilePriceResponse                = 0x02;
-static constexpr CommandId PowerProfileStateResponse                   = 0x02;
-static constexpr CommandId GetOverallSchedulePriceResponse             = 0x03;
-static constexpr CommandId GetPowerProfilePrice                        = 0x03;
-static constexpr CommandId EnergyPhasesScheduleNotification            = 0x04;
-static constexpr CommandId PowerProfilesStateNotification              = 0x04;
-static constexpr CommandId EnergyPhasesScheduleResponse                = 0x05;
-static constexpr CommandId GetOverallSchedulePrice                     = 0x05;
-static constexpr CommandId PowerProfileScheduleConstraintsRequest      = 0x06;
-static constexpr CommandId EnergyPhasesScheduleRequest                 = 0x06;
-static constexpr CommandId EnergyPhasesScheduleStateRequest            = 0x07;
-static constexpr CommandId EnergyPhasesScheduleStateResponse           = 0x07;
-static constexpr CommandId GetPowerProfilePriceExtendedResponse        = 0x08;
-static constexpr CommandId EnergyPhasesScheduleStateNotification       = 0x08;
-static constexpr CommandId PowerProfileScheduleConstraintsNotification = 0x09;
-static constexpr CommandId PowerProfileScheduleConstraintsResponse     = 0x0A;
-static constexpr CommandId GetPowerProfilePriceExtended                = 0x0B;
+static constexpr CommandId PowerProfileRequest                         = 0x00000000;
+static constexpr CommandId PowerProfileNotification                    = 0x00000000;
+static constexpr CommandId PowerProfileStateRequest                    = 0x00000001;
+static constexpr CommandId PowerProfileResponse                        = 0x00000001;
+static constexpr CommandId GetPowerProfilePriceResponse                = 0x00000002;
+static constexpr CommandId PowerProfileStateResponse                   = 0x00000002;
+static constexpr CommandId GetOverallSchedulePriceResponse             = 0x00000003;
+static constexpr CommandId GetPowerProfilePrice                        = 0x00000003;
+static constexpr CommandId EnergyPhasesScheduleNotification            = 0x00000004;
+static constexpr CommandId PowerProfilesStateNotification              = 0x00000004;
+static constexpr CommandId EnergyPhasesScheduleResponse                = 0x00000005;
+static constexpr CommandId GetOverallSchedulePrice                     = 0x00000005;
+static constexpr CommandId PowerProfileScheduleConstraintsRequest      = 0x00000006;
+static constexpr CommandId EnergyPhasesScheduleRequest                 = 0x00000006;
+static constexpr CommandId EnergyPhasesScheduleStateRequest            = 0x00000007;
+static constexpr CommandId EnergyPhasesScheduleStateResponse           = 0x00000007;
+static constexpr CommandId GetPowerProfilePriceExtendedResponse        = 0x00000008;
+static constexpr CommandId EnergyPhasesScheduleStateNotification       = 0x00000008;
+static constexpr CommandId PowerProfileScheduleConstraintsNotification = 0x00000009;
+static constexpr CommandId PowerProfileScheduleConstraintsResponse     = 0x0000000A;
+static constexpr CommandId GetPowerProfilePriceExtended                = 0x0000000B;
 } // namespace Ids
 } // namespace Commands
 } // namespace PowerProfile
@@ -188,14 +188,14 @@ static constexpr CommandId GetPowerProfilePriceExtended                = 0x0B;
 namespace ApplianceControl {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ExecutionOfACommand     = 0x00;
-static constexpr CommandId SignalStateResponse     = 0x00;
-static constexpr CommandId SignalState             = 0x01;
-static constexpr CommandId SignalStateNotification = 0x01;
-static constexpr CommandId WriteFunctions          = 0x02;
-static constexpr CommandId OverloadPauseResume     = 0x03;
-static constexpr CommandId OverloadPause           = 0x04;
-static constexpr CommandId OverloadWarning         = 0x05;
+static constexpr CommandId ExecutionOfACommand     = 0x00000000;
+static constexpr CommandId SignalStateResponse     = 0x00000000;
+static constexpr CommandId SignalState             = 0x00000001;
+static constexpr CommandId SignalStateNotification = 0x00000001;
+static constexpr CommandId WriteFunctions          = 0x00000002;
+static constexpr CommandId OverloadPauseResume     = 0x00000003;
+static constexpr CommandId OverloadPause           = 0x00000004;
+static constexpr CommandId OverloadWarning         = 0x00000005;
 } // namespace Ids
 } // namespace Commands
 } // namespace ApplianceControl
@@ -203,11 +203,11 @@ static constexpr CommandId OverloadWarning         = 0x05;
 namespace PollControl {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId CheckIn              = 0x00;
-static constexpr CommandId CheckInResponse      = 0x00;
-static constexpr CommandId FastPollStop         = 0x01;
-static constexpr CommandId SetLongPollInterval  = 0x02;
-static constexpr CommandId SetShortPollInterval = 0x03;
+static constexpr CommandId CheckIn              = 0x00000000;
+static constexpr CommandId CheckInResponse      = 0x00000000;
+static constexpr CommandId FastPollStop         = 0x00000001;
+static constexpr CommandId SetLongPollInterval  = 0x00000002;
+static constexpr CommandId SetShortPollInterval = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace PollControl
@@ -215,10 +215,10 @@ static constexpr CommandId SetShortPollInterval = 0x03;
 namespace Basic {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId StartUp         = 0x00;
-static constexpr CommandId MfgSpecificPing = 0x00;
-static constexpr CommandId ShutDown        = 0x01;
-static constexpr CommandId Leave           = 0x02;
+static constexpr CommandId StartUp         = 0x00000000;
+static constexpr CommandId MfgSpecificPing = 0x10020000;
+static constexpr CommandId ShutDown        = 0x00000001;
+static constexpr CommandId Leave           = 0x00000002;
 } // namespace Ids
 } // namespace Commands
 } // namespace Basic
@@ -226,11 +226,11 @@ static constexpr CommandId Leave           = 0x02;
 namespace OtaSoftwareUpdateProvider {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId QueryImage                 = 0x00;
-static constexpr CommandId ApplyUpdateRequest         = 0x01;
-static constexpr CommandId NotifyUpdateApplied        = 0x02;
-static constexpr CommandId QueryImageResponse         = 0x03;
-static constexpr CommandId ApplyUpdateRequestResponse = 0x04;
+static constexpr CommandId QueryImage                 = 0x00000000;
+static constexpr CommandId ApplyUpdateRequest         = 0x00000001;
+static constexpr CommandId NotifyUpdateApplied        = 0x00000002;
+static constexpr CommandId QueryImageResponse         = 0x00000003;
+static constexpr CommandId ApplyUpdateRequestResponse = 0x00000004;
 } // namespace Ids
 } // namespace Commands
 } // namespace OtaSoftwareUpdateProvider
@@ -238,7 +238,7 @@ static constexpr CommandId ApplyUpdateRequestResponse = 0x04;
 namespace OtaSoftwareUpdateRequestor {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId AnnounceOtaProvider = 0x00;
+static constexpr CommandId AnnounceOtaProvider = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace OtaSoftwareUpdateRequestor
@@ -246,12 +246,12 @@ static constexpr CommandId AnnounceOtaProvider = 0x00;
 namespace GeneralCommissioning {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ArmFailSafe                   = 0x00;
-static constexpr CommandId ArmFailSafeResponse           = 0x01;
-static constexpr CommandId SetRegulatoryConfig           = 0x02;
-static constexpr CommandId SetRegulatoryConfigResponse   = 0x03;
-static constexpr CommandId CommissioningComplete         = 0x04;
-static constexpr CommandId CommissioningCompleteResponse = 0x05;
+static constexpr CommandId ArmFailSafe                   = 0x00000000;
+static constexpr CommandId ArmFailSafeResponse           = 0x00000001;
+static constexpr CommandId SetRegulatoryConfig           = 0x00000002;
+static constexpr CommandId SetRegulatoryConfigResponse   = 0x00000003;
+static constexpr CommandId CommissioningComplete         = 0x00000004;
+static constexpr CommandId CommissioningCompleteResponse = 0x00000005;
 } // namespace Ids
 } // namespace Commands
 } // namespace GeneralCommissioning
@@ -259,23 +259,23 @@ static constexpr CommandId CommissioningCompleteResponse = 0x05;
 namespace NetworkCommissioning {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ScanNetworks                      = 0x00;
-static constexpr CommandId ScanNetworksResponse              = 0x01;
-static constexpr CommandId AddWiFiNetwork                    = 0x02;
-static constexpr CommandId AddWiFiNetworkResponse            = 0x03;
-static constexpr CommandId UpdateWiFiNetwork                 = 0x04;
-static constexpr CommandId UpdateWiFiNetworkResponse         = 0x05;
-static constexpr CommandId AddThreadNetwork                  = 0x06;
-static constexpr CommandId AddThreadNetworkResponse          = 0x07;
-static constexpr CommandId UpdateThreadNetwork               = 0x08;
-static constexpr CommandId UpdateThreadNetworkResponse       = 0x09;
-static constexpr CommandId RemoveNetwork                     = 0x0A;
-static constexpr CommandId RemoveNetworkResponse             = 0x0B;
-static constexpr CommandId EnableNetwork                     = 0x0C;
-static constexpr CommandId EnableNetworkResponse             = 0x0D;
-static constexpr CommandId DisableNetwork                    = 0x0E;
-static constexpr CommandId DisableNetworkResponse            = 0x0F;
-static constexpr CommandId GetLastNetworkCommissioningResult = 0x10;
+static constexpr CommandId ScanNetworks                      = 0x00000000;
+static constexpr CommandId ScanNetworksResponse              = 0x00000001;
+static constexpr CommandId AddWiFiNetwork                    = 0x00000002;
+static constexpr CommandId AddWiFiNetworkResponse            = 0x00000003;
+static constexpr CommandId UpdateWiFiNetwork                 = 0x00000004;
+static constexpr CommandId UpdateWiFiNetworkResponse         = 0x00000005;
+static constexpr CommandId AddThreadNetwork                  = 0x00000006;
+static constexpr CommandId AddThreadNetworkResponse          = 0x00000007;
+static constexpr CommandId UpdateThreadNetwork               = 0x00000008;
+static constexpr CommandId UpdateThreadNetworkResponse       = 0x00000009;
+static constexpr CommandId RemoveNetwork                     = 0x0000000A;
+static constexpr CommandId RemoveNetworkResponse             = 0x0000000B;
+static constexpr CommandId EnableNetwork                     = 0x0000000C;
+static constexpr CommandId EnableNetworkResponse             = 0x0000000D;
+static constexpr CommandId DisableNetwork                    = 0x0000000E;
+static constexpr CommandId DisableNetworkResponse            = 0x0000000F;
+static constexpr CommandId GetLastNetworkCommissioningResult = 0x00000010;
 } // namespace Ids
 } // namespace Commands
 } // namespace NetworkCommissioning
@@ -283,8 +283,8 @@ static constexpr CommandId GetLastNetworkCommissioningResult = 0x10;
 namespace DiagnosticLogs {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId RetrieveLogsRequest  = 0x00;
-static constexpr CommandId RetrieveLogsResponse = 0x01;
+static constexpr CommandId RetrieveLogsRequest  = 0x00000000;
+static constexpr CommandId RetrieveLogsResponse = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace DiagnosticLogs
@@ -292,7 +292,7 @@ static constexpr CommandId RetrieveLogsResponse = 0x01;
 namespace SoftwareDiagnostics {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ResetWatermarks = 0x00;
+static constexpr CommandId ResetWatermarks = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace SoftwareDiagnostics
@@ -300,7 +300,7 @@ static constexpr CommandId ResetWatermarks = 0x00;
 namespace ThreadNetworkDiagnostics {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ResetCounts = 0x00;
+static constexpr CommandId ResetCounts = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace ThreadNetworkDiagnostics
@@ -308,7 +308,7 @@ static constexpr CommandId ResetCounts = 0x00;
 namespace WiFiNetworkDiagnostics {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ResetCounts = 0x00;
+static constexpr CommandId ResetCounts = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace WiFiNetworkDiagnostics
@@ -316,7 +316,7 @@ static constexpr CommandId ResetCounts = 0x00;
 namespace EthernetNetworkDiagnostics {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ResetCounts = 0x00;
+static constexpr CommandId ResetCounts = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace EthernetNetworkDiagnostics
@@ -324,10 +324,10 @@ static constexpr CommandId ResetCounts = 0x00;
 namespace BridgedDeviceBasic {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId StartUp          = 0x00;
-static constexpr CommandId ShutDown         = 0x01;
-static constexpr CommandId Leave            = 0x02;
-static constexpr CommandId ReachableChanged = 0x03;
+static constexpr CommandId StartUp          = 0x00000000;
+static constexpr CommandId ShutDown         = 0x00000001;
+static constexpr CommandId Leave            = 0x00000002;
+static constexpr CommandId ReachableChanged = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace BridgedDeviceBasic
@@ -335,17 +335,17 @@ static constexpr CommandId ReachableChanged = 0x03;
 namespace OperationalCredentials {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId SetFabric                    = 0x00;
-static constexpr CommandId SetFabricResponse            = 0x01;
-static constexpr CommandId OpCSRRequest                 = 0x04;
-static constexpr CommandId OpCSRResponse                = 0x05;
-static constexpr CommandId AddOpCert                    = 0x06;
-static constexpr CommandId OpCertResponse               = 0x08;
-static constexpr CommandId UpdateFabricLabel            = 0x09;
-static constexpr CommandId RemoveFabric                 = 0x0A;
-static constexpr CommandId RemoveAllFabrics             = 0x0B;
-static constexpr CommandId AddTrustedRootCertificate    = 0xA1;
-static constexpr CommandId RemoveTrustedRootCertificate = 0xA2;
+static constexpr CommandId SetFabric                    = 0x00000000;
+static constexpr CommandId SetFabricResponse            = 0x00000001;
+static constexpr CommandId OpCSRRequest                 = 0x00000004;
+static constexpr CommandId OpCSRResponse                = 0x00000005;
+static constexpr CommandId AddOpCert                    = 0x00000006;
+static constexpr CommandId OpCertResponse               = 0x00000008;
+static constexpr CommandId UpdateFabricLabel            = 0x00000009;
+static constexpr CommandId RemoveFabric                 = 0x0000000A;
+static constexpr CommandId RemoveAllFabrics             = 0x0000000B;
+static constexpr CommandId AddTrustedRootCertificate    = 0x000000A1;
+static constexpr CommandId RemoveTrustedRootCertificate = 0x000000A2;
 } // namespace Ids
 } // namespace Commands
 } // namespace OperationalCredentials
@@ -353,60 +353,60 @@ static constexpr CommandId RemoveTrustedRootCertificate = 0xA2;
 namespace DoorLock {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId LockDoor                     = 0x00;
-static constexpr CommandId LockDoorResponse             = 0x00;
-static constexpr CommandId UnlockDoor                   = 0x01;
-static constexpr CommandId UnlockDoorResponse           = 0x01;
-static constexpr CommandId Toggle                       = 0x02;
-static constexpr CommandId ToggleResponse               = 0x02;
-static constexpr CommandId UnlockWithTimeout            = 0x03;
-static constexpr CommandId UnlockWithTimeoutResponse    = 0x03;
-static constexpr CommandId GetLogRecord                 = 0x04;
-static constexpr CommandId GetLogRecordResponse         = 0x04;
-static constexpr CommandId SetPin                       = 0x05;
-static constexpr CommandId SetPinResponse               = 0x05;
-static constexpr CommandId GetPin                       = 0x06;
-static constexpr CommandId GetPinResponse               = 0x06;
-static constexpr CommandId ClearPin                     = 0x07;
-static constexpr CommandId ClearPinResponse             = 0x07;
-static constexpr CommandId ClearAllPins                 = 0x08;
-static constexpr CommandId ClearAllPinsResponse         = 0x08;
-static constexpr CommandId SetUserStatus                = 0x09;
-static constexpr CommandId SetUserStatusResponse        = 0x09;
-static constexpr CommandId GetUserStatus                = 0x0A;
-static constexpr CommandId GetUserStatusResponse        = 0x0A;
-static constexpr CommandId SetWeekdaySchedule           = 0x0B;
-static constexpr CommandId SetWeekdayScheduleResponse   = 0x0B;
-static constexpr CommandId GetWeekdaySchedule           = 0x0C;
-static constexpr CommandId GetWeekdayScheduleResponse   = 0x0C;
-static constexpr CommandId ClearWeekdaySchedule         = 0x0D;
-static constexpr CommandId ClearWeekdayScheduleResponse = 0x0D;
-static constexpr CommandId SetYeardaySchedule           = 0x0E;
-static constexpr CommandId SetYeardayScheduleResponse   = 0x0E;
-static constexpr CommandId GetYeardaySchedule           = 0x0F;
-static constexpr CommandId GetYeardayScheduleResponse   = 0x0F;
-static constexpr CommandId ClearYeardaySchedule         = 0x10;
-static constexpr CommandId ClearYeardayScheduleResponse = 0x10;
-static constexpr CommandId SetHolidaySchedule           = 0x11;
-static constexpr CommandId SetHolidayScheduleResponse   = 0x11;
-static constexpr CommandId GetHolidaySchedule           = 0x12;
-static constexpr CommandId GetHolidayScheduleResponse   = 0x12;
-static constexpr CommandId ClearHolidaySchedule         = 0x13;
-static constexpr CommandId ClearHolidayScheduleResponse = 0x13;
-static constexpr CommandId SetUserType                  = 0x14;
-static constexpr CommandId SetUserTypeResponse          = 0x14;
-static constexpr CommandId GetUserType                  = 0x15;
-static constexpr CommandId GetUserTypeResponse          = 0x15;
-static constexpr CommandId SetRfid                      = 0x16;
-static constexpr CommandId SetRfidResponse              = 0x16;
-static constexpr CommandId GetRfid                      = 0x17;
-static constexpr CommandId GetRfidResponse              = 0x17;
-static constexpr CommandId ClearRfid                    = 0x18;
-static constexpr CommandId ClearRfidResponse            = 0x18;
-static constexpr CommandId ClearAllRfids                = 0x19;
-static constexpr CommandId ClearAllRfidsResponse        = 0x19;
-static constexpr CommandId OperationEventNotification   = 0x20;
-static constexpr CommandId ProgrammingEventNotification = 0x21;
+static constexpr CommandId LockDoor                     = 0x00000000;
+static constexpr CommandId LockDoorResponse             = 0x00000000;
+static constexpr CommandId UnlockDoor                   = 0x00000001;
+static constexpr CommandId UnlockDoorResponse           = 0x00000001;
+static constexpr CommandId Toggle                       = 0x00000002;
+static constexpr CommandId ToggleResponse               = 0x00000002;
+static constexpr CommandId UnlockWithTimeout            = 0x00000003;
+static constexpr CommandId UnlockWithTimeoutResponse    = 0x00000003;
+static constexpr CommandId GetLogRecord                 = 0x00000004;
+static constexpr CommandId GetLogRecordResponse         = 0x00000004;
+static constexpr CommandId SetPin                       = 0x00000005;
+static constexpr CommandId SetPinResponse               = 0x00000005;
+static constexpr CommandId GetPin                       = 0x00000006;
+static constexpr CommandId GetPinResponse               = 0x00000006;
+static constexpr CommandId ClearPin                     = 0x00000007;
+static constexpr CommandId ClearPinResponse             = 0x00000007;
+static constexpr CommandId ClearAllPins                 = 0x00000008;
+static constexpr CommandId ClearAllPinsResponse         = 0x00000008;
+static constexpr CommandId SetUserStatus                = 0x00000009;
+static constexpr CommandId SetUserStatusResponse        = 0x00000009;
+static constexpr CommandId GetUserStatus                = 0x0000000A;
+static constexpr CommandId GetUserStatusResponse        = 0x0000000A;
+static constexpr CommandId SetWeekdaySchedule           = 0x0000000B;
+static constexpr CommandId SetWeekdayScheduleResponse   = 0x0000000B;
+static constexpr CommandId GetWeekdaySchedule           = 0x0000000C;
+static constexpr CommandId GetWeekdayScheduleResponse   = 0x0000000C;
+static constexpr CommandId ClearWeekdaySchedule         = 0x0000000D;
+static constexpr CommandId ClearWeekdayScheduleResponse = 0x0000000D;
+static constexpr CommandId SetYeardaySchedule           = 0x0000000E;
+static constexpr CommandId SetYeardayScheduleResponse   = 0x0000000E;
+static constexpr CommandId GetYeardaySchedule           = 0x0000000F;
+static constexpr CommandId GetYeardayScheduleResponse   = 0x0000000F;
+static constexpr CommandId ClearYeardaySchedule         = 0x00000010;
+static constexpr CommandId ClearYeardayScheduleResponse = 0x00000010;
+static constexpr CommandId SetHolidaySchedule           = 0x00000011;
+static constexpr CommandId SetHolidayScheduleResponse   = 0x00000011;
+static constexpr CommandId GetHolidaySchedule           = 0x00000012;
+static constexpr CommandId GetHolidayScheduleResponse   = 0x00000012;
+static constexpr CommandId ClearHolidaySchedule         = 0x00000013;
+static constexpr CommandId ClearHolidayScheduleResponse = 0x00000013;
+static constexpr CommandId SetUserType                  = 0x00000014;
+static constexpr CommandId SetUserTypeResponse          = 0x00000014;
+static constexpr CommandId GetUserType                  = 0x00000015;
+static constexpr CommandId GetUserTypeResponse          = 0x00000015;
+static constexpr CommandId SetRfid                      = 0x00000016;
+static constexpr CommandId SetRfidResponse              = 0x00000016;
+static constexpr CommandId GetRfid                      = 0x00000017;
+static constexpr CommandId GetRfidResponse              = 0x00000017;
+static constexpr CommandId ClearRfid                    = 0x00000018;
+static constexpr CommandId ClearRfidResponse            = 0x00000018;
+static constexpr CommandId ClearAllRfids                = 0x00000019;
+static constexpr CommandId ClearAllRfidsResponse        = 0x00000019;
+static constexpr CommandId OperationEventNotification   = 0x00000020;
+static constexpr CommandId ProgrammingEventNotification = 0x00000021;
 } // namespace Ids
 } // namespace Commands
 } // namespace DoorLock
@@ -414,13 +414,13 @@ static constexpr CommandId ProgrammingEventNotification = 0x21;
 namespace WindowCovering {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId UpOrOpen           = 0x00;
-static constexpr CommandId DownOrClose        = 0x01;
-static constexpr CommandId StopMotion         = 0x02;
-static constexpr CommandId GoToLiftValue      = 0x04;
-static constexpr CommandId GoToLiftPercentage = 0x05;
-static constexpr CommandId GoToTiltValue      = 0x07;
-static constexpr CommandId GoToTiltPercentage = 0x08;
+static constexpr CommandId UpOrOpen           = 0x00000000;
+static constexpr CommandId DownOrClose        = 0x00000001;
+static constexpr CommandId StopMotion         = 0x00000002;
+static constexpr CommandId GoToLiftValue      = 0x00000004;
+static constexpr CommandId GoToLiftPercentage = 0x00000005;
+static constexpr CommandId GoToTiltValue      = 0x00000007;
+static constexpr CommandId GoToTiltPercentage = 0x00000008;
 } // namespace Ids
 } // namespace Commands
 } // namespace WindowCovering
@@ -428,8 +428,8 @@ static constexpr CommandId GoToTiltPercentage = 0x08;
 namespace BarrierControl {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId BarrierControlGoToPercent = 0x00;
-static constexpr CommandId BarrierControlStop        = 0x01;
+static constexpr CommandId BarrierControlGoToPercent = 0x00000000;
+static constexpr CommandId BarrierControlStop        = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace BarrierControl
@@ -437,13 +437,13 @@ static constexpr CommandId BarrierControlStop        = 0x01;
 namespace Thermostat {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId SetpointRaiseLower    = 0x00;
-static constexpr CommandId CurrentWeeklySchedule = 0x00;
-static constexpr CommandId SetWeeklySchedule     = 0x01;
-static constexpr CommandId RelayStatusLog        = 0x01;
-static constexpr CommandId GetWeeklySchedule     = 0x02;
-static constexpr CommandId ClearWeeklySchedule   = 0x03;
-static constexpr CommandId GetRelayStatusLog     = 0x04;
+static constexpr CommandId SetpointRaiseLower    = 0x00000000;
+static constexpr CommandId CurrentWeeklySchedule = 0x00000000;
+static constexpr CommandId SetWeeklySchedule     = 0x00000001;
+static constexpr CommandId RelayStatusLog        = 0x00000001;
+static constexpr CommandId GetWeeklySchedule     = 0x00000002;
+static constexpr CommandId ClearWeeklySchedule   = 0x00000003;
+static constexpr CommandId GetRelayStatusLog     = 0x00000004;
 } // namespace Ids
 } // namespace Commands
 } // namespace Thermostat
@@ -451,25 +451,25 @@ static constexpr CommandId GetRelayStatusLog     = 0x04;
 namespace ColorControl {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId MoveToHue                      = 0x00;
-static constexpr CommandId MoveHue                        = 0x01;
-static constexpr CommandId StepHue                        = 0x02;
-static constexpr CommandId MoveToSaturation               = 0x03;
-static constexpr CommandId MoveSaturation                 = 0x04;
-static constexpr CommandId StepSaturation                 = 0x05;
-static constexpr CommandId MoveToHueAndSaturation         = 0x06;
-static constexpr CommandId MoveToColor                    = 0x07;
-static constexpr CommandId MoveColor                      = 0x08;
-static constexpr CommandId StepColor                      = 0x09;
-static constexpr CommandId MoveToColorTemperature         = 0x0A;
-static constexpr CommandId EnhancedMoveToHue              = 0x40;
-static constexpr CommandId EnhancedMoveHue                = 0x41;
-static constexpr CommandId EnhancedStepHue                = 0x42;
-static constexpr CommandId EnhancedMoveToHueAndSaturation = 0x43;
-static constexpr CommandId ColorLoopSet                   = 0x44;
-static constexpr CommandId StopMoveStep                   = 0x47;
-static constexpr CommandId MoveColorTemperature           = 0x4B;
-static constexpr CommandId StepColorTemperature           = 0x4C;
+static constexpr CommandId MoveToHue                      = 0x00000000;
+static constexpr CommandId MoveHue                        = 0x00000001;
+static constexpr CommandId StepHue                        = 0x00000002;
+static constexpr CommandId MoveToSaturation               = 0x00000003;
+static constexpr CommandId MoveSaturation                 = 0x00000004;
+static constexpr CommandId StepSaturation                 = 0x00000005;
+static constexpr CommandId MoveToHueAndSaturation         = 0x00000006;
+static constexpr CommandId MoveToColor                    = 0x00000007;
+static constexpr CommandId MoveColor                      = 0x00000008;
+static constexpr CommandId StepColor                      = 0x00000009;
+static constexpr CommandId MoveToColorTemperature         = 0x0000000A;
+static constexpr CommandId EnhancedMoveToHue              = 0x00000040;
+static constexpr CommandId EnhancedMoveHue                = 0x00000041;
+static constexpr CommandId EnhancedStepHue                = 0x00000042;
+static constexpr CommandId EnhancedMoveToHueAndSaturation = 0x00000043;
+static constexpr CommandId ColorLoopSet                   = 0x00000044;
+static constexpr CommandId StopMoveStep                   = 0x00000047;
+static constexpr CommandId MoveColorTemperature           = 0x0000004B;
+static constexpr CommandId StepColorTemperature           = 0x0000004C;
 } // namespace Ids
 } // namespace Commands
 } // namespace ColorControl
@@ -477,13 +477,13 @@ static constexpr CommandId StepColorTemperature           = 0x4C;
 namespace IasZone {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ZoneEnrollResponse                  = 0x00;
-static constexpr CommandId ZoneStatusChangeNotification        = 0x00;
-static constexpr CommandId InitiateNormalOperationMode         = 0x01;
-static constexpr CommandId ZoneEnrollRequest                   = 0x01;
-static constexpr CommandId InitiateTestMode                    = 0x02;
-static constexpr CommandId InitiateNormalOperationModeResponse = 0x02;
-static constexpr CommandId InitiateTestModeResponse            = 0x03;
+static constexpr CommandId ZoneEnrollResponse                  = 0x00000000;
+static constexpr CommandId ZoneStatusChangeNotification        = 0x00000000;
+static constexpr CommandId InitiateNormalOperationMode         = 0x00000001;
+static constexpr CommandId ZoneEnrollRequest                   = 0x00000001;
+static constexpr CommandId InitiateTestMode                    = 0x00000002;
+static constexpr CommandId InitiateNormalOperationModeResponse = 0x00000002;
+static constexpr CommandId InitiateTestModeResponse            = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace IasZone
@@ -491,25 +491,25 @@ static constexpr CommandId InitiateTestModeResponse            = 0x03;
 namespace IasAce {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Arm                        = 0x00;
-static constexpr CommandId ArmResponse                = 0x00;
-static constexpr CommandId Bypass                     = 0x01;
-static constexpr CommandId GetZoneIdMapResponse       = 0x01;
-static constexpr CommandId Emergency                  = 0x02;
-static constexpr CommandId GetZoneInformationResponse = 0x02;
-static constexpr CommandId Fire                       = 0x03;
-static constexpr CommandId ZoneStatusChanged          = 0x03;
-static constexpr CommandId Panic                      = 0x04;
-static constexpr CommandId PanelStatusChanged         = 0x04;
-static constexpr CommandId GetZoneIdMap               = 0x05;
-static constexpr CommandId GetPanelStatusResponse     = 0x05;
-static constexpr CommandId GetZoneInformation         = 0x06;
-static constexpr CommandId SetBypassedZoneList        = 0x06;
-static constexpr CommandId GetPanelStatus             = 0x07;
-static constexpr CommandId BypassResponse             = 0x07;
-static constexpr CommandId GetBypassedZoneList        = 0x08;
-static constexpr CommandId GetZoneStatusResponse      = 0x08;
-static constexpr CommandId GetZoneStatus              = 0x09;
+static constexpr CommandId Arm                        = 0x00000000;
+static constexpr CommandId ArmResponse                = 0x00000000;
+static constexpr CommandId Bypass                     = 0x00000001;
+static constexpr CommandId GetZoneIdMapResponse       = 0x00000001;
+static constexpr CommandId Emergency                  = 0x00000002;
+static constexpr CommandId GetZoneInformationResponse = 0x00000002;
+static constexpr CommandId Fire                       = 0x00000003;
+static constexpr CommandId ZoneStatusChanged          = 0x00000003;
+static constexpr CommandId Panic                      = 0x00000004;
+static constexpr CommandId PanelStatusChanged         = 0x00000004;
+static constexpr CommandId GetZoneIdMap               = 0x00000005;
+static constexpr CommandId GetPanelStatusResponse     = 0x00000005;
+static constexpr CommandId GetZoneInformation         = 0x00000006;
+static constexpr CommandId SetBypassedZoneList        = 0x00000006;
+static constexpr CommandId GetPanelStatus             = 0x00000007;
+static constexpr CommandId BypassResponse             = 0x00000007;
+static constexpr CommandId GetBypassedZoneList        = 0x00000008;
+static constexpr CommandId GetZoneStatusResponse      = 0x00000008;
+static constexpr CommandId GetZoneStatus              = 0x00000009;
 } // namespace Ids
 } // namespace Commands
 } // namespace IasAce
@@ -517,8 +517,8 @@ static constexpr CommandId GetZoneStatus              = 0x09;
 namespace IasWd {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId StartWarning = 0x00;
-static constexpr CommandId Squawk       = 0x01;
+static constexpr CommandId StartWarning = 0x00000000;
+static constexpr CommandId Squawk       = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace IasWd
@@ -526,10 +526,10 @@ static constexpr CommandId Squawk       = 0x01;
 namespace TvChannel {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ChangeChannel         = 0x00;
-static constexpr CommandId ChangeChannelResponse = 0x00;
-static constexpr CommandId ChangeChannelByNumber = 0x01;
-static constexpr CommandId SkipChannel           = 0x02;
+static constexpr CommandId ChangeChannel         = 0x00000000;
+static constexpr CommandId ChangeChannelResponse = 0x00000000;
+static constexpr CommandId ChangeChannelByNumber = 0x00000001;
+static constexpr CommandId SkipChannel           = 0x00000002;
 } // namespace Ids
 } // namespace Commands
 } // namespace TvChannel
@@ -537,8 +537,8 @@ static constexpr CommandId SkipChannel           = 0x02;
 namespace TargetNavigator {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId NavigateTarget         = 0x00;
-static constexpr CommandId NavigateTargetResponse = 0x00;
+static constexpr CommandId NavigateTarget         = 0x00000000;
+static constexpr CommandId NavigateTargetResponse = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace TargetNavigator
@@ -546,28 +546,28 @@ static constexpr CommandId NavigateTargetResponse = 0x00;
 namespace MediaPlayback {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId MediaPlay                 = 0x00;
-static constexpr CommandId MediaPlayResponse         = 0x00;
-static constexpr CommandId MediaPause                = 0x01;
-static constexpr CommandId MediaPauseResponse        = 0x01;
-static constexpr CommandId MediaStop                 = 0x02;
-static constexpr CommandId MediaStopResponse         = 0x02;
-static constexpr CommandId MediaStartOver            = 0x03;
-static constexpr CommandId MediaStartOverResponse    = 0x03;
-static constexpr CommandId MediaPrevious             = 0x04;
-static constexpr CommandId MediaPreviousResponse     = 0x04;
-static constexpr CommandId MediaNext                 = 0x05;
-static constexpr CommandId MediaNextResponse         = 0x05;
-static constexpr CommandId MediaRewind               = 0x06;
-static constexpr CommandId MediaRewindResponse       = 0x06;
-static constexpr CommandId MediaFastForward          = 0x07;
-static constexpr CommandId MediaFastForwardResponse  = 0x07;
-static constexpr CommandId MediaSkipForward          = 0x08;
-static constexpr CommandId MediaSkipForwardResponse  = 0x08;
-static constexpr CommandId MediaSkipBackward         = 0x09;
-static constexpr CommandId MediaSkipBackwardResponse = 0x09;
-static constexpr CommandId MediaSeek                 = 0x0A;
-static constexpr CommandId MediaSeekResponse         = 0x0B;
+static constexpr CommandId MediaPlay                 = 0x00000000;
+static constexpr CommandId MediaPlayResponse         = 0x00000000;
+static constexpr CommandId MediaPause                = 0x00000001;
+static constexpr CommandId MediaPauseResponse        = 0x00000001;
+static constexpr CommandId MediaStop                 = 0x00000002;
+static constexpr CommandId MediaStopResponse         = 0x00000002;
+static constexpr CommandId MediaStartOver            = 0x00000003;
+static constexpr CommandId MediaStartOverResponse    = 0x00000003;
+static constexpr CommandId MediaPrevious             = 0x00000004;
+static constexpr CommandId MediaPreviousResponse     = 0x00000004;
+static constexpr CommandId MediaNext                 = 0x00000005;
+static constexpr CommandId MediaNextResponse         = 0x00000005;
+static constexpr CommandId MediaRewind               = 0x00000006;
+static constexpr CommandId MediaRewindResponse       = 0x00000006;
+static constexpr CommandId MediaFastForward          = 0x00000007;
+static constexpr CommandId MediaFastForwardResponse  = 0x00000007;
+static constexpr CommandId MediaSkipForward          = 0x00000008;
+static constexpr CommandId MediaSkipForwardResponse  = 0x00000008;
+static constexpr CommandId MediaSkipBackward         = 0x00000009;
+static constexpr CommandId MediaSkipBackwardResponse = 0x00000009;
+static constexpr CommandId MediaSeek                 = 0x0000000A;
+static constexpr CommandId MediaSeekResponse         = 0x0000000B;
 } // namespace Ids
 } // namespace Commands
 } // namespace MediaPlayback
@@ -575,10 +575,10 @@ static constexpr CommandId MediaSeekResponse         = 0x0B;
 namespace MediaInput {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId SelectInput     = 0x00;
-static constexpr CommandId ShowInputStatus = 0x01;
-static constexpr CommandId HideInputStatus = 0x02;
-static constexpr CommandId RenameInput     = 0x03;
+static constexpr CommandId SelectInput     = 0x00000000;
+static constexpr CommandId ShowInputStatus = 0x00000001;
+static constexpr CommandId HideInputStatus = 0x00000002;
+static constexpr CommandId RenameInput     = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace MediaInput
@@ -586,7 +586,7 @@ static constexpr CommandId RenameInput     = 0x03;
 namespace LowPower {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Sleep = 0x00;
+static constexpr CommandId Sleep = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace LowPower
@@ -594,8 +594,8 @@ static constexpr CommandId Sleep = 0x00;
 namespace KeypadInput {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId SendKey         = 0x00;
-static constexpr CommandId SendKeyResponse = 0x00;
+static constexpr CommandId SendKey         = 0x00000000;
+static constexpr CommandId SendKeyResponse = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace KeypadInput
@@ -603,10 +603,10 @@ static constexpr CommandId SendKeyResponse = 0x00;
 namespace ContentLauncher {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId LaunchContent         = 0x00;
-static constexpr CommandId LaunchContentResponse = 0x00;
-static constexpr CommandId LaunchURL             = 0x01;
-static constexpr CommandId LaunchURLResponse     = 0x01;
+static constexpr CommandId LaunchContent         = 0x00000000;
+static constexpr CommandId LaunchContentResponse = 0x00000000;
+static constexpr CommandId LaunchURL             = 0x00000001;
+static constexpr CommandId LaunchURLResponse     = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace ContentLauncher
@@ -614,8 +614,8 @@ static constexpr CommandId LaunchURLResponse     = 0x01;
 namespace AudioOutput {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId SelectOutput = 0x00;
-static constexpr CommandId RenameOutput = 0x01;
+static constexpr CommandId SelectOutput = 0x00000000;
+static constexpr CommandId RenameOutput = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace AudioOutput
@@ -623,8 +623,8 @@ static constexpr CommandId RenameOutput = 0x01;
 namespace ApplicationLauncher {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId LaunchApp         = 0x00;
-static constexpr CommandId LaunchAppResponse = 0x00;
+static constexpr CommandId LaunchApp         = 0x00000000;
+static constexpr CommandId LaunchAppResponse = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace ApplicationLauncher
@@ -632,7 +632,7 @@ static constexpr CommandId LaunchAppResponse = 0x00;
 namespace ApplicationBasic {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId ChangeStatus = 0x00;
+static constexpr CommandId ChangeStatus = 0x00000000;
 } // namespace Ids
 } // namespace Commands
 } // namespace ApplicationBasic
@@ -640,9 +640,9 @@ static constexpr CommandId ChangeStatus = 0x00;
 namespace AccountLogin {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId GetSetupPIN         = 0x00;
-static constexpr CommandId GetSetupPINResponse = 0x00;
-static constexpr CommandId Login               = 0x01;
+static constexpr CommandId GetSetupPIN         = 0x00000000;
+static constexpr CommandId GetSetupPINResponse = 0x00000000;
+static constexpr CommandId Login               = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace AccountLogin
@@ -650,11 +650,11 @@ static constexpr CommandId Login               = 0x01;
 namespace TestCluster {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Test                 = 0x00;
-static constexpr CommandId TestSpecificResponse = 0x00;
-static constexpr CommandId TestNotHandled       = 0x01;
-static constexpr CommandId TestSpecific         = 0x02;
-static constexpr CommandId TestUnknownCommand   = 0x03;
+static constexpr CommandId Test                 = 0x00000000;
+static constexpr CommandId TestSpecificResponse = 0x00000000;
+static constexpr CommandId TestNotHandled       = 0x00000001;
+static constexpr CommandId TestSpecific         = 0x00000002;
+static constexpr CommandId TestUnknownCommand   = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace TestCluster
@@ -662,13 +662,13 @@ static constexpr CommandId TestUnknownCommand   = 0x03;
 namespace Messaging {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId DisplayMessage          = 0x00;
-static constexpr CommandId GetLastMessage          = 0x00;
-static constexpr CommandId CancelMessage           = 0x01;
-static constexpr CommandId MessageConfirmation     = 0x01;
-static constexpr CommandId DisplayProtectedMessage = 0x02;
-static constexpr CommandId GetMessageCancellation  = 0x02;
-static constexpr CommandId CancelAllMessages       = 0x03;
+static constexpr CommandId DisplayMessage          = 0x00000000;
+static constexpr CommandId GetLastMessage          = 0x00000000;
+static constexpr CommandId CancelMessage           = 0x00000001;
+static constexpr CommandId MessageConfirmation     = 0x00000001;
+static constexpr CommandId DisplayProtectedMessage = 0x00000002;
+static constexpr CommandId GetMessageCancellation  = 0x00000002;
+static constexpr CommandId CancelAllMessages       = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace Messaging
@@ -676,10 +676,10 @@ static constexpr CommandId CancelAllMessages       = 0x03;
 namespace ApplianceEventsAndAlert {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId GetAlerts          = 0x00;
-static constexpr CommandId GetAlertsResponse  = 0x00;
-static constexpr CommandId AlertsNotification = 0x01;
-static constexpr CommandId EventsNotification = 0x02;
+static constexpr CommandId GetAlerts          = 0x00000000;
+static constexpr CommandId GetAlertsResponse  = 0x00000000;
+static constexpr CommandId AlertsNotification = 0x00000001;
+static constexpr CommandId EventsNotification = 0x00000002;
 } // namespace Ids
 } // namespace Commands
 } // namespace ApplianceEventsAndAlert
@@ -687,12 +687,12 @@ static constexpr CommandId EventsNotification = 0x02;
 namespace ApplianceStatistics {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId LogNotification     = 0x00;
-static constexpr CommandId LogRequest          = 0x00;
-static constexpr CommandId LogResponse         = 0x01;
-static constexpr CommandId LogQueueRequest     = 0x01;
-static constexpr CommandId LogQueueResponse    = 0x02;
-static constexpr CommandId StatisticsAvailable = 0x03;
+static constexpr CommandId LogNotification     = 0x00000000;
+static constexpr CommandId LogRequest          = 0x00000000;
+static constexpr CommandId LogResponse         = 0x00000001;
+static constexpr CommandId LogQueueRequest     = 0x00000001;
+static constexpr CommandId LogQueueResponse    = 0x00000002;
+static constexpr CommandId StatisticsAvailable = 0x00000003;
 } // namespace Ids
 } // namespace Commands
 } // namespace ApplianceStatistics
@@ -700,10 +700,10 @@ static constexpr CommandId StatisticsAvailable = 0x03;
 namespace ElectricalMeasurement {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId GetProfileInfoResponseCommand        = 0x00;
-static constexpr CommandId GetProfileInfoCommand                = 0x00;
-static constexpr CommandId GetMeasurementProfileResponseCommand = 0x01;
-static constexpr CommandId GetMeasurementProfileCommand         = 0x01;
+static constexpr CommandId GetProfileInfoResponseCommand        = 0x00000000;
+static constexpr CommandId GetProfileInfoCommand                = 0x00000000;
+static constexpr CommandId GetMeasurementProfileResponseCommand = 0x00000001;
+static constexpr CommandId GetMeasurementProfileCommand         = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace ElectricalMeasurement
@@ -711,8 +711,8 @@ static constexpr CommandId GetMeasurementProfileCommand         = 0x01;
 namespace Binding {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId Bind   = 0x00;
-static constexpr CommandId Unbind = 0x01;
+static constexpr CommandId Bind   = 0x00000000;
+static constexpr CommandId Unbind = 0x00000001;
 } // namespace Ids
 } // namespace Commands
 } // namespace Binding
@@ -720,7 +720,7 @@ static constexpr CommandId Unbind = 0x01;
 namespace SampleMfgSpecificCluster {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId CommandOne = 0x00;
+static constexpr CommandId CommandOne = 0x10020000;
 } // namespace Ids
 } // namespace Commands
 } // namespace SampleMfgSpecificCluster
@@ -728,7 +728,7 @@ static constexpr CommandId CommandOne = 0x00;
 namespace SampleMfgSpecificCluster2 {
 namespace Commands {
 namespace Ids {
-static constexpr CommandId CommandTwo = 0x00;
+static constexpr CommandId CommandTwo = 0x10490000;
 } // namespace Ids
 } // namespace Commands
 } // namespace SampleMfgSpecificCluster2

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -317,6 +317,11 @@ function asUpperCamelCase(label)
   return str.replace(/[\.:]/g, '');
 }
 
+function asMEI(prefix, suffix)
+{
+  return cHelper.asHex((prefix << 16) + suffix, 8);
+}
+
 //
 // Module exports
 //
@@ -329,3 +334,4 @@ exports.asTypeLiteralSuffix               = asTypeLiteralSuffix;
 exports.asLowerCamelCase                  = asLowerCamelCase;
 exports.asUpperCamelCase                  = asUpperCamelCase;
 exports.hasSpecificAttributes             = hasSpecificAttributes;
+exports.asMEI                             = asMEI;

--- a/src/app/zap-templates/templates/app/ids/Attributes.zapt
+++ b/src/app/zap-templates/templates/app/ids/Attributes.zapt
@@ -11,7 +11,7 @@ namespace Attributes {
 namespace Ids {
 {{#zcl_attributes_server}}
 {{#unless clusterRef}}
-static constexpr AttributeId {{asUpperCamelCase label}} = {{asHex code 4}};
+static constexpr AttributeId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
 {{/unless}}
 {{/zcl_attributes_server}}
 } // namespace Ids
@@ -28,7 +28,7 @@ namespace Attributes {
 namespace Ids {
 {{/first}}
 {{#if clusterRef}}
-static constexpr AttributeId {{asUpperCamelCase label}} = {{asHex code 4}};
+static constexpr AttributeId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
 {{/if}}
 {{#last}}
 } // namespace Ids

--- a/src/app/zap-templates/templates/app/ids/Clusters.zapt
+++ b/src/app/zap-templates/templates/app/ids/Clusters.zapt
@@ -10,7 +10,7 @@ namespace Clusters {
 
 {{#zcl_clusters}}
 namespace {{asUpperCamelCase label}} {
-static constexpr ClusterId Id = {{asHex code 4}};
+static constexpr ClusterId Id = {{asMEI manufacturerCode code}};
 } // namespace {{asUpperCamelCase label}} {
 {{/zcl_clusters}}
 

--- a/src/app/zap-templates/templates/app/ids/Commands.zapt
+++ b/src/app/zap-templates/templates/app/ids/Commands.zapt
@@ -12,7 +12,7 @@ namespace Globals {
 namespace Commands {
 namespace Ids {
 {{#zcl_global_commands}}
-static constexpr CommandId {{asUpperCamelCase label}} = {{asHex code 2}};
+static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
 {{/zcl_global_commands}}
 } // namespace Ids
 } // namespace Commands
@@ -26,7 +26,7 @@ namespace {{asCamelCased parent.label false}} {
 namespace Commands {
 namespace Ids {
 {{/first}}
-static constexpr CommandId {{asUpperCamelCase label}} = {{asHex code 2}};
+static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode code}};
 {{#last}}
 } // namespace Ids
 } // namespace Commands


### PR DESCRIPTION
#### Problem

Clusters/Commands/Attributes ids does not follow the MEI encoding specified in the specification at https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/0a4a76c4e3d01ae39804a1755e8f97de60698bb6/src/data_model/Data-Model-Namespace.adoc#manufacturer-extensible-identifier-mei

#### Change overview
 * Update the templates to generate ids following the MEI encoding specification
 * Update `gen/` folders

For reviewers, the interesting part is only the first commit. The second commit is the result of running the code generator from the templates.
The interesting change in the generated code is located mostly to the end of the generated files, where manufacturer specific extensions are taken into account.

#### Testing
Sadly the manufacturer specific support of IM does not work yet, so this is hard to test at the moment...