### PR TITLE
[server] Store all connection states in KVS

### DIFF
--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -27,6 +27,7 @@ static_library("server") {
   output_name = "libCHIPAppServer"
 
   sources = [
+    "ConnectionMonitor.h",
     "EchoHandler.cpp",
     "EchoHandler.h",
     "Mdns.cpp",

--- a/src/app/server/ConnectionMonitor.h
+++ b/src/app/server/ConnectionMonitor.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "StorablePeerConnection.h"
+
+#include <messaging/ExchangeMgr.h>
+#include <messaging/ExchangeMgrDelegate.h>
+#include <protocols/secure_channel/SessionIDAllocator.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+class PersistentStorageDelegate;
+
+class ConnectionMonitor : public Messaging::ExchangeMgrDelegate
+{
+public:
+    ConnectionMonitor(PersistentStorageDelegate & storage, SessionIDAllocator & idAllocator) :
+        mStorage(storage), mIDAllocator(idAllocator)
+    {}
+
+    void OnNewConnection(SecureSessionHandle session, Messaging::ExchangeManager * mgr) override
+    {
+        const auto connState = mgr->GetSessionMgr()->GetPeerConnectionState(session);
+        VerifyOrReturn(connState != nullptr);
+
+        StorablePeerConnection connection;
+        VerifyOrReturn(connection.Init(*connState) == CHIP_NO_ERROR,
+                       ChipLogError(AppServer, "Failed to init serializable connection state"));
+        VerifyOrReturn(connection.StoreIntoKVS(mStorage) == CHIP_NO_ERROR,
+                       ChipLogError(AppServer, "Failed to store connection state"));
+
+        // The Peek() is used to find the smallest key ID that's not been assigned to any session.
+        // This value is persisted, and on reboot, it is used to revive any previously
+        // active secure sessions.
+        // We support one active PASE session at any time. So the key ID should not be updated
+        // in another thread, while we retrieve it here.
+        VerifyOrReturn(StorablePeerConnection::StoreCountIntoKVS(mStorage, mIDAllocator.Peek()) == CHIP_NO_ERROR,
+                       ChipLogError(AppServer, "Failed to store connection count"));
+    }
+
+    void OnConnectionExpired(SecureSessionHandle session, Messaging::ExchangeManager * mgr) override
+    {
+        const auto connState = mgr->GetSessionMgr()->GetPeerConnectionState(session);
+        VerifyOrReturn(connState != nullptr);
+        StorablePeerConnection::DeleteFromKVS(mStorage, connState->GetLocalKeyID());
+    }
+
+private:
+    PersistentStorageDelegate & mStorage;
+    SessionIDAllocator & mIDAllocator;
+};
+} // namespace chip

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -178,19 +178,5 @@ void RendezvousServer::OnSessionEstablished()
     }
 
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
-    StorablePeerConnection connection(mPairingSession, mAdmin->GetAdminId());
-
-    VerifyOrReturn(mStorage != nullptr,
-                   ChipLogError(AppServer, "Storage delegate is not available. Cannot store the connection state"));
-    VerifyOrReturn(connection.StoreIntoKVS(*mStorage) == CHIP_NO_ERROR,
-                   ChipLogError(AppServer, "Failed to store the connection state"));
-
-    // The Peek() is used to find the smallest key ID that's not been assigned to any session.
-    // This value is persisted, and on reboot, it is used to revive any previously
-    // active secure sessions.
-    // We support one active PASE session at any time. So the key ID should not be updated
-    // in another thread, while we retrieve it here.
-    uint16_t keyID = mIDAllocator->Peek();
-    mStorage->SyncSetKeyValue(kStorablePeerConnectionCountKey, &keyID, sizeof(keyID));
 }
 } // namespace chip

--- a/src/app/server/StorablePeerConnection.cpp
+++ b/src/app/server/StorablePeerConnection.cpp
@@ -15,17 +15,53 @@
  *    limitations under the License.
  */
 
-#include <app/server/StorablePeerConnection.h>
-#include <core/CHIPEncoding.h>
-#include <support/SafeInt.h>
+#include "StorablePeerConnection.h"
+
+#include <core/CHIPPersistentStorageDelegate.h>
+#include <transport/PairingSession.h>
+#include <transport/PeerConnectionState.h>
+#include <transport/SecureSessionMgr.h>
 
 namespace chip {
 
-StorablePeerConnection::StorablePeerConnection(PASESession & session, Transport::AdminId admin)
+namespace {
+// KVS store is sensitive to length of key strings, based on the underlying
+// platform. Keeping them short.
+constexpr char kStorablePeerConnectionKeyPrefix[] = "CHIPConn";
+constexpr char kStorablePeerConnectionCountKey[]  = "CHIPConnCnt";
+
+class FetchedSession : public PairingSession
 {
-    session.ToSerializable(mSession.mOpCreds);
-    mSession.mAdmin = Encoding::LittleEndian::HostSwap16(admin);
-    mKeyId          = session.GetLocalKeyId();
+public:
+    FetchedSession(const SecureSession::Serializable & secureSession, uint16_t localKeyId, uint16_t peerKeyId) :
+        mSecureSessionSerializable(secureSession), mLocalKeyId(localKeyId), mPeerKeyId(peerKeyId)
+    {}
+
+    CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override
+    {
+        return session.InitFromSerializable(mSecureSessionSerializable, role);
+    }
+
+    uint16_t GetPeerKeyId() override { return mPeerKeyId; };
+    uint16_t GetLocalKeyId() override { return mLocalKeyId; };
+
+private:
+    const SecureSession::Serializable & mSecureSessionSerializable;
+    uint16_t mLocalKeyId;
+    uint16_t mPeerKeyId;
+};
+
+} // namespace
+
+CHIP_ERROR StorablePeerConnection::Init(const Transport::PeerConnectionState & connState)
+{
+    ReturnErrorCodeIf(!connState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+
+    connState.GetSecureSession().ToSerializable(mSerializable.mSecureSession);
+    mSerializable.mPeerKeyId = Encoding::LittleEndian::HostSwap16(connState.GetPeerKeyID());
+    mSerializable.mAdmin     = Encoding::LittleEndian::HostSwap16(connState.GetAdminId());
+    mKeyId                   = connState.GetLocalKeyID();
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
@@ -33,7 +69,7 @@ CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
     char key[KeySize()];
     ReturnErrorOnFailure(GenerateKey(mKeyId, key, sizeof(key)));
 
-    return kvs.SyncSetKeyValue(key, &mSession, sizeof(mSession));
+    return kvs.SyncSetKeyValue(key, &mSerializable, sizeof(mSerializable));
 }
 
 CHIP_ERROR StorablePeerConnection::FetchFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
@@ -41,8 +77,9 @@ CHIP_ERROR StorablePeerConnection::FetchFromKVS(PersistentStorageDelegate & kvs,
     char key[KeySize()];
     ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
 
-    uint16_t size = sizeof(mSession);
-    return kvs.SyncGetKeyValue(key, &mSession, size);
+    mKeyId        = keyId;
+    uint16_t size = sizeof(mSerializable);
+    return kvs.SyncGetKeyValue(key, &mSerializable, size);
 }
 
 CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
@@ -51,6 +88,35 @@ CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs
     ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
 
     return kvs.SyncDeleteKeyValue(key);
+}
+
+CHIP_ERROR StorablePeerConnection::StoreCountIntoKVS(PersistentStorageDelegate & kvs, uint16_t count)
+{
+    count = Encoding::LittleEndian::HostSwap16(count);
+    return kvs.SyncSetKeyValue(kStorablePeerConnectionCountKey, &count, sizeof(count));
+}
+
+CHIP_ERROR StorablePeerConnection::FetchCountFromKVS(PersistentStorageDelegate & kvs, uint16_t & count)
+{
+    uint16_t size = sizeof(count);
+    ReturnErrorOnFailure(kvs.SyncGetKeyValue(kStorablePeerConnectionCountKey, &count, size));
+
+    count = Encoding::LittleEndian::HostSwap16(count);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR StorablePeerConnection::DeleteCountFromKVS(PersistentStorageDelegate & kvs)
+{
+    return kvs.SyncDeleteKeyValue(kStorablePeerConnectionCountKey);
+}
+
+CHIP_ERROR StorablePeerConnection::AddNewPairing(SecureSessionMgr & mgr, SecureSession::SessionRole role)
+{
+    Transport::AdminId adminId = Encoding::LittleEndian::HostSwap16(mSerializable.mAdmin);
+    uint16_t peerKeyId         = Encoding::LittleEndian::HostSwap16(mSerializable.mPeerKeyId);
+    FetchedSession session{ mSerializable.mSecureSession, mKeyId, peerKeyId };
+
+    return mgr.NewPairing(Optional<Transport::PeerAddress>{}, NodeId{}, &session, role, adminId);
 }
 
 constexpr size_t StorablePeerConnection::KeySize()

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -153,10 +153,6 @@ public:
      */
     uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
 
-    const char * GetI2RSessionInfo() const override { return "Sigma I2R Key"; }
-
-    const char * GetR2ISessionInfo() const override { return "Sigma R2I Key"; }
-
     Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /**

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -165,10 +165,6 @@ public:
      */
     uint16_t GetLocalKeyId() override { return mConnectionState.GetLocalKeyID(); }
 
-    const char * GetI2RSessionInfo() const override { return kSpake2pI2RSessionInfo; }
-
-    const char * GetR2ISessionInfo() const override { return kSpake2pR2ISessionInfo; }
-
     Transport::PeerConnectionState & PeerConnection() { return mConnectionState; }
 
     /** @brief Serialize the Pairing Session to a string.
@@ -355,10 +351,6 @@ public:
     uint16_t GetPeerKeyId() override { return mPeerKeyID; }
 
     uint16_t GetLocalKeyId() override { return mLocalKeyID; }
-
-    const char * GetI2RSessionInfo() const override { return "i2r"; }
-
-    const char * GetR2ISessionInfo() const override { return "r2i"; }
 
 private:
     const char * kTestSecret = "Test secret for key derivation";

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <core/CHIPError.h>
+#include <transport/MessageCounter.h>
 #include <transport/SecureSession.h>
 
 namespace chip {
@@ -73,10 +74,6 @@ public:
         // TODO(#6652): This is a stub implementation, should be replaced by the real one when CASE and PASE is completed
         return LocalSessionMessageCounter::kInitialValue;
     }
-
-    virtual const char * GetI2RSessionInfo() const = 0;
-
-    virtual const char * GetR2ISessionInfo() const = 0;
 };
 
 } // namespace chip

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -74,12 +74,13 @@ public:
     uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
 
+    const SecureSession & GetSecureSession() const { return mSecureSession; }
     SecureSession & GetSecureSession() { return mSecureSession; }
 
     Transport::AdminId GetAdminId() const { return mAdmin; }
     void SetAdminId(Transport::AdminId admin) { mAdmin = admin; }
 
-    bool IsInitialized()
+    bool IsInitialized() const
     {
         return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerKeyID != UINT16_MAX ||
                 mLocalKeyID != UINT16_MAX);

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -30,6 +30,8 @@
 #include <support/Span.h>
 #include <transport/raw/MessageHeader.h>
 
+#include <type_traits>
+
 namespace chip {
 
 class DLL_EXPORT SecureSession
@@ -55,6 +57,8 @@ public:
         kSessionEstablishment, /**< A new secure session is established. */
         kSessionResumption,    /**< An old session is being resumed. */
     };
+
+    struct Serializable;
 
     /**
      * @brief
@@ -86,6 +90,16 @@ public:
 
     /**
      * @brief
+     *   Init the session using the serializable representation.
+     *
+     * @param serializable       A reference to the serializable object
+     * @param role               Role of the new session (initiator or responder)
+     * @return CHIP_ERROR        The result of initialization
+     */
+    CHIP_ERROR InitFromSerializable(const Serializable & serializable, SessionRole role);
+
+    /**
+     * @brief
      *   Encrypt the input data using keys established in the secure channel
      *
      * @param input Unencrypted input data
@@ -112,6 +126,15 @@ public:
      */
     CHIP_ERROR Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
                        const MessageAuthenticationCode & mac) const;
+
+    /**
+     * @brief
+     *   Store the session into the serializable object.
+     *
+     * @param serializable       A reference to the serializable object
+     * @return CHIP_ERROR        The result of the store
+     */
+    CHIP_ERROR ToSerializable(Serializable & serializable) const;
 
     /**
      * @brief
@@ -151,6 +174,11 @@ private:
     // The encryption operations includes AAD when message authentication tag is generated. This tag
     // is used at the time of decryption to integrity check the received data.
     static CHIP_ERROR GetAdditionalAuthData(const PacketHeader & header, uint8_t * aad, uint16_t & len);
+};
+
+struct SecureSession::Serializable
+{
+    uint8_t mKeys[sizeof(std::declval<SecureSession>().mKeys)];
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
Once CASE session has been enabled, it is no longer possible to resume communication between the controller and the
device after the device reboot, because only PASE sessions are persisted.

#### Change overview
Rework the server code to be able to store any kind of connection (PASE and CASE) on the server side.
Also, handle connection expiration properly.

Note that at some point we may switch to another mechanism of resuming broken connections, but for now such a mechanism
does not exist.

Fixes #8321.

#### Testing
Tested using Python CHIP Controller and nRF Connect Lock Example:
- Verified that commissioning, establishing a CASE session and sending ZCL commands works.
- Verified that after the device reboot, ZCL commands can still be correctly processed by the device (although acknowledgments are sent with wrong message counters as the counter synchronization mechanism doesn't seem to work - this is to be investigated later).