### PR TITLE
More revisions to System::Layer

### DIFF
--- a/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
+++ b/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
@@ -79,7 +79,7 @@ void InitTestInetCommon()
 
 void InitSystemLayer()
 {
-    gSystemLayer.Init(nullptr);
+    gSystemLayer.Init();
 }
 
 void ShutdownSystemLayer()

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -424,7 +424,7 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    chip::gSystemLayer.Init(nullptr);
+    chip::gSystemLayer.Init();
 
     err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
                                      &chip::gMessageCounterManager);

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -79,7 +79,7 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    gSystemLayer.Init(nullptr);
+    gSystemLayer.Init();
 
     err = gSessionManager.Init(kTestDeviceNodeId1, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -117,7 +117,7 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    gSystemLayer.Init(nullptr);
+    gSystemLayer.Init();
 
     err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -446,7 +446,7 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    chip::gSystemLayer.Init(nullptr);
+    chip::gSystemLayer.Init();
 
     err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
                                      &chip::gMessageCounterManager);

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -156,7 +156,7 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    chip::gSystemLayer.Init(nullptr);
+    chip::gSystemLayer.Init();
 
     err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
                                      &chip::gMessageCounterManager);

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -151,7 +151,7 @@ jint JNI_OnLoad(JavaVM * jvm, void * reserved)
     ChipLogProgress(Controller, "Java class references loaded.");
 
     // Initialize the CHIP System Layer.
-    err = sSystemLayer.Init(NULL);
+    err = sSystemLayer.Init();
     SuccessOrExit(err);
 
     // Initialize the CHIP Inet layer.

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -170,14 +170,13 @@ private:
     template <class>
     friend class Internal::GenericConfigurationManagerImpl;
     // Parentheses used to fix clang parsing issue with these declarations
-    friend ::CHIP_ERROR(::chip::System::Platform::EventSupport::PostEvent)(::chip::System::Layer & aLayer, void * aContext,
-                                                                           ::chip::System::Object & aTarget,
-                                                                           ::chip::System::EventType aType, uintptr_t aArgument);
-    friend ::CHIP_ERROR(::chip::System::Platform::EventSupport::DispatchEvents)(::chip::System::Layer & aLayer, void * aContext);
-    friend ::CHIP_ERROR(::chip::System::Platform::EventSupport::DispatchEvent)(::chip::System::Layer & aLayer, void * aContext,
-                                                                               ::chip::System::Event aEvent);
-    friend ::CHIP_ERROR(::chip::System::Platform::EventSupport::StartTimer)(::chip::System::Layer & aLayer, void * aContext,
-                                                                            uint32_t aMilliseconds);
+    friend ::CHIP_ERROR(::chip::System::Platform::Eventing::PostEvent)(::chip::System::Layer & aLayer,
+                                                                       ::chip::System::Object & aTarget,
+                                                                       ::chip::System::EventType aType, uintptr_t aArgument);
+    friend ::CHIP_ERROR(::chip::System::Platform::Eventing::DispatchEvents)(::chip::System::Layer & aLayer);
+    friend ::CHIP_ERROR(::chip::System::Platform::Eventing::DispatchEvent)(::chip::System::Layer & aLayer,
+                                                                           ::chip::System::Event aEvent);
+    friend ::CHIP_ERROR(::chip::System::Platform::Eventing::StartTimer)(::chip::System::Layer & aLayer, uint32_t aMilliseconds);
 
     void PostEvent(const ChipDeviceEvent * event);
     void DispatchEvent(const ChipDeviceEvent * event);

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
 
     // Initialize the CHIP system layer.
     new (&SystemLayer) System::Layer();
-    err = SystemLayer.Init(nullptr);
+    err = SystemLayer.Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -148,11 +148,9 @@ void InitSystemLayer()
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     AcquireLwIP();
-
-    gSystemLayer.Init(sLwIPEventQueue);
-#else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
-    gSystemLayer.Init(nullptr);
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
+
+    gSystemLayer.Init();
 }
 
 void ShutdownSystemLayer()

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -216,7 +216,7 @@ void CheckFailRetrans(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     MockAppDelegate mockAppDelegate;
     ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockAppDelegate);
@@ -240,7 +240,7 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -305,7 +305,7 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -370,7 +370,7 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -425,7 +425,7 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -492,7 +492,7 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -574,7 +574,7 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     ctx.SetPeerKeyId(0);
     ctx.SetAdminId(kUndefinedAdminId);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -652,7 +652,7 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -726,7 +726,7 @@ void CheckReceiveAfterStandaloneAck(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -820,7 +820,7 @@ void CheckNoPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -957,7 +957,7 @@ void CheckSendUnsolicitedStandaloneAckMessage(nlTestSuite * inSuite, void * inCo
      */
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData("", 0);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -999,7 +999,7 @@ void CheckSendStandaloneAckMessage(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     MockAppDelegate mockAppDelegate;
     ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockAppDelegate);
@@ -1033,7 +1033,7 @@ void CheckMessageAfterClosed(nlTestSuite * inSuite, void * inContext)
 
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());

--- a/src/platform/SystemEventSupport.cpp
+++ b/src/platform/SystemEventSupport.cpp
@@ -30,12 +30,11 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace EventSupport {
+namespace Eventing {
 
 using namespace ::chip::DeviceLayer;
 
-CHIP_ERROR PostEvent(System::Layer & aLayer, void * aContext, System::Object & aTarget, System::EventType aType,
-                     uintptr_t aArgument)
+CHIP_ERROR PostEvent(System::Layer & aLayer, System::Object & aTarget, System::EventType aType, uintptr_t aArgument)
 {
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kChipSystemLayerEvent;
@@ -48,21 +47,21 @@ CHIP_ERROR PostEvent(System::Layer & aLayer, void * aContext, System::Object & a
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DispatchEvents(System::Layer & aLayer, void * aContext)
+CHIP_ERROR DispatchEvents(System::Layer & aLayer)
 {
     PlatformMgr().RunEventLoop();
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DispatchEvent(System::Layer & aLayer, void * aContext, const ChipDeviceEvent * aEvent)
+CHIP_ERROR DispatchEvent(System::Layer & aLayer, const ChipDeviceEvent * aEvent)
 {
     PlatformMgr().DispatchEvent(aEvent);
 
     return CHIP_NO_ERROR;
 }
 
-} // namespace EventSupport
+} // namespace Eventing
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/platform/SystemTimerSupport.cpp
+++ b/src/platform/SystemTimerSupport.cpp
@@ -30,16 +30,16 @@
 namespace chip {
 namespace System {
 namespace Platform {
-namespace EventSupport {
+namespace Eventing {
 
 using namespace ::chip::DeviceLayer;
 
-CHIP_ERROR StartTimer(System::Layer & aLayer, void * aContext, uint32_t aMilliseconds)
+CHIP_ERROR StartTimer(System::Layer & aLayer, uint32_t aMilliseconds)
 {
     return PlatformMgr().StartChipTimer(aMilliseconds);
 }
 
-} // namespace EventSupport
+} // namespace Eventing
 } // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -428,21 +428,6 @@ struct LwIPEvent;
 
 #endif /* CHIP_SYSTEM_CONFIG_USE_LWIP */
 
-
-/**
- *  @def CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS
- *
- *  @brief
- *      This defines whether (1) or not (0) your platform will provide the following platform-specific functions:
- *      - chip::System::Platform::WillInit
- *      - chip::System::Platform::WillShutdown
- *      - chip::System::Platform::DidInit
- *      - chip::System::Platform::DidShutdown
- */
-#ifndef CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS
-#define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS 0
-#endif /* CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS */
-
 /**
  *  @def CHIP_SYSTEM_CONFIG_NUM_TIMERS
  *

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -61,16 +61,6 @@
 namespace chip {
 namespace System {
 
-namespace Platform {
-
-extern CHIP_ERROR WillInit(System::Layer & aLayer, void * aContext);
-extern CHIP_ERROR WillShutdown(System::Layer & aLayer, void * aContext);
-
-extern void DidInit(System::Layer & aLayer, void * aContext, CHIP_ERROR aStatus);
-extern void DidShutdown(System::Layer & aLayer, void * aContext, CHIP_ERROR aStatus);
-
-} // namespace Platform
-
 namespace {
 
 Clock::MonotonicMilliseconds GetTimestamp(const Callback::Cancelable * timer)
@@ -106,26 +96,7 @@ int TimerCompare(void * p, const Callback::Cancelable * a, const Callback::Cance
 
 using namespace ::chip::Callback;
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-bool LwIPEventHandlerDelegate::IsInitialized() const
-{
-    return this->mFunction != NULL;
-}
-
-void LwIPEventHandlerDelegate::Init(LwIPEventHandlerFunction aFunction)
-{
-    this->mFunction     = aFunction;
-    this->mNextDelegate = NULL;
-}
-
-void LwIPEventHandlerDelegate::Prepend(const LwIPEventHandlerDelegate *& aDelegateList)
-{
-    this->mNextDelegate = aDelegateList;
-    aDelegateList       = this;
-}
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-Layer::Layer() : mLayerState(kLayerState_NotInitialized), mContext(nullptr), mPlatformData(nullptr)
+Layer::Layer() : mLayerState(kLayerState_NotInitialized), mPlatformData(nullptr)
 {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     if (!sSystemEventHandlerDelegate.IsInitialized())
@@ -143,10 +114,8 @@ Layer::Layer() : mLayerState(kLayerState_NotInitialized), mContext(nullptr), mPl
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 }
 
-CHIP_ERROR Layer::Init(void * aContext)
+CHIP_ERROR Layer::Init()
 {
-    CHIP_ERROR lReturn;
-
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     RegisterPOSIXErrorFormatter();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -157,9 +126,6 @@ CHIP_ERROR Layer::Init(void * aContext)
     if (this->mLayerState != kLayerState_NotInitialized)
         return CHIP_ERROR_INCORRECT_STATE;
 
-    lReturn = Platform::WillInit(*this, aContext);
-    SuccessOrExit(lReturn);
-
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     mWatchableEvents.Init(*this);
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -169,33 +135,21 @@ CHIP_ERROR Layer::Init(void * aContext)
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
     // Create an event to allow an arbitrary thread to wake the thread in the select loop.
-    lReturn = this->mWakeEvent.Open(mWatchableEvents);
-    SuccessOrExit(lReturn);
+    ReturnErrorOnFailure(this->mWakeEvent.Open(mWatchableEvents));
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     this->mLayerState = kLayerState_Initialized;
-    this->mContext    = aContext;
 
-exit:
-    Platform::DidInit(*this, aContext, lReturn);
-    return lReturn;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Layer::Shutdown()
 {
-    CHIP_ERROR lReturn;
-    void * lContext;
-
     if (this->mLayerState == kLayerState_NotInitialized)
         return CHIP_ERROR_INCORRECT_STATE;
 
-    lContext = this->mContext;
-    lReturn  = Platform::WillShutdown(*this, lContext);
-    SuccessOrExit(lReturn);
-
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    lReturn = mWakeEvent.Close();
-    SuccessOrExit(lReturn);
+    ReturnErrorOnFailure(mWakeEvent.Close());
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
     for (size_t i = 0; i < Timer::sPool.Size(); ++i)
@@ -212,34 +166,9 @@ CHIP_ERROR Layer::Shutdown()
     mWatchableEvents.Shutdown();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    this->mContext    = nullptr;
     this->mLayerState = kLayerState_NotInitialized;
 
-exit:
-    Platform::DidShutdown(*this, lContext, lReturn);
-    return lReturn;
-}
-
-/**
- * This returns any client-specific platform data assigned to the instance, if it has been previously set.
- *
- * @return Client-specific platform data, if is has been previously set; otherwise, NULL.
- */
-void * Layer::GetPlatformData() const
-{
-    return this->mPlatformData;
-}
-
-/**
- * This sets the specified client-specific platform data to the
- * instance for later retrieval by the client platform.
- *
- * @param[in]  aPlatformData  The client-specific platform data to set.
- *
- */
-void Layer::SetPlatformData(void * aPlatformData)
-{
-    this->mPlatformData = aPlatformData;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Layer::NewTimer(Timer *& aTimerPtr)
@@ -565,6 +494,23 @@ void Layer::WakeIOThread()
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 LwIPEventHandlerDelegate Layer::sSystemEventHandlerDelegate;
 
+bool LwIPEventHandlerDelegate::IsInitialized() const
+{
+    return this->mFunction != NULL;
+}
+
+void LwIPEventHandlerDelegate::Init(LwIPEventHandlerFunction aFunction)
+{
+    this->mFunction     = aFunction;
+    this->mNextDelegate = NULL;
+}
+
+void LwIPEventHandlerDelegate::Prepend(const LwIPEventHandlerDelegate *& aDelegateList)
+{
+    this->mNextDelegate = aDelegateList;
+    aDelegateList       = this;
+}
+
 /**
  * This is the dispatch handler for system layer events.
  *
@@ -638,7 +584,7 @@ CHIP_ERROR Layer::PostEvent(Object & aTarget, EventType aEventType, uintptr_t aA
     VerifyOrDieWithMsg(aTarget.IsRetained(*this), chipSystemLayer, "wrong poster! [target %p != this %p]", &(aTarget.SystemLayer()),
                        this);
 
-    lReturn = Platform::EventSupport::PostEvent(*this, this->mContext, aTarget, aEventType, aArgument);
+    lReturn = Platform::Eventing::PostEvent(*this, aTarget, aEventType, aArgument);
     if (lReturn != CHIP_NO_ERROR)
     {
         ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer event (type %d): %s", aEventType, ErrorStr(lReturn));
@@ -660,7 +606,7 @@ CHIP_ERROR Layer::DispatchEvents()
     CHIP_ERROR lReturn = CHIP_NO_ERROR;
     VerifyOrExit(this->State() == kLayerState_Initialized, lReturn = CHIP_ERROR_INCORRECT_STATE);
 
-    lReturn = Platform::EventSupport::DispatchEvents(*this, this->mContext);
+    lReturn = Platform::Eventing::DispatchEvents(*this);
     SuccessOrExit(lReturn);
 
 exit:
@@ -682,7 +628,7 @@ CHIP_ERROR Layer::DispatchEvent(Event aEvent)
     CHIP_ERROR lReturn = CHIP_NO_ERROR;
     VerifyOrExit(this->State() == kLayerState_Initialized, lReturn = CHIP_ERROR_INCORRECT_STATE);
 
-    lReturn = Platform::EventSupport::DispatchEvent(*this, this->mContext, aEvent);
+    lReturn = Platform::Eventing::DispatchEvent(*this, aEvent);
     SuccessOrExit(lReturn);
 
 exit:
@@ -754,7 +700,7 @@ CHIP_ERROR Layer::StartPlatformTimer(uint32_t aDelayMilliseconds)
     CHIP_ERROR lReturn = CHIP_NO_ERROR;
     VerifyOrExit(this->State() == kLayerState_Initialized, lReturn = CHIP_ERROR_INCORRECT_STATE);
 
-    lReturn = Platform::EventSupport::StartTimer(*this, this->mContext, aDelayMilliseconds);
+    lReturn = Platform::Eventing::StartTimer(*this, aDelayMilliseconds);
     SuccessOrExit(lReturn);
 
 exit:
@@ -787,87 +733,5 @@ exit:
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-namespace Platform {
-
-#if !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS
-
-/**
- * This is a platform-specific CHIP System Layer pre-initialization hook. This may be overridden by assserting the preprocessor
- * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
- *
- *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being initialized.
- *
- *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, \::Init.
- *
- *  @return #CHIP_NO_ERROR on success; otherwise, a specific error indicating the reason for initialization failure.
- *      Returning non-successful status will abort initialization.
- */
-DLL_EXPORT CHIP_ERROR WillInit(System::Layer & aLayer, void * aContext)
-{
-    static_cast<void>(aLayer);
-    static_cast<void>(aContext);
-
-    return CHIP_NO_ERROR;
-}
-
-/**
- * This is a platform-specific CHIP System Layer pre-shutdown hook. This may be overridden by assserting the preprocessor
- * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
- *
- *  @param[in,out] aLayer    A pointer to the CHIP System Layer instance being shutdown.
- *
- *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, \::Shutdown.
- *
- *  @return #CHIP_NO_ERROR on success; otherwise, a specific error indicating the reason for shutdown failure. Returning
- *      non-successful status will abort shutdown.
- */
-DLL_EXPORT CHIP_ERROR WillShutdown(System::Layer & aLayer, void * aContext)
-{
-    static_cast<void>(aLayer);
-    static_cast<void>(aContext);
-
-    return CHIP_NO_ERROR;
-}
-
-/**
- * This is a platform-specific CHIP System Layer post-initialization hook. This may be overridden by assserting the preprocessor
- * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
- *
- *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being initialized.
- *
- *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, \::Init.
- *
- *  @param[in]     aStatus   The overall status being returned via the CHIP System Layer \::Init method.
- */
-DLL_EXPORT void DidInit(System::Layer & aLayer, void * aContext, CHIP_ERROR aStatus)
-{
-    static_cast<void>(aLayer);
-    static_cast<void>(aContext);
-    static_cast<void>(aStatus);
-}
-
-/**
- * This is a platform-specific CHIP System Layer pre-shutdown hook. This may be overridden by assserting the preprocessor
- * definition, #CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS.
- *
- *  @param[in,out] aLayer    A reference to the CHIP System Layer instance being shutdown.
- *
- *  @param[in,out] aContext  Platform-specific context data passed to the layer initialization method, \::Shutdown.
- *
- *  @param[in]     aStatus   The overall status being returned via the CHIP System Layer \::Shutdown method.
- *
- *  @return #CHIP_NO_ERROR on success; otherwise, a specific error indicating the reason for shutdown failure. Returning
- *      non-successful status will abort shutdown.
- */
-DLL_EXPORT void DidShutdown(System::Layer & aLayer, void * aContext, CHIP_ERROR aStatus)
-{
-    static_cast<void>(aLayer);
-    static_cast<void>(aContext);
-    static_cast<void>(aStatus);
-}
-
-#endif // !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS
-
-} // namespace Platform
 } // namespace System
 } // namespace chip

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -121,7 +121,6 @@ namespace {
 struct TestContext
 {
     nlTestSuite * mTestSuite;
-    void * mLayerContext;
     volatile unsigned int mAccumulator;
 };
 
@@ -136,7 +135,7 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
     Layer lLayer;
     unsigned int i, j;
 
-    lLayer.Init(lContext.mLayerContext);
+    lLayer.Init();
     memset(&sPool, 0, sizeof(sPool));
 
     for (i = 0; i < kPoolSize; ++i)
@@ -222,7 +221,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
     Layer lLayer;
     unsigned int i;
 
-    lLayer.Init(lContext.mLayerContext);
+    lLayer.Init();
 
     // Take this thread's share of objects
 
@@ -378,7 +377,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     chip::System::Stats::count_t lNumInUse;
     chip::System::Stats::count_t lHighWatermark;
 
-    lLayer.Init(lContext.mLayerContext);
+    lLayer.Init();
 
     // Take all objects one at a time and check the watermark
     // increases monotonically
@@ -486,7 +485,6 @@ static nlTestSuite sTestSuite =
 static int Initialize(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
-    void * lLayerContext   = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
     static sys_mbox_t * sLwIPEventQueue = NULL;
@@ -495,13 +493,10 @@ static int Initialize(void * aContext)
     {
         sys_mbox_new(sLwIPEventQueue, 100);
     }
-
-    lLayerContext = &sLwIPEventQueue;
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    lContext.mTestSuite    = &sTestSuite;
-    lContext.mLayerContext = lLayerContext;
-    lContext.mAccumulator  = 0;
+    lContext.mTestSuite   = &sTestSuite;
+    lContext.mAccumulator = 0;
 
     return SUCCESS;
 }

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -217,19 +217,15 @@ static Layer sLayer;
 static int TestSetup(void * aContext)
 {
     TestContext & lContext = *reinterpret_cast<TestContext *>(aContext);
-    void * lLayerContext   = nullptr;
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#if LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
     static sys_mbox_t * sLwIPEventQueue = NULL;
 
     sys_mbox_new(sLwIPEventQueue, 100);
-    lLayerContext = &sLwIPEventQueue;
     tcpip_init(NULL, NULL);
-#endif
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_VERSION_MAJOR <= 2 && LWIP_VERSION_MINOR < 1
 
-    sLayer.Init(lLayerContext);
+    sLayer.Init();
 
     lContext.mLayer     = &sLayer;
     lContext.mTestSuite = &kTheSuite;

--- a/src/transport/raw/tests/NetworkTestHelpers.cpp
+++ b/src/transport/raw/tests/NetworkTestHelpers.cpp
@@ -30,7 +30,7 @@ CHIP_ERROR IOContext::Init(nlTestSuite * suite)
 {
     CHIP_ERROR err = Platform::MemoryInit();
 
-    gSystemLayer.Init(nullptr);
+    gSystemLayer.Init();
 
     InitNetwork();
 

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -118,7 +118,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
 
     CHIP_ERROR err;
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -136,7 +136,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     callback.LargeMessageSent = false;
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -234,7 +234,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     callback.LargeMessageSent = false;
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -316,7 +316,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     callback.LargeMessageSent = false;
 
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+    ctx.GetInetLayer().SystemLayer()->Init();
 
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());


### PR DESCRIPTION
#### Problem

System::Layer has unused code.

#### Change overview

- Removed `SystemLayer.mPlatformData`, which was never set or used,
  along with associated functions.

- Removed `SystemLayer.mContext`, which was set but never used,
  along with associated function arguments.

- Removed `CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_XTOR_FUNCTIONS`
  and associated functions, which were never used.

- Rearrangements to group LwIP-specific code together.

- #8267 review followup: rename namespace EventSupport to Eventing

#### Testing

Successful builds should confirm unused code is unused.
Sanity check using chip-tool.
