### PR TITLE
Extract OnOff cluster definition from general.xml and zll.xml

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -572,7 +572,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "on/off",
+              "name": "OnOff",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -6602,7 +6602,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "on/off",
+              "name": "OnOff",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -6617,7 +6617,7 @@
               "reportableChange": 0
             },
             {
-              "name": "global scene control",
+              "name": "GlobalSceneControl",
               "code": 16384,
               "mfgCode": null,
               "side": "server",
@@ -6632,7 +6632,7 @@
               "reportableChange": 0
             },
             {
-              "name": "on time",
+              "name": "OnTime",
               "code": 16385,
               "mfgCode": null,
               "side": "server",
@@ -6647,7 +6647,7 @@
               "reportableChange": 0
             },
             {
-              "name": "off wait time",
+              "name": "OffWaitTime",
               "code": 16386,
               "mfgCode": null,
               "side": "server",
@@ -6662,7 +6662,7 @@
               "reportableChange": 0
             },
             {
-              "name": "start up on off",
+              "name": "StartUpOnOff",
               "code": 16387,
               "mfgCode": null,
               "side": "server",
@@ -6700,7 +6700,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "3",
               "reportable": 0,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -14167,7 +14167,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "on/off",
+              "name": "OnOff",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -14177,6 +14177,81 @@
               "bounded": 0,
               "defaultValue": "0x00",
               "reportable": 1,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "GlobalSceneControl",
+              "code": 16384,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 0,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "OnTime",
+              "code": 16385,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 0,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "OffWaitTime",
+              "code": 16386,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 0,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "StartUpOnOff",
+              "code": 16387,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 0,
+              "minInterval": 0,
+              "maxInterval": 65344,
+              "reportableChange": 0
+            },
+            {
+              "name": "feature map",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0x0000",
+              "reportable": 0,
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0

--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -957,6 +957,11 @@
                                                                                                                                    \
             /* 10414 - total active power, */                                                                                      \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
+                                                                                                                                   \
+            /* Endpoint: 2, Cluster: On/off (server), big-endian */                                                                \
+                                                                                                                                   \
+            /* 10418 - feature map, */                                                                                             \
+            0x00, 0x00, 0x00, 0x00,                                                                                                \
     }
 
 #else // !BIGENDIAN_CPU
@@ -1893,11 +1898,16 @@
                                                                                                                                    \
             /* 10414 - total active power, */                                                                                      \
             0x00, 0x00, 0x00, 0x00,                                                                                                \
+                                                                                                                                   \
+            /* Endpoint: 2, Cluster: On/off (server), little-endian */                                                             \
+                                                                                                                                   \
+            /* 10418 - feature map, */                                                                                             \
+            0x00, 0x00, 0x00, 0x00,                                                                                                \
     }
 
 #endif // BIGENDIAN_CPU
 
-#define GENERATED_DEFAULTS_COUNT (126)
+#define GENERATED_DEFAULTS_COUNT (127)
 
 #define ZAP_TYPE(type) ZCL_##type##_ATTRIBUTE_TYPE
 #define ZAP_LONG_DEFAULTS_INDEX(index)                                                                                             \
@@ -1925,7 +1935,7 @@
 
 #define ZAP_ATTRIBUTE_MASK(mask) ATTRIBUTE_MASK_##mask
 // This is an array of EmberAfAttributeMetadata structures.
-#define GENERATED_ATTRIBUTE_COUNT 369
+#define GENERATED_ATTRIBUTE_COUNT 374
 #define GENERATED_ATTRIBUTES                                                                                                       \
     {                                                                                                                              \
                                                                                                                                    \
@@ -2106,13 +2116,13 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(3) },      /* cluster revision */                                 \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                             /* on/off */                \
-            { 0x4000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x01) },                             /* global scene control */  \
-            { 0x4001, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* on time */               \
-            { 0x4002, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* off wait time */         \
-            { 0x4003, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_EMPTY_DEFAULT() },         /* start up on off */       \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                             /* OnOff */                 \
+            { 0x4000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x01) },                             /* GlobalSceneControl */    \
+            { 0x4001, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* OnTime */                \
+            { 0x4002, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* OffWaitTime */           \
+            { 0x4003, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_EMPTY_DEFAULT() },         /* StartUpOnOff */          \
             { 0xFFFC, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(3482) },                         /* feature map */           \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },                                 /* cluster revision */      \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(3) },                                 /* cluster revision */      \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
             { 0x0000, ZAP_TYPE(INT8U), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                              /* current level */          \
@@ -2416,8 +2426,13 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* cluster revision */                                 \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                            \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },     /* cluster revision */                                  \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                        /* OnOff */                      \
+            { 0x4000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(1) },                           /* GlobalSceneControl */         \
+            { 0x4001, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0) }, /* OnTime */                     \
+            { 0x4002, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0) }, /* OffWaitTime */                \
+            { 0x4003, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_EMPTY_DEFAULT() },    /* StartUpOnOff */               \
+            { 0xFFFC, ZAP_TYPE(INT32U), 4, 0, ZAP_LONG_DEFAULTS_INDEX(10418) },                   /* feature map */                \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },                            /* cluster revision */           \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: Occupancy Sensing (server) */                                                                 \
             { 0x0000, ZAP_TYPE(BITMAP8), 1, 0, ZAP_EMPTY_DEFAULT() },  /* occupancy */                                             \
@@ -2667,12 +2682,12 @@
             }, /* Endpoint: 1, Cluster: Binding (server) */                                                                        \
             { 0x0006,                                                                                                              \
               ZAP_ATTRIBUTE_INDEX(363),                                                                                            \
-              2,                                                                                                                   \
-              3,                                                                                                                   \
+              7,                                                                                                                   \
+              13,                                                                                                                  \
               ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
               chipFuncArrayOnOffServer }, /* Endpoint: 2, Cluster: On/off (server) */                                              \
             { 0x0406,                                                                                                              \
-              ZAP_ATTRIBUTE_INDEX(365),                                                                                            \
+              ZAP_ATTRIBUTE_INDEX(370),                                                                                            \
               4,                                                                                                                   \
               5,                                                                                                                   \
               ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION),                                                          \
@@ -2684,7 +2699,7 @@
 // This is an array of EmberAfEndpointType structures.
 #define GENERATED_ENDPOINT_TYPES                                                                                                   \
     {                                                                                                                              \
-        { ZAP_CLUSTER_INDEX(0), 15, 3560 }, { ZAP_CLUSTER_INDEX(15), 37, 7252 }, { ZAP_CLUSTER_INDEX(52), 2, 8 },                  \
+        { ZAP_CLUSTER_INDEX(0), 15, 3560 }, { ZAP_CLUSTER_INDEX(15), 37, 7252 }, { ZAP_CLUSTER_INDEX(52), 2, 18 },                 \
     }
 
 // Largest attribute size is needed for various buffers
@@ -2694,7 +2709,7 @@
 #define ATTRIBUTE_SINGLETONS_SIZE (1497)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE (10820)
+#define ATTRIBUTE_MAX_SIZE (10830)
 
 // Number of fixed endpoints
 #define FIXED_ENDPOINT_COUNT (3)
@@ -3068,7 +3083,7 @@
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
             {                                                                                                                      \
                 ZAP_REPORT_DIRECTION(REPORTED), 0x0001, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }      \
-            }, /* on/off */                                                                                                        \
+            }, /* OnOff */                                                                                                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
             {                                                                                                                      \
@@ -3208,7 +3223,7 @@
             /* Endpoint: 2, Cluster: On/off (server) */                                                                            \
             {                                                                                                                      \
                 ZAP_REPORT_DIRECTION(REPORTED), 0x0002, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }      \
-            }, /* on/off */                                                                                                        \
+            }, /* OnOff */                                                                                                         \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: Occupancy Sensing (server) */                                                                 \
             {                                                                                                                      \

--- a/examples/bridge-app/bridge-common/gen/endpoint_config.h
+++ b/examples/bridge-app/bridge-common/gen/endpoint_config.h
@@ -881,7 +881,7 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* cluster revision */                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                            \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* OnOff */                                             \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },     /* cluster revision */                                  \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
@@ -1140,7 +1140,7 @@
         /* Endpoint: 1, Cluster: On/off (server) */                                                                                \
         {                                                                                                                          \
             ZAP_REPORT_DIRECTION(REPORTED), 0x0001, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }          \
-        }, /* on/off */                                                                                                            \
+        }, /* OnOff */                                                                                                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
             {                                                                                                                      \

--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -10148,9 +10148,9 @@ private:
             return;
         }
 
-        if (clusterRevision != 2U)
+        if (clusterRevision != 3U)
         {
-            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2");
+            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "3");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
@@ -10210,9 +10210,9 @@ private:
             return;
         }
 
-        if (clusterRevision != 2U)
+        if (clusterRevision != 3U)
         {
-            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2");
+            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "3");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }

--- a/examples/lighting-app/lighting-common/gen/endpoint_config.h
+++ b/examples/lighting-app/lighting-common/gen/endpoint_config.h
@@ -781,11 +781,11 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* cluster revision */                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                             /* on/off */                \
-            { 0x4000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x01) },                             /* global scene control */  \
-            { 0x4001, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* on time */               \
-            { 0x4002, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* off wait time */         \
-            { 0x4003, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_EMPTY_DEFAULT() },         /* start up on off */       \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },                             /* OnOff */                 \
+            { 0x4000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x01) },                             /* GlobalSceneControl */    \
+            { 0x4001, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* OnTime */                \
+            { 0x4002, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x0000) }, /* OffWaitTime */           \
+            { 0x4003, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_EMPTY_DEFAULT() },         /* StartUpOnOff */          \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },                                 /* cluster revision */      \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \

--- a/examples/lock-app/lock-common/gen/endpoint_config.h
+++ b/examples/lock-app/lock-common/gen/endpoint_config.h
@@ -706,7 +706,7 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* cluster revision */                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                            \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* OnOff */                                             \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },     /* cluster revision */                                  \
     }
 
@@ -932,5 +932,5 @@
         /* Endpoint: 1, Cluster: On/off (server) */                                                                                \
         {                                                                                                                          \
             ZAP_REPORT_DIRECTION(REPORTED), 0x0001, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }          \
-        }, /* on/off */                                                                                                            \
+        }, /* OnOff */                                                                                                             \
     }

--- a/examples/pump-app/pump-common/gen/endpoint_config.h
+++ b/examples/pump-app/pump-common/gen/endpoint_config.h
@@ -588,7 +588,7 @@
     {                                                                                                                              \
                                                                                                                                    \
         /* Endpoint: 0, Cluster: On/off (server) */                                                                                \
-        { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                                \
+        { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* OnOff */                                                 \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) }, /* cluster revision */                                      \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Level Control (server) */                                                                     \

--- a/examples/pump-controller-app/pump-controller-common/gen/chip-zcl-zpro-codec-api.h
+++ b/examples/pump-controller-app/pump-controller-common/gen/chip-zcl-zpro-codec-api.h
@@ -170,7 +170,7 @@ chip::System::PacketBufferHandle encodeOnOffClusterDiscoverAttributes(uint8_t se
 
 /**
  * @brief
- *    Encode a On/off server read command for the on/off attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the OnOff attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadOnOffAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint);
 

--- a/examples/tv-app/tv-common/gen/endpoint_config.h
+++ b/examples/tv-app/tv-common/gen/endpoint_config.h
@@ -1548,7 +1548,7 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* cluster revision */                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                            \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* OnOff */                                             \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },     /* cluster revision */                                  \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Wake on LAN (server) */                                                                       \
@@ -1588,7 +1588,7 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* cluster revision */                             \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: On/off (server) */                                                                            \
-            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* on/off */                                            \
+            { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) }, /* OnOff */                                             \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },     /* cluster revision */                                  \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: Level Control (server) */                                                                     \
@@ -2072,12 +2072,12 @@
             /* Endpoint: 1, Cluster: On/off (server) */                                                                            \
             {                                                                                                                      \
                 ZAP_REPORT_DIRECTION(REPORTED), 0x0001, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }      \
-            }, /* on/off */                                                                                                        \
+            }, /* OnOff */                                                                                                         \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: On/off (server) */                                                                            \
             {                                                                                                                      \
                 ZAP_REPORT_DIRECTION(REPORTED), 0x0002, 0x0006, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, { { 0, 65344, 0 } }      \
-            }, /* on/off */                                                                                                        \
+            }, /* OnOff */                                                                                                         \
                                                                                                                                    \
             /* Endpoint: 2, Cluster: Level Control (server) */                                                                     \
             {                                                                                                                      \

--- a/src/app/common/gen/callback.h
+++ b/src/app/common/gen/callback.h
@@ -15317,7 +15317,7 @@ bool emberAfOnOffClusterSampleMfgSpecificToggleWithTransition2Callback(chip::app
 /**
  * @brief  Cluster OffWithEffect Command callback
  */
-bool emberAfOnOffClusterOffWithEffectCallback(chip::app::Command * commandObj, uint8_t effectId, uint8_t effectVariant);
+bool emberAfOnOffClusterOffWithEffectCallback(chip::app::Command * commandObj, uint8_t EffectId, uint8_t EffectVariant);
 
 /**
  * @brief  Cluster OnWithRecallGlobalScene Command callback
@@ -15327,8 +15327,8 @@ bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::Command * com
 /**
  * @brief  Cluster OnWithTimedOff Command callback
  */
-bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::Command * commandObj, uint8_t onOffControl, uint16_t onTime,
-                                               uint16_t offWaitTime);
+bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::Command * commandObj, uint8_t OnOffControl, uint16_t OnTime,
+                                               uint16_t OffWaitTime);
 
 /**
  * @brief  Cluster MoveToLevel Command callback

--- a/src/app/common/gen/client-command-macro.h
+++ b/src/app/common/gen/client-command-macro.h
@@ -946,15 +946,15 @@
 /** @brief Command description for OffWithEffect
  *
  * Command: OffWithEffect
- * @param effectId OnOffEffectIdentifier
- * @param effectVariant ENUM8
+ * @param EffectId OnOffEffectIdentifier
+ * @param EffectVariant enum8
  */
 #define emberAfFillCommandOn                                                                                                       \
     /                                                                                                                              \
-        offClusterOffWithEffect(effectId, effectVariant)                                                                           \
+        offClusterOffWithEffect(EffectId, EffectVariant)                                                                           \
             emberAfFillExternalBuffer(mask,                                                                                        \
                                                                                                                                    \
-                                      ZCL_OFF_WITH_EFFECT_COMMAND_ID, "uu", effectId, effectVariant);
+                                      ZCL_OFF_WITH_EFFECT_COMMAND_ID, "uu", EffectId, EffectVariant);
 
 /** @brief Command description for OnWithRecallGlobalScene
  *
@@ -969,16 +969,16 @@
 /** @brief Command description for OnWithTimedOff
  *
  * Command: OnWithTimedOff
- * @param onOffControl OnOffControl
- * @param onTime INT16U
- * @param offWaitTime INT16U
+ * @param OnOffControl OnOffControl
+ * @param OnTime int16u
+ * @param OffWaitTime int16u
  */
 #define emberAfFillCommandOn                                                                                                       \
     /                                                                                                                              \
-        offClusterOnWithTimedOff(onOffControl, onTime, offWaitTime)                                                                \
+        offClusterOnWithTimedOff(OnOffControl, OnTime, OffWaitTime)                                                                \
             emberAfFillExternalBuffer(mask,                                                                                        \
                                                                                                                                    \
-                                      ZCL_ON_WITH_TIMED_OFF_COMMAND_ID, "uuu", onOffControl, onTime, offWaitTime);
+                                      ZCL_ON_WITH_TIMED_OFF_COMMAND_ID, "uuu", OnOffControl, OnTime, OffWaitTime);
 
 /** @brief Command description for MoveToLevel
  *

--- a/src/app/tests/suites/Test_TC_OO_1_1.yaml
+++ b/src/app/tests/suites/Test_TC_OO_1_1.yaml
@@ -23,7 +23,7 @@ tests:
       command: "readAttribute"
       attribute: "Cluster Revision"
       response:
-          value: 2
+          value: 3
 
     - label:
           "write the default values to mandatory global attribute:
@@ -32,7 +32,7 @@ tests:
       command: "writeAttribute"
       attribute: "Cluster Revision"
       arguments:
-          value: 2
+          value: 3
       response:
           error: 1
 
@@ -40,7 +40,7 @@ tests:
       command: "readAttribute"
       attribute: "Cluster Revision"
       response:
-          value: 2
+          value: 3
 
     - label: "read the optional global attribute: FeatureMap"
       command: "readAttribute"

--- a/src/app/tests/suites/Test_TC_OO_2_1.yaml
+++ b/src/app/tests/suites/Test_TC_OO_2_1.yaml
@@ -21,14 +21,14 @@ config:
 tests:
     - label: "read the mandatory attribute: OnOff"
       command: "readAttribute"
-      attribute: "On/Off"
+      attribute: "OnOff"
       response:
           value: 0
 
     - label: "write the default value of mandatory attribute: OnOff"
       disabled: true
       command: "writeAttribute"
-      attribute: "On/Off"
+      attribute: "OnOff"
       arguments:
           value: 0
       response:
@@ -36,38 +36,38 @@ tests:
 
     - label: "reads back mandatory attribute: OnOff"
       command: "readAttribute"
-      attribute: "On/Off"
+      attribute: "OnOff"
       response:
           value: 0
 
     - label: "read LT attribute: GlobalSceneControl"
       command: "readAttribute"
-      attribute: "Global Scene Control"
+      attribute: "GlobalSceneControl"
       response:
           value: 1
 
     - label: "read LT attribute: OnTime"
       command: "readAttribute"
-      attribute: "On Time"
+      attribute: "OnTime"
       response:
           value: 0
 
     - label: "read LT attribute: OffWaitTime"
       command: "readAttribute"
-      attribute: "Off Wait Time"
+      attribute: "OffWaitTime"
       response:
           value: 0
 
     - label: "read LT attribute: StartUpOnOff"
       command: "readAttribute"
-      attribute: "Start Up On Off"
+      attribute: "StartUpOnOff"
       response:
           value: 0
 
     - label: "write the default value to LT attribute: GlobalSceneControl"
       disabled: true
       command: "writeAttribute"
-      attribute: "Global Scene Control"
+      attribute: "GlobalSceneControl"
       arguments:
           value: 0
       response:
@@ -75,43 +75,43 @@ tests:
 
     - label: "write the default value to LT attribute: OnTime"
       command: "writeAttribute"
-      attribute: "On Time"
+      attribute: "OnTime"
       arguments:
           value: 0
 
     - label: "write the default value to LT attribute: OffWaitTime"
       command: "writeAttribute"
-      attribute: "Off Wait Time"
+      attribute: "OffWaitTime"
       arguments:
           value: 0
 
     - label: "write the default value to LT attribute: StartUpOnOff"
       command: "writeAttribute"
-      attribute: "Start Up On Off"
+      attribute: "StartUpOnOff"
       arguments:
           value: 0
 
     - label: "reads back LT attribute: GlobalSceneControl"
       disabled: true
       command: "readAttribute"
-      attribute: "Global Scene Control"
+      attribute: "GlobalSceneControl"
       response:
           value: 1
 
     - label: "reads back LT attribute: OnTime"
       command: "readAttribute"
-      attribute: "On Time"
+      attribute: "OnTime"
       response:
           value: 0
 
     - label: "reads back LT attribute: OffWaitTime"
       command: "readAttribute"
-      attribute: "Off Wait Time"
+      attribute: "OffWaitTime"
       response:
           value: 0
 
     - label: "reads back LT attribute: StartUpOnOff"
       command: "readAttribute"
-      attribute: "Start Up On Off"
+      attribute: "StartUpOnOff"
       response:
           value: 0

--- a/src/app/tests/suites/Test_TC_OO_2_2.yaml
+++ b/src/app/tests/suites/Test_TC_OO_2_2.yaml
@@ -20,47 +20,47 @@ config:
 
 tests:
     - label: "Send Off Command"
-      command: "off"
+      command: "Off"
 
     - label: "Check on/off attribute value is false after off command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 0
 
     - label: "Send On Command"
-      command: "on"
+      command: "On"
 
     - label: "Check on/off attribute value is true after on command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 1
 
     - label: "Send Off Command"
-      command: "off"
+      command: "Off"
 
     - label: "Check on/off attribute value is false after off command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 0
 
     - label: "Send Toggle Command"
-      command: "toggle"
+      command: "Toggle"
 
     - label: "Check on/off attribute value is true after toggle command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 1
 
     - label: "Send Toggle Command"
-      command: "toggle"
+      command: "Toggle"
 
     - label: "Check on/off attribute value is false after toggle command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 0
 
@@ -69,15 +69,15 @@ tests:
 
     - label: "Check on/off attribute value is true after on command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 1
 
     - label: "Send Off Command"
-      command: "off"
+      command: "Off"
 
     - label: "Check on/off attribute value is false after off command"
       command: "readAttribute"
-      attribute: "on/off"
+      attribute: "OnOff"
       response:
           value: 0

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="General"/>
+
+  <enum name="OnOffEffectIdentifier" type="enum8">
+    <item name="DelayedAllOff" value="0x00"/>
+    <item name="DyingLight" value="0x01"/>
+  </enum>
+
+  <enum name="OnOffDelayedAllOffEffectVariant" type="enum8">
+    <item name="FadeToOffIn_0p8Seconds" value="0x00"/>
+    <item name="NoFade" value="0x01"/>
+    <item name="50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" value="0x02"/>
+  </enum>
+
+  <enum name="OnOffDyingLightEffectVariant" type="enum8">
+    <item name="20PercenterDimUpIn_0p5SecondsThenFadeToOffIn_1Second" value="0x00"/>
+  </enum>
+
+  <bitmap name="OnOffControl" type="BITMAP8">
+    <field name="AcceptOnlyWhenOn" mask="0x01"/>
+  </bitmap>
+
+  <cluster>
+    <name>On/off</name>
+    <domain>General</domain>
+    <code>0x0006</code>
+    <define>ON_OFF_CLUSTER</define>
+    <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <attribute side="server" code="0x0000" define="ON_OFF"               type="boolean" default="0" reportable="true"              >OnOff</attribute>
+    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1"                 optional="true">GlobalSceneControl</attribute>
+    <attribute side="server" code="0x4001" define="ON_TIME"              type="int16u"  default="0" writable="true" optional="true">OnTime</attribute>
+    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME"        type="int16u"  default="0" writable="true" optional="true">OffWaitTime</attribute>
+    <attribute side="server" code="0x4003" define="START_UP_ON_OFF"      type="enum8"               writable="true" optional="true">StartUpOnOff</attribute>
+
+    <command source="client" code="0x00" name="Off" optional="false">
+      <description>On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.</description>
+    </command>
+
+    <command source="client" code="0x01" name="On" optional="false">
+      <description>On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.</description>
+    </command>
+
+    <command source="client" code="0x02" name="Toggle" optional="false">
+      <description>On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.</description>
+    </command>
+
+    <command source="client" code="0x40" name="OffWithEffect" optional="true">
+      <description>The OffWithEffect command allows devices to be turned off using enhanced ways of fading.</description>
+      <arg name="EffectId" type="OnOffEffectIdentifier"/>
+      <arg name="EffectVariant" type="enum8"/>
+    </command>
+
+    <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true">
+      <description>The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.</description>
+    </command>
+
+    <command source="client" code="0x42" name="OnWithTimedOff" optional="true">
+      <description>The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off duration so that SHOULD the device be subsequently switched off, further OnWithTimedOff commands, received during this time, are prevented from turning the devices back on.</description>
+      <arg name="OnOffControl" type="OnOffControl"/>
+      <arg name="OnTime" type="int16u"/><!-- min:0 max:0xfe -->
+      <arg name="OffWaitTime" type="int16u"/><!-- min:0 max:0xfe -->
+    </command>
+
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -495,33 +495,6 @@ limitations under the License.
     </command>
   </cluster>
   <cluster>
-    <name>On/off</name>
-    <domain>General</domain>
-    <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
-    <code>0x0006</code>
-    <define>ON_OFF_CLUSTER</define>
-    <client tick="false" init="false">true</client>
-    <server tick="false" init="false">true</server>
-    <globalAttribute side="either" code="0xFFFD" value="2"/>
-    <attribute side="server" code="0x0000" define="ON_OFF" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">on/off</attribute>
-    <attribute side="server" code="0x4003" define="START_UP_ON_OFF" type="ENUM8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">start up on off</attribute>
-    <command source="client" code="0x00" name="Off" optional="false" cli="zcl on-off off">
-      <description>
-        Command description for Off
-      </description>
-    </command>
-    <command source="client" code="0x01" name="On" optional="false" cli="zcl on-off on">
-      <description>
-        Command description for On
-      </description>
-    </command>
-    <command source="client" code="0x02" name="Toggle" optional="false" cli="zcl on-off toggle">
-      <description>
-        Command description for Toggle
-      </description>
-    </command>
-  </cluster>
-  <cluster>
     <name>On/off Switch Configuration</name>
     <domain>General</domain>
     <description>Attributes and commands for configuring On/Off switching devices.</description>

--- a/src/app/zap-templates/zcl/data-model/silabs/zll.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/zll.xml
@@ -31,21 +31,6 @@ limitations under the License.
   <bitmap name="ScenesCopyMode" type="BITMAP8">
     <field name="CopyAllScenes" mask="0x01"/>
   </bitmap>
-  <enum name="OnOffEffectIdentifier" type="ENUM8">
-    <item name="DelayedAllOff" value="0x00"/>
-    <item name="DyingLight" value="0x01"/>
-  </enum>
-  <enum name="OnOffDelayedAllOffEffectVariant" type="ENUM8">
-    <item name="FadeToOffIn_0p8Seconds" value="0x00"/>
-    <item name="NoFade" value="0x01"/>
-    <item name="50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" value="0x02"/>
-  </enum>
-  <enum name="OnOffDyingLightEffectVariant" type="ENUM8">
-    <item name="20PercenterDimUpIn_0p5SecondsThenFadeToOffIn_1Second" value="0x00"/>
-  </enum>
-  <bitmap name="OnOffControl" type="BITMAP8">
-    <field name="AcceptOnlyWhenOn" mask="0x01"/>
-  </bitmap>
   <enum name="EnhancedColorMode" type="ENUM8">
     <item name="CurrentHueAndCurrentSaturation" value="0x00"/>
     <item name="CurrentXAndCurrentY" value="0x01"/>
@@ -140,31 +125,6 @@ limitations under the License.
       <arg name="status" type="Status"/>
       <arg name="groupIdFrom" type="INT16U"/>
       <arg name="sceneIdFrom" type="INT8U"/>
-    </command>
-  </clusterExtension>
-  <clusterExtension code="0x0006">
-    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="true" introducedIn="zll-1.0-11-0037-10">global scene control</attribute>
-    <attribute side="server" code="0x4001" define="ON_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">on time</attribute>
-    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">off wait time</attribute>
-    <command source="client" code="0x40" name="OffWithEffect" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off offeffect">
-      <description>
-        Command description for OffWithEffect
-      </description>
-      <arg name="effectId" type="OnOffEffectIdentifier"/>
-      <arg name="effectVariant" type="ENUM8"/>
-    </command>
-    <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off onrecall">
-      <description>
-        Command description for OnWithRecallGlobalScene
-      </description>
-    </command>
-    <command source="client" code="0x42" name="OnWithTimedOff" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off ontimedoff">
-      <description>
-        Command description for OnWithTimedOff
-      </description>
-      <arg name="onOffControl" type="OnOffControl"/>
-      <arg name="onTime" type="INT16U"/>
-      <arg name="offWaitTime" type="INT16U"/>
     </command>
   </clusterExtension>
   <clusterExtension code="0x0300">

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -27,6 +27,7 @@
         "low-power-cluster.xml",
         "media-input-cluster.xml",
         "media-playback-cluster.xml",
+        "onoff-cluster.xml",
         "operational-credentials-cluster.xml",
         "pressure-measurement-cluster.xml",
         "pump-configuration-and-control-cluster.xml",

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -542,6 +542,30 @@
               "source": "client",
               "incoming": 1,
               "outgoing": 1
+            },
+            {
+              "name": "OffWithEffect",
+              "code": 64,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "OnWithRecallGlobalScene",
+              "code": 65,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "OnWithTimedOff",
+              "code": 66,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 0,
+              "outgoing": 1
             }
           ],
           "attributes": [
@@ -572,7 +596,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "on/off",
+              "name": "OnOff",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -587,7 +611,7 @@
               "reportableChange": 0
             },
             {
-              "name": "global scene control",
+              "name": "GlobalSceneControl",
               "code": 16384,
               "mfgCode": null,
               "side": "server",
@@ -602,7 +626,7 @@
               "reportableChange": 0
             },
             {
-              "name": "on time",
+              "name": "OnTime",
               "code": 16385,
               "mfgCode": null,
               "side": "server",
@@ -617,7 +641,7 @@
               "reportableChange": 0
             },
             {
-              "name": "off wait time",
+              "name": "OffWaitTime",
               "code": 16386,
               "mfgCode": null,
               "side": "server",
@@ -632,7 +656,7 @@
               "reportableChange": 0
             },
             {
-              "name": "start up on off",
+              "name": "StartUpOnOff",
               "code": 16387,
               "mfgCode": null,
               "side": "server",

--- a/src/controller/data_model/gen/CHIPClusters.cpp
+++ b/src/controller/data_model/gen/CHIPClusters.cpp
@@ -7359,6 +7359,49 @@ exit:
     return err;
 }
 
+CHIP_ERROR OnOffCluster::OffWithEffect(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                                       uint8_t effectId, uint8_t effectVariant)
+{
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    app::CommandSender * sender = nullptr;
+    TLV::TLVWriter * writer     = nullptr;
+    uint8_t argSeqNumber        = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffWithEffectCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+    SuccessOrExit(err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // effectId: onOffEffectIdentifier
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), effectId));
+    // effectVariant: enum8
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), effectVariant));
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender, onSuccessCallback, onFailureCallback);
+
+    err = mDevice->SendCommands(sender);
+
+exit:
+    // On error, we are responsible to close the sender.
+    if (err != CHIP_NO_ERROR && sender != nullptr)
+    {
+        sender->Shutdown();
+    }
+    return err;
+}
+
 CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
@@ -7380,6 +7423,89 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
     // Command takes no arguments.
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender, onSuccessCallback, onFailureCallback);
+
+    err = mDevice->SendCommands(sender);
+
+exit:
+    // On error, we are responsible to close the sender.
+    if (err != CHIP_NO_ERROR && sender != nullptr)
+    {
+        sender->Shutdown();
+    }
+    return err;
+}
+
+CHIP_ERROR OnOffCluster::OnWithRecallGlobalScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
+{
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    app::CommandSender * sender = nullptr;
+    TLV::TLVWriter * writer     = nullptr;
+    uint8_t argSeqNumber        = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnWithRecallGlobalSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+    SuccessOrExit(err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    // Command takes no arguments.
+
+    SuccessOrExit(err = sender->FinishCommand());
+
+    // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
+    mDevice->AddIMResponseHandler(sender, onSuccessCallback, onFailureCallback);
+
+    err = mDevice->SendCommands(sender);
+
+exit:
+    // On error, we are responsible to close the sender.
+    if (err != CHIP_NO_ERROR && sender != nullptr)
+    {
+        sender->Shutdown();
+    }
+    return err;
+}
+
+CHIP_ERROR OnOffCluster::OnWithTimedOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                                        uint8_t onOffControl, uint16_t onTime, uint16_t offWaitTime)
+{
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    app::CommandSender * sender = nullptr;
+    TLV::TLVWriter * writer     = nullptr;
+    uint8_t argSeqNumber        = 0;
+
+    // Used when encoding non-empty command. Suppress error message when encoding empty commands.
+    (void) writer;
+    (void) argSeqNumber;
+
+    VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnWithTimedOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+    SuccessOrExit(err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&sender));
+
+    SuccessOrExit(err = sender->PrepareCommand(cmdParams));
+
+    VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    // onOffControl: onOffControl
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), onOffControl));
+    // onTime: int16u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), onTime));
+    // offWaitTime: int16u
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), offWaitTime));
 
     SuccessOrExit(err = sender->FinishCommand());
 

--- a/src/controller/data_model/gen/CHIPClusters.h
+++ b/src/controller/data_model/gen/CHIPClusters.h
@@ -1035,7 +1035,12 @@ public:
 
     // Cluster Commands
     CHIP_ERROR Off(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
+    CHIP_ERROR OffWithEffect(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t effectId,
+                             uint8_t effectVariant);
     CHIP_ERROR On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
+    CHIP_ERROR OnWithRecallGlobalScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
+    CHIP_ERROR OnWithTimedOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                              uint8_t onOffControl, uint16_t onTime, uint16_t offWaitTime);
     CHIP_ERROR Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
 
     // Cluster Attributes
@@ -1058,9 +1063,12 @@ public:
     CHIP_ERROR ReportAttributeOnOff(Callback::Cancelable * onReportCallback);
 
 private:
-    static constexpr CommandId kOffCommandId    = 0x00;
-    static constexpr CommandId kOnCommandId     = 0x01;
-    static constexpr CommandId kToggleCommandId = 0x02;
+    static constexpr CommandId kOffCommandId                     = 0x00;
+    static constexpr CommandId kOffWithEffectCommandId           = 0x40;
+    static constexpr CommandId kOnCommandId                      = 0x01;
+    static constexpr CommandId kOnWithRecallGlobalSceneCommandId = 0x41;
+    static constexpr CommandId kOnWithTimedOffCommandId          = 0x42;
+    static constexpr CommandId kToggleCommandId                  = 0x02;
 };
 
 class DLL_EXPORT OperationalCredentialsCluster : public ClusterBase

--- a/src/controller/data_model/gen/chip-zcl-zpro-codec-api.h
+++ b/src/controller/data_model/gen/chip-zcl-zpro-codec-api.h
@@ -2270,7 +2270,10 @@ chip::System::PacketBufferHandle encodeOccupancySensingClusterReadClusterRevisio
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Off                                                               |   0x00 |
+| * OffWithEffect                                                     |   0x40 |
 | * On                                                                |   0x01 |
+| * OnWithRecallGlobalScene                                           |   0x41 |
+| * OnWithTimedOff                                                    |   0x42 |
 | * Toggle                                                            |   0x02 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
@@ -2291,59 +2294,59 @@ chip::System::PacketBufferHandle encodeOnOffClusterDiscoverAttributes(uint8_t se
 
 /**
  * @brief
- *    Encode a On/off server read command for the on/off attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the OnOff attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadOnOffAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
- *    Encode a On/off server configure report command for the on/off attribute into buffer including the APS frame
+ *    Encode a On/off server configure report command for the OnOff attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterConfigureOnOffAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint,
                                                                            uint16_t minInterval, uint16_t maxInterval);
 
 /**
  * @brief
- *    Encode a On/off server read command for the global scene control attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the GlobalSceneControl attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadGlobalSceneControlAttribute(uint8_t seqNum,
                                                                                    chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
- *    Encode a On/off server read command for the on time attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the OnTime attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadOnTimeAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
- *    Encode a On/off server write command for the on time attribute into buffer including the APS frame
+ *    Encode a On/off server write command for the OnTime attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterWriteOnTimeAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint,
                                                                         uint16_t onTime);
 
 /**
  * @brief
- *    Encode a On/off server read command for the off wait time attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the OffWaitTime attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadOffWaitTimeAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
- *    Encode a On/off server write command for the off wait time attribute into buffer including the APS frame
+ *    Encode a On/off server write command for the OffWaitTime attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterWriteOffWaitTimeAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint,
                                                                              uint16_t offWaitTime);
 
 /**
  * @brief
- *    Encode a On/off server read command for the start up on off attribute into buffer including the APS frame
+ *    Encode a On/off server read command for the StartUpOnOff attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterReadStartUpOnOffAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
- *    Encode a On/off server write command for the start up on off attribute into buffer including the APS frame
+ *    Encode a On/off server write command for the StartUpOnOff attribute into buffer including the APS frame
  */
 chip::System::PacketBufferHandle encodeOnOffClusterWriteStartUpOnOffAttribute(uint8_t seqNum, chip::EndpointId destinationEndpoint,
                                                                               uint8_t startUpOnOff);

--- a/src/controller/data_model/gen/encoder.cpp
+++ b/src/controller/data_model/gen/encoder.cpp
@@ -3596,7 +3596,10 @@ PacketBufferHandle encodeOccupancySensingClusterReadClusterRevisionAttribute(uin
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * Off                                                               |   0x00 |
+| * OffWithEffect                                                     |   0x40 |
 | * On                                                                |   0x01 |
+| * OnWithRecallGlobalScene                                           |   0x41 |
+| * OnWithTimedOff                                                    |   0x42 |
 | * Toggle                                                            |   0x02 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |

--- a/src/controller/data_model/gen/endpoint_config.h
+++ b/src/controller/data_model/gen/endpoint_config.h
@@ -414,7 +414,7 @@
 
 // Array of EmberAfCommandMetadata structs.
 #define ZAP_COMMAND_MASK(mask) COMMAND_MASK_##mask
-#define EMBER_AF_GENERATED_COMMAND_COUNT (225)
+#define EMBER_AF_GENERATED_COMMAND_COUNT (228)
 #define GENERATED_COMMANDS                                                                                                         \
     {                                                                                                                              \
                                                                                                                                    \
@@ -454,6 +454,9 @@
             { 0x0006, 0x00, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* Off */                                                         \
             { 0x0006, 0x01, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On */                                                          \
             { 0x0006, 0x02, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* Toggle */                                                      \
+            { 0x0006, 0x40, ZAP_COMMAND_MASK(OUTGOING_CLIENT) }, /* OffWithEffect */                                               \
+            { 0x0006, 0x41, ZAP_COMMAND_MASK(OUTGOING_CLIENT) }, /* OnWithRecallGlobalScene */                                     \
+            { 0x0006, 0x42, ZAP_COMMAND_MASK(OUTGOING_CLIENT) }, /* OnWithTimedOff */                                              \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Level Control (client) */                                                                     \
             { 0x0008, 0x00, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* MoveToLevel */                                                 \
@@ -725,7 +728,7 @@
 #define GENERATED_COMMAND_MANUFACTURER_CODE_COUNT (1)
 #define GENERATED_COMMAND_MANUFACTURER_CODES                                                                                       \
     {                                                                                                                              \
-        { 40, 4098 },                                                                                                              \
+        { 43, 4098 },                                                                                                              \
     }
 
 // This is an array of EmberAfManufacturerCodeEntry structures for clusters.

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -10365,6 +10365,52 @@ exit:
         env->CallVoidMethod(callback, method, exception);
     }
 }
+JNI_METHOD(void, OnOffCluster, offWithEffect)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint effectId, jint effectVariant)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OnOffCluster * cppCluster;
+
+    CHIPDefaultSuccessCallback * onSuccess;
+    CHIPDefaultFailureCallback * onFailure;
+
+    cppCluster = reinterpret_cast<OnOffCluster *>(clusterPtr);
+    VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    onSuccess = new CHIPDefaultSuccessCallback(callback);
+    VerifyOrExit(onSuccess != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    onFailure = new CHIPDefaultFailureCallback(callback);
+    VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = cppCluster->OffWithEffect(onSuccess->Cancel(), onFailure->Cancel(), effectId, effectVariant);
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        delete onSuccess;
+        delete onFailure;
+
+        jthrowable exception;
+        jmethodID method;
+
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+
+        err = CreateIllegalStateException(env, "Error invoking cluster", err, exception);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+        env->CallVoidMethod(callback, method, exception);
+    }
+}
 JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
@@ -10383,6 +10429,97 @@ JNI_METHOD(void, OnOffCluster, on)(JNIEnv * env, jobject self, jlong clusterPtr,
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = cppCluster->On(onSuccess->Cancel(), onFailure->Cancel());
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        delete onSuccess;
+        delete onFailure;
+
+        jthrowable exception;
+        jmethodID method;
+
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+
+        err = CreateIllegalStateException(env, "Error invoking cluster", err, exception);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+        env->CallVoidMethod(callback, method, exception);
+    }
+}
+JNI_METHOD(void, OnOffCluster, onWithRecallGlobalScene)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OnOffCluster * cppCluster;
+
+    CHIPDefaultSuccessCallback * onSuccess;
+    CHIPDefaultFailureCallback * onFailure;
+
+    cppCluster = reinterpret_cast<OnOffCluster *>(clusterPtr);
+    VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    onSuccess = new CHIPDefaultSuccessCallback(callback);
+    VerifyOrExit(onSuccess != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    onFailure = new CHIPDefaultFailureCallback(callback);
+    VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = cppCluster->OnWithRecallGlobalScene(onSuccess->Cancel(), onFailure->Cancel());
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        delete onSuccess;
+        delete onFailure;
+
+        jthrowable exception;
+        jmethodID method;
+
+        err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+
+        err = CreateIllegalStateException(env, "Error invoking cluster", err, exception);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Error throwing IllegalStateException %d", err);
+            return;
+        }
+        env->CallVoidMethod(callback, method, exception);
+    }
+}
+JNI_METHOD(void, OnOffCluster, onWithTimedOff)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint onOffControl, jint onTime, jint offWaitTime)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    OnOffCluster * cppCluster;
+
+    CHIPDefaultSuccessCallback * onSuccess;
+    CHIPDefaultFailureCallback * onFailure;
+
+    cppCluster = reinterpret_cast<OnOffCluster *>(clusterPtr);
+    VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    onSuccess = new CHIPDefaultSuccessCallback(callback);
+    VerifyOrExit(onSuccess != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    onFailure = new CHIPDefaultFailureCallback(callback);
+    VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = cppCluster->OnWithTimedOff(onSuccess->Cancel(), onFailure->Cancel(), onOffControl, onTime, offWaitTime);
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/java/gen/ChipClusters.java
+++ b/src/controller/java/gen/ChipClusters.java
@@ -1998,8 +1998,21 @@ public class ChipClusters {
       off(chipClusterPtr, callback);
     }
 
+    public void offWithEffect(DefaultClusterCallback callback, int effectId, int effectVariant) {
+      offWithEffect(chipClusterPtr, callback, effectId, effectVariant);
+    }
+
     public void on(DefaultClusterCallback callback) {
       on(chipClusterPtr, callback);
+    }
+
+    public void onWithRecallGlobalScene(DefaultClusterCallback callback) {
+      onWithRecallGlobalScene(chipClusterPtr, callback);
+    }
+
+    public void onWithTimedOff(
+        DefaultClusterCallback callback, int onOffControl, int onTime, int offWaitTime) {
+      onWithTimedOff(chipClusterPtr, callback, onOffControl, onTime, offWaitTime);
     }
 
     public void toggle(DefaultClusterCallback callback) {
@@ -2008,7 +2021,20 @@ public class ChipClusters {
 
     private native void off(long chipClusterPtr, DefaultClusterCallback callback);
 
+    private native void offWithEffect(
+        long chipClusterPtr, DefaultClusterCallback callback, int effectId, int effectVariant);
+
     private native void on(long chipClusterPtr, DefaultClusterCallback callback);
+
+    private native void onWithRecallGlobalScene(
+        long chipClusterPtr, DefaultClusterCallback callback);
+
+    private native void onWithTimedOff(
+        long chipClusterPtr,
+        DefaultClusterCallback callback,
+        int onOffControl,
+        int onTime,
+        int offWaitTime);
 
     private native void toggle(long chipClusterPtr, DefaultClusterCallback callback);
   }

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -3280,12 +3280,36 @@ CHIP_ERROR chip_ime_AppendCommand_OnOff_Off(chip::Controller::Device * device, c
     cluster.Associate(device, ZCLendpointId);
     return cluster.Off(nullptr, nullptr);
 }
+CHIP_ERROR chip_ime_AppendCommand_OnOff_OffWithEffect(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                      chip::GroupId, uint8_t effectId, uint8_t effectVariant)
+{
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::Controller::OnOffCluster cluster;
+    cluster.Associate(device, ZCLendpointId);
+    return cluster.OffWithEffect(nullptr, nullptr, effectId, effectVariant);
+}
 CHIP_ERROR chip_ime_AppendCommand_OnOff_On(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     chip::Controller::OnOffCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster.On(nullptr, nullptr);
+}
+CHIP_ERROR chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                                chip::GroupId)
+{
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::Controller::OnOffCluster cluster;
+    cluster.Associate(device, ZCLendpointId);
+    return cluster.OnWithRecallGlobalScene(nullptr, nullptr);
+}
+CHIP_ERROR chip_ime_AppendCommand_OnOff_OnWithTimedOff(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                       chip::GroupId, uint8_t onOffControl, uint16_t onTime, uint16_t offWaitTime)
+{
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::Controller::OnOffCluster cluster;
+    cluster.Associate(device, ZCLendpointId);
+    return cluster.OnWithTimedOff(nullptr, nullptr, onOffControl, onTime, offWaitTime);
 }
 CHIP_ERROR chip_ime_AppendCommand_OnOff_Toggle(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
 {

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -560,7 +560,18 @@ class ChipClusters:
             "OnOff": {
                 "Off": {
                 },
+                "OffWithEffect": {
+                    "effectId": "int",
+                    "effectVariant": "int",
+                },
                 "On": {
+                },
+                "OnWithRecallGlobalScene": {
+                },
+                "OnWithTimedOff": {
+                    "onOffControl": "int",
+                    "onTime": "int",
+                    "offWaitTime": "int",
                 },
                 "Toggle": {
                 },
@@ -2725,9 +2736,21 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_OnOff_Off(
                 device, ZCLendpoint, ZCLgroupid
         )
+    def ClusterOnOff_CommandOffWithEffect(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, effectId: int, effectVariant: int):
+        return self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect(
+                device, ZCLendpoint, ZCLgroupid, effectId, effectVariant
+        )
     def ClusterOnOff_CommandOn(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_On(
                 device, ZCLendpoint, ZCLgroupid
+        )
+    def ClusterOnOff_CommandOnWithRecallGlobalScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+        return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene(
+                device, ZCLendpoint, ZCLgroupid
+        )
+    def ClusterOnOff_CommandOnWithTimedOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, onOffControl: int, onTime: int, offWaitTime: int):
+        return self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff(
+                device, ZCLendpoint, ZCLgroupid, onOffControl, onTime, offWaitTime
         )
     def ClusterOnOff_CommandToggle(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_Toggle(
@@ -4694,9 +4717,18 @@ class ChipClusters:
         # Cluster OnOff Command Off
         self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Off.restype = ctypes.c_uint32
+        # Cluster OnOff Command OffWithEffect
+        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OffWithEffect.restype = ctypes.c_uint32
         # Cluster OnOff Command On
         self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_On.restype = ctypes.c_uint32
+        # Cluster OnOff Command OnWithRecallGlobalScene
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithRecallGlobalScene.restype = ctypes.c_uint32
+        # Cluster OnOff Command OnWithTimedOff
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_OnWithTimedOff.restype = ctypes.c_uint32
         # Cluster OnOff Command Toggle
         self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.restype = ctypes.c_uint32

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.h
@@ -883,7 +883,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPOnOff : CHIPCluster
 
 - (void)off:(ResponseHandler)responseHandler;
+- (void)offWithEffect:(uint8_t)effectId effectVariant:(uint8_t)effectVariant responseHandler:(ResponseHandler)responseHandler;
 - (void)on:(ResponseHandler)responseHandler;
+- (void)onWithRecallGlobalScene:(ResponseHandler)responseHandler;
+- (void)onWithTimedOff:(uint8_t)onOffControl
+                onTime:(uint16_t)onTime
+           offWaitTime:(uint16_t)offWaitTime
+       responseHandler:(ResponseHandler)responseHandler;
 - (void)toggle:(ResponseHandler)responseHandler;
 
 - (void)readAttributeOnOffWithResponseHandler:(ResponseHandler)responseHandler;

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -12946,6 +12946,32 @@ private:
         responseHandler([CHIPError errorForCHIPErrorCode:err], nil);
     }
 }
+- (void)offWithEffect:(uint8_t)effectId effectVariant:(uint8_t)effectVariant responseHandler:(ResponseHandler)responseHandler
+{
+    CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onSuccess) {
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    CHIPDefaultFailureCallbackBridge * onFailure = new CHIPDefaultFailureCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onFailure) {
+        delete onSuccess;
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    __block CHIP_ERROR err;
+    dispatch_sync([self chipWorkQueue], ^{
+        err = self.cppCluster.OffWithEffect(onSuccess->Cancel(), onFailure->Cancel(), effectId, effectVariant);
+    });
+
+    if (err != CHIP_NO_ERROR) {
+        delete onSuccess;
+        delete onFailure;
+        responseHandler([CHIPError errorForCHIPErrorCode:err], nil);
+    }
+}
 - (void)on:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -12964,6 +12990,61 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.On(onSuccess->Cancel(), onFailure->Cancel());
+    });
+
+    if (err != CHIP_NO_ERROR) {
+        delete onSuccess;
+        delete onFailure;
+        responseHandler([CHIPError errorForCHIPErrorCode:err], nil);
+    }
+}
+- (void)onWithRecallGlobalScene:(ResponseHandler)responseHandler
+{
+    CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onSuccess) {
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    CHIPDefaultFailureCallbackBridge * onFailure = new CHIPDefaultFailureCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onFailure) {
+        delete onSuccess;
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    __block CHIP_ERROR err;
+    dispatch_sync([self chipWorkQueue], ^{
+        err = self.cppCluster.OnWithRecallGlobalScene(onSuccess->Cancel(), onFailure->Cancel());
+    });
+
+    if (err != CHIP_NO_ERROR) {
+        delete onSuccess;
+        delete onFailure;
+        responseHandler([CHIPError errorForCHIPErrorCode:err], nil);
+    }
+}
+- (void)onWithTimedOff:(uint8_t)onOffControl
+                onTime:(uint16_t)onTime
+           offWaitTime:(uint16_t)offWaitTime
+       responseHandler:(ResponseHandler)responseHandler
+{
+    CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onSuccess) {
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    CHIPDefaultFailureCallbackBridge * onFailure = new CHIPDefaultFailureCallbackBridge(responseHandler, [self callbackQueue]);
+    if (!onFailure) {
+        delete onSuccess;
+        responseHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
+        return;
+    }
+
+    __block CHIP_ERROR err;
+    dispatch_sync([self chipWorkQueue], ^{
+        err = self.cppCluster.OnWithTimedOff(onSuccess->Cancel(), onFailure->Cancel(), onOffControl, onTime, offWaitTime);
     });
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -418,16 +418,16 @@ private:
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_responses}}
-class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge : public Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>
+class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge : public Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>
 {
 public:
-    CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge(ResponseHandler handler, dispatch_queue_t queue): Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>(CallbackFn, this), mHandler(handler), mQueue(queue) {}
+    CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge(ResponseHandler handler, dispatch_queue_t queue): Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>(CallbackFn, this), mHandler(handler), mQueue(queue) {}
 
-    ~CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge() {};
+    ~CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge() {};
 
     static void CallbackFn(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
     {
-        CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge * callback = reinterpret_cast<CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}CallbackBridge *>(context);
+        CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge * callback = reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge *>(context);
         if (callback && callback->mQueue)
         {
             dispatch_async(callback->mQueue, ^{
@@ -464,16 +464,16 @@ private:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge : public Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>
+class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge : public Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>
 {
 public:
-    CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge(ResponseHandler handler, dispatch_queue_t queue): Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>(CallbackFn, this), mHandler(handler), mQueue(queue) {}
+    CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge(ResponseHandler handler, dispatch_queue_t queue): Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(CallbackFn, this), mHandler(handler), mQueue(queue) {}
 
-    ~CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge() {};
+    ~CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge() {};
 
     static void CallbackFn(void * context, uint16_t count, {{chipType}} * entries)
     {
-        CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge * callback = reinterpret_cast<CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge *>(context);
+        CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge * callback = reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge *>(context);
         if (callback && callback->mQueue)
         {
             id values[count];
@@ -571,11 +571,11 @@ private:
 
 {{#chip_client_clusters}}
 
-@interface CHIP{{asCamelCased name false}} ()
-@property (readonly) Controller::{{asCamelCased name false}}Cluster cppCluster;
+@interface CHIP{{asUpperCamelCase name}} ()
+@property (readonly) Controller::{{asUpperCamelCase name}}Cluster cppCluster;
 @end
 
-@implementation CHIP{{asCamelCased name false}}
+@implementation CHIP{{asUpperCamelCase name}}
 
 - (Controller::ClusterBase *)getCluster
 {
@@ -584,13 +584,13 @@ private:
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
+- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asLowerCamelCase label}}:{{/if}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
-- (void){{asCamelCased name}}:(ResponseHandler)responseHandler
+- (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler
 {{/if}}
 {
 {{#if hasSpecificResponse}}
-    CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}CallbackBridge * onSuccess = new CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}CallbackBridge(responseHandler, [self callbackQueue]);
+    CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}CallbackBridge * onSuccess = new CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}CallbackBridge(responseHandler, [self callbackQueue]);
 {{else}}
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
 {{/if}}
@@ -608,7 +608,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asCamelCased label}}.bytes, {{asCamelCased label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asCamelCased label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asCamelCased label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        err = self.cppCluster.{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asLowerCamelCase label}}.bytes, {{asLowerCamelCase label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asLowerCamelCase label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asLowerCamelCase label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_server_cluster_command_arguments}});
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -620,10 +620,10 @@ private:
 {{/chip_server_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-- (void)readAttribute{{asCamelCased name false}}WithResponseHandler:(ResponseHandler)responseHandler
+- (void)readAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler
 {
 {{#if isList}}
-    CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge * onSuccess = new CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallbackBridge(responseHandler, [self callbackQueue]);
+    CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge * onSuccess = new CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallbackBridge(responseHandler, [self callbackQueue]);
 {{else}}
     CHIP{{chipCallback.name}}AttributeCallbackBridge * onSuccess = new CHIP{{chipCallback.name}}AttributeCallbackBridge(responseHandler, [self callbackQueue]{{#if (isString type)}},{{#if (isOctetString type)}}true{{else}}false{{/if}}{{/if}});
 {{/if}}
@@ -641,7 +641,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ReadAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel());
+        err = self.cppCluster.ReadAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel());
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -652,7 +652,7 @@ private:
 }
 
 {{#if isWritableAttribute}}
-- (void)writeAttribute{{asCamelCased name false}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttribute{{asUpperCamelCase name}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -670,12 +670,12 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         {{#if (isOctetString type)}}
-        err = self.cppCluster.WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)value.bytes, value.length));
+        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)value.bytes, value.length));
         {{else if (isCharString type)}}
         NSData * data = [value dataUsingEncoding:NSUTF8StringEncoding];
-        err = self.cppCluster.WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)data.bytes, data.length));
+        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*)data.bytes, data.length));
         {{else}}
-        err = self.cppCluster.WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), value);
+        err = self.cppCluster.WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), value);
         {{/if}}
     });
 
@@ -688,7 +688,7 @@ private:
 
 {{/if}}
 {{#if isReportableAttribute}}
-- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler
+- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -706,7 +706,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
+        err = self.cppCluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -716,7 +716,7 @@ private:
     }
 }
 
-- (void) reportAttribute{{asCamelCased name false}}WithResponseHandler:(ResponseHandler)reportHandler
+- (void) reportAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)reportHandler
 {
     CHIP{{chipCallback.name}}AttributeCallbackBridge * onReport = new CHIP{{chipCallback.name}}AttributeCallbackBridge(reportHandler, [self callbackQueue]{{#if (isString type)}},{{#if (isOctetString type)}}true{{else}}false{{/if}}{{/if}}, true);
     if (!onReport) {
@@ -726,7 +726,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ReportAttribute{{asCamelCased name false}}(onReport->Cancel());
+        err = self.cppCluster.ReportAttribute{{asUpperCamelCase name}}(onReport->Cancel());
     });
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -31,24 +31,24 @@ NS_ASSUME_NONNULL_BEGIN
  * Cluster {{name}}
  *    {{description}}
  */
-@interface CHIP{{asCamelCased name false}} : CHIPCluster
+@interface CHIP{{asUpperCamelCase name}} : CHIPCluster
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asCamelCased name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asCamelCased label}}:{{/if}}({{asObjectiveCBasicType type}}){{asCamelCased label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
+- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asLowerCamelCase label}}:{{/if}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
 {{else}}
-- (void){{asCamelCased name}}:(ResponseHandler)responseHandler;
+- (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler;
 {{/if}}
 {{/chip_server_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-- (void)readAttribute{{asCamelCased name false}}WithResponseHandler:(ResponseHandler)responseHandler;
+- (void)readAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler;
 {{#if isWritableAttribute}}
-- (void)writeAttribute{{asCamelCased name false}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttribute{{asUpperCamelCase name}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{#if isReportableAttribute}}
-- (void) configureAttribute{{asCamelCased name false}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler;
-- (void) reportAttribute{{asCamelCased name false}}WithResponseHandler:(ResponseHandler)responseHandler;
+- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler;
+- (void) reportAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{/chip_server_cluster_attributes}}
 

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -143,17 +143,17 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 {{#unless (isStrEqual "Test Cluster" name)}}
 {{#unless (isStrEqual "Basic" name)}}
 {{#chip_server_cluster_attributes}}
-- (void)testSendCluster{{asCamelCased parent.name false}}ReadAttribute{{asCamelCased name false}}WithResponseHandler
+- (void)testSendCluster{{asUpperCamelCase parent.name}}ReadAttribute{{asUpperCamelCase name}}WithResponseHandler
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"{{asCamelCased parent.name false}}ReadAttribute{{asCamelCased name false}}WithResponseHandler"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"{{asUpperCamelCase parent.name}}ReadAttribute{{asUpperCamelCase name}}WithResponseHandler"];
 
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIP{{asCamelCased parent.name false}} * cluster = [[CHIP{{asCamelCased parent.name false}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asCamelCased parent.name false)}} queue:queue];
+    CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asUpperCamelCase parent.name)}} queue:queue];
     XCTAssertNotNil(cluster);
 
-    [cluster readAttribute{{asCamelCased name false}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"{{asCamelCased parent.name false}} {{asCamelCased name false}} Error: %@", err);
+    [cluster readAttribute{{asUpperCamelCase name}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} Error: %@", err);
         XCTAssertEqual(err.code, 0);
         [expectation fulfill];
     }];
@@ -162,18 +162,18 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 }
 
 {{#if isWritableAttribute}}
-- (void)testSendCluster{{asCamelCased parent.name false}}WriteAttribute{{asCamelCased name false}}WithValue
+- (void)testSendCluster{{asUpperCamelCase parent.name}}WriteAttribute{{asUpperCamelCase name}}WithValue
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"{{asCamelCased parent.name false}}WriteAttribute{{asCamelCased name false}}WithValue"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"{{asUpperCamelCase parent.name}}WriteAttribute{{asUpperCamelCase name}}WithValue"];
 
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIP{{asCamelCased parent.name false}} * cluster = [[CHIP{{asCamelCased parent.name false}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asCamelCased parent.name false)}} queue:queue];
+    CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:{{asExpectedEndpointForCluster (asUpperCamelCase parent.name)}} queue:queue];
     XCTAssertNotNil(cluster);
 
     {{asObjectiveCBasicType type}} value = {{asTestValue}};
-    [cluster writeAttribute{{asCamelCased name false}}WithValue:value responseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"{{asCamelCased parent.name false}} {{asCamelCased name false}} Error: %@", err);
+    [cluster writeAttribute{{asUpperCamelCase name}}WithValue:value responseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} Error: %@", err);
         XCTAssertEqual(err.code, 0);
         [expectation fulfill];
     }];

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -1,31 +1,31 @@
 {{#chip_tests tests}}
 {{#chip_tests_items}}
-- (void)testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asCamelCased command false}}
+- (void)testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"{{label}}"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIP{{asCamelCased cluster false}} * cluster = [[CHIP{{asCamelCased cluster false}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:queue];
+    CHIP{{asUpperCamelCase cluster}} * cluster = [[CHIP{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:queue];
     XCTAssertNotNil(cluster);
 
     {{#if isCommand}}
-    [cluster {{command}}:^(NSError * err, NSDictionary * values) {
+    [cluster {{asLowerCamelCase command}}:^(NSError * err, NSDictionary * values) {
     {{else if isReadAttribute}}
-    [cluster readAttribute{{asCamelCased attribute false}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
+    [cluster readAttribute{{asUpperCamelCase attribute}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
     {{else if isWriteAttribute}}
     {{#chip_tests_item_parameters}}
     {{#if (isString type)}}
     {{#if (isOctetString type)}}
-    NSString * {{asCamelCased name true}}ArgumentString= @"{{definedValue}}";
-    NSData * {{asCamelCased name true}}Argument = [{{asCamelCased name true}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+    NSString * {{asLowerCamelCase name}}ArgumentString= @"{{definedValue}}";
+    NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
     {{else}}
-    NSString * {{asCamelCased name true}}Argument= @"{{definedValue}}";
+    NSString * {{asLowerCamelCase name}}Argument= @"{{definedValue}}";
     {{/if}}
     {{else}}
-    {{chipType}} {{asCamelCased name true}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
+    {{chipType}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
     {{/if}}
     {{/chip_tests_item_parameters}}
-    [cluster writeAttribute{{asCamelCased attribute false}}WithValue:{{#chip_tests_item_parameters}}{{asCamelCased name true}}Argument{{/chip_tests_item_parameters}} responseHandler:^(NSError * err, NSDictionary * values) {
+    [cluster writeAttribute{{asUpperCamelCase attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} responseHandler:^(NSError * err, NSDictionary * values) {
     {{/if}}
         NSLog(@"{{label}} Error: %@", err);
 
@@ -47,12 +47,12 @@
         {{else}}
         {{#if (isString type)}}
         {{#if (isOctetString type)}}
-        NSString * {{asCamelCased name true}}ArgumentString= @"{{expectedValue}}";
-        NSData * {{asCamelCased name true}}Argument = [{{asCamelCased name true}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
-        XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToData:{{asCamelCased name true}}Argument]);
+        NSString * {{asLowerCamelCase name}}ArgumentString= @"{{expectedValue}}";
+        NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+        XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToData:{{asLowerCamelCase name}}Argument]);
         {{else}}
-        NSString * {{asCamelCased name true}}Argument= @"{{expectedValue}}";
-        XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToString:{{asCamelCased name true}}Argument]);
+        NSString * {{asLowerCamelCase name}}Argument= @"{{expectedValue}}";
+        XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToString:{{asLowerCamelCase name}}Argument]);
         {{/if}}
         {{else}}
         XCTAssertEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedValue}}{{asTypeLiteralSuffix}});

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -2230,7 +2230,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-        XCTAssertEqual([values[@"value"] unsignedShortValue], 2);
+        XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
         [expectation fulfill];
     }];
 
@@ -2248,7 +2248,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-        XCTAssertEqual([values[@"value"] unsignedShortValue], 2);
+        XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
         [expectation fulfill];
     }];
 
@@ -6435,7 +6435,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    uint16_t value = 0;
     [cluster writeAttributeOnTimeWithValue:value
                            responseHandler:^(NSError * err, NSDictionary * values) {
                                NSLog(@"OnOff OnTime Error: %@", err);
@@ -6472,7 +6472,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t value = 0x0000;
+    uint16_t value = 0;
     [cluster writeAttributeOffWaitTimeWithValue:value
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"OnOff OffWaitTime Error: %@", err);
@@ -6509,7 +6509,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    uint8_t value = 0;
     [cluster writeAttributeStartUpOnOffWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"OnOff StartUpOnOff Error: %@", err);


### PR DESCRIPTION
#### Problem

The OnOff cluster definition from Silabs is defined in 2 separated files, and the attributes names formatting is a bit different from the spec at: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/OnOff.adoc

#### Change overview
 * Remove the definitions from `Silabs/general.xml` and `Silabs/zll.xml` and move it to `Chip/onoff-cluster.xml`
 * Update the attributes names to match the formatting from the spec
 * Update the cluster revision from `2` to `3`
 * Update some test cases with the proper name and the proper cluster revision
 * Update `gen/` folders

For reviewers, the last commit is autogenerated code from the changes in the previous commits.
 
#### Testing
I have runned `./scripts/tests/suites.sh` locally with the changes from this patch. In fact this PR is a step to add an other set of test that uses the ZLL code from https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/zll-on-off-server that I still need to port to cpp.
