### PR TITLE
[K32W] Logging: Fix K32W buffer index

### DIFF
--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -70,7 +70,7 @@ void GetMessageString(char * buf, uint8_t bufLen, const char * module, uint8_t c
         buf += writtenLen;
     }
 
-    writtenLen = snprintf(buf + writtenLen, bufLen, "[%s]", module);
+    writtenLen = snprintf(buf, bufLen, "[%s]", module);
 }
 
 } // namespace Platform


### PR DESCRIPTION
#### Problem
Logging: The buffer index for writing the module name is not correct

#### Change overview
Fix buffer index.

#### Testing
Manual testing

See also: https://github.com/project-chip/connectedhomeip/pull/8451