### PR TITLE
[K32W] Improve logging

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -240,7 +240,7 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
     uint32_t delta = (static_cast<uint32_t>(System::Clock::GetMonotonicMicroseconds() - startUS)) / 1000;
     if (delta > 100)
     {
-        ChipLogError(DeviceLayer, "Long dispatch time: %" PRId32 " ms", delta);
+        ChipLogError(DeviceLayer, "Long dispatch time: %" PRId32 " ms, for event type %d", delta, event->Type);
     }
 #endif // CHIP_PROGRESS_LOGGING
 }

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -13,6 +13,12 @@
 #define EOL_CHARS "\r\n" /* End of Line Characters */
 #define EOL_CHARS_LEN 2  /* Length of EOL */
 
+/* maximum value for uint32_t is 4294967295 - 10 bytes + 2 bytes for the brackets */
+static constexpr uint8_t timestamp_max_len_bytes = 12;
+
+/* one byte for the category + 2 bytes for the brackets */
+static constexpr uint8_t category_max_len_bytes = 3;
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <openthread/platform/logging.h>
 #include <utils/uart.h>
@@ -21,60 +27,59 @@
 static bool isLogInitialized;
 extern uint8_t gOtLogUartInstance;
 extern "C" void K32WWriteBlocking(const uint8_t * aBuf, uint32_t len);
+extern "C" uint32_t otPlatAlarmMilliGetNow(void);
 
 namespace chip {
 namespace Logging {
 namespace Platform {
 
-void GetMessageString(char * buf, uint8_t chipCategory, uint8_t otLevelLog)
+void GetMessageString(char * buf, uint8_t bufLen, const char * module, uint8_t category)
 {
-    if (chipCategory != kLogCategory_None)
+    int writtenLen = 0;
+    const char * categoryString;
+
+    /* bufLen must accommodate the length of the timestamp + length of the category +
+     * length of the module + 2 bytes for the module's brackets +
+     * 1 byte for the terminating character.
+     */
+    assert(bufLen >= (timestamp_max_len_bytes + category_max_len_bytes + (strlen(module) + 2) + 1));
+
+    writtenLen = snprintf(buf, bufLen, "[%lu]", otPlatAlarmMilliGetNow());
+    bufLen -= writtenLen;
+    buf += writtenLen;
+
+    if (category != kLogCategory_None)
     {
-        switch (chipCategory)
+        switch (category)
         {
         case kLogCategory_Error:
-            memcpy(buf, "[Error]", 7);
+            categoryString = "E";
             break;
         case kLogCategory_Progress:
-        default:
-            memcpy(buf, "[Progress]", 10);
+            categoryString = "P";
             break;
         case kLogCategory_Detail:
-            memcpy(buf, "[Debug]", 7);
+            categoryString = "D";
             break;
+        default:
+            categoryString = "U";
         }
+
+        writtenLen = snprintf(buf, bufLen, "[%s]", categoryString);
+        bufLen -= writtenLen;
+        buf += writtenLen;
     }
 
-    if (otLevelLog != OT_LOG_LEVEL_NONE)
-    {
-        switch (otLevelLog)
-        {
-        case OT_LOG_LEVEL_CRIT:
-            memcpy(buf, "[Error]", 7);
-            break;
-        case OT_LOG_LEVEL_WARN:
-            memcpy(buf, "[Warn]", 6);
-            break;
-        case OT_LOG_LEVEL_NOTE:
-        case OT_LOG_LEVEL_INFO:
-        default:
-            memcpy(buf, "[Info]", 6);
-            break;
-        case OT_LOG_LEVEL_DEBG:
-            memcpy(buf, "[Debug]", 7);
-            break;
-        }
-    }
+    writtenLen = snprintf(buf + writtenLen, bufLen, "[%s]", module);
 }
 
 } // namespace Platform
 } // namespace Logging
 } // namespace chip
 
-void FillPrefix(char * buf, uint8_t bufLen, uint8_t chipCategory, uint8_t otLevelLog)
+void FillPrefix(char * buf, uint8_t bufLen, const char * module, uint8_t category)
 {
-    /* add the error string */
-    chip::Logging::Platform::GetMessageString(buf, chipCategory, otLevelLog);
+    chip::Logging::Platform::GetMessageString(buf, bufLen, module, category);
 }
 
 namespace chip {
@@ -91,7 +96,7 @@ void __attribute__((weak)) OnLogOutput(void) {}
 } // namespace DeviceLayer
 } // namespace chip
 
-void GenericLog(const char * format, va_list arg)
+void GenericLog(const char * format, va_list arg, const char * module, uint8_t category)
 {
 
 #if K32W_LOG_ENABLED
@@ -106,9 +111,8 @@ void GenericLog(const char * format, va_list arg)
         otPlatUartEnable();
     }
 
-    /* Prefix is composed of [Debug String][MOdule Name String] */
-    FillPrefix(formattedMsg, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE - 1, chip::Logging::kLogCategory_None,
-               chip::Logging::kLogCategory_Detail);
+    /* Prefix is composed of [Time Reference][Debug String][Module Name String] */
+    FillPrefix(formattedMsg, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE - 1, module, category);
     prefixLen = strlen(formattedMsg);
 
     // Append the log message.
@@ -137,7 +141,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     (void) category;
 
 #if K32W_LOG_ENABLED
-    GenericLog(msg, v);
+    GenericLog(msg, v, module, category);
     // Let the application know that a log message has been emitted.
     DeviceLayer::OnLogOutput();
 
@@ -157,9 +161,10 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 extern "C" void LwIPLog(const char * msg, ...)
 {
     va_list v;
+    const char * module = "LWIP";
 
     va_start(v, msg);
-    GenericLog(msg, v);
+    GenericLog(msg, v, module, chip::Logging::kLogCategory_None);
     va_end(v);
 }
 
@@ -171,12 +176,13 @@ extern "C" void LwIPLog(const char * msg, ...)
 extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char * aFormat, ...)
 {
     va_list v;
+    const char * module = "OT";
 
     (void) aLogLevel;
     (void) aLogRegion;
 
     va_start(v, aFormat);
-    GenericLog(aFormat, v);
+    GenericLog(aFormat, v, module, chip::Logging::kLogCategory_None);
     va_end(v);
 }
 


### PR DESCRIPTION
#### Problem
* k32w was lacking timestamp logging;
* event type was not printed during a long dispatch time.

#### Change overview
* add a timestamp for each logged line;
* print the event type during a long dispatch time.

#### Testing
* manual testing
