### PR TITLE
Add ChipLogFormatMEI/ChipLogValueMEI

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -128,7 +128,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::BarrierControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::BarrierControl::Id));
             return;
         }
         }
@@ -183,7 +184,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Basic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Basic::Id));
             return;
         }
         }
@@ -378,7 +380,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Binding::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Binding::Id));
             return;
         }
         }
@@ -1844,7 +1847,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ColorControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ColorControl::Id));
             return;
         }
         }
@@ -1969,7 +1973,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -3359,7 +3364,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DoorLock::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DoorLock::Id));
             return;
         }
         }
@@ -3419,8 +3425,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::EthernetNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::EthernetNetworkDiagnostics::Id));
             return;
         }
         }
@@ -3619,7 +3625,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -3986,7 +3993,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Groups::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Groups::Id));
             return;
         }
         }
@@ -4103,7 +4111,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::IasZone::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::IasZone::Id));
             return;
         }
         }
@@ -4221,7 +4230,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Identify::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Identify::Id));
             return;
         }
         }
@@ -4752,7 +4762,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -4812,7 +4823,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LowPower::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LowPower::Id));
             return;
         }
         }
@@ -5500,7 +5512,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -5784,8 +5797,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::OtaSoftwareUpdateProvider::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OtaSoftwareUpdateProvider::Id));
             return;
         }
         }
@@ -5855,7 +5868,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -6362,7 +6376,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -6862,7 +6877,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Scenes::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Scenes::Id));
             return;
         }
         }
@@ -6922,7 +6938,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::SoftwareDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::SoftwareDiagnostics::Id));
             return;
         }
         }
@@ -7054,7 +7071,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TestCluster::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TestCluster::Id));
             return;
         }
         }
@@ -7114,8 +7132,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::ThreadNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ThreadNetworkDiagnostics::Id));
             return;
         }
         }
@@ -7175,7 +7193,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::WiFiNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::WiFiNetworkDiagnostics::Id));
             return;
         }
         }
@@ -7208,8 +7227,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -7315,7 +7334,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -952,7 +952,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/bridge-app/bridge-common/gen/IMClusterCommandHandler.cpp
@@ -135,7 +135,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -334,7 +335,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -865,7 +867,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -1553,7 +1556,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1623,7 +1627,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -2130,7 +2135,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -2163,8 +2169,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -2222,7 +2228,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/bridge-app/bridge-common/gen/attribute-size.cpp
+++ b/examples/bridge-app/bridge-common/gen/attribute-size.cpp
@@ -511,7 +511,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -26,8 +26,9 @@ using namespace ::chip;
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {
-    ChipLogDetail(Controller, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Controller,
+                  "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     ChipLogError(
         Controller,
         "Default DispatchSingleClusterCommand is called, this should be replaced by actual dispatched for cluster commands");

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -25,43 +25,46 @@
 
 #include "LightingManager.h"
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId == OnOff::Id)
     {
-        if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+        if (attributeId != OnOff::Attributes::Ids::OnOff)
         {
-            ChipLogError(Zcl, "ON OFF attribute ID: 0x%" PRIx32 " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
-                         attributeId, type, *value, size);
+            ChipLogError(Zcl, "ON OFF attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+                         ChipLogValueMEI(attributeId), type, *value, size);
             return;
         }
 
         LightMgr().InitiateAction(AppEvent::kEventType_Light, *value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION);
     }
-    else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
+    else if (clusterId == LevelControl::Id)
     {
-        ChipLogProgress(Zcl, "Level Control attribute ID: 0x%" PRIx32 " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
-                        attributeId, type, *value, size);
+        ChipLogProgress(Zcl,
+                        "Level Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+                        ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
-    else if (clusterId == ZCL_COLOR_CONTROL_CLUSTER_ID)
+    else if (clusterId == ColorControl::Id)
     {
-        ChipLogProgress(Zcl, "Color Control attribute ID: 0x%" PRIx32 " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
-                        attributeId, type, *value, size);
+        ChipLogProgress(Zcl,
+                        "Color Control attribute ID: " ChipLogFormatMEI " Type: %" PRIu8 " Value: %" PRIu16 ", length %" PRIu16,
+                        ChipLogValueMEI(attributeId), type, *value, size);
 
         // WIP Apply attribute change to Light
     }
     else
     {
-        ChipLogProgress(Zcl, "Unknown Cluster ID: 0x%" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown Cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     }
 }
 

--- a/examples/lighting-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/k32w/main/ZclCallbacks.cpp
@@ -21,25 +21,26 @@
 #include "AppTask.h"
 #include "LightingManager.h"
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lighting-app/lighting-common/gen/IMClusterCommandHandler.cpp
@@ -1476,7 +1476,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ColorControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ColorControl::Id));
             return;
         }
         }
@@ -1601,7 +1602,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -1661,8 +1663,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::EthernetNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::EthernetNetworkDiagnostics::Id));
             return;
         }
         }
@@ -1861,7 +1863,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -2392,7 +2395,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -3080,7 +3084,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -3150,7 +3155,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -3657,7 +3663,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -3717,7 +3724,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::SoftwareDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::SoftwareDiagnostics::Id));
             return;
         }
         }
@@ -3777,8 +3785,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::ThreadNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ThreadNetworkDiagnostics::Id));
             return;
         }
         }
@@ -3838,7 +3846,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::WiFiNetworkDiagnostics::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::WiFiNetworkDiagnostics::Id));
             return;
         }
         }
@@ -3871,8 +3880,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -3945,7 +3954,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/lighting-app/lighting-common/gen/attribute-size.cpp
+++ b/examples/lighting-app/lighting-common/gen/attribute-size.cpp
@@ -383,7 +383,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -20,8 +20,8 @@
 #include <platform/PlatformManager.h>
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
@@ -39,20 +39,21 @@
 #include <iostream>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -18,9 +18,9 @@
 
 #include <support/logging/CHIPLogging.h>
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
-#include <app/common/gen/command-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
+#include <app/common/gen/ids/Commands.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 
@@ -28,28 +28,29 @@
 #include "LightingManager.h"
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    ChipLogProgress(Zcl, "Cluster callback: %" PRIx32, clusterId);
+    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
-    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId == OnOff::Id)
     {
-        if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+        if (attributeId != OnOff::Attributes::Ids::OnOff)
         {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+            ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;
         }
 
         LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION,
                                      AppEvent::kEventType_Lighting, size, value);
     }
-    else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
+    else if (clusterId == LevelControl::Id)
     {
-        if (attributeId != ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
+        if (attributeId != LevelControl::Attributes::Ids::CurrentLevel)
         {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+            ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;
         }
 
@@ -65,7 +66,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
     else
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 }

--- a/examples/lighting-app/telink/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/telink/src/ZclCallbacks.cpp
@@ -18,9 +18,9 @@
 
 #include <support/logging/CHIPLogging.h>
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
-#include <app/common/gen/command-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
+#include <app/common/gen/ids/Commands.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 
@@ -28,28 +28,29 @@
 #include "LightingManager.h"
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    ChipLogProgress(Zcl, "Cluster callback: %" PRIx32, clusterId);
+    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
-    if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId == OnOff::Id)
     {
-        if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+        if (attributeId != OnOff::Attributes::Ids::OnOff)
         {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+            ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;
         }
 
         LightingMgr().InitiateAction(*value ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION,
                                      AppEvent::kEventType_Lighting, size, value);
     }
-    else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
+    else if (clusterId == LevelControl::Id)
     {
-        if (attributeId != ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
+        if (attributeId != LevelControl::Attributes::Ids::CurrentLevel)
         {
-            ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+            ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             return;
         }
 
@@ -65,7 +66,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
     else
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 }

--- a/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -21,26 +21,27 @@
 #include "BoltLockManager.h"
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -23,24 +23,25 @@
 #include "AppConfig.h"
 #include "BoltLockManager.h"
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        EFR32_LOG("Unknown cluster ID: %" PRIx32, clusterId);
+        EFR32_LOG("Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        EFR32_LOG("Unknown attribute ID: %" PRIx32, attributeId);
+        EFR32_LOG("Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -21,25 +21,26 @@
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/lock-app/lock-common/gen/IMClusterCommandHandler.cpp
@@ -135,7 +135,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -334,7 +335,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -1022,7 +1024,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1092,7 +1095,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -1599,7 +1603,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -1632,8 +1637,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -1688,7 +1693,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/lock-app/lock-common/gen/attribute-size.cpp
+++ b/examples/lock-app/lock-common/gen/attribute-size.cpp
@@ -383,7 +383,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -21,26 +21,26 @@
 #include "AppTask.h"
 #include "BoltLockManager.h"
 
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
-#include <app/common/gen/command-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/af.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -21,27 +21,28 @@
 #include "PumpManager.h"
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
 #include <app/common/gen/enums.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-app/nrfconnect/main/ZclCallbacks.cpp
@@ -21,28 +21,30 @@
 #include "PumpManager.h"
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
 #include <app/common/gen/enums.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx16 " %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, attributeId, *value);
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    ChipLogProgress(Zcl, "%s: %" PRIx16 " " ChipLogFormatMEI " " ChipLogFormatMEI " %d", __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId), *value);
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 
@@ -105,7 +107,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                         chip::AttributeId attributeId)
 {
-    ChipLogProgress(Zcl, "%s: %d %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, manufacturerCode, attributeId);
+    ChipLogProgress(Zcl, "%s: %d " ChipLogFormatMEI " %" PRIx16 " " ChipLogFormatMEI, __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), manufacturerCode, ChipLogValueMEI(attributeId));
     return true;
 }
 
@@ -120,7 +123,8 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, c
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                          chip::AttributeId attributeId)
 {
-    ChipLogProgress(Zcl, "%s: %d %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, manufacturerCode, attributeId);
+    ChipLogProgress(Zcl, "%s: %d " ChipLogFormatMEI " %" PRIx16 " " ChipLogFormatMEI, __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), manufacturerCode, ChipLogValueMEI(attributeId));
     return true;
 }
 
@@ -171,44 +175,44 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::
 
 bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
                                                bool extended)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 

--- a/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-app/pump-common/gen/CHIPClientCallbacks.cpp
@@ -403,8 +403,8 @@ app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInsta
 bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     ChipLogProgress(Zcl, "DefaultResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
-    ChipLogProgress(Zcl, "  CommandId: 0x%08x", commandId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogProgress(Zcl, "  CommandId: " ChipLogFormatMEI, ChipLogValueMEI(commandId));
     LogStatus(status);
 
     GET_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
@@ -485,7 +485,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
                                             TLV::TLVReader * apData, Protocols::InteractionModel::ProtocolCode status)
 {
     ChipLogProgress(Zcl, "ReadAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%04x", aPath.mClusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mClusterId));
 
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -514,7 +514,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         return true;
     }
 
-    ChipLogProgress(Zcl, "  attributeId: 0x%04x", aPath.mFieldId);
+    ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mFieldId));
     LogIMStatus(status);
 
     if (status == Protocols::InteractionModel::ProtocolCode::Success && apData != nullptr)
@@ -536,7 +536,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
 bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "WriteAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfWriteAttributesResponseCallback");
 
@@ -557,7 +557,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
         {
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -585,7 +585,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
 bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ConfigureReportingResponseCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfConfigureReportingResponseCallback");
 
@@ -615,7 +615,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -643,7 +643,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ReadReportingConfigurationResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfReadReportingConfigurationResponseCallback");
 
@@ -656,7 +656,7 @@ bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId
 
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -707,7 +707,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
                                                bool extended)
 {
     ChipLogProgress(Zcl, "DiscoverAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  extended: %d", extended);
 
@@ -718,7 +718,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -743,14 +743,15 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint1
                                                       CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsGeneratedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -763,14 +764,15 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsReceivedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -807,13 +809,13 @@ static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t 
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     NodeId sourceId = emberAfCurrentCommand()->SourceNodeId();
     ChipLogProgress(Zcl, "  Source NodeId: %" PRIu64, sourceId);
 
     EndpointId endpointId = emberAfCurrentCommand()->apsFrame->sourceEndpoint;
-    ChipLogProgress(Zcl, "  Source EndpointId: 0x%08x", endpointId);
+    ChipLogProgress(Zcl, "  Source EndpointId: 0x%04x", endpointId);
 
     // TODO onFailureCallback is just here because of the CHECK_MESSAGE_LENGTH macro. It needs to be removed.
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -822,7 +824,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
 
         GET_REPORT_CALLBACK("emberAfReportAttributesCallback");
 

--- a/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-app/pump-common/gen/IMClusterCommandHandler.cpp
@@ -65,7 +65,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Basic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Basic::Id));
             return;
         }
         }
@@ -190,7 +191,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -389,7 +391,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -920,7 +923,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -1549,7 +1553,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1619,7 +1624,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -2126,7 +2132,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -2159,8 +2166,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -2221,7 +2228,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/pump-app/pump-common/gen/attribute-size.cpp
+++ b/examples/pump-app/pump-common/gen/attribute-size.cpp
@@ -383,7 +383,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -21,27 +21,28 @@
 #include "PumpManager.h"
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
 #include <app/common/gen/enums.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 

--- a/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/ZclCallbacks.cpp
@@ -21,28 +21,30 @@
 #include "PumpManager.h"
 
 #include <app/chip-zcl-zpro-codec.h>
-#include <app/common/gen/attribute-id.h>
-#include <app/common/gen/cluster-id.h>
 #include <app/common/gen/enums-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
 using namespace ::chip;
+using namespace ::chip::app::Clusters;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
-    ChipLogProgress(Zcl, "%s: %d %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, attributeId, *value);
-    if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
+    ChipLogProgress(Zcl, "%s: %" PRIx16 " " ChipLogFormatMEI " " ChipLogFormatMEI " %d", __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId), *value);
+    if (clusterId != OnOff::Id)
     {
-        ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
+        ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
 
-    if (attributeId != ZCL_ON_OFF_ATTRIBUTE_ID)
+    if (attributeId != OnOff::Attributes::Ids::OnOff)
     {
-        ChipLogProgress(Zcl, "Unknown attribute ID: %" PRIx32, attributeId);
+        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         return;
     }
 
@@ -95,7 +97,8 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 bool emberAfAttributeReadAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                         chip::AttributeId attributeId)
 {
-    ChipLogProgress(Zcl, "%s: %d %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, manufacturerCode, attributeId);
+    ChipLogProgress(Zcl, "%s: %d " ChipLogFormatMEI " %" PRIx16 " " ChipLogFormatMEI, __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), manufacturerCode, ChipLogValueMEI(attributeId));
     return true;
 }
 
@@ -110,7 +113,8 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(chip::EndpointId endpoint, c
 bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, uint16_t manufacturerCode,
                                          chip::AttributeId attributeId)
 {
-    ChipLogProgress(Zcl, "%s: %d %" PRIx32 " %" PRIx32 " %d", __FUNCTION__, endpoint, clusterId, manufacturerCode, attributeId);
+    ChipLogProgress(Zcl, "%s: %d " ChipLogFormatMEI " %" PRIx16 " " ChipLogFormatMEI, __FUNCTION__, endpoint,
+                    ChipLogValueMEI(clusterId), manufacturerCode, ChipLogValueMEI(attributeId));
     return true;
 }
 
@@ -161,44 +165,44 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(chip::
 
 bool emberAfReadAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfWriteAttributesResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfReportAttributesCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 
 bool emberAfDiscoverAttributesResponseCallback(chip::ClusterId clusterId, bool discoveryComplete, uint8_t * buffer, uint16_t bufLen,
                                                bool extended)
 {
-    ChipLogProgress(Zcl, "%s: %" PRIx32, __FUNCTION__, clusterId);
+    ChipLogProgress(Zcl, "%s: " ChipLogFormatMEI, __FUNCTION__, ChipLogValueMEI(clusterId));
     return false;
 }
 

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClientCallbacks.cpp
@@ -403,8 +403,8 @@ app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInsta
 bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     ChipLogProgress(Zcl, "DefaultResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
-    ChipLogProgress(Zcl, "  CommandId: 0x%08x", commandId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogProgress(Zcl, "  CommandId: " ChipLogFormatMEI, ChipLogValueMEI(commandId));
     LogStatus(status);
 
     GET_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
@@ -485,7 +485,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
                                             TLV::TLVReader * apData, Protocols::InteractionModel::ProtocolCode status)
 {
     ChipLogProgress(Zcl, "ReadAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%04x", aPath.mClusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mClusterId));
 
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -514,7 +514,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         return true;
     }
 
-    ChipLogProgress(Zcl, "  attributeId: 0x%04x", aPath.mFieldId);
+    ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mFieldId));
     LogIMStatus(status);
 
     if (status == Protocols::InteractionModel::ProtocolCode::Success && apData != nullptr)
@@ -536,7 +536,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
 bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "WriteAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfWriteAttributesResponseCallback");
 
@@ -557,7 +557,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
         {
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -585,7 +585,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
 bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ConfigureReportingResponseCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfConfigureReportingResponseCallback");
 
@@ -615,7 +615,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -643,7 +643,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ReadReportingConfigurationResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfReadReportingConfigurationResponseCallback");
 
@@ -656,7 +656,7 @@ bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId
 
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -707,7 +707,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
                                                bool extended)
 {
     ChipLogProgress(Zcl, "DiscoverAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  extended: %d", extended);
 
@@ -718,7 +718,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -743,14 +743,15 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint1
                                                       CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsGeneratedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -763,14 +764,15 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsReceivedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -807,13 +809,13 @@ static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t 
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     NodeId sourceId = emberAfCurrentCommand()->SourceNodeId();
     ChipLogProgress(Zcl, "  Source NodeId: %" PRIu64, sourceId);
 
     EndpointId endpointId = emberAfCurrentCommand()->apsFrame->sourceEndpoint;
-    ChipLogProgress(Zcl, "  Source EndpointId: 0x%08x", endpointId);
+    ChipLogProgress(Zcl, "  Source EndpointId: 0x%04x", endpointId);
 
     // TODO onFailureCallback is just here because of the CHECK_MESSAGE_LENGTH macro. It needs to be removed.
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -822,7 +824,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
 
         GET_REPORT_CALLBACK("emberAfReportAttributesCallback");
 

--- a/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/IMClusterCommandHandler.cpp
@@ -65,7 +65,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Basic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Basic::Id));
             return;
         }
         }
@@ -190,7 +191,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -389,7 +391,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -1077,7 +1080,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1584,7 +1588,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -1617,8 +1622,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -1673,7 +1678,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
@@ -383,7 +383,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
@@ -135,7 +135,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -334,7 +335,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -882,7 +884,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1389,7 +1392,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -1422,8 +1426,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -1475,7 +1479,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
@@ -203,7 +203,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
@@ -128,7 +128,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::BarrierControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::BarrierControl::Id));
             return;
         }
         }
@@ -183,7 +184,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Basic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Basic::Id));
             return;
         }
         }
@@ -378,7 +380,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Binding::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Binding::Id));
             return;
         }
         }
@@ -1465,7 +1468,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ColorControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ColorControl::Id));
             return;
         }
         }
@@ -1590,7 +1594,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -2980,7 +2985,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DoorLock::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DoorLock::Id));
             return;
         }
         }
@@ -3179,7 +3185,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -3546,7 +3553,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Groups::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Groups::Id));
             return;
         }
         }
@@ -3663,7 +3671,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::IasZone::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::IasZone::Id));
             return;
         }
         }
@@ -3781,7 +3790,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Identify::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Identify::Id));
             return;
         }
         }
@@ -4312,7 +4322,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -4372,7 +4383,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LowPower::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LowPower::Id));
             return;
         }
         }
@@ -5060,7 +5072,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -5344,8 +5357,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::OtaSoftwareUpdateProvider::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OtaSoftwareUpdateProvider::Id));
             return;
         }
         }
@@ -5415,7 +5428,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -5922,7 +5936,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -6422,7 +6437,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Scenes::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Scenes::Id));
             return;
         }
         }
@@ -6492,7 +6508,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TestCluster::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TestCluster::Id));
             return;
         }
         }
@@ -6525,8 +6542,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -6620,7 +6637,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/thermostat/thermostat-common/gen/attribute-size.cpp
+++ b/examples/thermostat/thermostat-common/gen/attribute-size.cpp
@@ -952,7 +952,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -190,7 +190,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::AccountLogin::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::AccountLogin::Id));
             return;
         }
         }
@@ -303,7 +304,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ApplicationBasic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ApplicationBasic::Id));
             return;
         }
         }
@@ -427,7 +429,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ApplicationLauncher::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ApplicationLauncher::Id));
             return;
         }
         }
@@ -604,7 +607,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::AudioOutput::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::AudioOutput::Id));
             return;
         }
         }
@@ -659,7 +663,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Basic::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Basic::Id));
             return;
         }
         }
@@ -854,7 +859,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Binding::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Binding::Id));
             return;
         }
         }
@@ -1038,7 +1044,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ContentLauncher::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ContentLauncher::Id));
             return;
         }
         }
@@ -1163,7 +1170,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DiagnosticLogs::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DiagnosticLogs::Id));
             return;
         }
         }
@@ -1362,7 +1370,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -1475,7 +1484,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::KeypadInput::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::KeypadInput::Id));
             return;
         }
         }
@@ -2006,7 +2016,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LevelControl::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LevelControl::Id));
             return;
         }
         }
@@ -2066,7 +2077,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::LowPower::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::LowPower::Id));
             return;
         }
         }
@@ -2253,7 +2265,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::MediaInput::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::MediaInput::Id));
             return;
         }
         }
@@ -2524,7 +2537,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::MediaPlayback::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::MediaPlayback::Id));
             return;
         }
         }
@@ -3212,7 +3226,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -3496,8 +3511,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::OtaSoftwareUpdateProvider::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OtaSoftwareUpdateProvider::Id));
             return;
         }
         }
@@ -3567,7 +3582,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OnOff::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OnOff::Id));
             return;
         }
         }
@@ -4074,7 +4090,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -4309,7 +4326,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TvChannel::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TvChannel::Id));
             return;
         }
         }
@@ -4428,7 +4446,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TargetNavigator::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TargetNavigator::Id));
             return;
         }
         }
@@ -4461,8 +4480,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -4562,7 +4581,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -818,7 +818,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/examples/window-app/common/gen/IMClusterCommandHandler.cpp
+++ b/examples/window-app/common/gen/IMClusterCommandHandler.cpp
@@ -209,7 +209,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -897,7 +898,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -1404,7 +1406,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -1716,7 +1719,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::WindowCovering::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::WindowCovering::Id));
             return;
         }
         }
@@ -1749,8 +1753,8 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -1802,7 +1806,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/examples/window-app/common/gen/attribute-size.cpp
+++ b/examples/window-app/common/gen/attribute-size.cpp
@@ -383,7 +383,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -101,7 +101,7 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
     if (CHIP_END_OF_TLV == err)
     {
         err = CHIP_NO_ERROR;
-        ChipLogDetail(DataManagement, "Received command without data for cluster %" PRIx32, clusterId);
+        ChipLogDetail(DataManagement, "Received command without data for cluster " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     }
     if (CHIP_NO_ERROR == err)
     {
@@ -121,7 +121,8 @@ exit:
         // TODO: The error code should be updated after #7072 added error codes required by IM.
         if (err == CHIP_ERROR_INVALID_PROFILE_ID)
         {
-            ChipLogDetail(DataManagement, "No Cluster 0x%" PRIx32 " on Endpoint 0x%" PRIx16, clusterId, endpointId);
+            ChipLogDetail(DataManagement, "No Cluster " ChipLogFormatMEI " on Endpoint 0x%" PRIx16, ChipLogValueMEI(clusterId),
+                          endpointId);
         }
 
         AddStatusCode(returnStatusParam,

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -569,10 +569,11 @@ exit:
 
 #if CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
         ChipLogDetail(EventLogging,
-                      "LogEvent event number: 0x" ChipLogFormatX64 " schema priority: %u cluster id: 0x%" PRIx32
+                      "LogEvent event number: 0x" ChipLogFormatX64 " schema priority: %u cluster id: " ChipLogFormatMEI
                       " event id: 0x%" PRIx32 " sys timestamp: 0x" ChipLogFormatX64,
                       ChipLogValueX64(aEventNumber), static_cast<unsigned>(opts.mpEventSchema->mPriority),
-                      opts.mpEventSchema->mClusterId, opts.mpEventSchema->mEventId, ChipLogValueX64(opts.mTimestamp.mValue));
+                      ChipLogValueMEI(opts.mpEventSchema->mClusterId), opts.mpEventSchema->mEventId,
+                      ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
         ScheduleFlushIfNeeded(opts.mUrgent);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -342,10 +342,10 @@ CHIP_ERROR __attribute__((weak))
 WriteSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVReader & aReader, WriteHandler * apWriteHandler)
 {
     ChipLogDetail(DataManagement,
-                  "Received Cluster Attribute: Cluster=%" PRIx32 " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx16
+                  "Received Cluster Attribute: Cluster=" ChipLogFormatMEI " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx16
                   " FieldId=%" PRIx32 " ListIndex=%" PRIx16,
-                  aClusterInfo.mClusterId, ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId, aClusterInfo.mFieldId,
-                  aClusterInfo.mListIndex);
+                  ChipLogValueMEI(aClusterInfo.mClusterId), ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId,
+                  aClusterInfo.mFieldId, aClusterInfo.mListIndex);
     ChipLogError(DataManagement,
                  "Default WriteSingleClusterData is called, this should be replaced by actual dispatched for cluster");
     return CHIP_NO_ERROR;

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -21,15 +21,16 @@
  ***************************************************************************/
 
 #include <app/common/gen/af-structs.h>
-#include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
-#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/ids/Attributes.h>
+#include <app/common/gen/ids/Clusters.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
 using namespace chip;
+using namespace chip::app::Clusters;
 
 constexpr const char * kErrorStr = "Descriptor cluster (0x%02x) Error setting '%s' attribute: 0x%02x";
 
@@ -37,7 +38,7 @@ EmberAfStatus writeAttribute(EndpointId endpoint, AttributeId attributeId, uint8
 {
     EmberAfAttributeSearchRecord record;
     record.endpoint         = endpoint;
-    record.clusterId        = ZCL_DESCRIPTOR_CLUSTER_ID;
+    record.clusterId        = Descriptor::Id;
     record.clusterMask      = CLUSTER_MASK_SERVER;
     record.manufacturerCode = EMBER_AF_NULL_MANUFACTURER_CODE;
     record.attributeId      = attributeId;
@@ -56,7 +57,7 @@ EmberAfStatus writeAttribute(EndpointId endpoint, AttributeId attributeId, uint8
 EmberAfStatus writeClientServerAttribute(EndpointId endpoint, bool server)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = server ? ZCL_SERVER_LIST_ATTRIBUTE_ID : ZCL_CLIENT_LIST_ATTRIBUTE_ID;
+    AttributeId attributeId = server ? Descriptor::Attributes::Ids::ServerList : Descriptor::Attributes::Ids::ClientList;
 
     uint16_t clusterCount = emberAfClusterCount(endpoint, server);
 
@@ -84,7 +85,7 @@ EmberAfStatus writeClientAttribute(EndpointId endpoint)
 EmberAfStatus writeDeviceAttribute(EndpointId endpoint, uint16_t index)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = ZCL_DEVICE_LIST_ATTRIBUTE_ID;
+    AttributeId attributeId = Descriptor::Attributes::Ids::DeviceList;
 
     uint16_t deviceTypeCount  = 1;
     DeviceTypeId deviceTypeId = emberAfDeviceIdFromIndex(index);
@@ -103,7 +104,7 @@ EmberAfStatus writeDeviceAttribute(EndpointId endpoint, uint16_t index)
 EmberAfStatus writePartsAttribute(EndpointId endpoint)
 {
     EmberAfStatus status    = EMBER_ZCL_STATUS_SUCCESS;
-    AttributeId attributeId = ZCL_PARTS_LIST_ATTRIBUTE_ID;
+    AttributeId attributeId = Descriptor::Attributes::Ids::PartsList;
 
     uint16_t partsCount = 0;
 
@@ -131,7 +132,7 @@ void emberAfPluginDescriptorServerInitCallback(void)
     for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
     {
         EndpointId endpoint = emberAfEndpointFromIndex(index);
-        if (!emberAfContainsCluster(endpoint, ZCL_DESCRIPTOR_CLUSTER_ID))
+        if (!emberAfContainsCluster(endpoint, Descriptor::Id))
         {
             continue;
         }

--- a/src/app/common/gen/ids/Attributes.h
+++ b/src/app/common/gen/ids/Attributes.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <app/util/basic-types.h>
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/src/app/decoder.cpp
+++ b/src/app/decoder.cpp
@@ -59,11 +59,11 @@ uint16_t extractApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * 
 void printApsFrame(EmberApsFrame * frame)
 {
     ChipLogProgress(Zcl,
-                    "\n<EmberApsFrame %p> clusterID %" PRIx32
+                    "\n<EmberApsFrame %p> clusterID " ChipLogFormatMEI
                     ", sourceEndpoint %d, destinationEndPoint %d, options %d, groupID %d, "
                     "sequence %d, radius %d\n",
-                    frame, frame->clusterId, frame->sourceEndpoint, frame->destinationEndpoint, frame->options, frame->groupId,
-                    frame->sequence, frame->radius);
+                    frame, ChipLogValueMEI(frame->clusterId), frame->sourceEndpoint, frame->destinationEndpoint, frame->options,
+                    frame->groupId, frame->sequence, frame->radius);
 }
 
 uint16_t extractMessage(uint8_t * buffer, uint16_t buffer_length, uint8_t ** msg)

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -76,8 +76,8 @@ exit:
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DataManagement, "Error retrieving data from clusterId: %" PRIx32 ", err = %" CHIP_ERROR_FORMAT,
-                     aClusterInfo.mClusterId, ChipError::FormatError(err));
+        ChipLogError(DataManagement, "Error retrieving data from clusterId: " ChipLogFormatMEI ", err = %" CHIP_ERROR_FORMAT,
+                     ChipLogValueMEI(aClusterInfo.mClusterId), ChipError::FormatError(err));
     }
 
     return err;
@@ -98,8 +98,8 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeDataList(ReportData::Builder & 
         if (clusterInfo->IsDirty())
         {
             AttributeDataElement::Builder attributeDataElementBuilder = attributeDataList.CreateAttributeDataElementBuilder();
-            ChipLogDetail(DataManagement, "<RE:Run> Cluster %" PRIx32 ", Field %" PRIx32 " is dirty", clusterInfo->mClusterId,
-                          clusterInfo->mFieldId);
+            ChipLogDetail(DataManagement, "<RE:Run> Cluster " ChipLogFormatMEI ", Field %" PRIx32 " is dirty",
+                          ChipLogValueMEI(clusterInfo->mClusterId), clusterInfo->mFieldId);
             // Retrieve data for this cluster instance and clear its dirty flag.
             err = RetrieveClusterData(attributeDataElementBuilder, *clusterInfo);
             VerifyOrExit(err == CHIP_NO_ERROR,

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -73,8 +73,9 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                                                        aCommandId,  // CommandId
                                                        (chip::app::CommandPathFlags::kEndpointIdValid) };
 
-    ChipLogDetail(Controller, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Controller,
+                  "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
 
     apCommandObj->AddStatusCode(commandPathParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
                                 Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::Success);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -189,10 +189,10 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
     static uint8_t data[kAttributeReadBufferSize];
 
     ChipLogDetail(DataManagement,
-                  "Received Cluster Command: Cluster=%" PRIx32 " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx16
+                  "Received Cluster Command: Cluster=" ChipLogFormatMEI " NodeId=0x" ChipLogFormatX64 " Endpoint=%" PRIx16
                   " FieldId=%" PRIx32 " ListIndex=%" PRIx16,
-                  aClusterInfo.mClusterId, ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId, aClusterInfo.mFieldId,
-                  aClusterInfo.mListIndex);
+                  ChipLogValueMEI(aClusterInfo.mClusterId), ChipLogValueX64(aClusterInfo.mNodeId), aClusterInfo.mEndpointId,
+                  aClusterInfo.mFieldId, aClusterInfo.mListIndex);
 
     EmberAfAttributeType attributeType;
     EmberAfStatus status;

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -388,8 +388,8 @@ app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInsta
 bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     ChipLogProgress(Zcl, "DefaultResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
-    ChipLogProgress(Zcl, "  CommandId: 0x%08x", commandId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogProgress(Zcl, "  CommandId: " ChipLogFormatMEI, ChipLogValueMEI(commandId));
     LogStatus(status);
 
     GET_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
@@ -467,7 +467,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
                                             TLV::TLVReader * apData, Protocols::InteractionModel::ProtocolCode status)
 {
     ChipLogProgress(Zcl, "ReadAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%04x", aPath.mClusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mClusterId));
 
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -496,7 +496,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         return true;
     }
 
-    ChipLogProgress(Zcl, "  attributeId: 0x%04x", aPath.mFieldId);
+    ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mFieldId));
     LogIMStatus(status);
 
     if (status == Protocols::InteractionModel::ProtocolCode::Success && apData != nullptr)
@@ -518,7 +518,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
 bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "WriteAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfWriteAttributesResponseCallback");
 
@@ -538,7 +538,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
         {
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -565,7 +565,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
 bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ConfigureReportingResponseCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfConfigureReportingResponseCallback");
 
@@ -594,7 +594,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -621,7 +621,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ReadReportingConfigurationResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfReadReportingConfigurationResponseCallback");
 
@@ -634,7 +634,7 @@ bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId
 
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -683,7 +683,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
                                                bool extended)
 {
     ChipLogProgress(Zcl, "DiscoverAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  extended: %d", extended);
 
@@ -694,7 +694,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -719,14 +719,15 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint1
                                                       CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsGeneratedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -739,14 +740,15 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsReceivedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -877,13 +879,13 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     NodeId sourceId = emberAfCurrentCommand()->SourceNodeId();
     ChipLogProgress(Zcl, "  Source NodeId: %" PRIu64, sourceId);
 
     EndpointId endpointId = emberAfCurrentCommand()->apsFrame->sourceEndpoint;
-    ChipLogProgress(Zcl, "  Source EndpointId: 0x%08x", endpointId);
+    ChipLogProgress(Zcl, "  Source EndpointId: 0x%04x", endpointId);
 
     // TODO onFailureCallback is just here because of the CHECK_MESSAGE_LENGTH macro. It needs to be removed.
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -892,7 +894,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
 
         GET_REPORT_CALLBACK("emberAfReportAttributesCallback");
 

--- a/src/app/zap-templates/templates/app/attribute-size-src.zapt
+++ b/src/app/zap-templates/templates/app/attribute-size-src.zapt
@@ -181,7 +181,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.", ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/src/app/zap-templates/templates/app/ids/Attributes.zapt
+++ b/src/app/zap-templates/templates/app/ids/Attributes.zapt
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <app/util/basic-types.h>
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -61,7 +61,7 @@ void Dispatch{{asCamelCased side false}}Command({{#if (isServer side)}}app::Comm
                                                        (chip::app::CommandPathFlags::kEndpointIdValid) };
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::{{asUpperCamelCase name}}::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId), ChipLogValueMEI(Clusters::{{asUpperCamelCase name}}::Id));
             return;
         }
         }
@@ -94,8 +94,8 @@ void Dispatch{{asCamelCased side false}}Command({{#if (isServer side)}}app::Comm
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                              chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16, ChipLogValueMEI(aClusterId),
+                  ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -151,7 +151,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                        (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
                                     Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -403,8 +403,8 @@ app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInsta
 bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     ChipLogProgress(Zcl, "DefaultResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
-    ChipLogProgress(Zcl, "  CommandId: 0x%08x", commandId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogProgress(Zcl, "  CommandId: " ChipLogFormatMEI, ChipLogValueMEI(commandId));
     LogStatus(status);
 
     GET_RESPONSE_CALLBACKS("emberAfDefaultResponseCallback");
@@ -485,7 +485,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
                                             TLV::TLVReader * apData, Protocols::InteractionModel::ProtocolCode status)
 {
     ChipLogProgress(Zcl, "ReadAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%04x", aPath.mClusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mClusterId));
 
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -514,7 +514,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
         return true;
     }
 
-    ChipLogProgress(Zcl, "  attributeId: 0x%04x", aPath.mFieldId);
+    ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(aPath.mFieldId));
     LogIMStatus(status);
 
     if (status == Protocols::InteractionModel::ProtocolCode::Success && apData != nullptr)
@@ -536,7 +536,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
 bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "WriteAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfWriteAttributesResponseCallback");
 
@@ -557,7 +557,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
         {
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -585,7 +585,7 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * messa
 bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ConfigureReportingResponseCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfConfigureReportingResponseCallback");
 
@@ -615,7 +615,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 
             CHECK_MESSAGE_LENGTH(4);
             AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-            ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+            ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
             // Silence unused var warning if progress logging is disabled.  Note
             // that we _do_ want to call Read32 unconditionally here, because we
             // want to advance the 'message' pointer even if we don't use
@@ -643,7 +643,7 @@ bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * me
 bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "ReadReportingConfigurationResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     GET_RESPONSE_CALLBACKS("emberAfReadReportingConfigurationResponseCallback");
 
@@ -656,7 +656,7 @@ bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId
 
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -707,7 +707,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
                                                bool extended)
 {
     ChipLogProgress(Zcl, "DiscoverAttributesResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  extended: %d", extended);
 
@@ -718,7 +718,7 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
         // Silence unused var warning if progress logging is disabled.  Note
         // that we _do_ want to call Read32 unconditionally here, because we
         // want to advance the 'message' pointer even if we don't use
@@ -743,14 +743,15 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint1
                                                       CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsGeneratedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -763,14 +764,15 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     ChipLogProgress(Zcl, "DiscoverCommandsReceivedResponse:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
     ChipLogProgress(Zcl, "  manufacturerCode: 0x%04x", manufacturerCode);
     ChipLogProgress(Zcl, "  discoveryComplete: %d", discoveryComplete);
     ChipLogProgress(Zcl, "  commandIdCount: %" PRIu16, commandIdCount);
 
     for (uint16_t i = 0; i < commandIdCount; i++)
     {
-        ChipLogProgress(Zcl, "  commandId: 0x%08x", *commandIds++);
+        ChipLogProgress(Zcl, "  commandId: " ChipLogFormatMEI, ChipLogValueMEI(*commandIds));
+        commandIds++;
     }
 
     GET_RESPONSE_CALLBACKS("emberAfDiscoverCommandsGeneratedResponseCallback");
@@ -3063,13 +3065,13 @@ bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::EndpointId endp
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");
-    ChipLogProgress(Zcl, "  ClusterId: 0x%08x", clusterId);
+    ChipLogProgress(Zcl, "  ClusterId: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     NodeId sourceId = emberAfCurrentCommand()->SourceNodeId();
     ChipLogProgress(Zcl, "  Source NodeId: %" PRIu64, sourceId);
 
     EndpointId endpointId = emberAfCurrentCommand()->apsFrame->sourceEndpoint;
-    ChipLogProgress(Zcl, "  Source EndpointId: 0x%08x", endpointId);
+    ChipLogProgress(Zcl, "  Source EndpointId: 0x%04x", endpointId);
 
     // TODO onFailureCallback is just here because of the CHECK_MESSAGE_LENGTH macro. It needs to be removed.
     Callback::Cancelable * onFailureCallback = nullptr;
@@ -3078,7 +3080,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uin
     {
         CHECK_MESSAGE_LENGTH(4);
         AttributeId attributeId = chip::Encoding::LittleEndian::Read32(message); // attribId
-        ChipLogProgress(Zcl, "  attributeId: 0x%08x", attributeId);
+        ChipLogProgress(Zcl, "  attributeId: " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
 
         GET_REPORT_CALLBACK("emberAfReportAttributesCallback");
 

--- a/src/controller/data_model/gen/IMClusterCommandHandler.cpp
+++ b/src/controller/data_model/gen/IMClusterCommandHandler.cpp
@@ -125,7 +125,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::AccountLogin::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::AccountLogin::Id));
             return;
         }
         }
@@ -244,7 +245,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ApplicationLauncher::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ApplicationLauncher::Id));
             return;
         }
         }
@@ -427,7 +429,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::ContentLauncher::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::ContentLauncher::Id));
             return;
         }
         }
@@ -1938,7 +1941,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::DoorLock::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::DoorLock::Id));
             return;
         }
         }
@@ -2185,7 +2189,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::GeneralCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::GeneralCommissioning::Id));
             return;
         }
         }
@@ -2500,7 +2505,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Groups::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Groups::Id));
             return;
         }
         }
@@ -2613,7 +2619,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Identify::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Identify::Id));
             return;
         }
         }
@@ -2726,7 +2733,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::KeypadInput::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::KeypadInput::Id));
             return;
         }
         }
@@ -3424,7 +3432,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::MediaPlayback::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::MediaPlayback::Id));
             return;
         }
         }
@@ -4001,7 +4010,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::NetworkCommissioning::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::NetworkCommissioning::Id));
             return;
         }
         }
@@ -4210,8 +4220,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId,
-                         Clusters::OtaSoftwareUpdateProvider::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OtaSoftwareUpdateProvider::Id));
             return;
         }
         }
@@ -4491,7 +4501,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::OperationalCredentials::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::OperationalCredentials::Id));
             return;
         }
         }
@@ -4964,7 +4975,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::Scenes::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::Scenes::Id));
             return;
         }
         }
@@ -5083,7 +5095,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TvChannel::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TvChannel::Id));
             return;
         }
         }
@@ -5202,7 +5215,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TargetNavigator::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TargetNavigator::Id));
             return;
         }
         }
@@ -5373,7 +5387,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                         Protocols::SecureChannel::Id,
                                         Protocols::InteractionModel::ProtocolCode::UnsupportedCommand);
-            ChipLogError(Zcl, "Unknown command %" PRIx32 " for cluster %" PRIx32, aCommandId, Clusters::TestCluster::Id);
+            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandId),
+                         ChipLogValueMEI(Clusters::TestCluster::Id));
             return;
         }
         }
@@ -5406,8 +5421,8 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
 {
-    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=%" PRIx32 " Command=%" PRIx32 " Endpoint=%" PRIx16, aClusterId,
-                  aCommandId, aEndPointId);
+    ChipLogDetail(Zcl, "Received Cluster Command: Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " Endpoint=%" PRIx16,
+                  ChipLogValueMEI(aClusterId), ChipLogValueMEI(aCommandId), aEndPointId);
     Compatibility::SetupEmberAfObjects(apCommandObj, aClusterId, aCommandId, aEndPointId);
     TLV::TLVType dataTlvType;
     SuccessOrExit(aReader.EnterContainer(dataTlvType));
@@ -5495,7 +5510,7 @@ void DispatchSingleClusterResponseCommand(chip::ClusterId aClusterId, chip::Comm
                                                            (chip::app::CommandPathFlags::kEndpointIdValid) };
         apCommandObj->AddStatusCode(returnStatusParam, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
                                     Protocols::SecureChannel::Id, Protocols::InteractionModel::ProtocolCode::InvalidCommand);
-        ChipLogError(Zcl, "Unknown cluster %" PRIx32, aClusterId);
+        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aClusterId));
         break;
     }
 exit:

--- a/src/controller/data_model/gen/attribute-size.cpp
+++ b/src/controller/data_model/gen/attribute-size.cpp
@@ -102,7 +102,8 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
     uint32_t totalSize = kSizeLengthInBytes + (entryCount * entryLength);
     if (!chip::CanCastTo<uint16_t>(totalSize))
     {
-        ChipLogError(Zcl, "Cluster %" PRIx32 ": Size of attribute %" PRIx32 " is too large.", clusterId, attributeId);
+        ChipLogError(Zcl, "Cluster " ChipLogFormatMEI ": Size of attribute " ChipLogFormatMEI " is too large.",
+                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
         return 0;
     }
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -345,5 +345,40 @@ bool IsCategoryEnabled(uint8_t category);
  */
 #define ChipLogValueX64(aValue) static_cast<uint32_t>(aValue >> 32), static_cast<uint32_t>(aValue)
 
+/*
+ *  @brief
+ *      Macro for use in a string formatter for a MEI hex print.
+ *      Will split into 2x 16-bit prints to display both the MEI prefix/suffix
+ *
+ *  Example Usage:
+ *
+ *  @code
+ *  void foo() {
+ *      chip::CommandId value = 0x12340001;
+ *      ChipLogProgress(Foo, "A MEI value: " ChipLogFormatMEI, ChipLogValueMEI(value));
+ *  }
+ *  @endcode
+ *
+ */
+#define ChipLogFormatMEI "0x%04" PRIX16 "_%04" PRIX16
+
+/*
+ *  @brief
+ *      Macro for use in a printf parameter list for MEI value.
+ *      Will split into MSB/LSB 16-bit values to separate prefix/suffix.
+ *
+ *  Example Usage:
+ *
+ *  @code
+ *  void foo() {
+ *      chip::CommandId value = 0x12340001;
+ *      ChipLogProgress(Foo, "A MEI value: " ChipLogFormatMEI, ChipLogValueMEI(value));
+ *  }
+ *  @endcode
+ *
+ *  @param[in]  aValue    "32-bit value that will be split in 16-bit MSB/LSB part
+ */
+#define ChipLogValueMEI(aValue) static_cast<uint16_t>(aValue >> 16), static_cast<uint16_t>(aValue)
+
 } // namespace Logging
 } // namespace chip

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -99,7 +99,7 @@ class TestPythonController(CHIPVirtualHome):
         for device_id in server_ids:
             self.logger.info("checking device log for {}".format(
                 self.get_device_pretty_id(device_id)))
-            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)", "No Cluster 0x6 on Endpoint 0xe9"]),
+            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)", "No Cluster 0x0000_0006 on Endpoint 0xe9"]),
                             "Datamodel test failed: cannot find matching string from device {}".format(device_id))
 
 


### PR DESCRIPTION
#### Problem

Clusters/Commands/Attributes ids carries out both a prefix and a suffix. In the current codebase those are printed with different formats.

#### Change overview
 * Add `ChipLogFormatMEI` and `ChipLogValueMEI` to `ChipLogging` which prints MEI such as `0x1234_0001`.
 * Update various examples to use it
 * Update internal code to use it

For reviewers, only the first commit contains manual changes. The second commit is generated code only.

#### Testing
It was tested locally by looking at the logs...

