### PR TITLE
Identify secure session test suite

### DIFF
--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -459,7 +459,7 @@ int CASE_TestSecurePairing_Teardown(void * inContext);
 // clang-format off
 static nlTestSuite sSuite =
 {
-    "Test-CHIP-SecurePairing",
+    "Test-CHIP-SecurePairing-CASE",
     &sTests[0],
     CASE_TestSecurePairing_Setup,
     CASE_TestSecurePairing_Teardown,

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -360,7 +360,7 @@ int TestSecurePairing_Teardown(void * inContext);
 // clang-format off
 static nlTestSuite sSuite =
 {
-    "Test-CHIP-SecurePairing",
+    "Test-CHIP-SecurePairing-PASE",
     &sTests[0],
     TestSecurePairing_Setup,
     TestSecurePairing_Teardown,


### PR DESCRIPTION
#### Problem
The test suite in TestCASESession and TestPASESession are both named `Test-CHIP-SecurePairing` and share similar test name like `Handshake`. If one of the test in these test suite fail it is difficult to know which test suite really failed.

#### Change overview
Add a suffix to the `Test-CHIP-SecurePairing` test suites. 

#### Testing
How was this tested? (at least one bullet point required)
Run of unit tests

