### PR TITLE
Rename TestSrv into TestTxt

### DIFF
--- a/src/lib/mdns/minimal/records/tests/TestResourceRecordTxt.cpp
+++ b/src/lib/mdns/minimal/records/tests/TestResourceRecordTxt.cpp
@@ -26,7 +26,7 @@ using namespace chip;
 using namespace chip::Encoding;
 using namespace mdns::Minimal;
 
-void TestSrv(nlTestSuite * inSuite, void * inContext)
+void TestTxt(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -67,17 +67,17 @@ void TestSrv(nlTestSuite * inSuite, void * inContext)
 }
 
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestSrv", TestSrv), //
+    NL_TEST_DEF("TestTxt", TestTxt), //
     NL_TEST_SENTINEL()               //
 };
 
 } // namespace
 
-int TestSrv(void)
+int TestTxt(void)
 {
-    nlTestSuite theSuite = { "Srv", sTests, nullptr, nullptr };
+    nlTestSuite theSuite = { "Txt", sTests, nullptr, nullptr };
     nlTestRunner(&theSuite, nullptr);
     return nlTestRunnerStats(&theSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestSrv)
+CHIP_REGISTER_TEST_SUITE(TestTxt)


### PR DESCRIPTION
#### Problem
The test in `TestResourceRecordTxt.cpp` present in `src/lib/mdns/minimal/records/tests` is named `TestSrv` which collides with `TestSrv` defined in `TestResourceRecordSrv.cpp`

#### Change overview
Rename the test into `TestTxt`.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
Unit tests cover the issues they were not built. A PR to enable unit tests on Mbed OS will follow.  
