### PR TITLE
Turn off CodeQL for pushes to non-ToT branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
               with:
                   submodules: true
             - name: Initialize CodeQL
-              if: ${{ github.event_name == 'push' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
+              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
               uses: github/codeql-action/init@v1
               with:
                   languages: "cpp"
@@ -109,7 +109,7 @@ jobs:
             # - name: Remove nrfxlib binaries for CodeQL Analysis
             #   run: find . -type d -name "nrfxlib" -exec rm -rf {} +
             - name: Perform CodeQL Analysis
-              if: ${{ github.event_name == 'push' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
+              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
               uses: github/codeql-action/analyze@v1
     build_darwin:
         name: Build on Darwin


### PR DESCRIPTION
#### Problem
We end up running CodeQL for things like test event cherry-picks

#### Change overview
Only run it for pushes to master.

#### Testing
Tried pushing to my fork of the connectedhomeip, both to master and a non-master branch.  The push to master ran CodeQL; the non-master branch did not.