### PR TITLE
Merge Android jobs into a single multistep job to better amortize setup time

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -27,13 +27,7 @@ jobs:
         name: Build Android
         timeout-minutes: 60
 
-        strategy:
-            matrix:
-                type: [arm, arm64, x64]
-
         env:
-            BUILD_TYPE: android_${{ matrix.type }}
-            TARGET_CPU: ${{ matrix.type }}
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
 
         runs-on: ubuntu-latest
@@ -60,13 +54,51 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Build libs
+            - name: Build arm libs
               timeout-minutes: 2
               run: |
                   ./scripts/examples/android_app.sh
-            - name: Build App
+              env:
+                BUILD_TYPE: android_arm
+                TARGET_CPU: arm
+            - name: Build arm App
               timeout-minutes: 5
               run: |
                   yes | "$ANDROID_HOME"/tools/bin/sdkmanager --licenses
                   cd src/android/CHIPTool
                   ./gradlew build
+              env:
+                BUILD_TYPE: android_arm
+                TARGET_CPU: arm
+            - name: Build arm64 libs
+              timeout-minutes: 2
+              run: |
+                  ./scripts/examples/android_app.sh
+              env:
+                BUILD_TYPE: android_arm64
+                TARGET_CPU: arm64
+            - name: Build arm64 App
+              timeout-minutes: 5
+              run: |
+                  yes | "$ANDROID_HOME"/tools/bin/sdkmanager --licenses
+                  cd src/android/CHIPTool
+                  ./gradlew build
+              env:
+                BUILD_TYPE: android_arm64
+                TARGET_CPU: arm64
+            - name: Build x64 libs
+              timeout-minutes: 2
+              run: |
+                  ./scripts/examples/android_app.sh
+              env:
+                BUILD_TYPE: android_x64
+                TARGET_CPU: x64
+            - name: Build x64 App
+              timeout-minutes: 5
+              run: |
+                  yes | "$ANDROID_HOME"/tools/bin/sdkmanager --licenses
+                  cd src/android/CHIPTool
+                  ./gradlew build
+              env:
+                BUILD_TYPE: android_x64
+                TARGET_CPU: x64


### PR DESCRIPTION
#### Problem
Android CI uses a total of ~30 minutes CI time, but a lot of this seems to be work that is duplicated across the three Android jobs.

#### Change overview
Combine the jobs into one job with steps that build the different configurations.

#### Testing
Checked that the overall job ran in ~15 minutes.

@mspang I'm a little concerned that the builds after the first one are clearly reusing some build artifacts for the "app" builds; the log at https://github.com/bzbarsky-apple/connectedhomeip/runs/3089960361 shows things like:
```
> Task :app:javaPreCompileRelease UP-TO-DATE
...
> Task :app:testReleaseUnitTest UP-TO-DATE
```
etc.  Should we instead be deleting something between the steps to ensure more proper "clean" builds, or do we trust whatever build system is involved here enough to assume that it's going to redo whatever work differs between the three configurations correctly?