### PR TITLE
[ChipTool] Update ReportingCommand.cpp to use the async GetConnectedD…

### DIFF
--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -26,19 +26,38 @@ using namespace ::chip;
 
 CHIP_ERROR ReportingCommand::Run()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Controller::BasicCluster cluster;
-
     auto * ctx = GetExecContext();
-    err        = ctx->commissioner->GetDevice(ctx->remoteId, &mDevice);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(chipTool, "Init failure! No pairing for device: %" PRIu64, ctx->localId));
 
-    AddReportCallbacks(mEndPointId);
-    cluster.Associate(mDevice, mEndPointId);
-
-    err = cluster.MfgSpecificPing(nullptr, nullptr);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
+    CHIP_ERROR err =
+        ctx->commissioner->GetConnectedDevice(ctx->remoteId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    VerifyOrExit(err == CHIP_NO_ERROR,
+                 ChipLogError(chipTool, "Failed in initiating connection to the device: %" PRIu64 ", error %s", ctx->remoteId,
+                              ErrorStr(err)));
 
 exit:
     return err;
+}
+
+void ReportingCommand::OnDeviceConnectedFn(void * context, chip::Controller::Device * device)
+{
+    ReportingCommand * command = reinterpret_cast<ReportingCommand *>(context);
+    VerifyOrReturn(command != nullptr,
+                   ChipLogError(chipTool, "Device connected, but cannot send the command, as the context is null"));
+
+    chip::Controller::BasicCluster cluster;
+    cluster.Associate(device, command->mEndPointId);
+
+    command->AddReportCallbacks(command->mEndPointId);
+
+    CHIP_ERROR err = cluster.MfgSpecificPing(nullptr, nullptr);
+    VerifyOrReturn(CHIP_NO_ERROR == err, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
+}
+
+void ReportingCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR err)
+{
+    ChipLogError(chipTool, "Failed in connecting to the device %" PRIu64 ". Error %s", deviceId, ErrorStr(err));
+
+    ReportingCommand * command = reinterpret_cast<ReportingCommand *>(context);
+    VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "ReportingCommand context is null"));
+    command->SetCommandExitStatus(err);
 }

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -50,7 +50,11 @@ void ReportingCommand::OnDeviceConnectedFn(void * context, chip::Controller::Dev
     command->AddReportCallbacks(command->mEndPointId);
 
     CHIP_ERROR err = cluster.MfgSpecificPing(nullptr, nullptr);
-    VerifyOrReturn(CHIP_NO_ERROR == err, ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err)));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Init failure! Ping failure: %s", ErrorStr(err));
+        command->SetCommandExitStatus(err);
+    }
 }
 
 void ReportingCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR err)

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -30,7 +30,9 @@
 class ReportingCommand : public Command
 {
 public:
-    ReportingCommand(const char * commandName) : Command(commandName)
+    ReportingCommand(const char * commandName) :
+        Command(commandName), mOnDeviceConnectedCallback(OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         AddArgument("endpoint-id", CHIP_ZCL_ENDPOINT_MIN, CHIP_ZCL_ENDPOINT_MAX, &mEndPointId);
     }
@@ -43,5 +45,10 @@ public:
 
 private:
     uint8_t mEndPointId;
-    ChipDevice * mDevice;
+
+    static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
+    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+
+    chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 };


### PR DESCRIPTION
…evice method

#### Problem

The `reporting` command of `chip-tool` has not been updated to use the new `GetConnectedDevice` api and so it fails to start.

#### Change overview
 * Update the code to use the async API
 
#### Testing
It was tested using `chip-tool reporting listen 1`
