### PR TITLE
Combine the no-detail-logging and no-progress-logging builds with the gcc_debug build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
 
         strategy:
             matrix:
-                type: [gcc_debug, gcc_release, clang, mbedtls, no_detail_logging, no_progress_logging]
+                type: [gcc_debug, gcc_release, clang, mbedtls]
         env:
             BUILD_TYPE: ${{ matrix.type }}
 
@@ -82,8 +82,6 @@ jobs:
                      "gcc_release") GN_ARGS='is_debug=false';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
-                     "no_detail_logging") GN_ARGS='chip_progress_logging=false';;
-                     "no_progress_logging") GN_ARGS='chip_progress_logging=false chip_detail_logging=false';;
                       *) echo >&2 "Unrecognized build type: ${BUILD_TYPE}"; exit 1;;
                   esac
 
@@ -111,6 +109,20 @@ jobs:
             - name: Perform CodeQL Analysis
               if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
               uses: github/codeql-action/analyze@v1
+            - name: Setup Build Without Detail Logging
+              if: ${{ matrix.type == 'gcc_debug' }}
+              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
+            - name: Run Build Without Detail Logging
+              if: ${{ matrix.type == 'gcc_debug' }}
+              timeout-minutes: 10
+              run: scripts/build/gn_build.sh
+            - name: Setup Build Without Progress Logging
+              if: ${{ matrix.type == 'gcc_debug' }}
+              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
+            - name: Run Build Without Progress Logging
+              if: ${{ matrix.type == 'gcc_debug' }}
+              timeout-minutes: 10
+              run: scripts/build/gn_build.sh
     build_darwin:
         name: Build on Darwin
         timeout-minutes: 60


### PR DESCRIPTION
This better amortizes setup costs: the builds themselves are pretty
cheap compared to the various setup we have to do to get to them.

#### Problem
We use a lot of CI resources for these logging-compilation tests.  Something like 7-8 minutes of CI time of which only about 2-2.5 minutes is the actual build.

#### Change overview
Just do these builds as part of the gcc_debug job.  Don't run tests for them, because we're just trying to ensure things compile.

#### Testing
* Verified that CI runs more quickly for this one task (~13 mins) than for the three tasks before (~21 mins).
* Verified that if I introduce a variable that's only used in a progress log statement, the no-progress-logging build fails with an unused variable error.