### PR TITLE
Re-enable cirque workflow

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -14,7 +14,10 @@
 
 name: Cirque
 
-on: workflow_dispatch
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}


### PR DESCRIPTION
#### Problem
Current chip instability issues cirque has discovered have been fixed. In https://github.com/yunhanw-google/connectedhomeip/actions/workflows/cirque.yaml, run 20 times, no failure happens.

#### Change overview
Re-enable cirque in presubmit and postsubmit.

#### Testing
Run github cirque action for 20 times, no failure has been found.
