### PR TITLE
Fix warning on heap tracing.

### DIFF
--- a/examples/platform/esp32/shell_extension/heap_trace.cpp
+++ b/examples/platform/esp32/shell_extension/heap_trace.cpp
@@ -42,7 +42,9 @@ constexpr size_t kNumHeapTraceRecords = 100;
 constexpr size_t kNumHeapTasks        = 20;
 constexpr size_t kNumHeapBlocks       = 20;
 
+#if CONFIG_HEAP_TRACING_STANDALONE
 heap_trace_record_t sTraceRecords[kNumHeapTraceRecords];
+#endif
 
 Engine sShellHeapSubCommands;
 


### PR DESCRIPTION
#### Problem
Unused variable warning when heap tracing isn't on

#### Change overview
adds define guards

#### Testing
Built and saw warning was gone.
