### PR TITLE
Add src/app/common/gen/attributes/Accessors.cpp to the build list of applications

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_CURRENT_LIST_DIR}"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/gen"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/shell_extension"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/common/gen/attributes"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/test-cluster-server"

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -93,6 +93,7 @@ template("chip_data_model") {
       "${_app_root}/clusters/zll-level-control-server/zll-level-control-server.h",
       "${_app_root}/clusters/zll-on-off-server/zll-on-off-server.h",
       "${_app_root}/clusters/zll-scenes-server/zll-scenes-server.h",
+      "${_app_root}/common/gen/attributes/Accessors.cpp",
       "${_app_root}/encoder-common.cpp",
       "${_app_root}/reporting/reporting-default-configuration.cpp",
       "${_app_root}/reporting/reporting-tokens.h",

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -41,9 +41,8 @@
 #include "barrier-control-server.h"
 #include <app/Command.h>
 #include <app/common/gen/af-structs.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/attribute-type.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/attributes/Accessors.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af.h>
 
 #include <assert.h>
@@ -52,6 +51,7 @@
 #include <app/reporting/reporting.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 typedef struct
 {
@@ -85,68 +85,55 @@ void emberAfPluginBarrierControlServerInitCallback(void) {}
 uint8_t emAfPluginBarrierControlServerGetBarrierPosition(EndpointId endpoint)
 {
     uint8_t position;
-    EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, ZCL_BARRIER_POSITION_ATTRIBUTE_ID,
-                                                      &position, sizeof(position));
+    EmberAfStatus status = BarrierControl::Attributes::GetBarrierPosition(endpoint, &position);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return position;
 }
 
 void emAfPluginBarrierControlServerSetBarrierPosition(EndpointId endpoint, uint8_t position)
 {
-    EmberAfStatus status = emberAfWriteServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, ZCL_BARRIER_POSITION_ATTRIBUTE_ID,
-                                                       &position, ZCL_INT8U_ATTRIBUTE_TYPE);
+    EmberAfStatus status = BarrierControl::Attributes::SetBarrierPosition(endpoint, position);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 
 bool emAfPluginBarrierControlServerIsPartialBarrierSupported(EndpointId endpoint)
 {
     uint8_t bitmap;
-    EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID,
-                                                      ZCL_BARRIER_CAPABILITIES_ATTRIBUTE_ID, &bitmap, sizeof(bitmap));
+    EmberAfStatus status = BarrierControl::Attributes::GetBarrierCapabilities(endpoint, &bitmap);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return READBITS(bitmap, EMBER_AF_BARRIER_CONTROL_CAPABILITIES_PARTIAL_BARRIER);
 }
 
 static uint16_t getOpenOrClosePeriod(EndpointId endpoint, bool open)
 {
-    uint16_t period         = 0;
-    AttributeId attributeId = 0xFFFF;
+    uint16_t period      = 0;
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_PERIOD_ATTRIBUTE)
     if (open)
     {
-        attributeId = ZCL_BARRIER_OPEN_PERIOD_ATTRIBUTE_ID;
+        status = BarrierControl::Attributes::GetBarrierOpenPeriod(endpoint, &period);
     }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_PERIOD_ATTRIBUTE)
     if (!open)
     {
-        attributeId = ZCL_BARRIER_CLOSE_PERIOD_ATTRIBUTE_ID;
+        status = BarrierControl::Attributes::GetBarrierClosePeriod(endpoint, &period);
     }
 #endif
-
-    if (attributeId != 0xFFFF)
-    {
-        EmberAfStatus status =
-            emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, attributeId, (uint8_t *) &period, sizeof(period));
-        assert(status == EMBER_ZCL_STATUS_SUCCESS);
-    }
-
+    assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return period;
 }
 
 static void setMovingState(EndpointId endpoint, uint8_t newState)
 {
-    EmberAfStatus status = emberAfWriteServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID,
-                                                       ZCL_BARRIER_MOVING_STATE_ATTRIBUTE_ID, &newState, ZCL_ENUM8_ATTRIBUTE_TYPE);
+    EmberAfStatus status = BarrierControl::Attributes::SetBarrierMovingState(endpoint, newState);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 
 uint16_t emAfPluginBarrierControlServerGetSafetyStatus(EndpointId endpoint)
 {
     uint16_t safetyStatus;
-    EmberAfStatus status =
-        emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, ZCL_BARRIER_SAFETY_STATUS_ATTRIBUTE_ID,
-                                   (uint8_t *) &safetyStatus, sizeof(safetyStatus));
+    EmberAfStatus status = BarrierControl::Attributes::GetBarrierSafetyStatus(endpoint, &safetyStatus);
     assert(status == EMBER_ZCL_STATUS_SUCCESS);
     return safetyStatus;
 }
@@ -159,44 +146,69 @@ static bool isRemoteLockoutOn(EndpointId endpoint)
 
 void emAfPluginBarrierControlServerIncrementEvents(EndpointId endpoint, bool open, bool command)
 {
-    uint8_t mask = (0
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    uint16_t events      = 0;
+
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_EVENTS_ATTRIBUTE)
-                    | (open && !command ? BIT(0) : 0)
+    if (open && !command)
+    {
+        status = BarrierControl::Attributes::GetBarrierOpenEvents(endpoint, &events);
+    }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_EVENTS_ATTRIBUTE)
-                    | (!open && !command ? BIT(1) : 0)
+    if (!open && !command)
+    {
+        status = BarrierControl::Attributes::GetBarrierCloseEvents(endpoint, &events);
+    }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_OPEN_EVENTS_ATTRIBUTE)
-                    | (open && command ? BIT(2) : 0)
+    if (open && command)
+    {
+        status = BarrierControl::Attributes::GetBarrierCommandOpenEvents(endpoint, &events);
+    }
 #endif
 #if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_CLOSE_EVENTS_ATTRIBUTE)
-                    | (!open && command ? BIT(3) : 0)
-#endif
-    );
-
-    AttributeId baseEventAttributeId = ZCL_BARRIER_OPEN_EVENTS_ATTRIBUTE_ID;
-    for (size_t bit = 0; bit < 4; bit++)
+    if (!open && command)
     {
-        if (READBIT(mask, bit))
-        {
-            AttributeId attributeId = static_cast<AttributeId>(baseEventAttributeId + bit);
-            uint16_t events;
-            EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, attributeId,
-                                                              (uint8_t *) &events, sizeof(events));
-            assert(status == EMBER_ZCL_STATUS_SUCCESS);
-
-            // Section 7.1.2.1.5-8 says that this events counter SHALL NOT roll over.
-            // The maximum 16-bit unsigned integer in Zigbee is 0xFFFE, so we have this
-            // check here.
-            if (events != UINT16_MAX - 1)
-            {
-                events++;
-                status = emberAfWriteServerAttribute(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, attributeId, (uint8_t *) &events,
-                                                     ZCL_INT16U_ATTRIBUTE_TYPE);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
-            }
-        }
+        status = BarrierControl::Attributes::GetBarrierCommandCloseEvents(endpoint, &events);
     }
+#endif
+    assert(status == EMBER_ZCL_STATUS_SUCCESS);
+
+    // Section 7.1.2.1.5-8 says that this events counter SHALL NOT roll over.
+    // The maximum 16-bit unsigned integer in Zigbee is 0xFFFE, so we have this
+    // check here.
+    if (events == UINT16_MAX - 1)
+    {
+        return;
+    }
+    events++;
+
+#if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_OPEN_EVENTS_ATTRIBUTE)
+    if (open && !command)
+    {
+        status = BarrierControl::Attributes::SetBarrierOpenEvents(endpoint, events);
+    }
+#endif
+#if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_CLOSE_EVENTS_ATTRIBUTE)
+    if (!open && !command)
+    {
+        status = BarrierControl::Attributes::SetBarrierCloseEvents(endpoint, events);
+    }
+#endif
+#if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_OPEN_EVENTS_ATTRIBUTE)
+    if (open && command)
+    {
+        status = BarrierControl::Attributes::SetBarrierCommandOpenEvents(endpoint, events);
+    }
+#endif
+#if defined(ZCL_USING_BARRIER_CONTROL_CLUSTER_BARRIER_COMMAND_CLOSE_EVENTS_ATTRIBUTE)
+    if (!open && command)
+    {
+        status = BarrierControl::Attributes::SetBarrierCommandCloseEvents(endpoint, events);
+    }
+#endif
+    assert(status == EMBER_ZCL_STATUS_SUCCESS);
 }
 
 // -----------------------------------------------------------------------------
@@ -241,7 +253,7 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
     {
         emAfPluginBarrierControlServerSetBarrierPosition(endpoint, state.currentPosition);
         setMovingState(endpoint, EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_STOPPED);
-        emberAfDeactivateServerTick(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID);
+        emberAfDeactivateServerTick(endpoint, BarrierControl::Id);
     }
     else
     {
@@ -269,7 +281,7 @@ void emberAfBarrierControlClusterServerTickCallback(EndpointId endpoint)
         setMovingState(
             endpoint,
             (state.increasing ? EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_OPENING : EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_CLOSING));
-        emberAfScheduleServerTick(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, state.delayMs);
+        emberAfScheduleServerTick(endpoint, BarrierControl::Id, state.delayMs);
     }
 }
 
@@ -309,7 +321,7 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Co
         state.delayMs         = calculateDelayMs(endpoint, state.targetPosition, &state.increasing);
         emberAfBarrierControlClusterPrintln("Scheduling barrier move from %d to %d with %dms delay", state.currentPosition,
                                             state.targetPosition, state.delayMs);
-        emberAfScheduleServerTick(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID, state.delayMs);
+        emberAfScheduleServerTick(endpoint, BarrierControl::Id, state.delayMs);
 
         if (state.currentPosition < state.targetPosition)
         {
@@ -329,7 +341,7 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Co
 bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::app::Command * commandObj)
 {
     EndpointId endpoint = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
-    emberAfDeactivateServerTick(endpoint, ZCL_BARRIER_CONTROL_CLUSTER_ID);
+    emberAfDeactivateServerTick(endpoint, BarrierControl::Id);
     setMovingState(endpoint, EMBER_ZCL_BARRIER_CONTROL_MOVING_STATE_STOPPED);
     sendDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;

--- a/src/app/common/gen/attributes/Accessors.cpp
+++ b/src/app/common/gen/attributes/Accessors.cpp
@@ -22,12 +22,12 @@
  *    This file contains definitions for accessors around clusters attributes.
  */
 
-#pragma once
-
 #include <app/common/gen/attributes/Accessors.h>
 
+#include <app/common/gen/attribute-type.h>
 #include <app/common/gen/ids/Attributes.h>
 #include <app/common/gen/ids/Clusters.h>
+#include <app/util/af.h>
 
 namespace chip {
 namespace app {
@@ -735,16 +735,6 @@ EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::NameSupport, (uint8_t *) &nameSupport,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
-}
-EmberAfStatus GetLastConfiguredBy(chip::EndpointId endpoint, /* TYPE WARNING: unknown defaults to */ uint8_t ** lastConfiguredBy)
-{
-    return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::LastConfiguredBy, (uint8_t *) lastConfiguredBy,
-                                      sizeof(*lastConfiguredBy));
-}
-EmberAfStatus SetLastConfiguredBy(chip::EndpointId endpoint, /* TYPE WARNING: unknown defaults to */ uint8_t * lastConfiguredBy)
-{
-    return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::LastConfiguredBy, (uint8_t *) &lastConfiguredBy,
-                                       ZCL_EUI64_ATTRIBUTE_TYPE);
 }
 } // namespace Attributes
 } // namespace Scenes

--- a/src/app/common/gen/attributes/Accessors.h
+++ b/src/app/common/gen/attributes/Accessors.h
@@ -191,9 +191,6 @@ EmberAfStatus GetSceneValid(chip::EndpointId endpoint, uint8_t * sceneValid); //
 EmberAfStatus SetSceneValid(chip::EndpointId endpoint, uint8_t sceneValid);
 EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
 EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport);
-EmberAfStatus GetLastConfiguredBy(chip::EndpointId endpoint,
-                                  /* TYPE WARNING: unknown defaults to */ uint8_t ** lastConfiguredBy); // eui64
-EmberAfStatus SetLastConfiguredBy(chip::EndpointId endpoint, /* TYPE WARNING: unknown defaults to */ uint8_t * lastConfiguredBy);
 } // namespace Attributes
 } // namespace Scenes
 

--- a/src/app/zap-templates/common/attributes/Accessors.js
+++ b/src/app/zap-templates/common/attributes/Accessors.js
@@ -23,7 +23,7 @@ const StructHelper = require('../../common/StructHelper.js');
 // The specification allow non-standard signed and unsigned integer with a width of 24, 40, 48 or 56, but those types does not have
 // proper support yet into the codebase and the resulting generated code can not be built with them.
 // Once they are supported, the following method could be removed.
-const unsupportedTypes = [ 'INT24S', 'INT40S', 'INT48S', 'INT56S', 'INT24U', 'INT40U', 'INT48U', 'INT56U' ];
+const unsupportedTypes = [ 'INT24S', 'INT40S', 'INT48S', 'INT56S', 'INT24U', 'INT40U', 'INT48U', 'INT56U', 'EUI64' ];
 function isUnsupportedType(type)
 {
   return unsupportedTypes.includes(type.toUpperCase());

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -5,12 +5,12 @@
  *    This file contains definitions for accessors around clusters attributes.
  */
 
-#pragma once
-
 #include <app/common/gen/attributes/Accessors.h>
 
+#include <app/common/gen/attribute-type.h>
 #include <app/common/gen/ids/Attributes.h>
 #include <app/common/gen/ids/Clusters.h>
+#include <app/util/af.h>
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
#### Problem

The original version of #7183 was emitting accessors code under `APP/gen/callback-stub.cpp`, and so the file was already part of what is built. I did a late change to #7183 to emit accessors code once for every APP into `src/app/gen/common/attributes/Accessors.cpp` but forgot to commit the change that glue it with applications.

#### Change overview
 * Add `Accessors.cpp` source file to `src/app/chip_data_model.gni`
 * Update `src/app/clusters/barrier-control-server/barrier-control-server.cpp` to use the methods from `Accessors.cpp` in order to make sure it is really built
 * Do not emit accessors from `EUI64`. I still need to figure how to have some aliases in ZAP in order to map a type to pre-existing types. This is only appearing as an issue for `EUI64` but really this is a global issue for all types that are marked as `Derived Types` in the spec.
 * Update the generated code (`./scripts/tools/zap_regen_all.py`)

#### Testing
It has been tested manually with `chip-tool` and a local `all-clusters-app`, by calling commands against the `Barrier Control` cluster.
