### PR TITLE
Close exchanges automatically after a message send if no response is expected

### DIFF
--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -40,8 +40,6 @@ using namespace Logging;
 
 namespace {
 
-Messaging::ExchangeContext * gExchangeCtx = nullptr;
-
 class SendArguments
 {
 public:
@@ -110,7 +108,6 @@ public:
         streamer_printf(sout, "Response received: len=%u time=%.3fms\n", buffer->DataLength(),
                         static_cast<double>(transitTime) / 1000);
 
-        gExchangeCtx = nullptr;
         return CHIP_NO_ERROR;
     }
 
@@ -118,8 +115,6 @@ public:
     {
         streamer_t * sout = streamer_get();
         streamer_printf(sout, "No response received\n");
-
-        gExchangeCtx = nullptr;
     }
 } gMockAppDelegate;
 
@@ -131,17 +126,9 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     System::PacketBufferHandle payloadBuf;
     uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
-    // Discard any existing exchange context. Effectively we can only have one exchange with
-    // a single node at any one time.
-    if (gExchangeCtx != nullptr)
-    {
-        gExchangeCtx->Abort();
-        gExchangeCtx = nullptr;
-    }
-
     // Create a new exchange context.
-    gExchangeCtx = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gFabricIndex }, &gMockAppDelegate);
-    VerifyOrExit(gExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    auto * ec = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gFabricIndex }, &gMockAppDelegate);
+    VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);
     VerifyOrExit(!payloadBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
@@ -158,7 +145,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
         sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
     }
 
-    gExchangeCtx->SetResponseTimeout(kResponseTimeOut);
+    ec->SetResponseTimeout(kResponseTimeOut);
     sendFlags.Set(Messaging::SendMessageFlags::kExpectResponse);
 
     gSendArguments.SetLastSendTime(System::Clock::GetMonotonicMilliseconds());
@@ -166,18 +153,16 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     streamer_printf(stream, "\nSend CHIP message with payload size: %d bytes to Node: %" PRIu64 "\n", payloadSize,
                     kTestDeviceNodeId);
 
-    err = gExchangeCtx->SendMessage(Protocols::Id(VendorId::Common, gSendArguments.GetProtocolId()),
-                                    gSendArguments.GetMessageType(), std::move(payloadBuf), sendFlags);
-
-    if (err != CHIP_NO_ERROR)
-    {
-        gExchangeCtx->Abort();
-        gExchangeCtx = nullptr;
-    }
+    err = ec->SendMessage(Protocols::Id(VendorId::Common, gSendArguments.GetProtocolId()), gSendArguments.GetMessageType(),
+                          std::move(payloadBuf), sendFlags);
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
+        if (ec != nullptr)
+        {
+            ec->Close();
+        }
         streamer_printf(stream, "Send CHIP message failed, err: %s\n", ErrorStr(err));
     }
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -129,10 +129,8 @@ private:
     void MoveToState(const HandlerState aTargetState);
 
     const char * GetStateStr() const;
-    CHIP_ERROR AbortExistingExchangeContext();
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
-    InteractionModelDelegate * mpDelegate      = nullptr;
 
     // Don't need the response for report data if true
     bool mSuppressResponse = false;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -29,8 +29,6 @@ CHIP_ERROR WriteHandler::Init(InteractionModelDelegate * apDelegate)
 {
     VerifyOrReturnError(apDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mpExchangeCtx = nullptr;
-    mpDelegate    = apDelegate;
 
     System::PacketBufferHandle packet = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
     VerifyOrReturnError(!packet.IsNull(), CHIP_ERROR_NO_MEMORY);
@@ -50,18 +48,8 @@ void WriteHandler::Shutdown()
 {
     VerifyOrReturn(mState != State::Uninitialized);
     mMessageWriter.Reset();
-    ClearExistingExchangeContext();
-    mpDelegate = nullptr;
+    mpExchangeCtx = nullptr;
     ClearState();
-}
-
-void WriteHandler::ClearExistingExchangeContext()
-{
-    if (mpExchangeCtx != nullptr)
-    {
-        mpExchangeCtx->Close();
-        mpExchangeCtx = nullptr;
-    }
 }
 
 CHIP_ERROR WriteHandler::OnWriteRequest(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload)
@@ -75,8 +63,6 @@ CHIP_ERROR WriteHandler::OnWriteRequest(Messaging::ExchangeContext * apExchangeC
 
 exit:
     ChipLogFunctError(err);
-    // Keep Shutdown() from double-closing our exchange.
-    mpExchangeCtx = nullptr;
     Shutdown();
     return err;
 }

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -99,10 +99,8 @@ private:
     void MoveToState(const State aTargetState);
     void ClearState();
     const char * GetStateStr() const;
-    void ClearExistingExchangeContext();
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
-    InteractionModelDelegate * mpDelegate      = nullptr;
     WriteResponse::Builder mWriteResponseBuilder;
     System::PacketBufferTLVWriter mMessageWriter;
     State mState = State::Uninitialized;

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -246,10 +246,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
     Messaging::ExchangeContext * exchange = ctx.NewExchangeToLocal(&delegate);
     err                                   = writeHandler.OnWriteRequest(exchange, std::move(buf));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    // Manually close the exchange, because we're bypassing the normal "you
-    // received a message" flow for the exchange, so the automatic closing is
-    // not going to happen.
-    exchange->Close();
 
     Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
     NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);

--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -130,8 +130,12 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
 
     EmberStatus err = chipSendUnicast(exchange, apsFrame, messageLength, message, sendFlags);
 
-    // Make sure we always close the temporary exchange we just created.
-    exchange->Close();
+    // Make sure we always close the temporary exchange we just created, unless
+    // we sent a message successfully.
+    if (err != EMBER_SUCCESS)
+    {
+        exchange->Close();
+    }
 
     return err;
 }

--- a/src/channel/tests/TestChannel.cpp
+++ b/src/channel/tests/TestChannel.cpp
@@ -111,11 +111,14 @@ void CheckExchangeChannels(nlTestSuite * inSuite, void * inContext)
     ec1->SendMessage(0x0001, 0x0002, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
+    // Need to sort out what this test should really be testing and how; sending
+    // two messages in a row on an exchange is not something that really
+    // happens.
+
     // send a good packet
     ec1->SendMessage(0x0001, 0x0001, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
-    ec1->Close();
     channelHandle.Release();
 #endif
 }

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -52,6 +52,7 @@ CHIP_ERROR ClusterBase::SendCommand(uint8_t seqNum, chip::System::PacketBufferHa
                                     Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    Messaging::SendFlags sendFlags;
 
     VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(!payload.IsNull(), err = CHIP_ERROR_INTERNAL);
@@ -61,7 +62,12 @@ CHIP_ERROR ClusterBase::SendCommand(uint8_t seqNum, chip::System::PacketBufferHa
         mDevice->AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback);
     }
 
-    err = mDevice->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest, std::move(payload));
+    if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
+    {
+        sendFlags.Set(Messaging::SendMessageFlags::kExpectResponse);
+    }
+
+    err = mDevice->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest, sendFlags, std::move(payload));
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -60,11 +60,11 @@ using namespace chip::Callback;
 
 namespace chip {
 namespace Controller {
-CHIP_ERROR Device::SendMessage(Protocols::Id protocolId, uint8_t msgType, System::PacketBufferHandle && buffer)
+CHIP_ERROR Device::SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
+                               System::PacketBufferHandle && buffer)
 {
     System::PacketBufferHandle resend;
     bool loadedSecureSession = false;
-    Messaging::SendFlags sendFlags;
 
     VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -372,7 +372,8 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption optio
     System::PacketBufferHandle outBuffer;
     ReturnErrorOnFailure(writer.Finalize(&outBuffer));
 
-    ReturnErrorOnFailure(SendMessage(Protocols::ServiceProvisioning::MsgType::ServiceProvisioningRequest, std::move(outBuffer)));
+    ReturnErrorOnFailure(SendMessage(Protocols::ServiceProvisioning::MsgType::ServiceProvisioningRequest,
+                                     Messaging::SendMessageFlags::kNone, std::move(outBuffer)));
 
     setupPayload.version               = 0;
     setupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kBLE);

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -36,6 +36,7 @@
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
 #include <protocols/secure_channel/CASESession.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <protocols/secure_channel/SessionIDAllocator.h>
@@ -124,19 +125,22 @@ public:
      *
      * @param[in] protocolId  The protocol identifier of the CHIP message to be sent.
      * @param[in] msgType     The message type of the message to be sent.  Must be a valid message type for protocolId.
+     * @param [in] sendFlags  SendMessageFlags::kExpectResponse or SendMessageFlags::kNone
      * @param[in] message     The message payload to be sent.
      *
      * @return CHIP_ERROR   CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, System::PacketBufferHandle && message);
+    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
+                           System::PacketBufferHandle && message);
 
     /**
      * A strongly-message-typed version of SendMessage.
      */
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
-    CHIP_ERROR SendMessage(MessageType msgType, System::PacketBufferHandle && message)
+    CHIP_ERROR SendMessage(MessageType msgType, Messaging::SendFlags sendFlags, System::PacketBufferHandle && message)
     {
-        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), std::move(message));
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), sendFlags,
+                           std::move(message));
     }
 
     CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -486,7 +486,9 @@ JNI_METHOD(void, sendMessage)(JNIEnv * env, jobject self, jlong handle, jlong de
         }
         else
         {
-            err = chipDevice->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest, std::move(buffer));
+            // We don't install a response handler, so aren't waiting for a response
+            err = chipDevice->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest, Messaging::SendMessageFlags::kNone,
+                                          std::move(buffer));
         }
     }
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -81,7 +81,9 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
 CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle && msgBuf,
                                         const SendFlags & sendFlags)
 {
-    if (protocolId != Protocols::SecureChannel::Id || msgType != to_underlying(Protocols::SecureChannel::MsgType::StandaloneAck))
+    bool isStandaloneAck =
+        (protocolId == Protocols::SecureChannel::Id) && msgType == to_underlying(Protocols::SecureChannel::MsgType::StandaloneAck);
+    if (!isStandaloneAck)
     {
         // If we were waiting for a message send, this is it.  Standalone acks
         // are not application-level sends, which is why we don't allow those to
@@ -146,6 +148,12 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
         {
             CancelResponseTimer();
             SetResponseExpected(false);
+        }
+
+        // Standalone acks are not application-level message sends.
+        if (err == CHIP_NO_ERROR && !isStandaloneAck)
+        {
+            MessageHandled();
         }
 
         return err;

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -80,6 +80,12 @@ public:
     /**
      *  Send a CHIP message on this exchange.
      *
+     *  If SendMessage returns success and the message was not expecting a
+     *  response, the exchange will close itself before returning, unless the
+     *  message being sent is a standalone ack.  If SendMessage returns failure,
+     *  the caller is responsible for deciding what to do (e.g. closing the
+     *  exchange, trying to re-establish a secure session, etc).
+     *
      *  @param[in]    protocolId    The protocol identifier of the CHIP message to be sent.
      *
      *  @param[in]    msgType       The message type of the corresponding protocol.
@@ -177,7 +183,7 @@ public:
     void SetResponseTimeout(Timeout timeout);
 
 private:
-    Timeout mResponseTimeout; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.
+    Timeout mResponseTimeout       = 0; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.
     ExchangeDelegate * mDelegate   = nullptr;
     ExchangeManager * mExchangeMgr = nullptr;
     ExchangeACL * mExchangeACL     = nullptr;

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -133,8 +133,8 @@ void CheckSessionExpirationBasics(nlTestSuite * inSuite, void * inContext)
                            SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !receiveDelegate.IsOnMessageReceivedCalled);
-
     ec1->Close();
+
     err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
@@ -203,12 +203,13 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
                      SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
+    ec1 = ctx.NewExchangeToPeer(&mockSolicitedAppDelegate);
+
     // send a good packet
     ec1->SendMessage(Protocols::BDX::Id, kMsgType_TEST1, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
                      SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
-    ec1->Close();
     err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -89,13 +89,15 @@ public:
      *
      * @param payload       A PacketBufferHandle with the payload.
      * @param sendFlags     Flags set by the application for the CHIP message being sent.
+     *                      SendEchoRequest will always add
+     *                      SendMessageFlags::kExpectResponse to the flags.
      *
      * @return CHIP_ERROR_NO_MEMORY if no ExchangeContext is available.
      *         Other CHIP_ERROR codes as returned by the lower layers.
      *
      */
     CHIP_ERROR SendEchoRequest(System::PacketBufferHandle && payload,
-                               const Messaging::SendFlags & sendFlags = Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
+                               Messaging::SendFlags sendFlags = Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
 
 private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -55,7 +55,7 @@ void EchoClient::Shutdown()
     mExchangeMgr           = nullptr;
 }
 
-CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, const Messaging::SendFlags & sendFlags)
+CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, Messaging::SendFlags sendFlags)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -75,7 +75,8 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, co
     }
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
-    err = mExchangeCtx->SendMessage(MsgType::EchoRequest, std::move(payload), sendFlags);
+    err = mExchangeCtx->SendMessage(MsgType::EchoRequest, std::move(payload),
+                                    sendFlags.Set(Messaging::SendMessageFlags::kExpectResponse));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -84,8 +84,6 @@ CHIP_ERROR EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const 
     // Send an Echo Response back to the sender.
     err = ec->SendMessage(MsgType::EchoResponse, std::move(response));
 
-    // Discard the exchange context.
-    ec->Close();
     return err;
 }
 

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -208,6 +208,10 @@ CHIP_ERROR MessageCounterManager::SendMsgCounterSyncReq(SecureSessionHandle sess
 exit:
     if (err != CHIP_NO_ERROR)
     {
+        if (exchangeContext != nullptr)
+        {
+            exchangeContext->Close();
+        }
         state->GetSessionMessageCounter().GetPeerMessageCounter().SyncFailed();
         ChipLogError(SecureChannel, "Failed to send message counter synchronization request with error:%s", ErrorStr(err));
     }

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -117,8 +117,6 @@ void CheckReceiveMessage(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, peerState->GetSessionMessageCounter().GetPeerMessageCounter().IsSynchronized());
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
-
-    ec->Close();
 }
 
 // Test Suite


### PR DESCRIPTION
#### Problem
Right now we rely on people manually getting their "response expected" flag synced up with their actual handling of the exchange closing.

#### Change overview
Derive the exchange closing behavior from the "response expected" state.

As a followup, I'd like to look into having ExchangeHandle (the one being added in #8106 or a derivative of it) grow better facilities for handling closing exchanges on destruction, have dedicated APIs for "send last message" that null out the handle, etc.

#### Testing
Should be no observable; behavior changes CI passes.