### PR TITLE
Update cirque.yaml

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -65,8 +65,8 @@ jobs:
                   path: ${{ env.GITHUB_CACHE_PATH }}
                   key: ${{ runner.os }}-cirque-${{ steps.cirque-key.outputs.val }}
 
-            - name: Bootstrap
-              timeout-minutes: 10
+            - name: Cirque Bootstrap
+              timeout-minutes: 15
               run: |
                   integrations/docker/images/chip-build-cirque/run.sh \
                     --env GITHUB_ACTION_RUN=1 \


### PR DESCRIPTION
#### Problem
Cirque boostrap download and install several cirque-related python package, then also call scripts/bootstrap.sh, temporarily increase the timeout from 10 min to 15min,
follow-up would move matter scripts/bootstrap.sh out from cirque boostrap, and understand how long actual cirque boostrap takes, and if matter's bootrap script take longer time.

#### Change overview
Rename the stage's name and increase the timeout for cirque bootrap
#### Testing
CI cover this
