### PR TITLE
Add utilities for extracting a PeerId from an opcert, and use them in CASE

### DIFF
--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -33,6 +33,7 @@
 #include <core/CHIPConfig.h>
 #include <core/CHIPTLV.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/PeerId.h>
 #include <support/BitFlags.h>
 #include <support/DLLUtil.h>
 
@@ -866,6 +867,37 @@ CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, ASN1::AS
  * @retval  #CHIP_NO_ERROR  If the signature value was successfully converted.
  */
 CHIP_ERROR ConvertECDSASignatureDERToRaw(ASN1::ASN1Reader & reader, chip::TLV::TLVWriter & writer, uint64_t tag);
+
+/**
+ * Extract a PeerId from an operational certificate that has already been
+ * parsed.
+ *
+ * @return CHIP_ERROR_INVALID_ARGUMENT if the passed-in cert does not have at
+ * least one NodeId RDN and one FabricId RDN in the Subject DN.  No other
+ * validation (e.g. checkign that there is exactly one RDN of each type) is
+ * performed.
+ */
+CHIP_ERROR ExtractPeerIdFromOpCert(const ChipCertificateData & opcert, PeerId * peerId);
+
+/**
+ * Extract a PeerId from an operational certificate in ByteSpan TLV-encoded
+ * form.  This does not perform any sort of validation on the certificate
+ * structure other than parsing it.
+ *
+ * Can return any error that can be returned from parsing the cert or from the
+ * ChipCertificateData* version of ExtractPeerIdFromOpCert.
+ */
+CHIP_ERROR ExtractPeerIdFromOpCert(const ByteSpan & opcert, PeerId * peerId);
+
+/**
+ * Extract a PeerId from an operational certificate array in ByteSpan
+ * TLV-encoded form.  This does not perform any sort of validation on the
+ * certificate structure other than parsing it.
+ *
+ * Can return any error that can be returned from parsing the array or from the
+ * ChipCertificateData* version of ExtractPeerIdFromOpCert.
+ */
+CHIP_ERROR ExtractPeerIdFromOpCertArray(const ByteSpan & opcertarray, PeerId * peerId);
 
 } // namespace Credentials
 } // namespace chip

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1215,6 +1215,12 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t * respond
         const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
         ReturnErrorOnFailure(mOpCredSet->FindValidCert(mTrustedRootId, subjectDN, subjectKeyId, mValidContext, resultCert));
+
+        // Now that we have verified that this is a valid cert, try to get the
+        // peer's operational identity from it.
+        PeerId peerId;
+        ReturnErrorOnFailure(ExtractPeerIdFromOpCert(certSet.GetCertSet()[0], &peerId));
+        mConnectionState.SetPeerNodeId(peerId.GetNodeId());
     }
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
This sets up the PeerNodeId for our CASE session's PeerConnectionState
correctly.

Without doing this, when we try to expire existing connections to the
peer node id at the end of CASE setup (which would normally drop stale
CASE sessions to the same node, PASE sessions, etc), we fail to do
that, because we try to do it for kUndefinedNodeId instead of the
right node id.

#### Problem
When we finish commissioning a device, it does not properly tear down its PASE session.  Then if it tries to initiate communication with is it can end up using that PASE session, which might be using a close BLE connection and whatnot.

#### Change overview
Make sure we properly determine the node id of the peer we establish a CASE session with and tear down all other connections to that peer.

This also adds utilities for extracting PeerId from a chip cert, which we need elsewhere anyway.

#### Testing
Manual testing so far.  Specifically I compiled all-clusters-app for m5stack like so:
```
idf.py -p /dev/tty.SLAB_USBtoUART erase_flash flash monitor
```
and then ran the following chip-tool commands:
```
% ./out/debug/standalone/chip-tool pairing ble-wifi ssid password 0 20202021 3840 
% ./out/debug/standalone/chip-tool binding bind 112233 0 1 6 1   
% ./out/debug/standalone/chip-tool onoff report on-off 1 2 1      
```

Without this fix, that ends up with the device trying to send the reports over BLE (and fail to send after the first one, because nothing is listening). With this fix the device ends up sending over UDP to the right IP address.

There is some work to be done to fix `./out/debug/standalone/chip-tool reporting listen 1` to work, but once that's done I will try to set up CI for this.