### PR TITLE
Enable Inet tests for platform not supporting raw sockets.

### DIFF
--- a/config/mbed/chip-gn/args.gni
+++ b/config/mbed/chip-gn/args.gni
@@ -20,7 +20,7 @@ chip_project_config_include = ""
 chip_system_project_config_include = ""
 chip_device_project_config_include = ""
 
-chip_inet_config_enable_raw_endpoint = true
+chip_inet_config_enable_raw_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 chip_inet_config_enable_tcp_endpoint = true
 chip_inet_config_enable_dns_resolver = true

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -315,10 +315,12 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     InterfaceId intId;
 
     // EndPoint
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     RawEndPoint * testRaw6EP = nullptr;
 #if INET_CONFIG_ENABLE_IPV4
     RawEndPoint * testRaw4EP = nullptr;
 #endif // INET_CONFIG_ENABLE_IPV4
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
     UDPEndPoint * testUDPEP  = nullptr;
     TCPEndPoint * testTCPEP1 = nullptr;
     PacketBufferHandle buf   = PacketBufferHandle::New(PacketBuffer::kMaxSize);
@@ -326,6 +328,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     bool didListen           = false;
 
     // init all the EndPoints
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRaw6EP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -333,6 +336,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     err = gInet.NewRawEndPoint(kIPVersion_4, kIPProtocol_ICMPv4, &testRaw4EP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 #endif // INET_CONFIG_ENABLE_IPV4
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
     err = gInet.NewUDPEndPoint(&testUDPEP);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -352,6 +356,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 #endif // INET_CONFIG_ENABLE_IPV4
 
     // error bind cases
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     err = testRaw6EP->Bind(kIPAddressType_Unknown, addr_any);
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
 #if INET_CONFIG_ENABLE_IPV4
@@ -410,6 +415,7 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == INET_ERROR_WRONG_ADDRESS_TYPE);
     testRaw4EP->Free();
 #endif // INET_CONFIG_ENABLE_IPV4
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
     // UdpEndPoint special cases to cover the error branch
     err = testUDPEP->Listen(nullptr /*OnMessageReceived*/, nullptr /*OnReceiveError*/);
@@ -488,15 +494,19 @@ static void TestInetEndPointInternal(nlTestSuite * inSuite, void * inContext)
 // Test the InetLayer resource limitation
 static void TestInetEndPointLimit(nlTestSuite * inSuite, void * inContext)
 {
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     RawEndPoint * testRawEP = nullptr;
+#endif //
     UDPEndPoint * testUDPEP = nullptr;
     TCPEndPoint * testTCPEP = nullptr;
     CHIP_ERROR err;
     char numTimersTest[CHIP_SYSTEM_CONFIG_NUM_TIMERS + 1];
 
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     for (int i = 0; i < INET_CONFIG_NUM_RAW_ENDPOINTS + 1; i++)
         err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRawEP);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_ENDPOINT_POOL_FULL);
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
     for (int i = 0; i < INET_CONFIG_NUM_UDP_ENDPOINTS + 1; i++)
         err = gInet.NewUDPEndPoint(&testUDPEP);

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -937,6 +937,7 @@ static void StartTest()
 
     // Allocate the endpoints for sending or receiving.
 
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
     if (gOptFlags & kOptFlagUseRawIP)
     {
         lStatus = gInet.NewRawEndPoint(lIPVersion, lIPProtocol, &sRawIPEndPoint);
@@ -948,7 +949,9 @@ static void StartTest()
             INET_FAIL_ERROR(lStatus, "RawEndPoint::BindInterface failed");
         }
     }
-    else if (gOptFlags & kOptFlagUseUDPIP)
+    else
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+        if (gOptFlags & kOptFlagUseUDPIP)
     {
         lStatus = gInet.NewUDPEndPoint(&sUDPIPEndPoint);
         INET_FAIL_ERROR(lStatus, "InetLayer::NewUDPEndPoint failed");
@@ -962,6 +965,7 @@ static void StartTest()
 
     if (Common::IsReceiver())
     {
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
         if (gOptFlags & kOptFlagUseRawIP)
         {
             lStatus = sRawIPEndPoint->Bind(lIPAddressType, lAddress);
@@ -976,7 +980,9 @@ static void StartTest()
             lStatus = sRawIPEndPoint->Listen(HandleRawMessageReceived, HandleRawReceiveError);
             INET_FAIL_ERROR(lStatus, "RawEndPoint::Listen failed");
         }
-        else if (gOptFlags & kOptFlagUseUDPIP)
+        else
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+            if (gOptFlags & kOptFlagUseUDPIP)
         {
             lStatus = sUDPIPEndPoint->Bind(lIPAddressType, IPAddress::Any, kUDPPort);
             INET_FAIL_ERROR(lStatus, "UDPEndPoint::Bind failed");


### PR DESCRIPTION
#### Problem
Some inet test do not compile if raw endpoints aren't supported. 

#### Change overview
Conditionally compile raw endpoint tests based on `INET_CONFIG_ENABLE_RAW_ENDPOINT`.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests existed, how were they fixed/modified to prevent this in future?
PR with Mbed OS unit test to follow. The update to Mbed OS chip config has been preserved in this commit. 