### PR TITLE
Make CHIP_ERROR a class type on cc13x2_26x2, EFR32, QPG.

### DIFF
--- a/examples/lighting-app/efr32/include/AppConfig.h
+++ b/examples/lighting-app/efr32/include/AppConfig.h
@@ -66,4 +66,7 @@ void appError(int err);
 
 #ifdef __cplusplus
 }
+
+#include <core/CHIPError.h>
+void appError(CHIP_ERROR error);
 #endif

--- a/examples/lighting-app/efr32/include/LightingManager.h
+++ b/examples/lighting-app/efr32/include/LightingManager.h
@@ -26,6 +26,8 @@
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
 
+#include <core/CHIPError.h>
+
 class LightingManager
 {
 public:
@@ -45,7 +47,7 @@ public:
         kState_OnCompleted,
     } State;
 
-    int Init();
+    CHIP_ERROR Init();
     bool IsLightOn();
     void EnableAutoTurnOff(bool aOn);
     void SetAutoTurnOffDuration(uint32_t aDurationInSecs);

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -157,10 +157,9 @@ CHIP_ERROR AppTask::Init()
 
 void AppTask::AppTaskMain(void * pvParameter)
 {
-    int err;
     AppEvent event;
 
-    err = sAppTask.Init();
+    CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("AppTask.Init() failed");

--- a/examples/lighting-app/efr32/src/LightingManager.cpp
+++ b/examples/lighting-app/efr32/src/LightingManager.cpp
@@ -27,7 +27,7 @@ LightingManager LightingManager::sLight;
 
 TimerHandle_t sLightTimer;
 
-int LightingManager::Init()
+CHIP_ERROR LightingManager::Init()
 {
     // Create FreeRTOS sw timer for light timer.
     sLightTimer = xTimerCreate("lightTmr",       // Just a text name, not used by the RTOS kernel
@@ -40,7 +40,7 @@ int LightingManager::Init()
     if (sLightTimer == NULL)
     {
         EFR32_LOG("sLightTimer timer create failed");
-        appError(APP_ERROR_CREATE_TIMER_FAILED);
+        return APP_ERROR_CREATE_TIMER_FAILED;
     }
 
     mState                 = kState_OffCompleted;

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -83,6 +83,11 @@ void appError(int err)
         ;
 }
 
+void appError(CHIP_ERROR error)
+{
+    appError(static_cast<int>(chip::ChipError::AsInteger(error)));
+}
+
 // ================================================================================
 // FreeRTOS Callbacks
 // ================================================================================

--- a/examples/lighting-app/qpg/include/AppTask.h
+++ b/examples/lighting-app/qpg/include/AppTask.h
@@ -36,7 +36,7 @@ class AppTask
 {
 
 public:
-    int StartAppTask();
+    CHIP_ERROR StartAppTask();
     static void AppTaskMain(void * pvParameter);
 
     void PostLightActionRequest(int32_t aActor, LightingManager::Action_t aAction);
@@ -48,7 +48,7 @@ public:
 private:
     friend AppTask & GetAppTask(void);
 
-    int Init();
+    CHIP_ERROR Init();
 
     static void ActionInitiated(LightingManager::Action_t aAction);
     static void ActionCompleted(LightingManager::Action_t aAction);

--- a/examples/lighting-app/qpg/include/LightingManager.h
+++ b/examples/lighting-app/qpg/include/LightingManager.h
@@ -28,6 +28,8 @@
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
 
+#include <core/CHIPError.h>
+
 class LightingManager
 {
 public:
@@ -45,7 +47,7 @@ public:
         kState_Off,
     } State;
 
-    int Init();
+    CHIP_ERROR Init();
     bool IsTurnedOn();
     uint8_t GetLevel();
     bool InitiateAction(Action_t aAction, int32_t aActor, uint16_t size, uint8_t * value);

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -60,7 +60,7 @@ static bool sHaveServiceConnectivity = false;
 
 AppTask AppTask::sAppTask;
 
-int AppTask::StartAppTask()
+CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreate(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent));
     if (sAppEventQueue == NULL)
@@ -78,7 +78,7 @@ int AppTask::StartAppTask()
     return CHIP_NO_ERROR;
 }
 
-int AppTask::Init()
+CHIP_ERROR AppTask::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -111,13 +111,12 @@ int AppTask::Init()
 
 void AppTask::AppTaskMain(void * pvParameter)
 {
-    int err;
     AppEvent event;
 
-    err = sAppTask.Init();
+    CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "AppTask.Init() failed");
+        ChipLogError(NotSpecified, "AppTask.Init() failed: %" CHIP_ERROR_FORMAT, chip::ChipError::FormatError(err));
         // appError(err);
     }
 

--- a/examples/lighting-app/qpg/src/LightingManager.cpp
+++ b/examples/lighting-app/qpg/src/LightingManager.cpp
@@ -23,11 +23,11 @@
 
 LightingManager LightingManager::sLight;
 
-int LightingManager::Init()
+CHIP_ERROR LightingManager::Init()
 {
     mState = kState_Off;
     mLevel = 64;
-    return 0;
+    return CHIP_NO_ERROR;
 }
 
 bool LightingManager::IsTurnedOn()

--- a/examples/lock-app/cc13x2x7_26x2x7/main/main.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/main.cpp
@@ -77,8 +77,8 @@ int main(void)
 
     SHA2_init();
 
-    CHIP_ERROR ret = GetAppTask().StartAppTask();
-    if (ret != CHIP_NO_ERROR)
+    int ret = GetAppTask().StartAppTask();
+    if (ret != 0)
     {
         // can't log until the kernel is started
         // PLAT_LOG("GetAppTask().StartAppTask() failed");

--- a/examples/lock-app/efr32/include/AppConfig.h
+++ b/examples/lock-app/efr32/include/AppConfig.h
@@ -66,4 +66,7 @@ void appError(int err);
 
 #ifdef __cplusplus
 }
+
+#include <core/CHIPError.h>
+void appError(CHIP_ERROR error);
 #endif

--- a/examples/lock-app/efr32/include/BoltLockManager.h
+++ b/examples/lock-app/efr32/include/BoltLockManager.h
@@ -26,6 +26,8 @@
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
 
+#include <core/CHIPError.h>
+
 class BoltLockManager
 {
 public:
@@ -45,7 +47,7 @@ public:
         kState_UnlockingCompleted,
     } State;
 
-    int Init();
+    CHIP_ERROR Init();
     bool IsUnlocked();
     void EnableAutoRelock(bool aOn);
     void SetAutoLockDuration(uint32_t aDurationInSecs);

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -90,8 +90,6 @@ CHIP_ERROR AppTask::StartAppTask()
 
 CHIP_ERROR AppTask::Init()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     // Init ZCL Data Model
     InitServer();
 
@@ -108,11 +106,11 @@ CHIP_ERROR AppTask::Init()
     if (sFunctionTimer == NULL)
     {
         EFR32_LOG("funct timer create failed");
-        appError(err);
+        appError(APP_ERROR_CREATE_TIMER_FAILED);
     }
 
     EFR32_LOG("Current Firmware Version: %s", CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
-    err = BoltLockMgr().Init();
+    CHIP_ERROR err = BoltLockMgr().Init();
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("BoltLockMgr().Init() failed");
@@ -152,10 +150,9 @@ CHIP_ERROR AppTask::Init()
 
 void AppTask::AppTaskMain(void * pvParameter)
 {
-    int err;
     AppEvent event;
 
-    err = sAppTask.Init();
+    CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("AppTask.Init() failed");
@@ -231,7 +228,7 @@ void AppTask::LockActionEventHandler(AppEvent * aEvent)
     bool initiated = false;
     BoltLockManager::Action_t action;
     int32_t actor;
-    int err = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     if (aEvent->Type == AppEvent::kEventType_Lock)
     {

--- a/examples/lock-app/efr32/src/BoltLockManager.cpp
+++ b/examples/lock-app/efr32/src/BoltLockManager.cpp
@@ -27,7 +27,7 @@ BoltLockManager BoltLockManager::sLock;
 
 TimerHandle_t sLockTimer;
 
-int BoltLockManager::Init()
+CHIP_ERROR BoltLockManager::Init()
 {
     // Create FreeRTOS sw timer for lock timer.
     sLockTimer = xTimerCreate("lockTmr",        // Just a text name, not used by the RTOS kernel

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -75,6 +75,11 @@ void appError(int err)
         ;
 }
 
+void appError(CHIP_ERROR error)
+{
+    appError(static_cast<int>(chip::ChipError::AsInteger(error)));
+}
+
 // ================================================================================
 // FreeRTOS Callbacks
 // ================================================================================

--- a/examples/lock-app/qpg/include/AppTask.h
+++ b/examples/lock-app/qpg/include/AppTask.h
@@ -28,14 +28,18 @@
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
 #include <ble/BLEEndPoint.h>
+#include <core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
+
+// Application-defined error codes in the CHIP_ERROR space.
+#define APP_ERROR_CREATE_TIMER_FAILED CHIP_APPLICATION_ERROR(0x01)
 
 #define APP_NAME "Lock-app"
 class AppTask
 {
 
 public:
-    int StartAppTask();
+    CHIP_ERROR StartAppTask();
     static void AppTaskMain(void * pvParameter);
 
     void PostLockActionRequest(int32_t aActor, BoltLockManager::Action_t aAction);
@@ -47,7 +51,7 @@ public:
 private:
     friend AppTask & GetAppTask(void);
 
-    int Init();
+    CHIP_ERROR Init();
 
     static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
     static void ActionCompleted(BoltLockManager::Action_t aAction);

--- a/examples/lock-app/qpg/include/BoltLockManager.h
+++ b/examples/lock-app/qpg/include/BoltLockManager.h
@@ -27,6 +27,8 @@
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
 
+#include <core/CHIPError.h>
+
 class BoltLockManager
 {
 public:
@@ -46,7 +48,7 @@ public:
         kState_UnlockingCompleted,
     } State;
 
-    int Init();
+    CHIP_ERROR Init();
     bool IsUnlocked();
     void EnableAutoRelock(bool aOn);
     void SetAutoLockDuration(uint32_t aDurationInSecs);

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -61,7 +61,7 @@ static bool sHaveServiceConnectivity = false;
 
 AppTask AppTask::sAppTask;
 
-int AppTask::StartAppTask()
+CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreate(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent));
     if (sAppEventQueue == NULL)
@@ -79,7 +79,7 @@ int AppTask::StartAppTask()
     return CHIP_NO_ERROR;
 }
 
-int AppTask::Init()
+CHIP_ERROR AppTask::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -110,13 +110,12 @@ int AppTask::Init()
 
 void AppTask::AppTaskMain(void * pvParameter)
 {
-    int err;
     AppEvent event;
 
-    err = sAppTask.Init();
+    CHIP_ERROR err = sAppTask.Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "AppTask.Init() failed");
+        ChipLogError(NotSpecified, "AppTask.Init() failed: %" CHIP_ERROR_FORMAT, chip::ChipError::FormatError(err));
         // appError(err);
     }
 
@@ -186,7 +185,7 @@ void AppTask::LockActionEventHandler(AppEvent * aEvent)
     bool initiated = false;
     BoltLockManager::Action_t action;
     int32_t actor;
-    int err = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     if (aEvent->Type == AppEvent::kEventType_Lock)
     {

--- a/examples/lock-app/qpg/src/BoltLockManager.cpp
+++ b/examples/lock-app/qpg/src/BoltLockManager.cpp
@@ -27,7 +27,7 @@ BoltLockManager BoltLockManager::sLock;
 
 TimerHandle_t sLockTimer;
 
-int BoltLockManager::Init()
+CHIP_ERROR BoltLockManager::Init()
 {
     // Create FreeRTOS sw timer for lock timer.
     sLockTimer = xTimerCreate("lockTmr",        // Just a text name, not used by the RTOS kernel
@@ -40,8 +40,7 @@ int BoltLockManager::Init()
     if (sLockTimer == NULL)
     {
         ChipLogProgress(NotSpecified, "sLockTimer timer create failed");
-        // TODO:
-        // appError(APP_ERROR_CREATE_TIMER_FAILED);
+        return APP_ERROR_CREATE_TIMER_FAILED;
     }
 
     mState              = kState_LockingCompleted;

--- a/examples/persistent-storage/KeyValueStorageTest.cpp
+++ b/examples/persistent-storage/KeyValueStorageTest.cpp
@@ -36,8 +36,7 @@ using namespace chip::DeviceLayer::PersistedStorage;
         {                                                                                                                          \
             char error_str[255];                                                                                                   \
             chip::FormatCHIPError(error_str, sizeof(error_str), temp_test_result);                                                 \
-            ChipLogError(NotSpecified, "%s: FAILED %" PRId32 " [%s]", #test_result, temp_test_result,                              \
-                         chip::ErrorStr(temp_test_result));                                                                        \
+            ChipLogError(NotSpecified, "%s: FAILED [%s]", #test_result, chip::ErrorStr(temp_test_result));                         \
         }                                                                                                                          \
         else                                                                                                                       \
         {                                                                                                                          \

--- a/examples/platform/qpg/app/main.cpp
+++ b/examples/platform/qpg/app/main.cpp
@@ -75,7 +75,7 @@ int Application_Init(void)
     return 0;
 }
 
-int CHIP_Init(void)
+CHIP_ERROR CHIP_Init(void)
 {
     CHIP_ERROR ret = chip::Platform::MemoryInit();
     if (ret != CHIP_NO_ERROR)
@@ -141,6 +141,7 @@ exit:
 int main(void)
 {
     int result;
+    CHIP_ERROR error;
 
     /* Initialize Qorvo stack */
     result = qvCHIP_init();
@@ -150,8 +151,8 @@ int main(void)
     }
 
     /* Initialize CHIP stack */
-    result = CHIP_Init();
-    if (result != CHIP_NO_ERROR)
+    error = CHIP_Init();
+    if (error != CHIP_NO_ERROR)
     {
         goto exit;
     }

--- a/examples/window-app/efr32/include/AppConfig.h
+++ b/examples/window-app/efr32/include/AppConfig.h
@@ -64,4 +64,7 @@ void appError(int err);
 
 #ifdef __cplusplus
 }
+
+#include <core/CHIPError.h>
+void appError(CHIP_ERROR error);
 #endif

--- a/examples/window-app/efr32/include/AppTask.h
+++ b/examples/window-app/efr32/include/AppTask.h
@@ -84,7 +84,7 @@ private:
     std::string mQRCode;
     bool mResetWarning;
 
-    int Init(void);
+    CHIP_ERROR Init(void);
     void DispatchEvents(void);
     void DispatchButtonEvent(AppEvent::EventType type, void * context);
     void DispatchWindowCoverEvent(AppEvent::EventType type, void * context);

--- a/examples/window-app/efr32/src/AppTask.cpp
+++ b/examples/window-app/efr32/src/AppTask.cpp
@@ -92,9 +92,8 @@ CHIP_ERROR AppTask::Start()
 void AppTask::Main(void * pvParameter)
 {
     AppTask & app = AppTask::sInstance;
-    int err;
 
-    err = app.Init();
+    CHIP_ERROR err = app.Init();
     if (err != CHIP_NO_ERROR)
     {
         appError(err);
@@ -169,10 +168,8 @@ void AppTask::Main(void * pvParameter)
     }
 }
 
-int AppTask::Init()
+CHIP_ERROR AppTask::Init()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     // Init ZCL Data Model
     InitServer();
 
@@ -193,9 +190,11 @@ int AppTask::Init()
 
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    if (!GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
+    CHIP_ERROR err = GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+    if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("Getting QR code failed!");
+        return err;
     }
 #else
     PrintQRCode(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
@@ -204,7 +203,7 @@ int AppTask::Init()
     // Force LCD refresh
     mLastThreadProvisioned = !ConnectivityMgr().IsThreadProvisioned();
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void AppTask::PostEvent(const AppEvent & event)

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -79,6 +79,11 @@ void appError(int err)
         ;
 }
 
+void appError(CHIP_ERROR error)
+{
+    appError(static_cast<int>(chip::ChipError::AsInteger(error)));
+}
+
 // ================================================================================
 // FreeRTOS Callbacks
 // ================================================================================

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -306,7 +306,7 @@ void Device::OnNewConnection(SecureSessionHandle session)
     Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
     VerifyOrReturn(connectionState != nullptr);
     MessageCounter & localCounter = connectionState->GetSessionMessageCounter().GetLocalMessageCounter();
-    if (localCounter.SetCounter(mLocalMessageCounter))
+    if (localCounter.SetCounter(mLocalMessageCounter) != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Unable to restore local counter to %" PRIu32, mLocalMessageCounter);
     }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -823,7 +823,7 @@ CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, CommissionerInitParams
     uint16_t nextKeyID = 0;
     uint16_t size      = sizeof(nextKeyID);
     CHIP_ERROR error   = mStorageDelegate->SyncGetKeyValue(kNextAvailableKeyID, &nextKeyID, size);
-    if (error || (size != sizeof(nextKeyID)))
+    if ((error != CHIP_NO_ERROR) || (size != sizeof(nextKeyID)))
     {
         nextKeyID = 0;
     }

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -110,7 +110,6 @@ public:
     bool operator==(const ChipError & other) const { return mError == other.mError; }
     bool operator!=(const ChipError & other) const { return mError != other.mError; }
 
-    constexpr explicit operator bool() const { return mError; }
     static constexpr StorageType AsInteger(StorageType error) { return error; }
     static constexpr StorageType AsInteger(ChipError error) { return error.mError; }
 

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -643,7 +643,7 @@ void WriteEncoding3(nlTestSuite * inSuite, TLVWriter & writer)
         TLVWriter writer1;
 
         err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
-        if (err)
+        if (err != CHIP_NO_ERROR)
             NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);

--- a/src/lib/shell/Engine.cpp
+++ b/src/lib/shell/Engine.cpp
@@ -50,7 +50,7 @@ void Engine::ForEachCommand(shell_command_iterator_t * on_command, void * arg)
     {
         for (unsigned j = 0; j < _commandSetSize[i]; j++)
         {
-            if (on_command(&_commandSet[i][j], arg))
+            if (on_command(&_commandSet[i][j], arg) != CHIP_NO_ERROR)
             {
                 return;
             }

--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -155,7 +155,7 @@ void ProcessShellLine(intptr_t args)
     {
         CHIP_ERROR retval = Engine::Root().ExecCommand(argc, argv);
 
-        if (retval)
+        if (retval != CHIP_NO_ERROR)
         {
             char errorStr[160];
             bool errorStrFound = FormatCHIPError(errorStr, sizeof(errorStr), retval);

--- a/src/platform/EFR32/CHIPPlatformConfig.h
+++ b/src/platform/EFR32/CHIPPlatformConfig.h
@@ -40,6 +40,8 @@
 #define CHIP_CONFIG_TIME_ENABLE_CLIENT 1
 #define CHIP_CONFIG_TIME_ENABLE_SERVER 0
 
+#define CHIP_CONFIG_ERROR_CLASS 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -281,7 +281,7 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     EnqueueEvtHdrMsg(BLEManagerIMPL_CHIPOBLE_CLOSE_CONN_EVT, (void *) pMsg);
 
-    return CHIP_NO_ERROR;
+    return false;
 }
 
 uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const

--- a/src/platform/cc13x2_26x2/CHIPPlatformConfig.h
+++ b/src/platform/cc13x2_26x2/CHIPPlatformConfig.h
@@ -39,6 +39,8 @@
 #define CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY 0x01
 #define CHIP_CONFIG_PERSISTED_STORAGE_KEY_GLOBAL_MESSAGE_COUNTER 0x2
 
+#define CHIP_CONFIG_ERROR_CLASS 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0

--- a/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
@@ -66,7 +66,7 @@ static int app_get_random(uint8_t * aOutput, size_t aLen)
         while (1)
             ;
     }
-    return CHIP_NO_ERROR;
+    return 0;
 }
 
 static void app_random_init(void)

--- a/src/platform/qpg/CHIPPlatformConfig.h
+++ b/src/platform/qpg/CHIPPlatformConfig.h
@@ -41,6 +41,8 @@
 #define CHIP_CONFIG_TIME_ENABLE_CLIENT 1
 #define CHIP_CONFIG_TIME_ENABLE_SERVER 0
 
+#define CHIP_CONFIG_ERROR_CLASS 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0

--- a/src/platform/qpg/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/qpg/KeyValueStoreManagerImpl.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 
     VerifyOrExit(key != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = qvCHIP_KvsDelete(key);
+    result = qvCHIP_KvsDelete(key);
     if (result != QV_STATUS_NO_ERROR)
     {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;

--- a/src/setup_payload/Base38.cpp
+++ b/src/setup_payload/Base38.cpp
@@ -176,7 +176,7 @@ CHIP_ERROR base38Decode(std::string base38, std::vector<uint8_t> & result)
 
         for (int i = (base38CharactersInChunk - 1); i >= 0; i--)
         {
-            uint8_t v;
+            uint8_t v      = 0;
             CHIP_ERROR err = decodeChar(base38[static_cast<uint8_t>(decodedBase38Characters + i)], v);
 
             if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
#### Problem

Having `CHIP_ERROR` be a class type would provide (a) type safety,
and (b) the ability to trace the source of errors (issue #8340). A recent
change (#8383) made `CHIP_ERROR` a class type on Linux builds.

#### Change overview

- Enable `CHIP_CONFIG_ERROR_CLASS` on cc13x2_26x2, EFR32, QPG.

- Remove `operator bool()` (requested in #8383 review).

#### Testing

Existing tests should confirm no change to functionality.
