### PR TITLE
Address Printf formatting issues

### DIFF
--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR DebugPrettyPrint(const chip::System::PacketBufferHandle & aMsgBuf)
 
     if (CHIP_NO_ERROR != err)
     {
-        ChipLogProgress(DataManagement, "DebugPrettyPrint fails with err %d", err);
+        ChipLogProgress(DataManagement, "DebugPrettyPrint fails with err %" CHIP_ERROR_FORMAT, err);
     }
 
     return err;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -28,6 +28,7 @@
 
 #include <ble/CHIPBleServiceData.h>
 #include <core/CHIPConfig.h>
+#include <inttypes.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/GenericConfigurationManagerImpl.h>
 #include <support/Base64.h>

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -25,6 +25,7 @@
 #ifndef GENERIC_PLATFORM_MANAGER_IMPL_CPP
 #define GENERIC_PLATFORM_MANAGER_IMPL_CPP
 
+#include <inttypes.h>
 #include <new>
 #include <platform/PlatformManager.h>
 #include <platform/internal/BLEManager.h>

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -669,8 +669,8 @@ void CheckAddressQuartet(nlTestSuite * inSuite, const uint32_t & inFirstAddressQ
 
     if (!lResult)
     {
-        fprintf(stdout, "Address quartet %zu mismatch: actual 0x%08x, expected: 0x%08x\n", inWhich, inFirstAddressQuartet,
-                inSecondAddressQuartet);
+        fprintf(stdout, "Address quartet %zu mismatch: actual 0x%08" PRIX32 ", expected: 0x%08" PRIX32 "\n", inWhich,
+                inFirstAddressQuartet, inSecondAddressQuartet);
     }
 }
 

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -450,11 +450,7 @@ void ServiceEvents(struct ::timeval & aSleepTime)
         if (NetworkIsReady())
 #endif
         {
-#ifdef __MBED__
             printf("CHIP node ready to service events\n");
-#else
-            printf("CHIP node ready to service events; PID: %d; PPID: %d\n", getpid(), getppid());
-#endif // __MBED__
             fflush(stdout);
             printed = true;
         }

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -450,7 +450,11 @@ void ServiceEvents(struct ::timeval & aSleepTime)
         if (NetworkIsReady())
 #endif
         {
+#ifdef __MBED__
+            printf("CHIP node ready to service events\n");
+#else
             printf("CHIP node ready to service events; PID: %d; PPID: %d\n", getpid(), getppid());
+#endif // __MBED__
             fflush(stdout);
             printed = true;
         }
@@ -530,14 +534,14 @@ void ShutdownNetwork()
 
 void DumpMemory(const uint8_t * mem, uint32_t len, const char * prefix, uint32_t rowWidth)
 {
-    int indexWidth = snprintf(nullptr, 0, "%X", len);
+    int indexWidth = snprintf(nullptr, 0, "%" PRIX32, len);
 
     if (indexWidth < 4)
         indexWidth = 4;
 
     for (uint32_t i = 0; i < len; i += rowWidth)
     {
-        printf("%s%0*X: ", prefix, indexWidth, i);
+        printf("%s%0*" PRIX32 ": ", prefix, indexWidth, i);
 
         uint32_t rowEnd = i + rowWidth;
 

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -76,7 +76,7 @@ static void CheckInetErrorStr(nlTestSuite * inSuite, void * inContext)
     Inet::RegisterLayerErrorFormatter();
 
     // For each defined error...
-    for (int err : sContext)
+    for (int32_t err : sContext)
     {
         const char * errStr = ErrorStr(err);
         char expectedText[9];

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -497,7 +497,7 @@ bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
 
 static void PrintReceivedStats(const TransferStats & aStats)
 {
-    printf("%u/%u received\n", aStats.mReceive.mActual, aStats.mReceive.mExpected);
+    printf("%" PRIu32 "/%" PRIu32 "received\n", aStats.mReceive.mActual, aStats.mReceive.mExpected);
 }
 
 static bool HandleDataReceived(const PacketBufferHandle & aBuffer, bool aCheckBuffer, uint8_t aFirstValue)
@@ -891,8 +891,8 @@ void DriveSend()
 
             sTestState.mStats.mTransmit.mActual += lSendSize;
 
-            printf("%u/%u transmitted to %s\n", sTestState.mStats.mTransmit.mActual, sTestState.mStats.mTransmit.mExpected,
-                   sDestinationString);
+            printf("%" PRIu32 "/%" PRIu32 "transmitted to %s\n", sTestState.mStats.mTransmit.mActual,
+                   sTestState.mStats.mTransmit.mExpected, sDestinationString);
         }
     }
 

--- a/src/inet/tests/TestSetupFaultInjectionPosix.cpp
+++ b/src/inet/tests/TestSetupFaultInjectionPosix.cpp
@@ -116,15 +116,15 @@ static void PostInjectionCallbackFn(nl::FaultInjection::Manager * aManager, nl::
     uint16_t numargs = aFaultRecord->mNumArguments;
     uint16_t i;
 
-    printf("***** Injecting fault %s_%s, instance number: %u; reboot: %s", aManager->GetName(), aManager->GetFaultNames()[aId],
-           aFaultRecord->mNumTimesChecked, aFaultRecord->mReboot ? "yes" : "no");
+    printf("***** Injecting fault %s_%s, instance number: %" PRIu32 "; reboot: %s", aManager->GetName(),
+           aManager->GetFaultNames()[aId], aFaultRecord->mNumTimesChecked, aFaultRecord->mReboot ? "yes" : "no");
     if (numargs)
     {
         printf(" with %u args:", numargs);
 
         for (i = 0; i < numargs; i++)
         {
-            printf(" %d", aFaultRecord->mArguments[i]);
+            printf(" %" PRIi32, aFaultRecord->mArguments[i]);
         }
     }
 
@@ -138,8 +138,8 @@ static bool PrintFaultInjectionMaxArgCbFn(nl::FaultInjection::Manager & mgr, nl:
 
     if (gFaultInjectionOptions.PrintFaultCounters && aFaultRecord->mNumArguments)
     {
-        printf("FI_instance_params: %s_%s_s%u maxArg: %u;\n", mgr.GetName(), faultName, aFaultRecord->mNumTimesChecked,
-               aFaultRecord->mArguments[0]);
+        printf("FI_instance_params: %s_%s_s%" PRIu32 " maxArg: %" PRIi32 ";\n", mgr.GetName(), faultName,
+               aFaultRecord->mNumTimesChecked, aFaultRecord->mArguments[0]);
     }
 
     return false;

--- a/src/lib/mdns/tests/TestTxtFields.cpp
+++ b/src/lib/mdns/tests/TestTxtFields.cpp
@@ -108,7 +108,7 @@ void TestGetProduct(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 0);
 
     // overflow a uint16
-    sprintf(vp, "123+%u", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(vp, "123+%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetProduct(GetSpan(vp)) == 0);
 }
 void TestGetVendor(nlTestSuite * inSuite, void * inContext)
@@ -128,7 +128,7 @@ void TestGetVendor(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 123);
 
     // overflow a uint16
-    sprintf(vp, "%u+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(vp, "%" PRIu32 "+456", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetVendor(GetSpan(vp)) == 0);
 }
 
@@ -139,7 +139,7 @@ void TestGetLongDiscriminator(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetLongDisriminator(GetSpan(ld)) == 1234);
 
     // overflow a uint16
-    sprintf(ld, "%u", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(ld, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     printf("ld = %s\n", ld);
     NL_TEST_ASSERT(inSuite, GetLongDisriminator(GetSpan(ld)) == 0);
 }
@@ -176,7 +176,7 @@ void TestGetDeviceType(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 1234);
 
     // overflow a uint16
-    sprintf(dt, "%u", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(dt, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetDeviceType(GetSpan(dt)) == 0);
 }
 
@@ -249,7 +249,7 @@ void TestGetPairingHint(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, GetPairingHint(GetSpan(ph)) == 9);
 
     // overflow a uint16
-    sprintf(ph, "%u", static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+    sprintf(ph, "%" PRIu32, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
     NL_TEST_ASSERT(inSuite, GetPairingHint(GetSpan(ph)) == 0);
 }
 

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -839,7 +839,8 @@ void TestDaysSinceEpochConversion()
                     CalendarDateToDaysSinceUnixEpoch(year, month, dayOfMonth, calculatedDaysSinceEpoch);
 
                     if (calculatedDaysSinceEpoch != daysSinceEpoch)
-                        printf("%04u/%02u/%02u %u %u\n", year, month, dayOfMonth, daysSinceEpoch, calculatedDaysSinceEpoch);
+                        printf("%04u/%02u/%02u %" PRIu32 " %" PRIu32 "\n", year, month, dayOfMonth, daysSinceEpoch,
+                               calculatedDaysSinceEpoch);
 
                     TestAssert(calculatedDaysSinceEpoch == daysSinceEpoch,
                                "CalendarDateToDaysSinceUnixEpoch() returned unexpected value");


### PR DESCRIPTION
#### Problem
Not all unit tests can be built on 32 bits ARM targets due to printf formatting issue.

#### Change overview
Use C99 formatters to print correctly on all architecture.

#### Testing
How was this tested? (at least one bullet point required)
=> Compiled and run with Mbed OS unit test (PR to follow).  