### PR TITLE
Fix the length check in reporting message handling.

### DIFF
--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -820,7 +820,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
 
     while (messageLen)
     {
-        CHECK_MESSAGE_LENGTH(2);
+        CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
         ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
 

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -820,7 +820,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
 
     while (messageLen)
     {
-        CHECK_MESSAGE_LENGTH(2);
+        CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
         ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -890,7 +890,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
 
     while (messageLen)
     {
-        CHECK_MESSAGE_LENGTH(2);
+        CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
         ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
 

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -3013,7 +3013,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
 
     while (messageLen)
     {
-        CHECK_MESSAGE_LENGTH(2);
+        CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
         ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
 


### PR DESCRIPTION
We changed attribute ids to be 32-bit, but the length check is still
checking for 2 bytes.  As a result we can end up running off the end
of our buffer when reading data from it (and usually do, since this
loop continues until the length as seen by the length check has been
exhausted!).

#### Problem
Length check is wrong.

#### Change overview
Use the right check.

#### Testing
Manual testing using `./out/debug/standalone/chip-tool reporting listen 1` that depends on un-landed code to make this work.  But I am hoping to stand up CI for this once that code lands.