### PR TITLE
Add option 'version' to setup-payload generate command

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -326,8 +326,9 @@ class DeviceMgrCmd(Cmd):
         setup-payload generate [options]
 
         Options:
-          -v   Vendor ID
-          -p   Product ID
+          -vr  Version        
+          -vi  Vendor ID
+          -pi  Product ID
           -cf  Custom Flow [Standard = 0, UserActionRequired = 1, Custom = 2]
           -dc  Discovery Capabilities [SoftAP = 1 | BLE = 2 | OnNetwork = 4]
           -dv  Discriminator Value
@@ -344,15 +345,16 @@ class DeviceMgrCmd(Cmd):
 
             if arglist[0] == "generate":
                 parser = argparse.ArgumentParser()
-                parser.add_argument("-v", type=int, default=0, dest='vendorId')
-                parser.add_argument("-p", type=int, default=0, dest='productId')
+                parser.add_argument("-vr", type=int, default=0, dest='version')
+                parser.add_argument("-pi", type=int, default=0, dest='productId')
+                parser.add_argument("-vi", type=int, default=0, dest='vendorId')                
                 parser.add_argument('-cf', type=int, default=0, dest='customFlow')
                 parser.add_argument("-dc", type=int, default=0, dest='capabilities')
                 parser.add_argument("-dv", type=int, default=0, dest='discriminator')
                 parser.add_argument("-ps", type=int, dest='passcode')                
                 args = parser.parse_args(arglist[1:])
 
-                SetupPayload().PrintOnboardingCodes(args.passcode, args.vendorId, args.productId, args.discriminator, args.customFlow, args.capabilities)
+                SetupPayload().PrintOnboardingCodes(args.passcode, args.vendorId, args.productId, args.discriminator, args.customFlow, args.capabilities, args.version)
 
             if arglist[0] == "parse-manual":
                 SetupPayload().ParseManualPairingCode(arglist[1]).Print()

--- a/src/controller/python/chip/setup_payload/Generator.cpp
+++ b/src/controller/python/chip/setup_payload/Generator.cpp
@@ -24,14 +24,15 @@
 using namespace chip;
 
 extern "C" CHIP_ERROR pychip_SetupPayload_PrintOnboardingCodes(uint32_t passcode, uint16_t vendorId, uint16_t productId,
-                                                               uint16_t discriminator, uint8_t customFlow, uint8_t capabilities)
+                                                               uint16_t discriminator, uint8_t customFlow, uint8_t capabilities,
+                                                               uint8_t version)
 {
     std::string QRCode;
     std::string manualPairingCode;
     SetupPayload payload;
     RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kNone;
 
-    payload.version               = 0;
+    payload.version               = version;
     payload.setUpPINCode          = passcode;
     payload.vendorID              = vendorId;
     payload.productID             = productId;

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -62,9 +62,9 @@ class SetupPayload:
 
         return self
 
-    def PrintOnboardingCodes(self, passcode, vendorId, productId, discriminator, customFlow, capabilities):
+    def PrintOnboardingCodes(self, passcode, vendorId, productId, discriminator, customFlow, capabilities, version):
         self.Clear()
-        err = self.chipLib.pychip_SetupPayload_PrintOnboardingCodes(passcode, vendorId, productId, discriminator, customFlow, capabilities)
+        err = self.chipLib.pychip_SetupPayload_PrintOnboardingCodes(passcode, vendorId, productId, discriminator, customFlow, capabilities, version)
 
         if err != 0:
             raise ChipStackError(err)
@@ -104,4 +104,4 @@ class SetupPayload:
                    [c_char_p, SetupPayload.AttributeVisitor, SetupPayload.VendorAttributeVisitor])
         setter.Set("pychip_SetupPayload_PrintOnboardingCodes",
                    c_int32,
-                   [c_uint32, c_uint16, c_uint16, c_uint16, uint8_t, uint8_t])
+                   [c_uint32, c_uint16, c_uint16, c_uint16, uint8_t, uint8_t, uint8_t])


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
Feedback from TE4, Python controller misses option to specify version to generate setup code, QR code, this is needed to generated setupCode/QRcode with various parameters for certification testing of controllers to have them verify all invalid combinations. 

* Fixes #8402 

#### Change overview
Add option 'version' to setup-payload generate command

#### Testing
Test generate is added to setup-payload
chip-device-ctrl > setup-payload ?

setup-payload generate [options]

Options:
  -vr  Version        
  -vi  Vendor ID
  -pi  Product ID
  -cf  Custom Flow [Standard = 0, UserActionRequired = 1, Custom = 2]
  -dc  Discovery Capabilities [SoftAP = 1 | BLE = 2 | OnNetwork = 4]
  -dv  Discriminator Value
  -ps  Passcode

setup-payload parse-manual <manual-pairing-code>
setup-payload parse-qr <qr-code-payload>

chip-device-ctrl >

chip-device-ctrl > setup-payload generate -vr 1 -vi 9050 -pi 65279 -cf 0 -dc 2 -dv 2976 -ps 34567890
[1626646040.359296][140594:140594] CHIP:SPL: yujuan: pychip_SetupPayload_PrintOnboardingCodes:version:1
[1626646040.359326][140594:140594] CHIP:SPL: Manual pairing code: [26318621095]
[1626646040.359346][140594:140594] CHIP:SPL: SetupQRCode: [MT:ZNJV7VSC00CMVH7SR00]
