### PR TITLE
Fixed CHIP shell NFC commands compilation failure

### DIFF
--- a/src/lib/shell/commands/NFC.cpp
+++ b/src/lib/shell/commands/NFC.cpp
@@ -32,7 +32,7 @@ using chip::DeviceLayer::ConnectivityMgr;
 namespace chip {
 namespace Shell {
 
-static int NFCHandler(int argc, char ** argv)
+static CHIP_ERROR NFCHandler(int argc, char ** argv)
 {
     CHIP_ERROR error  = CHIP_NO_ERROR;
     streamer_t * sout = streamer_get();


### PR DESCRIPTION
#### Problem
The CHIP shell command handlers API changed and methods should return CHIP_ERROR instead of int. NFC commands file was not aligned and compilation for it fails.

#### Change overview
Changed NFCHandler to return CHIP_ERROR instead of int.

#### Testing
Verified that after change build for `NFC.cpp` file passes.
