### PR TITLE
Set default value to 0 for Hardware and Software Version attributes

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -385,7 +385,7 @@ menu "CHIP Device Layer"
         config DEFAULT_DEVICE_PRODUCT_REVISION
             int "Default Device Product Revision"
             range 0 65535
-            default 1
+            default 0
             help
                 The default device product revision.
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -130,9 +130,9 @@ class BaseTestHelper:
             "ProductID": 65279,
             "UserLabel": "",
             "Location": "",
-            "HardwareVersion": 1,
+            "HardwareVersion": 0,
             "HardwareVersionString": "TEST_VERSION",
-            "SoftwareVersion": 1,
+            "SoftwareVersion": 0,
             "SoftwareVersionString": "prerelease",
         }
         failed_zcl = {}

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -178,7 +178,7 @@
  * persistent storage (e.g. by a factory provisioning process).
  */
 #ifndef CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION
-#define CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION 1
+#define CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION 0
 #endif
 
 /**
@@ -196,7 +196,7 @@
  * A monothonic number identifying the firmware revision running on the device.
  */
 #ifndef CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION
-#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION 1
+#define CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION 0
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
* According to specs section 11.2.6.1 , the default value for Basic cluster attributes i.e hardware version and software version is 0.
* However in code it is set to 1.

#### Change overview
Change the default value.

#### Testing
* Commissioning and read the value on cluster attributes.