### PR TITLE
Force TCP server/listen socket to be non blocking.

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -301,6 +301,12 @@ CHIP_ERROR TCPEndPoint::Listen(uint16_t backlog)
 
     if (listen(mSocket.GetFD(), backlog) != 0)
         res = chip::System::MapErrorPOSIX(errno);
+    else
+    {
+        // Enable non-blocking mode for the socket.
+        int flags = fcntl(mSocket.GetFD(), F_GETFL, 0);
+        fcntl(mSocket.GetFD(), F_SETFL, flags | O_NONBLOCK);
+    }
 
     // Wait for ability to read on this endpoint.
     mSocket.SetCallback(HandlePendingIO, reinterpret_cast<intptr_t>(this));
@@ -2464,11 +2470,17 @@ void TCPEndPoint::HandlePendingIO()
         // The socket being writable indicates the connection has completed (successfully or otherwise).
         if (mSocket.HasPendingWrite())
         {
+#if !__MBED__
             // Get the connection result from the socket.
             int osConRes;
             socklen_t optLen = sizeof(osConRes);
             if (getsockopt(mSocket.GetFD(), SOL_SOCKET, SO_ERROR, &osConRes, &optLen) != 0)
                 osConRes = errno;
+#else
+            // On Mbed OS, connect blocks and never returns EINPROGRESS
+            // The socket option SO_ERROR is not available.
+            int osConRes = 0;
+#endif
             CHIP_ERROR conRes = chip::System::MapErrorPOSIX(osConRes);
 
             // Process the connection result.
@@ -2646,7 +2658,16 @@ void TCPEndPoint::HandleIncomingConnection()
     // Accept the new connection.
     int conSocket = accept(mSocket.GetFD(), &sa.any, &saLen);
     if (conSocket == -1)
-        err = chip::System::MapErrorPOSIX(errno);
+    {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            return;
+        }
+        else
+        {
+            err = chip::System::MapErrorPOSIX(errno);
+        }
+    }
 
     // If there's no callback available, fail with an error.
     if (err == CHIP_NO_ERROR && OnConnectionReceived == nullptr)


### PR DESCRIPTION
#### Problem
If no connection is pending in the backlog, calling `accept` will block the application until a new connection is formed. This is a problem if the backlog state change between the return from select and the call to accept. 

#### Change overview
Make _listening_ socket non blocking. If no connection is pending in the backlog, `accept` returns `EWOULDBLOCK`.

This also plays better with Mbed OS event system which is edge triggered and not level triggered like a regular select (we found the issue because the system was not able to advertise a change of pending connections in the backlog). 

#### Testing
How was this tested? (at least one bullet point required)
It has been reproduced on Mbed OS but it is hard to provide a test for this that runs on all platform without fiddling with the implementation of the `WatchableSocketSelect` in the test. Integration tests might be more do-able if the event loop is blocked for a long period of time before processing the listen socket but it isn't trivial either. 