### PR TITLE
Update the exchange match logic to align with the latest spec proposal

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -329,8 +329,7 @@ void StartPinging(streamer_t * stream, char * destination)
     err = EstablishSecureSession(stream, GetEchoPeerAddress());
     SuccessOrExit(err);
 
-    // TODO: temprary create a SecureSessionHandle from node id to unblock end-to-end test. Complete solution is tracked in PR:4451
-    err = gEchoClient.Init(&gExchangeManager, { kTestDeviceNodeId, 0, gFabricIndex });
+    err = gEchoClient.Init(&gExchangeManager, SessionHandle(kTestDeviceNodeId, 0, 0, gFabricIndex));
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
     // Create a new exchange context.
-    auto * ec = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gFabricIndex }, &gMockAppDelegate);
+    auto * ec = gExchangeManager.NewContext(SessionHandle(kTestDeviceNodeId, 0, 0, gFabricIndex), &gMockAppDelegate);
     VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -49,11 +49,9 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabric
     AbortExistingExchangeContext();
 
     // Create a new exchange context.
-    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
-    // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
     if (secureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext(SecureSessionHandle(aNodeId, 0, aFabricIndex), this);
     }
     else
     {

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -34,7 +34,7 @@ using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 namespace chip {
 namespace app {
 
-CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * secureSession)
+CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle commandPacket;
@@ -51,7 +51,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabric
     // Create a new exchange context.
     if (secureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext(SecureSessionHandle(aNodeId, 0, aFabricIndex), this);
+        mpExchangeCtx = mpExchangeMgr->NewContext(SessionHandle(aNodeId, 0, 0, aFabricIndex), this);
     }
     else
     {

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -52,7 +52,7 @@ public:
     //
     // If SendCommandRequest is never called, or the call fails, the API
     // consumer is responsible for calling Shutdown on the CommandSender.
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * secureSession = nullptr);
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession = nullptr);
 
 private:
     // ExchangeDelegate interface implementation.  Private so people won't

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -317,7 +317,7 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
     ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Exchange: %d", ec->GetExchangeId());
 }
 
-CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
+CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
                                                    EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                                    AttributePathParams * apAttributePathParamsList,
                                                    size_t aAttributePathParamsListSize, EventNumber aEventNumber,

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -112,7 +112,7 @@ public:
      *  @retval #CHIP_ERROR_NO_MEMORY If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
+    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                EventNumber aEventNumber, uint64_t aAppIdentifier = 0);

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -86,7 +86,7 @@ void ReadClient::MoveToState(const ClientState aTargetState)
                   GetStateStr());
 }
 
-CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
+CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
                                        EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                        AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                        EventNumber aEventNumber)
@@ -140,7 +140,7 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex,
     }
     else
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext(SessionHandle(aNodeId, 0, 0, aFabricIndex), this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -72,7 +72,7 @@ public:
      *  @retval #others fail to send read request
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * aSecureSession,
+    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * aSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                EventNumber aEventNumber);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -262,11 +262,9 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricInde
     ClearExistingExchangeContext();
 
     // Create a new exchange context.
-    // TODO: we temporarily create a SecureSessionHandle from node id, this will be fixed in PR 3602
-    // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
     if (apSecureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext(SecureSessionHandle(aNodeId, 0, aFabricIndex), this);
     }
     else
     {

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -247,7 +247,7 @@ void WriteClient::ClearState()
     MoveToState(State::Uninitialized);
 }
 
-CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession)
+CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle packet;
@@ -264,7 +264,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricInde
     // Create a new exchange context.
     if (apSecureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext(SecureSessionHandle(aNodeId, 0, aFabricIndex), this);
+        mpExchangeCtx = mpExchangeMgr->NewContext(SessionHandle(aNodeId, 0, 0, aFabricIndex), this);
     }
     else
     {
@@ -396,7 +396,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession)
+CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession)
 {
     CHIP_ERROR err = mpWriteClient->SendWriteRequest(aNodeId, aFabricIndex, apSecureSession);
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -92,7 +92,7 @@ private:
      *  If SendWriteRequest is never called, or the call fails, the API
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession);
 
     /**
      *  Initialize the client object. Within the lifetime
@@ -173,7 +173,7 @@ public:
      *  Finalize the message and send it to the desired node. The underlying write object will always be released, and the user
      * should not use this object after calling this function.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession);
 
     /**
      *  Encode an attribute value that can be directly encoded using TLVWriter::Put

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -259,7 +259,7 @@ void TestCommandInteraction::TestCommandHandlerWithWrongState(nlTestSuite * apSu
 
     err = commandHandler.Init(&chip::gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gExchangeManager.NewContext(SessionHandle(0, 0, 0, 0), nullptr);
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
     err = commandHandler.SendCommandResponse();
@@ -300,7 +300,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
     err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gExchangeManager.NewContext(SessionHandle(0, 0, 0, 0), nullptr);
 
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
@@ -337,7 +337,7 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     err = commandHandler.Init(&chip::gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gExchangeManager.NewContext(SessionHandle(0, 0, 0, 0), nullptr);
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -262,7 +262,7 @@ void TestReadInteraction::TestReadClient(nlTestSuite * apSuite, void * apContext
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
     err                            = readClient.Init(&ctx.GetExchangeManager(), &delegate, 0 /* application identifier */);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    SecureSessionHandle session = ctx.GetSessionLocalToPeer();
+    SessionHandle session = ctx.GetSessionLocalToPeer();
     err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session, nullptr /*apEventPathParamsList*/,
                                      0 /*aEventPathParamsListSize*/, nullptr /*apAttributePathParamsList*/,
                                      0 /*aAttributePathParamsListSize*/, eventNumber /*aEventNumber*/);
@@ -389,7 +389,7 @@ void TestReadInteraction::TestReadClientInvalidReport(nlTestSuite * apSuite, voi
     err                            = readClient.Init(&ctx.GetExchangeManager(), &delegate, 0 /* application identifier */);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    SecureSessionHandle session = ctx.GetSessionLocalToPeer();
+    SessionHandle session = ctx.GetSessionLocalToPeer();
     err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session, nullptr /*apEventPathParamsList*/,
                                      0 /*aEventPathParamsListSize*/, nullptr /*apAttributePathParamsList*/,
                                      0 /*aAttributePathParamsListSize*/, eventNumber /*aEventNumber*/);
@@ -578,7 +578,7 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     eventPathParams[1].mClusterId  = kTestClusterId;
     eventPathParams[1].mEventId    = kTestEventIdCritical;
 
-    SecureSessionHandle session = ctx.GetSessionLocalToPeer();
+    SessionHandle session = ctx.GetSessionLocalToPeer();
     err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(),
                                                                             &session, eventPathParams, 2, nullptr, 1, 0);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -111,7 +111,7 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
 
     err = InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    Messaging::ExchangeContext * exchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    Messaging::ExchangeContext * exchangeCtx = gExchangeManager.NewContext(SessionHandle(0, 0, 0, 0), nullptr);
     TestExchangeDelegate delegate;
     exchangeCtx->SetDelegate(&delegate);
 

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -216,8 +216,8 @@ void TestWriteInteraction::TestWriteClient(nlTestSuite * apSuite, void * apConte
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     AddAttributeDataElement(apSuite, apContext, writeClientHandle);
 
-    SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err                         = writeClientHandle.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
+    SessionHandle session = ctx.GetSessionLocalToPeer();
+    err                   = writeClientHandle.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     // The internal WriteClient should be nullptr once we SendWriteRequest.
     NL_TEST_ASSERT(apSuite, nullptr == writeClientHandle.mpWriteClient);
@@ -304,7 +304,7 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
 
     NL_TEST_ASSERT(apSuite, !delegate.mGotResponse);
 
-    SecureSessionHandle session = ctx.GetSessionLocalToPeer();
+    SessionHandle session = ctx.GetSessionLocalToPeer();
 
     err = writeClient.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -110,7 +110,8 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
         return EMBER_DELIVERY_FAILED;
     }
 
-    Messaging::ExchangeContext * exchange = exchangeMgr->NewContext({ destination, Transport::kAnyKeyId, 0 }, nullptr);
+    Messaging::ExchangeContext * exchange =
+        exchangeMgr->NewContext(SessionHandle(destination, 0, Transport::kAnyKeyId, 0), nullptr);
     if (exchange == nullptr)
     {
         return EMBER_DELIVERY_FAILED;

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -121,7 +121,7 @@ bool ChannelContext::IsCasePairing()
     return mState == ChannelState::kPreparing && GetPrepareVars().mState == PrepareState::kCasePairing;
 }
 
-bool ChannelContext::MatchesSession(SecureSessionHandle session, SecureSessionMgr * ssm)
+bool ChannelContext::MatchesSession(SessionHandle session, SecureSessionMgr * ssm)
 {
     switch (mState)
     {
@@ -258,7 +258,7 @@ void ChannelContext::EnterCasePairingState()
     auto & prepare              = GetPrepareVars();
     prepare.mCasePairingSession = Platform::New<CASESession>();
 
-    ExchangeContext * ctxt = mExchangeManager->NewContext(SecureSessionHandle(), prepare.mCasePairingSession);
+    ExchangeContext * ctxt = mExchangeManager->NewContext(SessionHandle(), prepare.mCasePairingSession);
     VerifyOrReturn(ctxt != nullptr);
 
     // TODO: currently only supports IP/UDP paring
@@ -312,7 +312,7 @@ void ChannelContext::OnSessionEstablished()
     }
 }
 
-void ChannelContext::OnNewConnection(SecureSessionHandle session)
+void ChannelContext::OnNewConnection(SessionHandle session)
 {
     if (mState != ChannelState::kPreparing)
         return;
@@ -323,14 +323,14 @@ void ChannelContext::OnNewConnection(SecureSessionHandle session)
     EnterReadyState(session);
 }
 
-void ChannelContext::EnterReadyState(SecureSessionHandle session)
+void ChannelContext::EnterReadyState(SessionHandle session)
 {
     mState = ChannelState::kReady;
     mStateVars.Set<ReadyVars>(session);
     mChannelManager->NotifyChannelEvent(this, [](ChannelDelegate * delegate) { delegate->OnEstablished(); });
 }
 
-void ChannelContext::OnConnectionExpired(SecureSessionHandle session)
+void ChannelContext::OnConnectionExpired(SessionHandle session)
 {
     if (mState != ChannelState::kReady)
         return;

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -102,14 +102,14 @@ public:
     bool IsCasePairing();
 
     bool MatchesBuilder(const ChannelBuilder & builder);
-    bool MatchesSession(SecureSessionHandle session, SecureSessionMgr * ssm);
+    bool MatchesSession(SessionHandle session, SecureSessionMgr * ssm);
 
     // events of ResolveDelegate, propagated from ExchangeManager
     void HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, const Mdns::MdnsService & address);
 
     // events of SecureSessionManager, propagated from ExchangeManager
-    void OnNewConnection(SecureSessionHandle session);
-    void OnConnectionExpired(SecureSessionHandle session);
+    void OnNewConnection(SessionHandle session);
+    void OnConnectionExpired(SessionHandle session);
 
     // Pairing callbacks
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -144,8 +144,8 @@ private:
     struct ReadyVars
     {
         static constexpr const size_t VariantId = 2;
-        ReadyVars(SecureSessionHandle session) : mSession(session) {}
-        const SecureSessionHandle mSession;
+        ReadyVars(SessionHandle session) : mSession(session) {}
+        const SessionHandle mSession;
     };
 
     Variant<PrepareVars, ReadyVars> mStateVars;
@@ -157,7 +157,7 @@ private:
     void EnterPreparingState(const ChannelBuilder & builder);
     void ExitPreparingState();
 
-    void EnterReadyState(SecureSessionHandle session);
+    void EnterReadyState(SessionHandle session);
     void ExitReadyState();
 
     void EnterFailedState(CHIP_ERROR error);

--- a/src/channel/Manager.h
+++ b/src/channel/Manager.h
@@ -58,7 +58,7 @@ public:
         });
     }
 
-    void OnNewConnection(SecureSessionHandle session, ExchangeManager * mgr) override
+    void OnNewConnection(SessionHandle session, ExchangeManager * mgr) override
     {
         mChannelContexts.ForEachActiveObject([&](ChannelContext * context) {
             if (context->MatchesSession(session, mgr->GetSessionMgr()))
@@ -70,7 +70,7 @@ public:
         });
     }
 
-    void OnConnectionExpired(SecureSessionHandle session, ExchangeManager * mgr) override
+    void OnConnectionExpired(SessionHandle session, ExchangeManager * mgr) override
     {
         mChannelContexts.ForEachActiveObject([&](ChannelContext * context) {
             if (context->MatchesSession(session, mgr->GetSessionMgr()))

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -300,7 +300,7 @@ CHIP_ERROR Device::Persist()
     return error;
 }
 
-void Device::OnNewConnection(SecureSessionHandle session)
+void Device::OnNewConnection(SessionHandle session)
 {
     mState         = ConnectionState::SecureConnected;
     mSecureSession = session;
@@ -319,12 +319,12 @@ void Device::OnNewConnection(SecureSessionHandle session)
     peerCounter.SetCounter(mPeerMessageCounter);
 }
 
-void Device::OnConnectionExpired(SecureSessionHandle session)
+void Device::OnConnectionExpired(SessionHandle session)
 {
     VerifyOrReturn(session == mSecureSession,
                    ChipLogDetail(Controller, "Connection expired, but it doesn't match the current session"));
     mState         = ConnectionState::NotConnected;
-    mSecureSession = SecureSessionHandle{};
+    mSecureSession = SessionHandle{};
 }
 
 CHIP_ERROR Device::OnMessageReceived(Messaging::ExchangeContext * exchange, const PacketHeader & header,
@@ -540,7 +540,7 @@ CHIP_ERROR Device::WarmupCASESession()
     VerifyOrReturnError(mDeviceOperationalCertProvisioned, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mState == ConnectionState::NotConnected, CHIP_NO_ERROR);
 
-    Messaging::ExchangeContext * exchange = mExchangeMgr->NewContext(SecureSessionHandle(), &mCASESession);
+    Messaging::ExchangeContext * exchange = mExchangeMgr->NewContext(SessionHandle(), &mCASESession);
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     ReturnErrorOnFailure(mCASESession.MessageDispatch().Init(mSessionManager->GetTransportManager()));

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -257,7 +257,7 @@ public:
      *
      * @param session A handle to the secure session
      */
-    void OnNewConnection(SecureSessionHandle session);
+    void OnNewConnection(SessionHandle session);
 
     /**
      * @brief
@@ -267,7 +267,7 @@ public:
      *
      * @param session A handle to the secure session
      */
-    void OnConnectionExpired(SecureSessionHandle session);
+    void OnConnectionExpired(SessionHandle session);
 
     /**
      * @brief
@@ -345,9 +345,9 @@ public:
 
     NodeId GetDeviceId() const { return mDeviceId; }
 
-    bool MatchesSession(SecureSessionHandle session) const { return mSecureSession == session; }
+    bool MatchesSession(SessionHandle session) const { return mSecureSession == session; }
 
-    SecureSessionHandle GetSecureSession() const { return mSecureSession; }
+    SessionHandle GetSecureSession() const { return mSecureSession; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
 
@@ -453,7 +453,7 @@ private:
 
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
-    SecureSessionHandle mSecureSession = {};
+    SessionHandle mSecureSession = {};
 
     uint8_t mSequenceNumber = 0;
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -515,7 +515,7 @@ void DeviceController::OnResponseTimeout(Messaging::ExchangeContext * ec)
     ChipLogProgress(Controller, "Time out! failed to receive response from Exchange: %p", ec);
 }
 
-void DeviceController::OnNewConnection(SecureSessionHandle session, Messaging::ExchangeManager * mgr)
+void DeviceController::OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr)
 {
     VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnNewConnection was called in incorrect state"));
 
@@ -526,7 +526,7 @@ void DeviceController::OnNewConnection(SecureSessionHandle session, Messaging::E
     mActiveDevices[index].OnNewConnection(session);
 }
 
-void DeviceController::OnConnectionExpired(SecureSessionHandle session, Messaging::ExchangeManager * mgr)
+void DeviceController::OnConnectionExpired(SessionHandle session, Messaging::ExchangeManager * mgr)
 {
     VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnConnectionExpired was called in incorrect state"));
 
@@ -582,7 +582,7 @@ void DeviceController::ReleaseAllDevices()
     }
 }
 
-uint16_t DeviceController::FindDeviceIndex(SecureSessionHandle session)
+uint16_t DeviceController::FindDeviceIndex(SessionHandle session)
 {
     uint16_t i = 0;
     while (i < kNumMaxActiveDevices)
@@ -905,7 +905,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
         }
     }
 #endif
-    exchangeCtxt = mExchangeMgr->NewContext(SecureSessionHandle(), &mPairingSession);
+    exchangeCtxt = mExchangeMgr->NewContext(SessionHandle(), &mPairingSession);
     VerifyOrExit(exchangeCtxt != nullptr, err = CHIP_ERROR_INTERNAL);
 
     err = mIDAllocator.Allocate(keyID);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -346,7 +346,7 @@ protected:
 
     uint16_t mListenPort;
     uint16_t GetInactiveDeviceIndex();
-    uint16_t FindDeviceIndex(SecureSessionHandle session);
+    uint16_t FindDeviceIndex(SessionHandle session);
     uint16_t FindDeviceIndex(NodeId id);
     void ReleaseDevice(uint16_t index);
     void ReleaseDeviceById(NodeId remoteDeviceId);
@@ -384,8 +384,8 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 
     //////////// ExchangeMgrDelegate Implementation ///////////////
-    void OnNewConnection(SecureSessionHandle session, Messaging::ExchangeManager * mgr) override;
-    void OnConnectionExpired(SecureSessionHandle session, Messaging::ExchangeManager * mgr) override;
+    void OnNewConnection(SessionHandle session, Messaging::ExchangeManager * mgr) override;
+    void OnConnectionExpired(SessionHandle session, Messaging::ExchangeManager * mgr) override;
 
     void ReleaseAllDevices();
 

--- a/src/messaging/ApplicationExchangeDispatch.cpp
+++ b/src/messaging/ApplicationExchangeDispatch.cpp
@@ -26,14 +26,14 @@
 namespace chip {
 namespace Messaging {
 
-CHIP_ERROR ApplicationExchangeDispatch::PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR ApplicationExchangeDispatch::PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader,
                                                        System::PacketBufferHandle && message,
                                                        EncryptedPacketBufferHandle & preparedMessage)
 {
     return mSessionMgr->BuildEncryptedMessagePayload(session, payloadHeader, std::move(message), preparedMessage);
 }
 
-CHIP_ERROR ApplicationExchangeDispatch::SendPreparedMessage(SecureSessionHandle session,
+CHIP_ERROR ApplicationExchangeDispatch::SendPreparedMessage(SessionHandle session,
                                                             const EncryptedPacketBufferHandle & preparedMessage) const
 {
     return mSessionMgr->SendPreparedMessage(session, preparedMessage);

--- a/src/messaging/ApplicationExchangeDispatch.h
+++ b/src/messaging/ApplicationExchangeDispatch.h
@@ -45,9 +45,9 @@ public:
         return ExchangeMessageDispatch::Init();
     }
 
-    CHIP_ERROR PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
                               EncryptedPacketBufferHandle & preparedMessage) override;
-    CHIP_ERROR SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & message) const override;
+    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & message) const override;
 
     SecureSessionMgr * GetSessionMgr() const { return mSessionMgr; }
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -229,7 +229,7 @@ void ExchangeContextDeletor::Release(ExchangeContext * ec)
     ec->mExchangeMgr->ReleaseContext(ec);
 }
 
-ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
+ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SessionHandle session, bool Initiator,
                                  ExchangeDelegate * delegate)
 {
     VerifyOrDie(mExchangeMgr == nullptr);
@@ -297,8 +297,7 @@ ExchangeContext::~ExchangeContext()
     SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumContexts);
 }
 
-bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader,
-                                    const PayloadHeader & payloadHeader)
+bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader)
 {
     // A given message is part of a particular exchange if...
     return
@@ -307,7 +306,7 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         (mExchangeId == payloadHeader.GetExchangeID())
 
         // AND The Session ID associated with the incoming message matches the Session ID associated with the exchange.
-        && (mSecureSession.GetPeerKeyId() == session.GetPeerKeyId())
+        && (mSecureSession.match(session))
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast
@@ -322,7 +321,7 @@ void ExchangeContext::OnConnectionExpired()
     // connection state) value, because it's still referencing the now-expired
     // connection.  This will mean that no more messages can be sent via this
     // exchange, which seems fine given the semantics of connection expiration.
-    mSecureSession = SecureSessionHandle();
+    mSecureSession = SessionHandle();
 
     if (!IsResponseExpected())
     {

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -306,8 +306,8 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         // The exchange identifier of the message matches the exchange identifier of the context.
         (mExchangeId == payloadHeader.GetExchangeID())
 
-        // AND The message was received from the peer node associated with the exchange
-        && (mSecureSession == session)
+        // AND The Session ID associated with the incoming message matches the Session ID associated with the exchange.
+        && (mSecureSession.GetPeerKeyId() == session.GetPeerKeyId())
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -306,7 +306,7 @@ bool ExchangeContext::MatchExchange(SessionHandle session, const PacketHeader & 
         (mExchangeId == payloadHeader.GetExchangeID())
 
         // AND The Session ID associated with the incoming message matches the Session ID associated with the exchange.
-        && (mSecureSession.match(session))
+        && (mSecureSession.MatchIncomingSession(session))
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -65,8 +65,7 @@ class DLL_EXPORT ExchangeContext : public ReliableMessageContext, public Referen
 public:
     typedef uint32_t Timeout; // Type used to express the timeout in this ExchangeContext, in milliseconds
 
-    ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
-                    ExchangeDelegate * delegate);
+    ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SessionHandle session, bool Initiator, ExchangeDelegate * delegate);
 
     ~ExchangeContext();
 
@@ -168,7 +167,7 @@ public:
         return mExchangeACL;
     }
 
-    SecureSessionHandle GetSecureSession() { return mSecureSession; }
+    SessionHandle GetSecureSession() { return mSecureSession; }
 
     uint16_t GetExchangeId() const { return mExchangeId; }
 
@@ -190,8 +189,8 @@ private:
 
     ExchangeMessageDispatch * mDispatch = nullptr;
 
-    SecureSessionHandle mSecureSession; // The connection state
-    uint16_t mExchangeId;               // Assigned exchange ID.
+    SessionHandle mSecureSession; // The connection state
+    uint16_t mExchangeId;         // Assigned exchange ID.
 
     /**
      *  Determine whether a response is currently expected for a message that was sent over
@@ -231,7 +230,7 @@ private:
      *  @retval  true                                       If a match is found.
      *  @retval  false                                      If a match is not found.
      */
-    bool MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
+    bool MatchExchange(SessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
 
     /**
      * Notify the exchange that its connection has expired.

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -40,7 +40,7 @@
 namespace chip {
 namespace Messaging {
 
-CHIP_ERROR ExchangeMessageDispatch::SendMessage(SecureSessionHandle session, uint16_t exchangeId, bool isInitiator,
+CHIP_ERROR ExchangeMessageDispatch::SendMessage(SessionHandle session, uint16_t exchangeId, bool isInitiator,
                                                 ReliableMessageContext * reliableMessageContext, bool isReliableTransmission,
                                                 Protocols::Id protocol, uint8_t type, System::PacketBufferHandle && message)
 {

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -41,7 +41,7 @@ public:
 
     CHIP_ERROR Init() { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(SecureSessionHandle session, uint16_t exchangeId, bool isInitiator,
+    CHIP_ERROR SendMessage(SessionHandle session, uint16_t exchangeId, bool isInitiator,
                            ReliableMessageContext * reliableMessageContext, bool isReliableTransmission, Protocols::Id protocol,
                            uint8_t type, System::PacketBufferHandle && message);
 
@@ -54,10 +54,9 @@ public:
      * @param message         The payload to be sent
      * @param preparedMessage The handle to hold the prepared message
      */
-    virtual CHIP_ERROR PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
-                                      System::PacketBufferHandle && message, EncryptedPacketBufferHandle & preparedMessage) = 0;
-    virtual CHIP_ERROR SendPreparedMessage(SecureSessionHandle session,
-                                           const EncryptedPacketBufferHandle & preparedMessage) const                       = 0;
+    virtual CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+                                      EncryptedPacketBufferHandle & preparedMessage)                                         = 0;
+    virtual CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const = 0;
 
     virtual CHIP_ERROR OnMessageReceived(const Header::Flags & headerFlags, const PayloadHeader & payloadHeader, uint32_t messageId,
                                          const Transport::PeerAddress & peerAddress, MessageFlags msgFlags,

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR ExchangeManager::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-ExchangeContext * ExchangeManager::NewContext(SecureSessionHandle session, ExchangeDelegate * delegate)
+ExchangeContext * ExchangeManager::NewContext(SessionHandle session, ExchangeDelegate * delegate)
 {
     return mContextPool.CreateObject(this, mNextExchangeId++, session, true, delegate);
 }
@@ -196,8 +196,8 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
 }
 
 void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                        SecureSessionHandle session, const Transport::PeerAddress & source,
-                                        DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf)
+                                        SessionHandle session, const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+                                        System::PacketBufferHandle && msgBuf)
 {
     UnsolicitedMessageHandler * matchingUMH = nullptr;
 
@@ -299,7 +299,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     }
 }
 
-void ExchangeManager::OnNewConnection(SecureSessionHandle session)
+void ExchangeManager::OnNewConnection(SessionHandle session)
 {
     if (mDelegate != nullptr)
     {
@@ -307,7 +307,7 @@ void ExchangeManager::OnNewConnection(SecureSessionHandle session)
     }
 }
 
-void ExchangeManager::OnConnectionExpired(SecureSessionHandle session)
+void ExchangeManager::OnConnectionExpired(SessionHandle session)
 {
     if (mDelegate != nullptr)
     {

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -100,7 +100,7 @@ public:
      *  @return   A pointer to the created ExchangeContext object On success. Otherwise NULL if no object
      *            can be allocated or is available.
      */
-    ExchangeContext * NewContext(SecureSessionHandle session, ExchangeDelegate * delegate);
+    ExchangeContext * NewContext(SessionHandle session, ExchangeDelegate * delegate);
 
     void ReleaseContext(ExchangeContext * ec) { mContextPool.ReleaseObject(ec); }
 
@@ -243,15 +243,15 @@ private:
 
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source) override;
 
-    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+    void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SessionHandle session,
                            const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                            System::PacketBufferHandle && msgBuf) override;
 
-    void OnNewConnection(SecureSessionHandle session) override;
+    void OnNewConnection(SessionHandle session) override;
 #if CHIP_CONFIG_TEST
 public: // Allow OnConnectionExpired to be called directly from tests.
 #endif  // CHIP_CONFIG_TEST
-    void OnConnectionExpired(SecureSessionHandle session) override;
+    void OnConnectionExpired(SessionHandle session) override;
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgrDelegate.h
+++ b/src/messaging/ExchangeMgrDelegate.h
@@ -43,7 +43,7 @@ public:
      * @param session   The handle to the secure session
      * @param mgr       A pointer to the ExchangeManager
      */
-    virtual void OnNewConnection(SecureSessionHandle session, ExchangeManager * mgr) {}
+    virtual void OnNewConnection(SessionHandle session, ExchangeManager * mgr) {}
 
     /**
      * @brief
@@ -52,7 +52,7 @@ public:
      * @param session   The handle to the secure session
      * @param mgr       A pointer to the ExchangeManager
      */
-    virtual void OnConnectionExpired(SecureSessionHandle session, ExchangeManager * mgr) {}
+    virtual void OnConnectionExpired(SessionHandle session, ExchangeManager * mgr) {}
 };
 
 } // namespace Messaging

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -55,27 +55,27 @@ CHIP_ERROR MessagingContext::Shutdown()
     return CHIP_NO_ERROR;
 }
 
-SecureSessionHandle MessagingContext::GetSessionLocalToPeer()
+SessionHandle MessagingContext::GetSessionLocalToPeer()
 {
-    // TODO: temporarily create a SecureSessionHandle from node id, will be fixed in PR 3602
-    return { GetDestinationNodeId(), GetPeerKeyId(), GetFabricIndex() };
+    // TODO: temporarily create a SessionHandle from node id, will be fixed in PR 3602
+    return SessionHandle(GetDestinationNodeId(), GetLocalKeyId(), GetPeerKeyId(), GetFabricIndex());
 }
 
-SecureSessionHandle MessagingContext::GetSessionPeerToLocal()
+SessionHandle MessagingContext::GetSessionPeerToLocal()
 {
-    // TODO: temporarily create a SecureSessionHandle from node id, will be fixed in PR 3602
-    return { GetSourceNodeId(), GetLocalKeyId(), mDestFabricIndex };
+    // TODO: temporarily create a SessionHandle from node id, will be fixed in PR 3602
+    return SessionHandle(GetSourceNodeId(), GetPeerKeyId(), GetLocalKeyId(), mDestFabricIndex);
 }
 
 Messaging::ExchangeContext * MessagingContext::NewExchangeToPeer(Messaging::ExchangeDelegate * delegate)
 {
-    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    // TODO: temprary create a SessionHandle from node id, will be fix in PR 3602
     return mExchangeManager.NewContext(GetSessionLocalToPeer(), delegate);
 }
 
 Messaging::ExchangeContext * MessagingContext::NewExchangeToLocal(Messaging::ExchangeDelegate * delegate)
 {
-    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    // TODO: temprary create a SessionHandle from node id, will be fix in PR 3602
     return mExchangeManager.NewContext(GetSessionPeerToLocal(), delegate);
 }
 

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -77,8 +77,8 @@ public:
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeManager; }
     secure_channel::MessageCounterManager & GetMessageCounterManager() { return mMessageCounterManager; }
 
-    SecureSessionHandle GetSessionLocalToPeer();
-    SecureSessionHandle GetSessionPeerToLocal();
+    SessionHandle GetSessionLocalToPeer();
+    SessionHandle GetSessionPeerToLocal();
 
     Messaging::ExchangeContext * NewExchangeToPeer(Messaging::ExchangeDelegate * delegate);
     Messaging::ExchangeContext * NewExchangeToLocal(Messaging::ExchangeDelegate * delegate);

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -127,7 +127,7 @@ public:
 class MockSessionEstablishmentExchangeDispatch : public Messaging::ExchangeMessageDispatch
 {
 public:
-    CHIP_ERROR PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
                               EncryptedPacketBufferHandle & preparedMessage) override
     {
         PacketHeader packetHeader;
@@ -139,7 +139,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override
+    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override
     {
         return gTransportMgr.SendMessage(Transport::PeerAddress(), preparedMessage.CastToWritable());
     }
@@ -242,7 +242,7 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     MockAppDelegate mockSender;
-    // TODO: temporarily create a SecureSessionHandle from node id, will be fix in PR 3602
+    // TODO: temporarily create a SessionHandle from node id, will be fix in PR 3602
     ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockSender);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
@@ -307,7 +307,7 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     MockAppDelegate mockSender;
-    // TODO: temporarily create a SecureSessionHandle from node id, will be fixed in PR 3602
+    // TODO: temporarily create a SessionHandle from node id, will be fixed in PR 3602
     ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockSender);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -258,7 +258,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, chip::SecureSessionHandle(chip::kTestDeviceNodeId, 0, gFabricIndex));
+    err = gEchoClient.Init(&gExchangeManager, chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex));
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -258,8 +258,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    // TODO: temprary create a SecureSessionHandle from node id to unblock end-to-end test. Complete solution is tracked in PR:4451
-    err = gEchoClient.Init(&gExchangeManager, { chip::kTestDeviceNodeId, 0, gFabricIndex });
+    err = gEchoClient.Init(&gExchangeManager, chip::SecureSessionHandle(chip::kTestDeviceNodeId, 0, gFabricIndex));
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -52,7 +52,7 @@ using EchoFunct = void (*)(Messaging::ExchangeContext * ec, System::PacketBuffer
 class DLL_EXPORT EchoClient : public Messaging::ExchangeDelegate
 {
 public:
-    // TODO: Init function will take a Channel instead a SecureSessionHandle, when Channel API is ready
+    // TODO: Init function will take a Channel instead a SessionHandle, when Channel API is ready
     /**
      *  Initialize the EchoClient object. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -67,7 +67,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeMgr, SessionHandle session);
 
     /**
      *  Shutdown the EchoClient. This terminates this instance
@@ -103,7 +103,7 @@ private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
     Messaging::ExchangeContext * mExchangeCtx = nullptr;
     EchoFunct OnEchoResponseReceived          = nullptr;
-    SecureSessionHandle mSecureSession;
+    SessionHandle mSecureSession;
 
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
                                  const PayloadHeader & payloadHeader, System::PacketBufferHandle && payload) override;

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -32,7 +32,7 @@ namespace Echo {
 // The Echo message timeout value in milliseconds.
 constexpr uint32_t kEchoMessageTimeoutMsec = 800;
 
-CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session)
+CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SessionHandle session)
 {
     // Error if already initialized.
     if (mExchangeMgr != nullptr)

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -58,7 +58,7 @@ void MessageCounterManager::Shutdown()
     }
 }
 
-CHIP_ERROR MessageCounterManager::StartSync(SecureSessionHandle session, Transport::PeerConnectionState * state)
+CHIP_ERROR MessageCounterManager::StartSync(SessionHandle session, Transport::PeerConnectionState * state)
 {
     // Initiate message counter synchronization if no message counter synchronization is in progress.
     Transport::PeerMessageCounter & counter = state->GetSessionMessageCounter().GetPeerMessageCounter();
@@ -70,7 +70,7 @@ CHIP_ERROR MessageCounterManager::StartSync(SecureSessionHandle session, Transpo
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SecureSessionHandle session,
+CHIP_ERROR MessageCounterManager::QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
                                                                    Transport::PeerConnectionState * state,
                                                                    const Transport::PeerAddress & peerAddress,
                                                                    System::PacketBufferHandle && msgBuf)
@@ -174,7 +174,7 @@ void MessageCounterManager::ProcessPendingMessages(NodeId peerNodeId)
     }
 }
 
-CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(SecureSessionHandle session, Transport::PeerConnectionState * state)
+CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(SessionHandle session, Transport::PeerConnectionState * state)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/protocols/secure_channel/MessageCounterManager.h
+++ b/src/protocols/secure_channel/MessageCounterManager.h
@@ -46,8 +46,8 @@ public:
     void Shutdown();
 
     // Implement MessageCounterManagerInterface
-    CHIP_ERROR StartSync(SecureSessionHandle session, Transport::PeerConnectionState * state) override;
-    CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SecureSessionHandle session,
+    CHIP_ERROR StartSync(SessionHandle session, Transport::PeerConnectionState * state) override;
+    CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
                                                 Transport::PeerConnectionState * state, const Transport::PeerAddress & peerAddress,
                                                 System::PacketBufferHandle && msgBuf) override;
 
@@ -63,7 +63,7 @@ public:
      * @retval  #CHIP_NO_ERROR                On success.
      *
      */
-    CHIP_ERROR SendMsgCounterSyncReq(SecureSessionHandle session, Transport::PeerConnectionState * state);
+    CHIP_ERROR SendMsgCounterSyncReq(SessionHandle session, Transport::PeerConnectionState * state);
 
     /**
      *  Add a CHIP message into the cache table to queue the incoming messages that trigger message counter synchronization

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -28,7 +28,7 @@ namespace chip {
 
 using namespace Messaging;
 
-CHIP_ERROR SessionEstablishmentExchangeDispatch::PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR SessionEstablishmentExchangeDispatch::PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader,
                                                                 System::PacketBufferHandle && message,
                                                                 EncryptedPacketBufferHandle & preparedMessage)
 {
@@ -40,7 +40,7 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::PrepareMessage(SecureSessionHan
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SessionEstablishmentExchangeDispatch::SendPreparedMessage(SecureSessionHandle session,
+CHIP_ERROR SessionEstablishmentExchangeDispatch::SendPreparedMessage(SessionHandle session,
                                                                      const EncryptedPacketBufferHandle & preparedMessage) const
 {
     ReturnErrorCodeIf(mTransportMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -43,9 +43,9 @@ public:
         return ExchangeMessageDispatch::Init();
     }
 
-    CHIP_ERROR PrepareMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
+    CHIP_ERROR PrepareMessage(SessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && message,
                               EncryptedPacketBufferHandle & out) override;
-    CHIP_ERROR SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override;
+    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage) const override;
 
     CHIP_ERROR OnMessageReceived(const Header::Flags & headerFlags, const PayloadHeader & payloadHeader, uint32_t messageId,
                                  const Transport::PeerAddress & peerAddress, Messaging::MessageFlags msgFlags,

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -78,8 +78,8 @@ void MessageCounterSyncProcess(nlTestSuite * inSuite, void * inContext)
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    SecureSessionHandle localSession = ctx.GetSessionLocalToPeer();
-    SecureSessionHandle peerSession  = ctx.GetSessionPeerToLocal();
+    SessionHandle localSession = ctx.GetSessionLocalToPeer();
+    SessionHandle peerSession  = ctx.GetSessionPeerToLocal();
 
     Transport::PeerConnectionState * localState = ctx.GetSecureSessionManager().GetPeerConnectionState(localSession);
     Transport::PeerConnectionState * peerState  = ctx.GetSecureSessionManager().GetPeerConnectionState(peerSession);
@@ -99,7 +99,7 @@ void CheckReceiveMessage(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
     CHIP_ERROR err    = CHIP_NO_ERROR;
 
-    SecureSessionHandle peerSession            = ctx.GetSessionPeerToLocal();
+    SessionHandle peerSession                  = ctx.GetSessionPeerToLocal();
     Transport::PeerConnectionState * peerState = ctx.GetSecureSessionManager().GetPeerConnectionState(peerSession);
     peerState->GetSessionMessageCounter().GetPeerMessageCounter().Reset();
 

--- a/src/transport/MessageCounterManagerInterface.h
+++ b/src/transport/MessageCounterManagerInterface.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <transport/PeerConnectionState.h>
-#include <transport/SecureSessionHandle.h>
+#include <transport/SessionHandle.h>
 
 namespace chip {
 namespace Transport {
@@ -31,13 +31,13 @@ public:
     /**
      * Start sync if the sync procedure is not started yet.
      */
-    virtual CHIP_ERROR StartSync(SecureSessionHandle session, Transport::PeerConnectionState * state) = 0;
+    virtual CHIP_ERROR StartSync(SessionHandle session, Transport::PeerConnectionState * state) = 0;
 
     /**
      * Called when have received a message but session message counter is not synced.  It will queue the message and start sync if
      * the sync procedure is not started yet.
      */
-    virtual CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SecureSessionHandle session,
+    virtual CHIP_ERROR QueueReceivedMessageAndStartSync(const PacketHeader & packetHeader, SessionHandle session,
                                                         Transport::PeerConnectionState * state,
                                                         const Transport::PeerAddress & peerAddress,
                                                         System::PacketBufferHandle && msgBuf) = 0;

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -105,7 +105,7 @@ void SecureSessionMgr::Shutdown()
     mCB           = nullptr;
 }
 
-CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SecureSessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SessionHandle session, PayloadHeader & payloadHeader,
                                                           System::PacketBufferHandle && msgBuf,
                                                           EncryptedPacketBufferHandle & encryptedMessage)
 {
@@ -134,7 +134,7 @@ CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SecureSessionHandle se
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SecureSessionMgr::SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & preparedMessage)
+CHIP_ERROR SecureSessionMgr::SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     PeerConnectionState * state = nullptr;
@@ -182,7 +182,7 @@ exit:
     return err;
 }
 
-void SecureSessionMgr::ExpirePairing(SecureSessionHandle session)
+void SecureSessionMgr::ExpirePairing(SessionHandle session)
 {
     PeerConnectionState * state = GetPeerConnectionState(session);
     if (state != nullptr)
@@ -253,7 +253,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     if (mCB != nullptr)
     {
         state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-        mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), fabric });
+        mCB->OnNewConnection(SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), fabric));
     }
 
     return CHIP_NO_ERROR;
@@ -298,7 +298,7 @@ void SecureSessionMgr::MessageDispatch(const PacketHeader & packetHeader, const 
     {
         PayloadHeader payloadHeader;
         ReturnOnFailure(payloadHeader.DecodeAndConsume(msg));
-        mCB->OnMessageReceived(packetHeader, payloadHeader, SecureSessionHandle(), peerAddress,
+        mCB->OnMessageReceived(packetHeader, payloadHeader, SessionHandle(), peerAddress,
                                SecureSessionMgrDelegate::DuplicateMessage::No, std::move(msg));
     }
 }
@@ -333,8 +333,9 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         {
             // Queue and start message sync procedure
             err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
-                packetHeader, { state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex() }, state, peerAddress,
-                std::move(msg));
+                packetHeader,
+                SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), state->GetFabricIndex()),
+                state, peerAddress, std::move(msg));
 
             if (err != CHIP_NO_ERROR)
             {
@@ -397,7 +398,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (mCB != nullptr)
     {
-        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex());
+        SessionHandle session(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), state->GetFabricIndex());
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
     }
 
@@ -415,7 +416,8 @@ void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionSt
 
     if (mCB != nullptr)
     {
-        mCB->OnConnectionExpired({ state.GetPeerNodeId(), state.GetPeerKeyID(), state.GetFabricIndex() });
+        mCB->OnConnectionExpired(
+            SessionHandle(state.GetPeerNodeId(), state.GetLocalKeyID(), state.GetPeerKeyID(), state.GetFabricIndex()));
     }
 
     mTransportMgr->Disconnect(state.GetPeerAddress());
@@ -434,7 +436,7 @@ void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param)
     mgr->ScheduleExpiryTimer(); // re-schedule the oneshot timer
 }
 
-PeerConnectionState * SecureSessionMgr::GetPeerConnectionState(SecureSessionHandle session)
+PeerConnectionState * SecureSessionMgr::GetPeerConnectionState(SessionHandle session)
 {
     return mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(session.mPeerNodeId), session.mPeerKeyId, nullptr);
 }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -438,7 +438,8 @@ void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param)
 
 PeerConnectionState * SecureSessionMgr::GetPeerConnectionState(SessionHandle session)
 {
-    return mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(session.mPeerNodeId), session.mPeerKeyId, nullptr);
+    return mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(session.mPeerNodeId), session.mPeerKeyId.ValueOr(0),
+                                                    nullptr);
 }
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -38,7 +38,7 @@
 #include <transport/PairingSession.h>
 #include <transport/PeerConnections.h>
 #include <transport/SecureSession.h>
-#include <transport/SecureSessionHandle.h>
+#include <transport/SessionHandle.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/Base.h>
 #include <transport/raw/PeerAddress.h>
@@ -141,8 +141,8 @@ public:
      * @param isDuplicate   The message is a duplicate of previously received message
      * @param msgBuf        The received message
      */
-    virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                   SecureSessionHandle session, const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
+    virtual void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SessionHandle session,
+                                   const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                                    System::PacketBufferHandle && msgBuf)
     {}
 
@@ -161,7 +161,7 @@ public:
      *
      * @param session The handle to the secure session
      */
-    virtual void OnNewConnection(SecureSessionHandle session) {}
+    virtual void OnNewConnection(SessionHandle session) {}
 
     /**
      * @brief
@@ -169,7 +169,7 @@ public:
      *
      * @param session The handle to the secure session
      */
-    virtual void OnConnectionExpired(SecureSessionHandle session) {}
+    virtual void OnConnectionExpired(SessionHandle session) {}
 
     virtual ~SecureSessionMgrDelegate() {}
 };
@@ -191,16 +191,16 @@ public:
      *    3. Encode the packet header and prepend it to message.
      *   Returns a encrypted message in encryptedMessage.
      */
-    CHIP_ERROR BuildEncryptedMessagePayload(SecureSessionHandle session, PayloadHeader & payloadHeader,
+    CHIP_ERROR BuildEncryptedMessagePayload(SessionHandle session, PayloadHeader & payloadHeader,
                                             System::PacketBufferHandle && msgBuf, EncryptedPacketBufferHandle & encryptedMessage);
 
     /**
      * @brief
      *   Send a prepared message to a currently connected peer.
      */
-    CHIP_ERROR SendPreparedMessage(SecureSessionHandle session, const EncryptedPacketBufferHandle & preparedMessage);
+    CHIP_ERROR SendPreparedMessage(SessionHandle session, const EncryptedPacketBufferHandle & preparedMessage);
 
-    Transport::PeerConnectionState * GetPeerConnectionState(SecureSessionHandle session);
+    Transport::PeerConnectionState * GetPeerConnectionState(SessionHandle session);
 
     /**
      * @brief
@@ -223,7 +223,7 @@ public:
     CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PairingSession * pairing,
                           SecureSession::SessionRole direction, FabricIndex fabric);
 
-    void ExpirePairing(SecureSessionHandle session);
+    void ExpirePairing(SessionHandle session);
     void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
 
     /**

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -21,31 +21,40 @@ namespace chip {
 
 class SecureSessionMgr;
 
-class SecureSessionHandle
+class SessionHandle
 {
 public:
-    SecureSessionHandle() : mPeerNodeId(kPlaceholderNodeId), mPeerKeyId(0), mFabric(Transport::kUndefinedFabricIndex) {}
-    SecureSessionHandle(NodeId peerNodeId, uint16_t peerKeyId, FabricIndex fabric) :
-        mPeerNodeId(peerNodeId), mPeerKeyId(peerKeyId), mFabric(fabric)
+    SessionHandle() :
+        mPeerNodeId(kPlaceholderNodeId), mLocalKeyId(0), mPeerKeyId(0), mFabric(Transport::kUndefinedFabricIndex)
+    {}
+    SessionHandle(NodeId peerNodeId, uint16_t localKeyId, uint16_t peerKeyId, FabricIndex fabric) :
+        mPeerNodeId(peerNodeId), mLocalKeyId(localKeyId), mPeerKeyId(peerKeyId), mFabric(fabric)
     {}
 
     bool HasFabricIndex() const { return (mFabric != Transport::kUndefinedFabricIndex); }
     FabricIndex GetFabricIndex() const { return mFabric; }
     void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 
-    bool operator==(const SecureSessionHandle & that) const
+    bool operator==(const SessionHandle & that) const
     {
         return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId;
     }
 
+    bool match(const SessionHandle & that) const
+    {
+        return mLocalKeyId == that.mLocalKeyId;
+    }    
+
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     uint16_t GetPeerKeyId() const { return mPeerKeyId; }
+    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
 
 private:
     friend class SecureSessionMgr;
     NodeId mPeerNodeId;
+    uint16_t mLocalKeyId;
     uint16_t mPeerKeyId;
-    // TODO: Re-evaluate the storing of Fabric ID in SecureSessionHandle
+    // TODO: Re-evaluate the storing of Fabric ID in SessionHandle
     //       The Fabric ID will not be available for PASE and group sessions. So need
     //       to identify an approach that'll allow looking up the corresponding information for
     //       such sessions.

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -24,36 +24,47 @@ class SecureSessionMgr;
 class SessionHandle
 {
 public:
-    SessionHandle() :
-        mPeerNodeId(kPlaceholderNodeId), mLocalKeyId(0), mPeerKeyId(0), mFabric(Transport::kUndefinedFabricIndex)
-    {}
+    SessionHandle() : mPeerNodeId(kPlaceholderNodeId), mFabric(Transport::kUndefinedFabricIndex) {}
+
+    SessionHandle(NodeId peerNodeId, FabricIndex fabric) : mPeerNodeId(peerNodeId), mFabric(fabric) {}
+
     SessionHandle(NodeId peerNodeId, uint16_t localKeyId, uint16_t peerKeyId, FabricIndex fabric) :
-        mPeerNodeId(peerNodeId), mLocalKeyId(localKeyId), mPeerKeyId(peerKeyId), mFabric(fabric)
-    {}
+        mPeerNodeId(peerNodeId), mFabric(fabric)
+    {
+        mLocalKeyId.SetValue(localKeyId);
+        mPeerKeyId.SetValue(peerKeyId);
+    }
 
     bool HasFabricIndex() const { return (mFabric != Transport::kUndefinedFabricIndex); }
     FabricIndex GetFabricIndex() const { return mFabric; }
     void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 
-    bool operator==(const SessionHandle & that) const
-    {
-        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId;
-    }
+    bool operator==(const SessionHandle & that) const { return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId; }
 
     bool match(const SessionHandle & that) const
     {
-        return mLocalKeyId == that.mLocalKeyId;
-    }    
+
+        if (that.GetLocalKeyId().HasValue())
+        {
+            return mLocalKeyId == that.mLocalKeyId;
+        }
+        else
+        {
+            // TODO: For unencrypted session, temporarily still rely on the old match logic in MatchExchange, need to update to
+            // match peer’s HW address (BLE) or peer’s IP/Port (for IP).
+            return true;
+        }
+    }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
-    uint16_t GetPeerKeyId() const { return mPeerKeyId; }
-    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
+    const Optional<uint16_t> & GetPeerKeyId() const { return mPeerKeyId; }
+    const Optional<uint16_t> & GetLocalKeyId() const { return mLocalKeyId; }
 
 private:
     friend class SecureSessionMgr;
     NodeId mPeerNodeId;
-    uint16_t mLocalKeyId;
-    uint16_t mPeerKeyId;
+    Optional<uint16_t> mLocalKeyId;
+    Optional<uint16_t> mPeerKeyId;
     // TODO: Re-evaluate the storing of Fabric ID in SessionHandle
     //       The Fabric ID will not be available for PASE and group sessions. So need
     //       to identify an approach that'll allow looking up the corresponding information for

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -39,9 +39,13 @@ public:
     FabricIndex GetFabricIndex() const { return mFabric; }
     void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 
-    bool operator==(const SessionHandle & that) const { return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId; }
+    bool operator==(const SessionHandle & that) const
+    {
+        // TODO: Temporarily keep the old logic, check why only those two fields are used in comparison.
+        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId;
+    }
 
-    bool match(const SessionHandle & that) const
+    bool MatchIncomingSession(const SessionHandle & that) const
     {
 
         if (that.GetLocalKeyId().HasValue())

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestPeerConnections.cpp",
     "TestSecureSession.cpp",
     "TestSecureSessionMgr.cpp",
+    "TestSessionHandle.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -62,7 +62,7 @@ const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
 class TestSessMgrCallback : public SecureSessionMgrDelegate
 {
 public:
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SessionHandle session,
                            const Transport::PeerAddress & source, DuplicateMessage isDuplicate,
                            System::PacketBufferHandle && msgBuf) override
     {
@@ -84,7 +84,7 @@ public:
         ReceiveHandlerCallCount++;
     }
 
-    void OnNewConnection(SecureSessionHandle session) override
+    void OnNewConnection(SessionHandle session) override
     {
         // Preset the MessageCounter
         if (NewConnectionHandlerCallCount == 0)
@@ -93,11 +93,11 @@ public:
             mLocalToRemoteSession = session;
         NewConnectionHandlerCallCount++;
     }
-    void OnConnectionExpired(SecureSessionHandle session) override {}
+    void OnConnectionExpired(SessionHandle session) override {}
 
     nlTestSuite * mSuite = nullptr;
-    SecureSessionHandle mRemoteToLocalSession;
-    SecureSessionHandle mLocalToRemoteSession;
+    SessionHandle mRemoteToLocalSession;
+    SessionHandle mLocalToRemoteSession;
     int ReceiveHandlerCallCount       = 0;
     int NewConnectionHandlerCallCount = 0;
 
@@ -164,7 +164,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
@@ -254,7 +254,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
@@ -328,7 +328,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
+    SessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
 
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;

--- a/src/transport/tests/TestSessionHandle.cpp
+++ b/src/transport/tests/TestSessionHandle.cpp
@@ -53,12 +53,12 @@ void TestMatchSession(nlTestSuite * inSuite, void * inContext)
     SessionHandle session1;
     SessionHandle session2;
     NL_TEST_ASSERT(inSuite, session1 == session2);
-    NL_TEST_ASSERT(inSuite, session1.match(session2));
+    NL_TEST_ASSERT(inSuite, session1.MatchIncomingSession(session2));
 
     SessionHandle session3(chip::kTestDeviceNodeId, 1, 1, 0);
     SessionHandle session4(chip::kTestDeviceNodeId, 1, 2, 0);
     NL_TEST_ASSERT(inSuite, !(session3 == session4));
-    NL_TEST_ASSERT(inSuite, session3.match(session4));
+    NL_TEST_ASSERT(inSuite, session3.MatchIncomingSession(session4));
 }
 
 // Test Suite

--- a/src/transport/tests/TestSessionHandle.cpp
+++ b/src/transport/tests/TestSessionHandle.cpp
@@ -1,0 +1,99 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the SecureSession implementation.
+ */
+
+#include <errno.h>
+#include <nlunit-test.h>
+
+#include <core/CHIPCore.h>
+
+#include <protocols/secure_channel/PASESession.h>
+#include <transport/FabricTable.h>
+#include <transport/SecureSession.h>
+#include <transport/SessionHandle.h>
+
+#include <stdarg.h>
+#include <support/CodeUtils.h>
+#include <support/UnitTestRegistration.h>
+
+using namespace chip;
+
+void TestInitialState(nlTestSuite * inSuite, void * inContext)
+{
+    SessionHandle session;
+
+    NL_TEST_ASSERT(inSuite, session.GetPeerNodeId() == kPlaceholderNodeId);
+    NL_TEST_ASSERT(inSuite, session.GetFabricIndex() == Transport::kUndefinedFabricIndex);
+    NL_TEST_ASSERT(inSuite, !session.HasFabricIndex());
+    NL_TEST_ASSERT(inSuite, !session.GetLocalKeyId().HasValue());
+    NL_TEST_ASSERT(inSuite, !session.GetPeerKeyId().HasValue());
+}
+
+void TestMatchSession(nlTestSuite * inSuite, void * inContext)
+{
+    SessionHandle session1;
+    SessionHandle session2;
+    NL_TEST_ASSERT(inSuite, session1 == session2);
+    NL_TEST_ASSERT(inSuite, session1.match(session2));
+
+    SessionHandle session3(chip::kTestDeviceNodeId, 1, 1, 0);
+    SessionHandle session4(chip::kTestDeviceNodeId, 1, 2, 0);
+    NL_TEST_ASSERT(inSuite, !(session3 == session4));
+    NL_TEST_ASSERT(inSuite, session3.match(session4));
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("InitialState",    TestInitialState),
+    NL_TEST_DEF("MatchSession",    TestMatchSession),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+static nlTestSuite sSuite =
+{
+    "Test-CHIP-SessionHandle",
+    &sTests[0],
+    nullptr,
+    nullptr
+};
+// clang-format on
+
+/**
+ *  Main
+ */
+int TestSessionHandle()
+{
+    // Run test suit against one context
+    nlTestRunner(&sSuite, nullptr);
+
+    return (nlTestRunnerStats(&sSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestSessionHandle)


### PR DESCRIPTION
#### Problem
What is being fixed?  
* Currently, SecureSessionHandle is used to match exchange for the incoming message in addition to exchange id and node id, but an exchange is not tied to a secure session in the spec. Before app send an message or create an new exchange, there is no way to know the keyid of a SecureSessionHandle up front, right now, we temporarily  hard coded the keyid to 0 to pass the exchange match check.

After discussion, we agree to update spec with the following changes.
1. reserve sessionId 0 for unsecured sessions
2. clearly specify the Session ID is one of the metadata associated with an Exchange.

* Fixes #4451

#### Change overview
1. Use sessionId 0 for unsecured session
2. Match incoming message's source Session ID with the Session ID associated with the exchange during the exchange match check.

#### Testing
How was this tested? (at least one bullet point required)
1. ./chip-echo-responder
2.  ./chip-echo-requester <ip>
confirm the echo test pass with this change.
1. ./chip-im-responder
2.  ./chip-im-initiator <ip>
confirm the im test pass with this change.
