### PR TITLE
Fix release of endpoints and shutdown SystemLayer in TestInetEndPoint.

### DIFF
--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -348,7 +348,7 @@ CHIP_ERROR InetLayer::Shutdown()
         TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
-                lEndPoint->Abort();
+                lEndPoint->Free();
             }
             return true;
         });
@@ -359,7 +359,7 @@ CHIP_ERROR InetLayer::Shutdown()
         UDPEndPoint::sPool.ForEachActiveObject([&](UDPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
-                lEndPoint->Close();
+                lEndPoint->Free();
             }
             return true;
         });

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -348,7 +348,7 @@ CHIP_ERROR InetLayer::Shutdown()
         TCPEndPoint::sPool.ForEachActiveObject([&](TCPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
-                lEndPoint->Free();
+                lEndPoint->Abort();
             }
             return true;
         });
@@ -359,7 +359,7 @@ CHIP_ERROR InetLayer::Shutdown()
         UDPEndPoint::sPool.ForEachActiveObject([&](UDPEndPoint * lEndPoint) {
             if ((lEndPoint != nullptr) && lEndPoint->IsCreatedByInetLayer(*this))
             {
-                lEndPoint->Free();
+                lEndPoint->Close();
             }
             return true;
         });

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -415,6 +415,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
     testRaw4EP->Free();
 #endif // INET_CONFIG_ENABLE_IPV4
+    testRaw6EP->Free();
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
     // UdpEndPoint special cases to cover the error branch


### PR DESCRIPTION
#### Problem
1. Memory of endpoints allocated by the inet layer were not released properly in TestInetEndPoint.
This can be observed if endpoints are allocated after the test InetEndPoint::TestEndPointLimit has been run.
TestInetEndpointInternal also does not release endpoint correctly, which cases that TestInetEndPointLimit crashed.
2.  TestInetPre failed because the SystemLayer is already initialized (probably some of the previous steps initialized it but didn't shutdown it doen properly). Starting new timer doesn't return CHIP_ERROR_INCORRECT_STATE.  


#### Change overview
Deinititialize system layer and network at the beginning of the TestInetPre to be sure that the system layer is shutdown before the test starts.
Release all endpoints in TestInetEndPointLimit test.
Release RAW and TCP endpoints in TestInetEndpointInternal test.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests existed, how were they fixed/modified to prevent this in future?
We caught the issue by running the tests on an actual embedded target. The solution is to enable this test on embedded target. (Mbed OS PR to follow)