### PR TITLE
Add flashing wrapper generation to nrfconnect examples

### DIFF
--- a/config/nrfconnect/app/flashing.cmake
+++ b/config/nrfconnect/app/flashing.cmake
@@ -1,0 +1,55 @@
+#
+#   Copyright (c) 2021 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Adds rules to generate a flashing wrapper script for an nrfconnect firmware.
+
+set(FLASHBUNDLE_FLASHER_COMMON ${CMAKE_PROJECT_NAME}/firmware_utils.py)
+set(FLASHBUNDLE_FLASHER_PLATFORM ${CMAKE_PROJECT_NAME}/nrfconnect_firmware_utils.py)
+set(FLASHBUNDLE_FLASHER_WRAPPER ${CMAKE_PROJECT_NAME}/${CMAKE_PROJECT_NAME}.flash.py)
+set(FLASHBUNDLE_FIRMWARE ${CMAKE_PROJECT_NAME}/${CMAKE_PROJECT_NAME}.hex)
+set(FLASHBUNDLE_FILES ${FLASHBUNDLE_FLASHER_COMMON} ${FLASHBUNDLE_FLASHER_PLATFORM} ${FLASHBUNDLE_FLASHER_WRAPPER} ${FLASHBUNDLE_FIRMWARE})
+
+get_filename_component(FLASHBUNDLE_FIRMWARE_BASENAME ${FLASHBUNDLE_FIRMWARE} NAME)
+
+list(JOIN FLASHBUNDLE_FILES "\n" FLASHBUNDLE_MANIFEST)
+
+file(GENERATE
+  OUTPUT ${CMAKE_PROJECT_NAME}.flashbundle.txt
+  CONTENT "${FLASHBUNDLE_MANIFEST}\n"
+  )
+
+add_custom_command(OUTPUT "${FLASHBUNDLE_FLASHER_COMMON}"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${PROJECT_SOURCE_DIR}/third_party/connectedhomeip/scripts/flashing/firmware_utils.py" "${FLASHBUNDLE_FLASHER_COMMON}"
+    VERBATIM)
+
+add_custom_command(OUTPUT "${FLASHBUNDLE_FLASHER_PLATFORM}"
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "${PROJECT_SOURCE_DIR}/third_party/connectedhomeip/scripts/flashing/nrfconnect_firmware_utils.py" "${FLASHBUNDLE_FLASHER_PLATFORM}"
+    VERBATIM)
+
+add_custom_command(OUTPUT "${FLASHBUNDLE_FIRMWARE}"
+    DEPENDS zephyr/${KERNEL_HEX_NAME}
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy "zephyr/${KERNEL_HEX_NAME}" "${FLASHBUNDLE_FIRMWARE}"
+    VERBATIM)
+
+add_custom_command(OUTPUT "${CMAKE_PROJECT_NAME}/${CMAKE_PROJECT_NAME}.flash.py"
+    COMMAND ${python}
+            "${PROJECT_SOURCE_DIR}/third_party/connectedhomeip/scripts/flashing/gen_flashing_script.py" nrfconnect
+            --output "${FLASHBUNDLE_FLASHER_WRAPPER}"
+            --application "${FLASHBUNDLE_FIRMWARE_BASENAME}"
+    COMMENT "To flash ${FLASHBUNDLE_FIRMWARE_BASENAME} run ${FLASHBUNDLE_FLASHER_WRAPPER}"
+    VERBATIM)
+
+add_custom_target(flashing_script DEPENDS ${FLASHBUNDLE_FILES})

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -178,3 +178,5 @@ target_link_libraries(app PRIVATE
 target_link_libraries(pw_build INTERFACE zephyr_interface)
 
 endif(CONFIG_CHIP_PW_RPC)
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -94,3 +94,5 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/network-commissioning/network-commissioning.cpp
                ${CHIP_ROOT}/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off-server.cpp)
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -79,3 +79,5 @@ target_link_libraries(app PUBLIC
 )
 
 target_link_libraries(pw_build INTERFACE zephyr_interface)
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -69,3 +69,5 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp
                ${CHIP_ROOT}/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp)
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -69,3 +69,5 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
                ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp
                ${CHIP_ROOT}/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp)
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -53,3 +53,5 @@ if(CONFIG_OPENTHREAD_FTD)
 elseif(CONFIG_OPENTHREAD_MTD)
     target_link_libraries(app INTERFACE openthread-cli-mtd)
 endif()
+
+include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)


### PR DESCRIPTION
#### Problem

As part of our interop testing we want flashing to be as easy as
possible and consistent across boards. To this end, the GN based builds
generate ".flash.py" helper scripts alongside any generated firmware.

With the move to nrfconnect, this functionality was lost for nrf5 boards. 

#### Change overview

Bring it back via the cmake build.

#### Testing

```
for x in lighting-app lock-app pigweed-app shell; do
  (source scripts/activate.sh; cd examples/$x/nrfconnect; west build -b nrf52840dk_nrf52840 -t flashing_script)
done

./examples/lighting-app/nrfconnect/build/chip-nrfconnect-lighting-example/chip-nrfconnect-lighting-example.flash.py -s 683565606
```