### PR TITLE
Prevent use of invalid pointer in MessageCounterManager::OnResponseTimeout

### DIFF
--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -53,6 +53,7 @@ void MessageCounterManager::Shutdown()
     if (mExchangeMgr != nullptr)
     {
         mExchangeMgr->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::MsgCounterSyncReq);
+        mExchangeMgr->CloseAllContextsForDelegate(this);
         mExchangeMgr = nullptr;
     }
 }


### PR DESCRIPTION
#### Problem
In one of the unit test (I don't remember which one) we discovered that `MessageCounterManager::OnResponseTimeout` could be called after the instance has been shutdown. This causes dereferencing of a nullptr. 

#### Change overview
Verify that `mExchangeMgr` before dereferencing it. 

#### Testing
How was this tested? (at least one bullet point required)
Existing unit tests.