### PR TITLE
[python] Add ChipStack.RunOnChipThread to run a python function on CHIP stack

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -281,8 +281,7 @@ class ChipDeviceController(object):
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
         im.ClearCommandStatus(im.PLACEHOLDER_COMMAND_HANDLE)
-        self._Cluster.SendCommand(
-            device, cluster, command, endpoint, groupid, args, True)
+        self._Cluster.SendCommand(device, cluster, command, endpoint, groupid, args, True)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(im.PLACEHOLDER_COMMAND_HANDLE, 1)
@@ -298,8 +297,7 @@ class ChipDeviceController(object):
             raise self._ChipStack.ErrorToException(res)
 
         # We are not using IM for Attributes.
-        res = self._Cluster.ReadAttribute(
-            device, cluster, attribute, endpoint, groupid, False)
+        res = self._Cluster.ReadAttribute(device, cluster, attribute, endpoint, groupid, False)
         if blocking:
             return im.GetAttributeReadResponse(im.DEFAULT_ATTRIBUTEREAD_APPID)
 

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -32,7 +32,7 @@ import time
 import glob
 import platform
 import logging
-from threading import Lock, Event
+from threading import Lock, Event, Condition
 from ctypes import *
 from .ChipUtility import ChipUtility
 from .exceptions import *
@@ -46,7 +46,6 @@ __all__ = [
 ]
 
 ChipStackDLLBaseName = "_ChipDeviceCtrl.so"
-
 
 def _singleton(cls):
     instance = [None]
@@ -120,10 +119,37 @@ class ChipLogFormatter(logging.Formatter):
             timestampStr = "%s.%03ld" % (timestampStr, timestampUS / 1000)
         return timestampStr
 
+class AsyncCallableHandle:
+    def __init__(self, callback):
+        self._callback = callback
+        self._res = None
+        self._exc = None
+        self._finish = False
+        self._cv_lock = Lock()
+        self._cv = Condition(self._cv_lock)
+
+    def __call__(self):
+        with self._cv_lock:
+            try:
+                self._res = self._callback()
+            except Exception as ex:
+                self._exc = ex
+            self._finish = True
+            self._cv.notify_all()
+        pythonapi.Py_DecRef(py_object(self))
+
+    def Wait(self):
+        with self._cv:
+            while self._finish is False:
+                self._cv.wait()
+            if self._exc is not None:
+                raise self._exc
+            return self._res
 
 _CompleteFunct = CFUNCTYPE(None, c_void_p, c_void_p)
 _ErrorFunct = CFUNCTYPE(None, c_void_p, c_void_p, c_ulong, POINTER(DeviceStatusStruct))
 _LogMessageFunct = CFUNCTYPE(None, c_int64, c_int64, c_char_p, c_uint8, c_char_p)
+_ChipThreadTaskRunnerFunct = CFUNCTYPE(None, py_object)
 
 
 @_singleton
@@ -193,6 +219,11 @@ class ChipStack(object):
             self.callbackRes = self.ErrorToException(err, devStatusPtr)
             self.completeEvent.set()
 
+        @_ChipThreadTaskRunnerFunct
+        def HandleChipThreadRun(callback):
+            callback()
+
+        self.cbHandleChipThreadRun = HandleChipThreadRun
         self.cbHandleComplete = _CompleteFunct(HandleComplete)
         self.cbHandleError = _ErrorFunct(HandleError)
         self.blockingCB = None  # set by other modules(BLE) that require service by thread while thread blocks.
@@ -258,22 +289,30 @@ class ChipStack(object):
         self.callbackRes = None
 
     def Call(self, callFunct):
+        '''Run a Python function on CHIP stack, and wait for the response.
+        This function is a wrapper of PostTaskOnChipThread, which includes some handling of application specific logics.
+        Calling this function on CHIP on CHIP mainloop thread will cause deadlock.
+        '''
         # throw error if op in progress
         self.callbackRes = None
         self.completeEvent.clear()
         with self.networkLock:
-            res = callFunct()
+            res = self.PostTaskOnChipThread(callFunct).Wait()
         self.completeEvent.set()
         if res == 0 and self.callbackRes != None:
             return self.callbackRes
         return res
 
     def CallAsync(self, callFunct):
+        '''Run a Python function on CHIP stack, and wait for the application specific response.
+        This function is a wrapper of PostTaskOnChipThread, which includes some handling of application specific logics.
+        Calling this function on CHIP on CHIP mainloop thread will cause deadlock.
+        '''
         # throw error if op in progress
         self.callbackRes = None
         self.completeEvent.clear()
         with self.networkLock:
-            res = callFunct()
+            res = self.PostTaskOnChipThread(callFunct).Wait()
 
         if res != 0:
             self.completeEvent.set()
@@ -286,6 +325,19 @@ class ChipStack(object):
         if isinstance(self.callbackRes, ChipStackException):
             raise self.callbackRes
         return self.callbackRes
+
+    def PostTaskOnChipThread(self, callFunct) -> AsyncCallableHandle:
+        '''Run a Python function on CHIP stack, and wait for the response.
+        This function will post a task on CHIP mainloop, and return an object with Wait() method for getting the result.
+        Calling Wait inside main loop will cause deadlock.
+        '''
+        callObj = AsyncCallableHandle(callFunct)
+        pythonapi.Py_IncRef(py_object(callObj))
+        res = self._ChipStackLib.pychip_DeviceController_PostTaskOnChipThread(self.cbHandleChipThreadRun, py_object(callObj))
+        if res != 0:
+            pythonapi.Py_DecRef(py_object(callObj))
+            raise self.ErrorToException(res)
+        return callObj
 
     def ErrorToException(self, err, devStatusPtr=None):
         if err == 4044 and devStatusPtr:
@@ -379,3 +431,6 @@ class ChipStack(object):
 
             self._ChipStackLib.pychip_BLEMgrImpl_ConfigureBle.argtypes = [c_uint32]
             self._ChipStackLib.pychip_BLEMgrImpl_ConfigureBle.restype = c_uint32
+
+            self._ChipStackLib.pychip_DeviceController_PostTaskOnChipThread.argtypes = [_ChipThreadTaskRunnerFunct, py_object]
+            self._ChipStackLib.pychip_DeviceController_PostTaskOnChipThread.restype = c_uint32


### PR DESCRIPTION
#### Problem
- https://github.com/project-chip/connectedhomeip/issues/6841 for Python device controller.
- Currently, the functions in Python device controller is running on Python thread, however, this will cause race conditions some times, causing the Cirque test a bit flicky and some other functions unstable.

#### Change overview
- Implement `CHIPAsyncCallableHandle` for posting tasks on CHIP thread and the caller can wait for the response so they can continue writing code in synchronous style.


#### Testing
- The test should be covered Cirque test already, please let me know if there are cases not covered by the test.