### PR TITLE
Allow ChipCertificateSet Initialization without Decode Buffer.

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -40,6 +40,7 @@
 #include <protocols/Protocols.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 #include <support/TimeUtils.h>
 
 namespace chip {
@@ -58,8 +59,6 @@ ChipCertificateSet::ChipCertificateSet()
     mCerts               = nullptr;
     mCertCount           = 0;
     mMaxCerts            = 0;
-    mDecodeBuf           = nullptr;
-    mDecodeBufSize       = 0;
     mMemoryAllocInternal = false;
 }
 
@@ -68,7 +67,7 @@ ChipCertificateSet::~ChipCertificateSet()
     Release();
 }
 
-CHIP_ERROR ChipCertificateSet::Init(uint8_t maxCertsArraySize, uint16_t decodeBufSize)
+CHIP_ERROR ChipCertificateSet::Init(uint8_t maxCertsArraySize)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -76,12 +75,7 @@ CHIP_ERROR ChipCertificateSet::Init(uint8_t maxCertsArraySize, uint16_t decodeBu
     mCerts = reinterpret_cast<ChipCertificateData *>(chip::Platform::MemoryAlloc(sizeof(ChipCertificateData) * maxCertsArraySize));
     VerifyOrExit(mCerts != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    VerifyOrExit(decodeBufSize > 0, err = CHIP_ERROR_INVALID_ARGUMENT);
-    mDecodeBuf = reinterpret_cast<uint8_t *>(chip::Platform::MemoryAlloc(decodeBufSize));
-    VerifyOrExit(mDecodeBuf != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
     mMaxCerts            = maxCertsArraySize;
-    mDecodeBufSize       = decodeBufSize;
     mMemoryAllocInternal = true;
 
     Clear();
@@ -95,20 +89,15 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::Init(ChipCertificateData * certsArray, uint8_t certsArraySize, uint8_t * decodeBuf,
-                                    uint16_t decodeBufSize)
+CHIP_ERROR ChipCertificateSet::Init(ChipCertificateData * certsArray, uint8_t certsArraySize)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(certsArray != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(certsArraySize > 0, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(decodeBuf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(decodeBufSize > 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     mCerts               = certsArray;
     mMaxCerts            = certsArraySize;
-    mDecodeBuf           = decodeBuf;
-    mDecodeBufSize       = decodeBufSize;
     mMemoryAllocInternal = false;
 
     Clear();
@@ -126,11 +115,6 @@ void ChipCertificateSet::Release()
             Clear();
             chip::Platform::MemoryFree(mCerts);
             mCerts = nullptr;
-        }
-        if (mDecodeBuf != nullptr)
-        {
-            chip::Platform::MemoryFree(mDecodeBuf);
-            mDecodeBuf = nullptr;
         }
     }
 }
@@ -187,11 +171,29 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
         // Enter the certificate structure...
         ReturnErrorOnFailure(reader.EnterContainer(containerType));
 
-        // Initialize an ASN1Writer and convert the TBS (to-be-signed) portion of the certificate to ASN.1 DER
-        // encoding.  At the same time, parse various components within the certificate and set the corresponding
-        // fields in the CertificateData object.
-        writer.Init(mDecodeBuf, mDecodeBufSize);
-        ReturnErrorOnFailure(DecodeConvertTBSCert(reader, writer, cert));
+        // If requested to generate the TBSHash.
+        if (decodeFlags.Has(CertDecodeFlags::kGenerateTBSHash))
+        {
+            chip::Platform::ScopedMemoryBuffer<uint8_t> asn1TBSBuf;
+            ReturnErrorCodeIf(!asn1TBSBuf.Alloc(kMaxCHIPCertDecodeBufLength), CHIP_ERROR_NO_MEMORY);
+
+            // Initialize an ASN1Writer and convert the TBS (to-be-signed) portion of the certificate to ASN.1 DER
+            // encoding. At the same time, parse various components within the certificate and set the corresponding
+            // fields in the CertificateData object.
+            writer.Init(asn1TBSBuf.Get(), kMaxCHIPCertDecodeBufLength);
+            ReturnErrorOnFailure(DecodeConvertTBSCert(reader, writer, cert));
+
+            // Generate a SHA hash of the encoded TBS certificate.
+            chip::Crypto::Hash_SHA256(asn1TBSBuf.Get(), writer.GetLengthWritten(), cert.mTBSHash);
+
+            cert.mCertFlags.Set(CertFlags::kTBSHashPresent);
+        }
+        else
+        {
+            // Initialize an ASN1Writer as a NullWriter.
+            writer.InitNullWriter();
+            ReturnErrorOnFailure(DecodeConvertTBSCert(reader, writer, cert));
+        }
 
         // Verify the cert has both the Subject Key Id and Authority Key Id extensions present.
         // Only certs with both these extensions are supported for the purposes of certificate validation.
@@ -200,15 +202,6 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
 
         // Verify the cert was signed with ECDSA-SHA256. This is the only signature algorithm currently supported.
         VerifyOrReturnError(cert.mSigAlgoOID == kOID_SigAlgo_ECDSAWithSHA256, CHIP_ERROR_UNSUPPORTED_SIGNATURE_TYPE);
-
-        // If requested, generate the hash of the TBS portion of the certificate...
-        if (decodeFlags.Has(CertDecodeFlags::kGenerateTBSHash))
-        {
-            // Generate a SHA hash of the encoded TBS certificate.
-            chip::Crypto::Hash_SHA256(mDecodeBuf, writer.GetLengthWritten(), cert.mTBSHash);
-
-            cert.mCertFlags.Set(CertFlags::kTBSHashPresent);
-        }
 
         // Decode the certificate's signature...
         ReturnErrorOnFailure(DecodeECDSASignature(reader, cert));
@@ -957,7 +950,7 @@ CHIP_ERROR ExtractPeerIdFromOpCert(const ByteSpan & opcert, PeerId * peerId)
 {
     ChipCertificateSet certSet;
 
-    ReturnErrorOnFailure(certSet.Init(1, kMaxCHIPCertDecodeBufLength));
+    ReturnErrorOnFailure(certSet.Init(1));
 
     ReturnErrorOnFailure(certSet.LoadCert(opcert.data(), static_cast<uint32_t>(opcert.size()), BitFlags<CertDecodeFlags>()));
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -366,9 +366,6 @@ public:
         aOther.mCerts        = nullptr;
         mCertCount           = aOther.mCertCount;
         mMaxCerts            = aOther.mMaxCerts;
-        mDecodeBuf           = aOther.mDecodeBuf;
-        aOther.mDecodeBuf    = nullptr;
-        mDecodeBufSize       = aOther.mDecodeBufSize;
         mMemoryAllocInternal = aOther.mMemoryAllocInternal;
 
         return *this;
@@ -380,11 +377,10 @@ public:
      *        allocated internally using chip::Platform::MemoryAlloc() and freed with chip::Platform::MemoryFree().
      *
      * @param maxCertsArraySize  Maximum number of CHIP certificates to be loaded to the set.
-     * @param decodeBufSize      Size of the buffer that should be allocated to perform CHIP certificate decoding.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Init(uint8_t maxCertsArraySize, uint16_t decodeBufSize);
+    CHIP_ERROR Init(uint8_t maxCertsArraySize);
 
     /**
      * @brief Initialize ChipCertificateSet.
@@ -393,12 +389,10 @@ public:
      *
      * @param certsArray      A pointer to the array of the ChipCertificateData structures.
      * @param certsArraySize  Number of ChipCertificateData entries in the array.
-     * @param decodeBuf       Buffer to use for temporary storage of intermediate processing results.
-     * @param decodeBufSize   Size of decoding buffer.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Init(ChipCertificateData * certsArray, uint8_t certsArraySize, uint8_t * decodeBuf, uint16_t decodeBufSize);
+    CHIP_ERROR Init(ChipCertificateData * certsArray, uint8_t certsArraySize);
 
     /**
      * @brief Release resources allocated by this class.
@@ -544,8 +538,6 @@ private:
                                      had their constructor called, or have had
                                      their destructor called since then. */
     uint8_t mMaxCerts;            /**< Length of mCerts array. */
-    uint8_t * mDecodeBuf;         /**< Certificate decode buffer. */
-    uint16_t mDecodeBufSize;      /**< Certificate decode buffer size. */
     bool mMemoryAllocInternal;    /**< Indicates whether temporary memory buffers are allocated internally. */
 
     /**

--- a/src/credentials/CHIPOperationalCredentials.cpp
+++ b/src/credentials/CHIPOperationalCredentials.cpp
@@ -35,8 +35,7 @@
 namespace chip {
 namespace Credentials {
 
-static constexpr size_t kOperationalCertificatesMax          = 3;
-static constexpr size_t kOperationalCertificateDecodeBufSize = 1024;
+static constexpr size_t kOperationalCertificatesMax = 3;
 
 using namespace chip::Crypto;
 
@@ -306,7 +305,7 @@ CHIP_ERROR OperationalCredentialSet::FromSerializable(const OperationalCredentia
     ChipCertificateSet certificateSet;
     CertificateKeyId trustedRootId;
 
-    SuccessOrExit(err = certificateSet.Init(kOperationalCertificatesMax, kOperationalCertificateDecodeBufSize));
+    SuccessOrExit(err = certificateSet.Init(kOperationalCertificatesMax));
 
     err = certificateSet.LoadCert(serializable.mRootCertificate, serializable.mRootCertificateLen,
                                   BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));

--- a/src/credentials/tests/TestChipOperationalCredentials.cpp
+++ b/src/credentials/tests/TestChipOperationalCredentials.cpp
@@ -121,8 +121,9 @@ static void TestChipOperationalCredentials_CertValidation(nlTestSuite * inSuite,
         ChipCertificateData * resultCert    = nullptr;
         const ValidationTestCase & testCase = sValidationTestCases[i];
 
-        // Initialize the certificate set and load the specified test certificates.
-        certSet.Init(kMaxCertsPerTestCase, kMaxCHIPCertDecodeBufLength);
+        err = certSet.Init(kMaxCertsPerTestCase);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
         for (size_t i2 = 0; i2 < kMaxCertsPerTestCase; i2++)
         {
             if (testCase.InputCerts[i2].Type != TestCerts::kNone)
@@ -193,7 +194,8 @@ static void TestChipOperationalCredentials_Serialization(nlTestSuite * inSuite, 
     };
 
     // Initialize the certificate set and load the specified test certificates.
-    certSet.Init(kMaxCerts, kMaxCHIPCertDecodeBufLength);
+    err = certSet.Init(kMaxCerts);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     err = LoadTestCert(certSet, TestCerts::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     err = LoadTestCert(certSet, TestCerts::kICA01, sNullLoadFlag, sGenTBSHashFlag);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1197,7 +1197,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t * respond
 
     ChipCertificateSet certSet;
     // Certificate set can contain up to 3 certs (NOC, ICA cert, and Root CA cert)
-    ReturnErrorOnFailure(certSet.Init(3, kMaxCHIPCertDecodeBufLength));
+    ReturnErrorOnFailure(certSet.Init(3));
 
     Encoding::LittleEndian::BufferWriter bbuf(responderID, responderID.Length());
     ReturnErrorOnFailure(

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -112,9 +112,9 @@ static CHIP_ERROR InitCredentialSets()
 
     ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
 
-    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength));
+    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount, kMaxCHIPCertDecodeBufLength));
+    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount));
 
     // Add the trusted root certificate to the certificate set.
     ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -221,7 +221,7 @@ bool PrintCert(const char * fileName, X509 * cert)
     res = X509ToChipCert(cert, certBuf.get(), kMaxCHIPCertLength, certLen);
     VerifyTrueOrExit(res);
 
-    err = certSet.Init(1, kMaxCHIPCertDecodeBufLength);
+    err = certSet.Init(1);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -159,7 +159,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
     VerifyTrueOrExit(res);
 
-    err = certSet.Init(kMaxCerts, kMaxCHIPCertDecodeBufLength);
+    err = certSet.Init(kMaxCerts);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -360,7 +360,7 @@ CHIP_ERROR AdminPairingInfo::GetCredentials(OperationalCredentialSet & credentia
                                             CertificateKeyId & rootKeyId)
 {
     constexpr uint8_t kMaxNumCertsInOpCreds = 3;
-    ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds, kMaxCHIPCertLength * kMaxNumCertsInOpCreds));
+    ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds));
 
     ReturnErrorOnFailure(
         certificates.LoadCert(mRootCert, mRootCertLen,


### PR DESCRIPTION

#### Problem
In the current implementation ChipCertificateSet always requires/allocates memory buffer even when it is not required.

#### Change overview
Updated implementation. 

#### Testing
-- Added new unit test
-- Updated some existing tests

Ticket: #8387 