### PR TITLE
Auto-close exchanges on response timeout, unless consumer says otherwise

### DIFF
--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -119,7 +119,6 @@ public:
         streamer_t * sout = streamer_get();
         streamer_printf(sout, "No response received\n");
 
-        gExchangeCtx->Close();
         gExchangeCtx = nullptr;
     }
 } gMockAppDelegate;

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -129,11 +129,16 @@ exit:
 void Command::Shutdown()
 {
     VerifyOrReturn(mState != CommandState::Uninitialized);
+    AbortExistingExchangeContext();
+    ShutdownInternal();
+}
+
+void Command::ShutdownInternal()
+{
     mCommandMessageWriter.Reset();
 
-    AbortExistingExchangeContext();
-
     mpExchangeMgr = nullptr;
+    mpExchangeCtx = nullptr;
     mpDelegate    = nullptr;
     ClearState();
 

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -78,9 +78,8 @@ public:
     CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
 
     /**
-     *  Shutdown the CommandSender. This terminates this instance
+     *  Shutdown the Command. This terminates this instance
      *  of the object and releases all held resources.
-     *
      */
     void Shutdown();
 
@@ -125,6 +124,12 @@ protected:
     CHIP_ERROR ConstructCommandPath(const CommandPathParams & aCommandPathParams, CommandDataElement::Builder aCommandDataElement);
     void ClearState();
     const char * GetStateStr() const;
+
+    /**
+     * Internal shutdown method that we use when we know what's going on with
+     * our exchange and don't need to manually close it.
+     */
+    void ShutdownInternal();
 
     InvokeCommand::Builder mInvokeCommandBuilder;
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -72,9 +72,7 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
     MoveToState(CommandState::Sending);
 
 exit:
-    // Keep Shutdown() from double-closing our exchange.
-    mpExchangeCtx = nullptr;
-    Shutdown();
+    ShutdownInternal();
     ChipLogFunctError(err);
     return err;
 }

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -92,10 +92,6 @@ CHIP_ERROR CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExcha
 exit:
     ChipLogFunctError(err);
 
-    // Null out mpExchangeCtx, so our Shutdown() call below won't try to abort
-    // it and fail to send an ack for the message we just received.
-    mpExchangeCtx = nullptr;
-
     if (mpDelegate != nullptr)
     {
         if (err != CHIP_NO_ERROR)
@@ -108,7 +104,7 @@ exit:
         }
     }
 
-    Shutdown();
+    ShutdownInternal();
     return err;
 }
 
@@ -122,7 +118,7 @@ void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeCon
         mpDelegate->CommandResponseError(this, CHIP_ERROR_TIMEOUT);
     }
 
-    Shutdown();
+    ShutdownInternal();
 }
 
 CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement)

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -56,7 +56,10 @@ public:
      *  all held resources.  The object must not be used after Shutdown() is called.
      *
      *  SDK consumer can choose when to shut down the ReadClient.
-     *  The ReadClient will never shut itself down, unless the overall InteractionModelEngine is shut down.
+     *  The ReadClient will automatically shut itself down when it receives a
+     *  response or the response times out.  So manual shutdown is only needed
+     *  to shut down a ReadClient before one of those two things has happened,
+     *  (e.g. if SendReadRequest returned failure).
      */
     void Shutdown();
 
@@ -126,6 +129,12 @@ private:
     CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload);
     CHIP_ERROR AbortExistingExchangeContext();
     const char * GetStateStr() const;
+
+    /**
+     * Internal shutdown method that we use when we know what's going on with
+     * our exchange and don't need to manually close it.
+     */
+    void ShutdownInternal();
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -115,6 +115,12 @@ private:
     const char * GetStateStr() const;
     void ClearState();
 
+    /**
+     * Internal shutdown method that we use when we know what's going on with
+     * our exchange and don't need to manually close it.
+     */
+    void ShutdownInternal();
+
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -339,10 +339,7 @@ CHIP_ERROR Device::OnMessageReceived(Messaging::ExchangeContext * exchange, cons
     return CHIP_NO_ERROR;
 }
 
-void Device::OnResponseTimeout(Messaging::ExchangeContext * ec)
-{
-    ec->Close();
-}
+void Device::OnResponseTimeout(Messaging::ExchangeContext * ec) {}
 
 CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption option, SetupPayload & setupPayload)
 {

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -357,14 +357,13 @@ void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void *
     if (ec == nullptr)
         return;
 
-    // NOTE: we don't set mResponseExpected to false here because the response could still arrive. If the user
-    // wants to never receive the response, they must close the exchange context.
-
     ec->NotifyResponseTimeout();
 }
 
 void ExchangeContext::NotifyResponseTimeout()
 {
+    SetResponseExpected(false);
+
     ExchangeDelegate * delegate = GetDelegate();
 
     // Call the user's timeout handler.
@@ -372,6 +371,8 @@ void ExchangeContext::NotifyResponseTimeout()
     {
         delegate->OnResponseTimeout(this);
     }
+
+    MessageHandled();
 }
 
 CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -75,6 +75,16 @@ public:
      *   This function is the protocol callback to invoke when the timeout for the receipt
      *   of a response message has expired.
      *
+     *   After calling this method an exchange will close itself unless one of
+     *   two things happens:
+     *
+     *   1) A call to SendMessage on the exchange with the kExpectResponse flag
+     *      set.
+     *   2) A call to WillSendMessage on the exchange.
+     *
+     *   Consumers that don't do one of those things MUST NOT retain a pointer
+     *   to the exchange.
+     *
      *  @param[in]    ec            A pointer to the ExchangeContext object.
      */
     virtual void OnResponseTimeout(ExchangeContext * ec) = 0;

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -84,11 +84,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    void OnResponseTimeout(ExchangeContext * ec) override
-    {
-        IsOnResponseTimeoutCalled = true;
-        ec->Close();
-    }
+    void OnResponseTimeout(ExchangeContext * ec) override { IsOnResponseTimeoutCalled = true; }
 
     bool IsOnResponseTimeoutCalled = false;
 };

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -303,6 +303,9 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
                  "CASESession timed out while waiting for a response from the peer. Expected message type was %" PRIu8,
                  to_underlying(mNextExpectedMsg));
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
+    // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
+    // exchange will handle that.
+    mExchangeCtxt = nullptr;
     Clear();
 }
 

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -112,8 +112,6 @@ void MessageCounterManager::OnResponseTimeout(Messaging::ExchangeContext * excha
     {
         ChipLogError(SecureChannel, "Timed out! Failed to clear message counter synchronization status.");
     }
-
-    exchangeContext->Close();
 }
 
 CHIP_ERROR MessageCounterManager::AddToReceiveTable(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -333,6 +333,9 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
                  "PASESession timed out while waiting for a response from the peer. Expected message type was %" PRIu8,
                  to_underlying(mNextExpectedMsg));
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
+    // Null out mExchangeCtxt so that Clear() doesn't try closing it.  The
+    // exchange will handle that.
+    mExchangeCtxt = nullptr;
     Clear();
 }
 


### PR DESCRIPTION
Unless the consumer sends another message or says to keep waiting, the
exchange should close.

#### Problem
Similar to #8050 but for timeouts instead of message receipt.  Right now a bunch of our exchange consumers fail to close them properly on timeout.

#### Change overview
Automatically close the exchange on timeout unless the consumer says otherwise.

#### Testing
Should have no observable behavior changes in non-error conditions.  Passes CI.