### PR TITLE
Fixes for esp32 flashing_script

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -18,6 +18,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -35,37 +36,4 @@ project(chip-all-clusters-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
-idf_build_get_property(build_dir BUILD_DIR)
-idf_build_get_property(project_path PROJECT_DIR)
-idf_build_get_property(sdkconfig SDKCONFIG)
-idf_build_get_property(idf_path IDF_PATH)
-
-add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-    COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
-            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-            --port "$ENV{ESPPORT}"
-            --baud "$ENV{ESPBAUD}"
-            --before ${CONFIG_ESPTOOLPY_BEFORE}
-            --after ${CONFIG_ESPTOOLPY_AFTER}
-            --application "${CMAKE_PROJECT_NAME}.bin"
-            --bootloader "bootloader/bootloader.bin"
-            --partition "partition_table/partition-table.bin"
-            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
-            --use-parttool ${idf_path}/components/partition_table/parttool.py
-            --use-sdkconfig ${project_path}/sdkconfig
-    WORKING_DIRECTORY ${build_dir}
-    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
-    VERBATIM)
-
-add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")
+flashing_script()

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -240,7 +240,6 @@ commissioning and cluster control.
 
 ```
         $ export ESPPORT=/dev/tty.SLAB_USBtoUART
-        $ export ESPBAUD=${baud_value}
         $ idf.py build
         $ idf.py flashing_script
         $ python ${app_name}.flash.py

--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -1,0 +1,71 @@
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Common cmake code for creating flash scripts.
+# Must include the IDF project.cmake file before this file.
+# Usage:
+#
+#   flashing_script([DEPENDS <dep1> <dep2>])
+#
+# where DEPENDS and its args are optional and list additional dependencies.
+# (use full path).
+
+function(get_additional_flashing_depends)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs DEPENDS)
+    cmake_parse_arguments(MYARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(additional_flashing_depends "${MYARGS_DEPENDS}" PARENT_SCOPE)
+endfunction(get_additional_flashing_depends)
+
+macro(flashing_script)
+  idf_build_get_property(build_dir BUILD_DIR)
+  idf_build_get_property(project_path PROJECT_DIR)
+  idf_build_get_property(sdkconfig SDKCONFIG)
+  idf_build_get_property(idf_path IDF_PATH)
+
+  set(flashing_utils_dir "${project_path}/third_party/connectedhomeip/scripts/flashing/")
+  set(board_firmware_utils "${IDF_TARGET}_firmware_utils.py")
+  configure_file("${flashing_utils_dir}/${board_firmware_utils}" "${build_dir}/${board_firmware_utils}")
+  configure_file("${flashing_utils_dir}/firmware_utils.py" "${build_dir}/firmware_utils.py")
+
+  get_additional_flashing_depends(${ARGN})
+  foreach(dep IN LISTS additional_flashing_depends)
+    get_filename_component(filename ${dep} NAME)
+    configure_file(${dep}, "${build_dir}/${filename}")
+    list(APPEND build_dir_depends "${build_dir}/${filename}")
+  endforeach(dep)
+
+  add_custom_target(flashing_script
+    COMMAND ${python}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" ${IDF_TARGET}
+            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
+            --port "$ENV{ESPPORT}"
+            --baud "$ENV{ESPBAUD}"
+            --before ${CONFIG_ESPTOOLPY_BEFORE}
+            --after ${CONFIG_ESPTOOLPY_AFTER}
+            --application "${CMAKE_PROJECT_NAME}.bin"
+            --bootloader "bootloader/bootloader.bin"
+            --partition "partition_table/partition-table.bin"
+            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
+            --use-parttool ${idf_path}/components/partition_table/parttool.py
+            --use-sdkconfig ${project_path}/sdkconfig
+    WORKING_DIRECTORY ${build_dir}
+    DEPENDS "${build_dir}/${board_firmware_utils}"
+            "${build_dir}/firmware_utils.py"
+            "${build_dir_deps}"
+    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
+    VERBATIM)
+endmacro(flashing_script)

--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -36,8 +36,16 @@ macro(flashing_script)
   idf_build_get_property(sdkconfig SDKCONFIG)
   idf_build_get_property(idf_path IDF_PATH)
 
+  if (${IDF_TARGET} MATCHES "esp32*")
+    set(board_type "esp32")
+  elseif (${IDF_TARGET} MATCHES "efr32*")
+    set(board_type "efr32")
+  else()
+    message(FATAL_ERROR "Unknown board type ${IDF_TARGET}")
+  endif()
+
   set(flashing_utils_dir "${project_path}/third_party/connectedhomeip/scripts/flashing/")
-  set(board_firmware_utils "${IDF_TARGET}_firmware_utils.py")
+  set(board_firmware_utils "${board_type}_firmware_utils.py")
   configure_file("${flashing_utils_dir}/${board_firmware_utils}" "${build_dir}/${board_firmware_utils}")
   configure_file("${flashing_utils_dir}/firmware_utils.py" "${build_dir}/firmware_utils.py")
 
@@ -50,7 +58,7 @@ macro(flashing_script)
 
   add_custom_target(flashing_script
     COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" ${IDF_TARGET}
+            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" ${board_type}
             --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
             --port "$ENV{ESPPORT}"
             --baud "$ENV{ESPBAUD}"

--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -38,21 +38,19 @@ macro(flashing_script)
 
   if (${IDF_TARGET} MATCHES "esp32*")
     set(board_type "esp32")
-  elseif (${IDF_TARGET} MATCHES "efr32*")
-    set(board_type "efr32")
   else()
     message(FATAL_ERROR "Unknown board type ${IDF_TARGET}")
   endif()
 
   set(flashing_utils_dir "${project_path}/third_party/connectedhomeip/scripts/flashing/")
   set(board_firmware_utils "${board_type}_firmware_utils.py")
-  configure_file("${flashing_utils_dir}/${board_firmware_utils}" "${build_dir}/${board_firmware_utils}")
-  configure_file("${flashing_utils_dir}/firmware_utils.py" "${build_dir}/firmware_utils.py")
+  configure_file("${flashing_utils_dir}/${board_firmware_utils}" "${build_dir}/${board_firmware_utils}" COPYONLY)
+  configure_file("${flashing_utils_dir}/firmware_utils.py" "${build_dir}/firmware_utils.py" COPYONLY)
 
   get_additional_flashing_depends(${ARGN})
   foreach(dep IN LISTS additional_flashing_depends)
     get_filename_component(filename ${dep} NAME)
-    configure_file("${dep}" "${build_dir}/${filename}")
+    configure_file("${dep}" "${build_dir}/${filename}" COPYONLY)
     list(APPEND build_dir_depends "${build_dir}/${filename}")
   endforeach(dep)
 
@@ -61,7 +59,7 @@ macro(flashing_script)
             "${project_path}/../../../scripts/flashing/gen_flashing_script.py" ${board_type}
             --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
             --port "$ENV{ESPPORT}"
-            --baud "$ENV{ESPBAUD}"
+            --baud 460800
             --before ${CONFIG_ESPTOOLPY_BEFORE}
             --after ${CONFIG_ESPTOOLPY_AFTER}
             --application "${CMAKE_PROJECT_NAME}.bin"

--- a/examples/common/cmake/idf_flashing.cmake
+++ b/examples/common/cmake/idf_flashing.cmake
@@ -52,7 +52,7 @@ macro(flashing_script)
   get_additional_flashing_depends(${ARGN})
   foreach(dep IN LISTS additional_flashing_depends)
     get_filename_component(filename ${dep} NAME)
-    configure_file(${dep}, "${build_dir}/${filename}")
+    configure_file("${dep}" "${build_dir}/${filename}")
     list(APPEND build_dir_depends "${build_dir}/${filename}")
   endforeach(dep)
 

--- a/examples/persistent-storage/esp32/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/CMakeLists.txt
@@ -17,6 +17,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -26,37 +27,4 @@ project(chip-persistent-storage)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
-idf_build_get_property(build_dir BUILD_DIR)
-idf_build_get_property(project_path PROJECT_DIR)
-idf_build_get_property(sdkconfig SDKCONFIG)
-idf_build_get_property(idf_path IDF_PATH)
-
-add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-    COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
-            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-            --port "$ENV{ESPPORT}"
-            --baud "$ENV{ESPBAUD}"
-            --before ${CONFIG_ESPTOOLPY_BEFORE}
-            --after ${CONFIG_ESPTOOLPY_AFTER}
-            --application "${CMAKE_PROJECT_NAME}.bin"
-            --bootloader "bootloader/bootloader.bin"
-            --partition "partition_table/partition-table.bin"
-            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
-            --use-parttool ${idf_path}/components/partition_table/parttool.py
-            --use-sdkconfig ${project_path}/sdkconfig
-    WORKING_DIRECTORY ${build_dir}
-    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
-    VERBATIM)
-
-add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")
+flashing_script()

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -120,7 +120,6 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 ```
         $ export ESPPORT=/dev/tty.SLAB_USBtoUART
-        $ export ESPBAUD=${baud_value}
         $ idf.py build
         $ idf.py flashing_script
         $ python ${app_name}.flash.py

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -29,4 +29,5 @@ project(chip-pigweed-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
+idf_build_get_property(project_path PROJECT_DIR)
 flashing_script(DEPENDS "${project_path}/echo_test_config.yml" "${project_path}/../mobly_tests/echo_test.py")

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -18,6 +18,8 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -27,47 +29,4 @@ project(chip-pigweed-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
-idf_build_get_property(build_dir BUILD_DIR)
-idf_build_get_property(project_path PROJECT_DIR)
-idf_build_get_property(sdkconfig SDKCONFIG)
-idf_build_get_property(idf_path IDF_PATH)
-
-add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/echo_test.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/../mobly_tests/echo_test.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/echo_test_config.yml"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/echo_test_config.yml" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-    COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
-            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-            --port "$ENV{ESPPORT}"
-            --baud "$ENV{ESPBAUD}"
-            --before ${CONFIG_ESPTOOLPY_BEFORE}
-            --after ${CONFIG_ESPTOOLPY_AFTER}
-            --application "${CMAKE_PROJECT_NAME}.bin"
-            --bootloader "bootloader/bootloader.bin"
-            --partition "partition_table/partition-table.bin"
-            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
-            --use-parttool ${idf_path}/components/partition_table/parttool.py
-            --use-sdkconfig ${project_path}/sdkconfig
-    WORKING_DIRECTORY ${build_dir}
-    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
-    VERBATIM)
-
-add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py" "${build_dir}/echo_test.py" "${build_dir}/echo_test_config.yml")
+flashing_script(DEPENDS "${project_path}/echo_test_config.yml" "${project_path}/../mobly_tests/echo_test.py")

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -114,7 +114,6 @@ To download and install packages.
 
 ```
         $ export ESPPORT=/dev/tty.SLAB_USBtoUART
-        $ export ESPBAUD=${baud_value}
         $ idf.py build
         $ idf.py flashing_script
         $ python ${app_name}.flash.py

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -24,6 +24,8 @@ if(NOT is_debug)
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
+
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -34,37 +36,4 @@ project(chip-temperature-measurement-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
-idf_build_get_property(build_dir BUILD_DIR)
-idf_build_get_property(project_path PROJECT_DIR)
-idf_build_get_property(sdkconfig SDKCONFIG)
-idf_build_get_property(idf_path IDF_PATH)
-
-add_custom_command(OUTPUT "${build_dir}/firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/esp32_firmware_utils.py"
-    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${project_path}/third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py" "${build_dir}/"
-    WORKING_DIRECTORY ${build_dir}
-    VERBATIM)
-
-add_custom_command(OUTPUT "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-    COMMAND ${python}
-            "${project_path}/../../../scripts/flashing/gen_flashing_script.py" esp32
-            --output "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py"
-            --port "$ENV{ESPPORT}"
-            --baud "$ENV{ESPBAUD}"
-            --before ${CONFIG_ESPTOOLPY_BEFORE}
-            --after ${CONFIG_ESPTOOLPY_AFTER}
-            --application "${CMAKE_PROJECT_NAME}.bin"
-            --bootloader "bootloader/bootloader.bin"
-            --partition "partition_table/partition-table.bin"
-            --use-partition-file "${build_dir}/partition_table/partition-table.bin"
-            --use-parttool ${idf_path}/components/partition_table/parttool.py
-            --use-sdkconfig ${project_path}/sdkconfig
-    WORKING_DIRECTORY ${build_dir}
-    COMMENT "To flash ${build_dir}/${CMAKE_PROJECT_NAME}.bin run ./build/${CMAKE_PROJECT_NAME}.flash.py"
-    VERBATIM)
-
-add_custom_target(flashing_script DEPENDS "${build_dir}/${CMAKE_PROJECT_NAME}.bin" "${build_dir}/${CMAKE_PROJECT_NAME}.flash.py" "${build_dir}/esp32_firmware_utils.py" "${build_dir}/firmware_utils.py")
+flashing_script()

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -199,7 +199,6 @@ commissioning and cluster control.
 
 ```
         $ export ESPPORT=/dev/tty.SLAB_USBtoUART
-        $ export ESPBAUD=${baud_value}
         $ idf.py build
         $ idf.py flashing_script
         $ python ${app_name}.flash.py

--- a/scripts/examples/build-all-clusters-app.py
+++ b/scripts/examples/build-all-clusters-app.py
@@ -59,12 +59,6 @@ def main():
 
   e = IDFExecutor()
 
-  if args.generate_flash_script:
-    if os.getenv('ESPPORT') is None:
-      logging.error('Port must be set to use flashing.')
-      logging.error('This can be set using the ESPPORT environment var')
-      return
-
   if args.clear_config:
     old_default_sdkconfig = None
     clear_curr = args.clear_config != 'curr'

--- a/scripts/examples/build-all-clusters-app.py
+++ b/scripts/examples/build-all-clusters-app.py
@@ -48,8 +48,6 @@ def main():
       '--generate-flash-script',
       action='store_true',
   )
-  parser.add_argument('--port', type=str, help='port to use for flashing. Ex. --port /dev/ttyUSB0')
-  parser.add_argument('--baud', type=int, help='baud rage to use for flasing')
 
   args = parser.parse_args()
 
@@ -61,25 +59,10 @@ def main():
 
   e = IDFExecutor()
 
-  port = os.getenv('ESPPORT')
-  baud = os.getenv('ESPBAUD')
   if args.generate_flash_script:
-    if args.port is not None:
-      port = args.port
-    if args.baud is not None:
-      baud = args.baud
-
-    envs_ok = True
-    if port is None:
+    if os.getenv('ESPPORT') is None:
       logging.error('Port must be set to use flashing.')
-      logging.error('This can be set using the ESPPORT environment var or the --port argument in this script')
-      envs_ok = False
-    if baud is None:
-      logging.error('Baud rate must be set to use flashing.')
-      logging.error('This can be set using the ESPBAUD environment var or the --baud argument in this script')
-      envs_ok = False
-      
-    if not envs_ok:
+      logging.error('This can be set using the ESPPORT environment var')
       return
 
   if args.clear_config:
@@ -110,6 +93,9 @@ def main():
 
   e.execute('build')
 
+  logging.info('Generating flash script')
+  if args.generate_flash_script:
+    e.execute('flashing_script')
 
 if __name__ == '__main__':
   # execute only if run as a script

--- a/scripts/flashing/esp32_firmware_utils.py
+++ b/scripts/flashing/esp32_firmware_utils.py
@@ -227,7 +227,7 @@ ESP32_OPTIONS = {
         },
         'bootloader_offset': {
             'help': 'Bootloader offset',
-            'default': None,
+            'default': '0x1000',
             'argparse': {
                 'metavar': 'OFFSET'
             },


### PR DESCRIPTION
#### Problem
Flash script for ESP32 throws an exception. Also, cmake code is duplicated in multiple projects.

#### Change overview
- brings back default for bootloader offset (this is what's causing the crash in most cases)
- puts cmake code into a macro in a common file rather than in each file.
- adds a flashing flag to the build-all-clusters-app.sh script that checks for the required environment variables and warns on unset variables (will also cause a crash)

#### Testing
- build (idf.py build) and created flashing script (idf.py flashing_script) in all clusters, pigweed and persistent storage