### PR TITLE
Use usleep instead of sleep/nanosleep on Mbed OS.

### DIFF
--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -183,14 +183,7 @@ public:
 
 void test_os_sleep_ms(uint64_t millisecs)
 {
-    struct timespec sleep_time;
-    uint64_t s = millisecs / 1000;
-
-    millisecs -= s * 1000;
-    sleep_time.tv_sec  = static_cast<time_t>(s);
-    sleep_time.tv_nsec = static_cast<long>(millisecs * 1000000);
-
-    nanosleep(&sleep_time, nullptr);
+    usleep((useconds_t)(millisecs * 1000));
 }
 
 void CheckAddClearRetrans(nlTestSuite * inSuite, void * inContext)

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -183,7 +183,7 @@ public:
 
 void test_os_sleep_ms(uint64_t millisecs)
 {
-    usleep((useconds_t)(millisecs * 1000));
+    usleep(static_cast<useconds_t>(millisecs * 1000));
 }
 
 void CheckAddClearRetrans(nlTestSuite * inSuite, void * inContext)

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -98,7 +98,7 @@ static bool sleepRan;
 
 static void SleepSome(intptr_t)
 {
-    sleep(1);
+    usleep((useconds_t)(1 * 1000 * 1000));
     sleepRan = true;
 }
 

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -98,7 +98,7 @@ static bool sleepRan;
 
 static void SleepSome(intptr_t)
 {
-    usleep((useconds_t)(1 * 1000 * 1000));
+    usleep(static_cast<useconds_t>(1 * 1000 * 1000));
     sleepRan = true;
 }
 

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -70,28 +70,14 @@ static const struct time_test_vector test_vector_system_time_us[] = {
 
 #include <unistd.h>
 
-void test_os_sleep_ms(uint64_t millisecs)
-{
-    struct timespec sleep_time;
-    int s = millisecs / 1000;
-
-    millisecs -= s * 1000;
-    sleep_time.tv_sec  = s;
-    sleep_time.tv_nsec = millisecs * 1000000;
-
-    nanosleep(&sleep_time, nullptr);
-}
-
 void test_os_sleep_us(uint64_t microsecs)
 {
-    struct timespec sleep_time;
-    int s = microsecs / 1000000;
+    usleep(microsecs);
+}
 
-    microsecs -= s * 1000000;
-    sleep_time.tv_sec  = s;
-    sleep_time.tv_nsec = microsecs * 1000;
-
-    nanosleep(&sleep_time, nullptr);
+void test_os_sleep_ms(uint64_t millisecs)
+{
+    test_os_sleep_us(millisecs * 1000);
 }
 
 // =================================

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -72,7 +72,7 @@ static const struct time_test_vector test_vector_system_time_us[] = {
 
 void test_os_sleep_us(uint64_t microsecs)
 {
-    usleep(microsecs);
+    usleep(static_cast<useconds_t>(microsecs));
 }
 
 void test_os_sleep_ms(uint64_t millisecs)

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -44,14 +44,7 @@ using TestContext = chip::Test::MessagingContext;
 
 static void test_os_sleep_ms(uint64_t millisecs)
 {
-    struct timespec sleep_time;
-    uint64_t s = millisecs / 1000;
-
-    millisecs -= s * 1000;
-    sleep_time.tv_sec  = static_cast<time_t>(s);
-    sleep_time.tv_nsec = static_cast<long>(millisecs * 1000000);
-
-    nanosleep(&sleep_time, nullptr);
+    usleep((useconds_t) millisecs * 1000);
 }
 
 class PASETestLoopbackTransport : public Test::LoopbackTransport

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -44,7 +44,7 @@ using TestContext = chip::Test::MessagingContext;
 
 static void test_os_sleep_ms(uint64_t millisecs)
 {
-    usleep((useconds_t) millisecs * 1000);
+    usleep(static_cast<useconds_t>(millisecs * 1000));
 }
 
 class PASETestLoopbackTransport : public Test::LoopbackTransport


### PR DESCRIPTION
#### Problem
`nanosleep` is not available on Mbed OS and `sleep` as a different semantic compared to POSIX (not tie to newlib). 
Some unit tests actively use this feature which cause a compilation error. 

#### Change overview
In unit tests, use `usleep` instead of `nanosleep` or `sleep` when compiled for Mbed OS.

#### Testing
>How was this tested? (at least one bullet point required)

Existing unit tests. 