### PR TITLE
Update to Matters officially assigned IANA port of 5540

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -731,7 +731,7 @@ menu "CHIP Device Layer"
             help
                 The IP address and port of the server to which the device should establish a service tunnel.
                 The supplied address must be a dot-notation IP address--not a host name.  The port number is
-                optional; if present it should be separated from the IP address with a colon (e.g. 192.168.1.100:11097).
+                optional; if present it should be separated from the IP address with a colon (e.g. 192.168.1.100:5540).
 
         config LOG_PROVISIONING_HASH
             bool "Enable Provisioning Hash Logging"

--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -344,5 +344,5 @@ uart:~$ matter dns resolve <fabric-id> <node-id>
 Resolving ...
 DNS resolve for 000000014A77CBB3-0000000000BC5C01 succeeded:
    IP address: fd08:b65e:db8e:f9c7:8052:1a8e:4dd4:e1f3
-   Port: 11097
+   Port: 5540
 ```

--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -41,7 +41,7 @@ choose the pairing mode.
 The command below pair a device with the provided IP address and port of the
 server to talk to.
 
-    $ chip-tool pairing bypass 192.168.0.30 11097
+    $ chip-tool pairing bypass 192.168.0.30 5540
 
 #### Pair a device over BLE
 

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -257,7 +257,7 @@ combination with JLinkRTTClient as follows:
 
     \*\* Currently, chip-tool for Mac or Linux do not yet have the Thread
     provisioning feature
-    `chip-tool bypass <Global ipv6 address of the node> 11097`
+    `chip-tool bypass <Global ipv6 address of the node> 5540`
 
     You can provision the Chip device using Chip tool Android or iOS app or
     through CLI commands on your OT BR

--- a/examples/lighting-app/telink/Readme.md
+++ b/examples/lighting-app/telink/Readme.md
@@ -155,13 +155,13 @@ following states:
 1. Pair with device
 
     ```
-    ${CHIP_TOOL_DIR}/chip-tool pairing bypass ${IP_ADDRESS_OF_CHIP_DEVICE} 11097
+    ${CHIP_TOOL_DIR}/chip-tool pairing bypass ${IP_ADDRESS_OF_CHIP_DEVICE} 5540
     ```
 
     here:
 
     - `${IP_ADDRESS_OF_CHIP_DEVICE}` is IPv6 address of CHIP device
-    - **11097** is standart CHIP TCP port
+    - **5540** is the standard CHIP TCP port
 
 1. Switch on the light:
 

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -246,7 +246,7 @@ combination with JLinkRTTClient as follows:
 
     \*\* Currently, chip-tool for Mac or Linux do not yet have the Thread
     provisioning feature
-    `chip-tool bypass <Global ipv6 address of the node> 11097`
+    `chip-tool bypass <Global ipv6 address of the node> 5540`
 
     You can provision the Chip device using Chip tool Android or iOS app or
     through CLI commands on your OT BR

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -122,7 +122,7 @@ for j in "${iter_array[@]}"; do
         # the data is there yet.
         background_pid="$(</tmp/pid)"
         echo "          * Pairing to device"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing onnetwork 0 20202021 3840 ::1 11097
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing onnetwork 0 20202021 3840 ::1 5540
         echo "          * Starting test run: $i"
         "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i"
         # Prevent cleanup trying to kill a process we already killed.

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -17,8 +17,8 @@ const uint16_t kTimeoutInSeconds = 3;
 const uint64_t kDeviceId = 1;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
-const uint16_t kRemotePort = 11097;
-const uint16_t kLocalPort = 11098;
+const uint16_t kRemotePort = 5540;
+const uint16_t kLocalPort = 5541;
 NSString * kAddress = @"::1";
 
 CHIPDevice * GetPairedDevice(uint64_t deviceId)

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -34,8 +34,8 @@ const uint16_t kTimeoutInSeconds = 3;
 const uint64_t kDeviceId = 1;
 const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
-const uint16_t kRemotePort = 11097;
-const uint16_t kLocalPort = 11098;
+const uint16_t kRemotePort = 5540;
+const uint16_t kLocalPort = 5541;
 NSString * kAddress = @"::1";
 
 CHIPDevice * GetPairedDevice(uint64_t deviceId)

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1337,7 +1337,7 @@
  *
  */
 #ifndef CHIP_PORT
-#define CHIP_PORT 11097
+#define CHIP_PORT 5540
 #endif // CHIP_PORT
 
 /**

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -48,7 +48,7 @@ DEVICE_CONFIG = {
     }
 }
 
-CHIP_PORT = 11097
+CHIP_PORT = 5540
 
 CIRQUE_URL = "http://localhost:5000"
 

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -48,7 +48,7 @@ DEVICE_CONFIG = {
     }
 }
 
-CHIP_PORT = 11097
+CHIP_PORT = 5540
 
 CIRQUE_URL = "http://localhost:5000"
 

--- a/src/test_driver/linux-cirque/test-manual.py
+++ b/src/test_driver/linux-cirque/test-manual.py
@@ -41,7 +41,7 @@ SETUP_TEST_THREAD_NETWORK = False
 # You can define your own consts here.
 SETUPPINCODE = 12345678
 DISCRIMINATOR = 1  # Randomw number, not used
-CHIP_PORT = 11097
+CHIP_PORT = 5540
 
 #############################################################
 

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -49,7 +49,7 @@ DEVICE_CONFIG = {
     }
 }
 
-CHIP_PORT = 11097
+CHIP_PORT = 5540
 
 CIRQUE_URL = "http://localhost:5000"
 

--- a/src/test_driver/linux-cirque/test-on-off-cluster.py
+++ b/src/test_driver/linux-cirque/test-on-off-cluster.py
@@ -48,7 +48,7 @@ DEVICE_CONFIG = {
 
 SETUPPINCODE = 20202021
 DISCRIMINATOR = 1  # Randomw number, not used
-CHIP_PORT = 11097
+CHIP_PORT = 5540
 
 CIRQUE_URL = "http://localhost:5000"
 


### PR DESCRIPTION
 #### Problem
Update the code to use the new officially assigned port number 5540 from IANA.

 #### Summary of Changes
Change all instances of the old port number 11097 to 5540 in the code, documentation, examples and test scripts

Fixes https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/1777

Tracks the spec PR found here: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/3247

#### Testing
* Manually tested by compiling and checking advertisements and listening ports
* This is a breaking change and requires all sides to update as the port number has changed