### PR TITLE
Rename admin pairing class and usage to fabric

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -339,7 +339,7 @@ public:
         if (i == 0)
         {
             ConnectivityMgr().ClearWiFiStationProvision();
-            OpenDefaultPairingWindow(ResetAdmins::kYes);
+            OpenDefaultPairingWindow(ResetFabrics::kYes);
         }
         else if (i == 1)
         {
@@ -348,7 +348,7 @@ public:
         else if (i == 2)
         {
             app::Mdns::AdvertiseCommissionableNode();
-            OpenDefaultPairingWindow(ResetAdmins::kYes, PairingWindowAdvertisement::kMdns);
+            OpenDefaultPairingWindow(ResetFabrics::kYes, PairingWindowAdvertisement::kMdns);
         }
     }
 

--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -482,7 +482,7 @@ void AppTask::BleHandler(AppEvent * aEvent)
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 
-        if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+        if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
         {
             K32W_LOG("Started BLE Advertising!");
         }

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -427,7 +427,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
         return;
     }
 
-    if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+    if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
     {
         LOG_INF("Enabled BLE Advertisement");
     }

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR AppTask::Init()
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
     // Enable BLE advertisements
-    OpenDefaultPairingWindow(chip::ResetAdmins::kNo);
+    OpenDefaultPairingWindow(chip::ResetFabrics::kNo);
     ChipLogProgress(NotSpecified, "BLE advertising started. Waiting for Pairing.");
 
     return err;

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -326,7 +326,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
             // Enable BLE advertisements
             if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
             {
-                if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+                if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
                 {
                     PLAT_LOG("Enabled BLE Advertisement");
                 }

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -486,7 +486,7 @@ void AppTask::BleHandler(AppEvent * aEvent)
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 
-        if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+        if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
         {
             K32W_LOG("Started BLE Advertising!");
         }

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -427,7 +427,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
         return;
     }
 
-    if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+    if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
     {
         LOG_INF("Enabled BLE Advertisement");
     }

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -342,7 +342,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
                 if (!ConnectivityMgr().IsThreadProvisioned())
                 {
                     // Enable BLE advertisements and pairing window
-                    if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+                    if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
                     {
                         ChipLogProgress(NotSpecified, "BLE advertising started. Waiting for Pairing.");
                     }

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -328,7 +328,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
             // Enable BLE advertisements
             if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
             {
-                if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+                if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
                 {
                     PLAT_LOG("Enabled BLE Advertisement");
                 }

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -395,7 +395,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
         return;
     }
 
-    if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+    if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
     {
         LOG_INF("Enabled BLE Advertisement");
     }

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -328,7 +328,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
             // Enable BLE advertisements
             if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
             {
-                if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+                if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
                 {
                     PLAT_LOG("Enabled BLE Advertisement");
                 }

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -395,7 +395,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
         return;
     }
 
-    if (OpenDefaultPairingWindow(chip::ResetAdmins::kNo) == CHIP_NO_ERROR)
+    if (OpenDefaultPairingWindow(chip::ResetFabrics::kNo) == CHIP_NO_ERROR)
     {
         LOG_INF("Enabled BLE Advertisement");
     }

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -129,7 +129,7 @@ private:
 } gPingArguments;
 
 Protocols::Echo::EchoClient gEchoClient;
-Transport::AdminPairingTable gAdmins;
+Transport::FabricTable gFabrics;
 
 CHIP_ERROR SendEchoRequest(streamer_t * stream);
 void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
@@ -250,7 +250,7 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, const Transport::PeerAddr
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, SecureSession::SessionRole::kInitiator,
-                                     gAdminId);
+                                     gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -285,7 +285,7 @@ void StartPinging(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Transport::AdminPairingInfo * adminInfo = nullptr;
+    Transport::FabricInfo * fabricInfo = nullptr;
 
     if (!IPAddress::FromString(destination, gDestAddr))
     {
@@ -293,8 +293,8 @@ void StartPinging(streamer_t * stream, char * destination)
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    adminInfo = gAdmins.AssignAdminId(gAdminId, kTestControllerNodeId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    fabricInfo = gFabrics.AssignFabricIndex(gFabricIndex, kTestControllerNodeId);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer)
@@ -311,8 +311,8 @@ void StartPinging(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
-        err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &gAdmins, &gMessageCounterManager);
+        err = gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &gFabrics,
+                                   &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);
@@ -321,8 +321,8 @@ void StartPinging(streamer_t * stream, char * destination)
     else
 #endif
     {
-        err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &gAdmins, &gMessageCounterManager);
+        err = gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &gFabrics,
+                                   &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);
@@ -337,7 +337,7 @@ void StartPinging(streamer_t * stream, char * destination)
     SuccessOrExit(err);
 
     // TODO: temprary create a SecureSessionHandle from node id to unblock end-to-end test. Complete solution is tracked in PR:4451
-    err = gEchoClient.Init(&gExchangeManager, { kTestDeviceNodeId, 0, gAdminId });
+    err = gEchoClient.Init(&gExchangeManager, { kTestDeviceNodeId, 0, gFabricIndex });
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -140,7 +140,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     }
 
     // Create a new exchange context.
-    gExchangeCtx = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gAdminId }, &gMockAppDelegate);
+    gExchangeCtx = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gFabricIndex }, &gMockAppDelegate);
     VerifyOrExit(gExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);
@@ -196,7 +196,7 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, SecureSession::SessionRole::kInitiator,
-                                     gAdminId);
+                                     gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -216,9 +216,9 @@ void ProcessCommand(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Transport::AdminPairingTable admins;
+    Transport::FabricTable fabrics;
     Transport::PeerAddress peerAddress;
-    Transport::AdminPairingInfo * adminInfo = nullptr;
+    Transport::FabricInfo * fabricInfo = nullptr;
 
     if (!chip::Inet::IPAddress::FromString(destination, gDestAddr))
     {
@@ -226,8 +226,8 @@ void ProcessCommand(streamer_t * stream, char * destination)
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    adminInfo = admins.AssignAdminId(gAdminId, kTestControllerNodeId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, kTestControllerNodeId);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer)
@@ -247,7 +247,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
         peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
 
         err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &admins, &gMessageCounterManager);
+            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -256,7 +256,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
         peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
 
         err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &admins, &gMessageCounterManager);
+            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/examples/shell/shell_common/globals.cpp
+++ b/examples/shell/shell_common/globals.cpp
@@ -22,7 +22,7 @@ chip::Messaging::ExchangeManager gExchangeManager;
 chip::SecureSessionMgr gSessionManager;
 chip::Inet::IPAddress gDestAddr;
 
-chip::Transport::AdminId gAdminId = 0;
+chip::FabricIndex gFabricIndex = 0;
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -35,7 +35,7 @@ extern chip::Messaging::ExchangeManager gExchangeManager;
 extern chip::SecureSessionMgr gSessionManager;
 extern chip::Inet::IPAddress gDestAddr;
 
-extern chip::Transport::AdminId gAdminId;
+extern chip::FabricIndex gFabricIndex;
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 extern chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -34,7 +34,7 @@ using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 namespace chip {
 namespace app {
 
-CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession)
+CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * secureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle commandPacket;
@@ -53,7 +53,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
     if (secureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
     }
     else
     {

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -52,7 +52,7 @@ public:
     //
     // If SendCommandRequest is never called, or the call fails, the API
     // consumer is responsible for calling Shutdown on the CommandSender.
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession = nullptr);
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * secureSession = nullptr);
 
 private:
     // ExchangeDelegate interface implementation.  Private so people won't

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -320,16 +320,16 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
     ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Exchange: %d", ec->GetExchangeId());
 }
 
-CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId,
-                                                   SecureSessionHandle * apSecureSession, EventPathParams * apEventPathParamsList,
-                                                   size_t aEventPathParamsListSize, AttributePathParams * apAttributePathParamsList,
+CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
+                                                   EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
+                                                   AttributePathParams * apAttributePathParamsList,
                                                    size_t aAttributePathParamsListSize, EventNumber aEventNumber,
                                                    intptr_t aAppIdentifier)
 {
     ReadClient * client = nullptr;
     CHIP_ERROR err      = CHIP_NO_ERROR;
     ReturnErrorOnFailure(NewReadClient(&client, aAppIdentifier));
-    err = client->SendReadRequest(aNodeId, aAdminId, apSecureSession, apEventPathParamsList, aEventPathParamsListSize,
+    err = client->SendReadRequest(aNodeId, aFabricIndex, apSecureSession, apEventPathParamsList, aEventPathParamsListSize,
                                   apAttributePathParamsList, aAttributePathParamsListSize, aEventNumber);
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -122,7 +122,7 @@ public:
      *  @retval #CHIP_ERROR_NO_MEMORY If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * apSecureSession,
+    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                EventNumber aEventNumber, intptr_t aAppIdentifier = 0);

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -86,7 +86,7 @@ void ReadClient::MoveToState(const ClientState aTargetState)
                   GetStateStr());
 }
 
-CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * apSecureSession,
+CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession,
                                        EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                        AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                        EventNumber aEventNumber)
@@ -140,7 +140,7 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdmin
     }
     else
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -72,7 +72,7 @@ public:
      *  @retval #others fail to send read request
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * aSecureSession,
+    CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * aSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
                                EventNumber aEventNumber);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -245,7 +245,7 @@ void WriteClient::ClearState()
     MoveToState(State::Uninitialized);
 }
 
-CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * apSecureSession)
+CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle packet;
@@ -264,7 +264,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, Transport::AdminId aAdm
     // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
     if (apSecureSession == nullptr)
     {
-        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aFabricIndex }, this);
     }
     else
     {

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -59,7 +59,7 @@ public:
      *  If SendWriteRequest is never called, or the call fails, the API
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * apSecureSession);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SecureSessionHandle * apSecureSession);
 
     CHIP_ERROR PrepareAttribute(const AttributePathParams & attributePathParams);
     CHIP_ERROR FinishAttribute();

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -37,7 +37,7 @@
 #include <support/CodeUtils.h>
 #include <support/ScopedBuffer.h>
 #include <support/logging/CHIPLogging.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 
 using namespace chip;
 using namespace ::chip::DeviceLayer;
@@ -45,12 +45,12 @@ using namespace ::chip::Transport;
 
 /*
  * Temporary flow for fabric management until addOptCert + fabric index are implemented:
- * 1) When Commissioner pairs with CHIP device, store device nodeId in Admin Pairing table as NodeId
- *    and store commissioner nodeId in Admin Pairing table as FabricId (This is temporary until AddOptCert is implemented and
+ * 1) When Commissioner pairs with CHIP device, store device nodeId in Fabric table as NodeId
+ *    and store commissioner nodeId in Fabric table as FabricId (This is temporary until AddOptCert is implemented and
  * Fabrics are implemented correctely) 2) When pairing is complete, commissioner calls SetFabric to set the vendorId on the newly
- * created fabric. The corresponding fabric is found by looking in admin pairing table and finding a fabric that has the matching
+ * created fabric. The corresponding fabric is found by looking in fabric table and finding a fabric that has the matching
  * commissioner node ID as fabricId + device nodeId as nodeId and an uninitialized vendorId. 3) RemoveFabric uses the passed in
- * fabricId, nodeId, vendorID to find matching entry and remove it from admin pairing table. Once fabricIndex is implemented, it
+ * fabricId, nodeId, vendorID to find matching entry and remove it from fabric table. Once fabricIndex is implemented, it
  * should use that instead.
  */
 
@@ -95,32 +95,32 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, c
     }
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                   "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64
+                   "OpCreds: Writing fabric into attribute store at index %d: fabricId 0x" ChipLogFormatX64
                    ", nodeId 0x" ChipLogFormatX64 " vendorId 0x%04" PRIX16,
                    index, ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
     status = writeFabricAttribute((uint8_t *) &fabricDescriptor, index);
     return status;
 }
 
-CHIP_ERROR writeAdminsIntoFabricsListAttribute()
+CHIP_ERROR writeFabricsIntoFabricsListAttribute()
 {
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Call to writeAdminsIntoFabricsListAttribute");
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Call to writeFabricsIntoFabricsListAttribute");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // Loop through admins
+    // Loop through fabrics
     int32_t fabricIndex = 0;
-    for (auto & pairing : GetGlobalAdminPairingTable())
+    for (auto & pairing : GetGlobalFabricTable())
     {
         NodeId nodeId               = pairing.GetNodeId();
         uint64_t fabricId           = pairing.GetFabricId();
         uint16_t vendorId           = pairing.GetVendorId();
         const uint8_t * fabricLabel = pairing.GetFabricLabel();
 
-        // Skip over uninitialized admins
+        // Skip over uninitialized fabrics
         if (nodeId == kUndefinedNodeId || fabricId == kUndefinedFabricId || vendorId == kUndefinedVendorId)
         {
             emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                           "OpCreds: Skipping over unitialized admin with fabricId 0x" ChipLogFormatX64
+                           "OpCreds: Skipping over unitialized fabric with fabricId 0x" ChipLogFormatX64
                            ", nodeId 0x" ChipLogFormatX64 " vendorId 0x%04" PRIX16,
                            ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
             continue;
@@ -128,7 +128,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
         else if (writeFabric(fabricId, nodeId, vendorId, fabricLabel, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
         {
             emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                           "OpCreds: Failed to write admin with fabricId 0x" ChipLogFormatX64 " in fabrics list",
+                           "OpCreds: Failed to write fabric with fabricId 0x" ChipLogFormatX64 " in fabrics list",
                            ChipLogValueX64(fabricId));
             err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
             break;
@@ -137,10 +137,10 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
     }
 
     // Store the count of fabrics we just stored
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Stored %" PRIu32 " admins in fabrics list attribute.", fabricIndex);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Stored %" PRIu32 " fabrics in fabrics list attribute.", fabricIndex);
     if (writeFabricAttribute((uint8_t *) &fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write admin count %" PRIu32 " in fabrics list", fabricIndex);
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Failed to write fabric count %" PRIu32 " in fabrics list", fabricIndex);
         err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 
@@ -149,66 +149,67 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
 
 /*
  * Look at "Temporary flow for fabric management" comment above for current fabric management flow.
- * To retrieve the current admin, we retrieve the emberAfCurrentCommand()->source which should be set
+ * To retrieve the current fabric, we retrieve the emberAfCurrentCommand()->source which should be set
  * to the commissioner node Id, which we are temporarily using as the fabricId.
  * We should also figure out how to retrieve the device nodeId and vendorId if we can so that we use multiple
- * fields to find the current admin. Once addOptCert and fabric index are implemented, remove all this and use fabricIndex.
+ * fields to find the current fabric. Once addOptCert and fabric index are implemented, remove all this and use fabricIndex.
  */
 
-static AdminPairingInfo * retrieveCurrentAdmin()
+static FabricInfo * retrieveCurrentFabric()
 {
     uint64_t fabricId = emberAfCurrentCommand()->SourceNodeId();
-    // TODO: Figure out how to get device node id so we can do FindAdminForNode(fabricId, nodeId)...
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Finding admin with fabricId 0x" ChipLogFormatX64 ".", ChipLogValueX64(fabricId));
-    return GetGlobalAdminPairingTable().FindAdminForNode(fabricId);
+    // TODO: Figure out how to get device node id so we can do FindFabricForNode(fabricId, nodeId)...
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Finding fabric with fabricId 0x" ChipLogFormatX64 ".",
+                   ChipLogValueX64(fabricId));
+    return GetGlobalFabricTable().FindFabricForNode(fabricId);
 }
 
-// TODO: The code currently has two sources of truths for admins, the pairing table + the attributes. There should only be one,
-// the attributes list. Currently the attributes are not persisted so we are keeping the admin pairing table to have the
+// TODO: The code currently has two sources of truths for fabrics, the pairing table + the attributes. There should only be one,
+// the attributes list. Currently the attributes are not persisted so we are keeping the fabric table to have the
 // fabrics/admrins be persisted. Once attributes are persisted, there should only be one sorce of truth, the attributes list and
 // only that should be modifed to perosst/read/write fabrics.
-// TODO: Once attributes are persisted, implement reading/writing/manipulation fabrics around that and remove adminPairingTable
+// TODO: Once attributes are persisted, implement reading/writing/manipulation fabrics around that and remove fabricPairingTable
 // logic.
-class OpCredsAdminPairingTableDelegate : public AdminPairingTableDelegate
+class OpCredsFabricTableDelegate : public FabricTableDelegate
 {
 
     // Gets called when a fabric is deleted from KVS store
-    void OnAdminDeletedFromStorage(AdminId adminId) override
+    void OnFabricDeletedFromStorage(FabricIndex fabricId) override
     {
-        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Admin 0x%" PRIX16 " was deleted from admin storage.", adminId);
-        writeAdminsIntoFabricsListAttribute();
+        emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Fabric 0x%" PRIX16 " was deleted from fabric storage.", fabricId);
+        writeFabricsIntoFabricsListAttribute();
     }
 
-    // Gets called when a fabric is loaded into the AdminPairingTable from KVS store.
-    void OnAdminRetrievedFromStorage(AdminPairingInfo * admin) override
+    // Gets called when a fabric is loaded into the FabricTable from KVS store.
+    void OnFabricRetrievedFromStorage(FabricInfo * fabric) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Admin 0x%" PRIX16 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
+                       "OpCreds: Fabric 0x%" PRIX16 " was retrieved from storage. FabricId 0x" ChipLogFormatX64
                        ", NodeId 0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
-                       admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
-                       admin->GetVendorId());
-        writeAdminsIntoFabricsListAttribute();
+                       fabric->GetFabricIndex(), ChipLogValueX64(fabric->GetFabricId()), ChipLogValueX64(fabric->GetNodeId()),
+                       fabric->GetVendorId());
+        writeFabricsIntoFabricsListAttribute();
     }
 
-    // Gets called when a fabric in AdminPairingTable is persisted to KVS store.
-    void OnAdminPersistedToStorage(AdminPairingInfo * admin) override
+    // Gets called when a fabric in FabricTable is persisted to KVS store.
+    void OnFabricPersistedToStorage(FabricInfo * fabric) override
     {
         emberAfPrintln(EMBER_AF_PRINT_DEBUG,
-                       "OpCreds: Admin %" PRIX16 " was persisted to storage. FabricId %0x" ChipLogFormatX64
+                       "OpCreds: Fabric %" PRIX16 " was persisted to storage. FabricId %0x" ChipLogFormatX64
                        ", NodeId %0x" ChipLogFormatX64 ", VendorId 0x%04" PRIX16,
-                       admin->GetAdminId(), ChipLogValueX64(admin->GetFabricId()), ChipLogValueX64(admin->GetNodeId()),
-                       admin->GetVendorId());
-        writeAdminsIntoFabricsListAttribute();
+                       fabric->GetFabricIndex(), ChipLogValueX64(fabric->GetFabricId()), ChipLogValueX64(fabric->GetNodeId()),
+                       fabric->GetVendorId());
+        writeFabricsIntoFabricsListAttribute();
     }
 };
 
-OpCredsAdminPairingTableDelegate gAdminDelegate;
+OpCredsFabricTableDelegate gFabricDelegate;
 
 void emberAfPluginOperationalCredentialsServerInitCallback(void)
 {
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Initiating OpCreds cluster by writing fabrics list from admin pairing table.");
-    GetGlobalAdminPairingTable().SetAdminPairingDelegate(&gAdminDelegate);
-    writeAdminsIntoFabricsListAttribute();
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Initiating OpCreds cluster by writing fabrics list from fabric table.");
+    GetGlobalFabricTable().SetFabricDelegate(&gFabricDelegate);
+    writeFabricsIntoFabricsListAttribute();
 }
 
 // TODO: Use FabricIndex as a parameter instead of fabricId/nodeId/vendorId once AddOptCert + FabricIndex are implemented
@@ -218,21 +219,21 @@ bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::Command
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: RemoveFabric"); // TODO: Generate emberAfFabricClusterPrintln
 
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-    AdminPairingInfo * admin;
-    AdminId adminId;
+    FabricInfo * fabric;
+    FabricIndex fabricIndex;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // Fetch matching admin
-    admin = GetGlobalAdminPairingTable().FindAdminForNode(fabricId, nodeId, vendorId);
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_SUCCESS); // Admin has already been removed
+    // Fetch matching fabric
+    fabric = GetGlobalFabricTable().FindFabricForNode(fabricId, nodeId, vendorId);
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_SUCCESS); // Fabric has already been removed
 
-    // Delete admin
-    adminId = admin->GetAdminId();
-    err     = GetGlobalAdminPairingTable().Delete(adminId);
+    // Delete fabric
+    fabricIndex = fabric->GetFabricIndex();
+    err         = GetGlobalFabricTable().Delete(fabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
 exit:
-    writeAdminsIntoFabricsListAttribute();
+    writeFabricsIntoFabricsListAttribute();
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
@@ -246,14 +247,14 @@ bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::CommandHan
     EmberStatus sendStatus = EMBER_SUCCESS;
     CHIP_ERROR err         = CHIP_NO_ERROR;
 
-    // Fetch current admin
-    AdminPairingInfo * admin = retrieveCurrentAdmin();
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+    // Fetch current fabric
+    FabricInfo * fabric = retrieveCurrentFabric();
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Store vendorId
-    admin->SetVendorId(VendorId);
-    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: vendorId is now set %" PRIX16, admin->GetVendorId());
-    err = GetGlobalAdminPairingTable().Store(admin->GetAdminId());
+    fabric->SetVendorId(VendorId);
+    emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: vendorId is now set %" PRIX16, fabric->GetVendorId());
+    err = GetGlobalFabricTable().Store(fabric->GetFabricIndex());
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Return FabricId - we are temporarily using commissioner nodeId (retrieved via emberAfCurrentCommand()->SourceNodeId()) as
@@ -297,19 +298,19 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Co
     CHIP_ERROR err;
 
     // Fetch current fabric
-    AdminPairingInfo * admin = retrieveCurrentAdmin();
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+    FabricInfo * fabric = retrieveCurrentFabric();
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Set Label on fabric
-    err = admin->SetFabricLabel(Label);
+    err = fabric->SetFabricLabel(Label);
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
     // Persist updated fabric
-    err = GetGlobalAdminPairingTable().Store(admin->GetAdminId());
+    err = GetGlobalFabricTable().Store(fabric->GetFabricIndex());
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
 exit:
-    writeAdminsIntoFabricsListAttribute();
+    writeFabricsIntoFabricsListAttribute();
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
@@ -317,7 +318,7 @@ exit:
 namespace {
 void DoRemoveAllFabrics(intptr_t)
 {
-    OpenDefaultPairingWindow(ResetAdmins::kYes);
+    OpenDefaultPairingWindow(ResetFabrics::kYes);
 }
 } // namespace
 
@@ -338,11 +339,11 @@ bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::CommandHan
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has added an Op Cert");
 
-    AdminPairingInfo * admin = retrieveCurrentAdmin();
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+    FabricInfo * fabric = retrieveCurrentFabric();
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
 
-    VerifyOrExit(admin->SetOperationalCertsFromCertArray(NOCArray) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
-    VerifyOrExit(GetGlobalAdminPairingTable().Store(admin->GetAdminId()) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(fabric->SetOperationalCertsFromCertArray(NOCArray) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(GetGlobalFabricTable().Store(fabric->GetFabricIndex()) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
     // We have a new operational identity and should start advertising it.  We
     // can't just wait until we get network configuration commands, because we
@@ -376,20 +377,20 @@ bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::Command
 
     TLV::TLVWriter * writer = nullptr;
 
-    // Fetch current admin
-    AdminPairingInfo * admin = retrieveCurrentAdmin();
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+    // Fetch current fabric
+    FabricInfo * fabric = retrieveCurrentFabric();
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
 
     VerifyOrExit(csr.Alloc(Crypto::kMAX_CSR_Length), status = EMBER_ZCL_STATUS_FAILURE);
 
-    if (admin->GetOperationalKey() == nullptr)
+    if (fabric->GetOperationalKey() == nullptr)
     {
         Crypto::P256Keypair keypair;
         keypair.Initialize();
-        VerifyOrExit(admin->SetOperationalKey(keypair) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+        VerifyOrExit(fabric->SetOperationalKey(keypair) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
     }
 
-    err = admin->GetOperationalKey()->NewCertificateSigningRequest(csr.Get(), csrLength);
+    err = fabric->GetOperationalKey()->NewCertificateSigningRequest(csr.Get(), csrLength);
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: NewCertificateSigningRequest returned %d", err);
     VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
     VerifyOrExit(csrLength < UINT8_MAX, status = EMBER_ZCL_STATUS_FAILURE);
@@ -439,12 +440,12 @@ bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip:
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has added a trusted root Cert");
 
-    // Fetch current admin
-    AdminPairingInfo * admin = retrieveCurrentAdmin();
-    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
-    VerifyOrExit(admin->SetRootCert(RootCertificate) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    // Fetch current fabric
+    FabricInfo * fabric = retrieveCurrentFabric();
+    VerifyOrExit(fabric != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(fabric->SetRootCert(RootCertificate) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
-    VerifyOrExit(GetGlobalAdminPairingTable().Store(admin->GetAdminId()) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    VerifyOrExit(GetGlobalFabricTable().Store(fabric->GetFabricIndex()) == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
 exit:
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -29,7 +29,7 @@
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
 #include <support/Span.h>
 #include <support/logging/CHIPLogging.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 
 #include <app/server/Server.h>
 
@@ -48,10 +48,10 @@ NodeId GetCurrentNodeId()
     // mdns advertises a single node id as parameter.
 
     // Search for one admin pairing and use its node id.
-    auto pairing = GetGlobalAdminPairingTable().cbegin();
-    if (pairing != GetGlobalAdminPairingTable().cend())
+    auto pairing = GetGlobalFabricTable().cbegin();
+    if (pairing != GetGlobalFabricTable().cend())
     {
-        ChipLogProgress(Discovery, "Found admin pairing for admin %" PRIX16 ", node 0x" ChipLogFormatX64, pairing->GetAdminId(),
+        ChipLogProgress(Discovery, "Found admin pairing for admin %" PRIX8 ", node 0x" ChipLogFormatX64, pairing->GetFabricIndex(),
                         ChipLogValueX64(pairing->GetNodeId()));
         return pairing->GetNodeId();
     }

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -30,7 +30,7 @@ class RendezvousServer : public SessionEstablishmentDelegate
 {
 public:
     CHIP_ERROR WaitForPairing(const RendezvousParameters & params, Messaging::ExchangeManager * exchangeManager,
-                              TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr, Transport::AdminPairingInfo * admin);
+                              TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr, Transport::FabricInfo * fabric);
 
     CHIP_ERROR Init(AppDelegate * delegate, PersistentStorageDelegate * storage, SessionIDAllocator * idAllocator)
     {
@@ -62,7 +62,7 @@ private:
     PASESession mPairingSession;
     SecureSessionMgr * mSessionMgr = nullptr;
 
-    Transport::AdminPairingInfo * mAdmin = nullptr;
+    Transport::FabricInfo * mFabric = nullptr;
 
     SessionIDAllocator * mIDAllocator = nullptr;
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -42,6 +42,7 @@
 #include <sys/param.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureSessionMgr.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
@@ -100,53 +101,53 @@ class ServerStorageDelegate : public PersistentStorageDelegate
 ServerStorageDelegate gServerStorage;
 SessionIDAllocator gSessionIDAllocator;
 
-CHIP_ERROR PersistAdminPairingToKVS(AdminPairingInfo * admin, AdminId nextAvailableId)
+CHIP_ERROR PersistFabricToKVS(FabricInfo * fabric, FabricIndex nextAvailableId)
 {
-    ReturnErrorCodeIf(admin == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    ChipLogProgress(AppServer, "Persisting admin ID %d, next available %d", admin->GetAdminId(), nextAvailableId);
+    ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ChipLogProgress(AppServer, "Persisting fabric ID %d, next available %d", fabric->GetFabricIndex(), nextAvailableId);
 
-    ReturnErrorOnFailure(GetGlobalAdminPairingTable().Store(admin->GetAdminId()));
-    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kAdminTableCountKey, &nextAvailableId, sizeof(nextAvailableId)));
+    ReturnErrorOnFailure(GetGlobalFabricTable().Store(fabric->GetFabricIndex()));
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kFabricTableCountKey, &nextAvailableId, sizeof(nextAvailableId)));
 
-    ChipLogProgress(AppServer, "Persisting admin ID successfully");
+    ChipLogProgress(AppServer, "Persisting fabric ID successfully");
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR RestoreAllAdminPairingsFromKVS(AdminPairingTable & adminPairings, AdminId & nextAvailableId)
+CHIP_ERROR RestoreAllFabricsFromKVS(FabricTable & fabrics, FabricIndex & nextAvailableId)
 {
     // It's not an error if the key doesn't exist. Just return right away.
-    VerifyOrReturnError(PersistedStorage::KeyValueStoreMgr().Get(kAdminTableCountKey, &nextAvailableId) == CHIP_NO_ERROR,
+    VerifyOrReturnError(PersistedStorage::KeyValueStoreMgr().Get(kFabricTableCountKey, &nextAvailableId) == CHIP_NO_ERROR,
                         CHIP_NO_ERROR);
-    ChipLogProgress(AppServer, "Next available admin ID is %d", nextAvailableId);
+    ChipLogProgress(AppServer, "Next available fabric ID is %d", nextAvailableId);
 
-    // TODO: The admin ID space allocation should be re-evaluated. With the current approach, the space could be
-    //       exhausted while IDs are still available (e.g. if the admin IDs are allocated and freed over a period of time).
+    // TODO: The fabric ID space allocation should be re-evaluated. With the current approach, the space could be
+    //       exhausted while IDs are still available (e.g. if the fabric IDs are allocated and freed over a period of time).
     //       Also, the current approach can make ID lookup slower as more IDs are allocated and freed.
-    for (AdminId id = 0; id < nextAvailableId; id++)
+    for (FabricIndex id = 0; id < nextAvailableId; id++)
     {
         // Recreate the binding if one exists in persistent storage. Else skip to the next ID
-        if (adminPairings.LoadFromStorage(id) == CHIP_NO_ERROR)
+        if (fabrics.LoadFromStorage(id) == CHIP_NO_ERROR)
         {
-            AdminPairingInfo * admin = adminPairings.FindAdminWithId(id);
-            if (admin != nullptr)
+            FabricInfo * fabric = fabrics.FindFabricWithIndex(id);
+            if (fabric != nullptr)
             {
-                ChipLogProgress(AppServer, "Found admin pairing for %d, node ID 0x" ChipLogFormatX64, admin->GetAdminId(),
-                                ChipLogValueX64(admin->GetNodeId()));
+                ChipLogProgress(AppServer, "Found fabric pairing for %d, node ID 0x" ChipLogFormatX64, fabric->GetFabricIndex(),
+                                ChipLogValueX64(fabric->GetNodeId()));
             }
         }
     }
-    ChipLogProgress(AppServer, "Restored all admin pairings from KVS.");
+    ChipLogProgress(AppServer, "Restored all fabric pairings from KVS.");
 
     return CHIP_NO_ERROR;
 }
 
-void EraseAllAdminPairingsUpTo(AdminId nextAvailableId)
+void EraseAllFabricsUpTo(FabricIndex nextAvailableId)
 {
-    PersistedStorage::KeyValueStoreMgr().Delete(kAdminTableCountKey);
+    PersistedStorage::KeyValueStoreMgr().Delete(kFabricTableCountKey);
 
-    for (AdminId id = 0; id < nextAvailableId; id++)
+    for (FabricIndex id = 0; id < nextAvailableId; id++)
     {
-        GetGlobalAdminPairingTable().Delete(id);
+        GetGlobalFabricTable().Delete(id);
     }
 }
 
@@ -175,7 +176,7 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr)
             {
                 sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->PeerConnection().GetPeerAddress()),
                                       session->PeerConnection().GetPeerNodeId(), session, SecureSession::SessionRole::kResponder,
-                                      connection.GetAdminId());
+                                      connection.GetFabricIndex());
             }
             else
             {
@@ -239,8 +240,8 @@ private:
 };
 
 DeviceDiscriminatorCache gDeviceDiscriminatorCache;
-AdminPairingTable gAdminPairings;
-AdminId gNextAvailableAdminId = 0;
+FabricTable gFabrics;
+FabricIndex gNextAvailableFabricIndex = 0;
 
 class ServerRendezvousAdvertisementDelegate : public RendezvousAdvertisementDelegate
 {
@@ -271,10 +272,10 @@ public:
             mDelegate->OnPairingWindowClosed();
         }
 
-        AdminPairingInfo * admin = gAdminPairings.FindAdminWithId(mAdmin);
-        if (admin != nullptr)
+        FabricInfo * fabric = gFabrics.FindFabricWithIndex(mFabric);
+        if (fabric != nullptr)
         {
-            ReturnErrorOnFailure(PersistAdminPairingToKVS(admin, gNextAvailableAdminId));
+            ReturnErrorOnFailure(PersistFabricToKVS(fabric, gNextAvailableFabricIndex));
         }
 
         return CHIP_NO_ERROR;
@@ -282,11 +283,11 @@ public:
 
     void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; }
     void SetBLE(bool ble) { isBLE = ble; }
-    void SetAdminId(AdminId id) { mAdmin = id; }
+    void SetFabricIndex(FabricIndex id) { mFabric = id; }
 
 private:
     AppDelegate * mDelegate = nullptr;
-    AdminId mAdmin;
+    FabricIndex mFabric;
     bool isBLE = true;
 };
 
@@ -312,12 +313,12 @@ static CHIP_ERROR OpenPairingWindowUsingVerifier(uint16_t discriminator, PASEVer
     params.SetPASEVerifier(verifier);
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-    AdminId admin                = gNextAvailableAdminId;
-    AdminPairingInfo * adminInfo = gAdminPairings.AssignAdminId(admin);
-    VerifyOrReturnError(adminInfo != nullptr, CHIP_ERROR_NO_MEMORY);
-    gNextAvailableAdminId++;
+    FabricIndex fabricIndex = gNextAvailableFabricIndex;
+    FabricInfo * fabricInfo = gFabrics.AssignFabricIndex(fabricIndex);
+    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_NO_MEMORY);
+    gNextAvailableFabricIndex++;
 
-    return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, adminInfo);
+    return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, fabricInfo);
 }
 
 class ServerCallback : public ExchangeDelegate
@@ -371,7 +372,7 @@ public:
 
             if (err != CHIP_NO_ERROR)
             {
-                SuccessOrExit(err = OpenDefaultPairingWindow(ResetAdmins::kNo));
+                SuccessOrExit(err = OpenDefaultPairingWindow(ResetFabrics::kNo));
             }
             else
             {
@@ -413,7 +414,7 @@ SecurePairingUsingTestSecret gTestPairing;
 
 } // namespace
 
-CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindowAdvertisement advertisementMode)
+CHIP_ERROR OpenDefaultPairingWindow(ResetFabrics resetFabrics, chip::PairingWindowAdvertisement advertisementMode)
 {
     // TODO(cecille): If this is re-called when the window is already open, what should happen?
     gDeviceDiscriminatorCache.RestoreDiscriminator();
@@ -433,22 +434,22 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindow
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-    if (resetAdmins == ResetAdmins::kYes)
+    if (resetFabrics == ResetFabrics::kYes)
     {
-        EraseAllAdminPairingsUpTo(gNextAvailableAdminId);
+        EraseAllFabricsUpTo(gNextAvailableFabricIndex);
         EraseAllSessionsUpTo(gSessionIDAllocator.Peek());
-        // Only resetting gNextAvailableAdminId at reboot otherwise previously paired device with adminID 0
-        // can continue sending messages to accessory as next available admin will also be 0.
+        // Only resetting gNextAvailableFabricIndex at reboot otherwise previously paired device with fabricID 0
+        // can continue sending messages to accessory as next available fabric will also be 0.
         // This logic is not up to spec, will be implemented up to spec once AddOptCert is implemented.
-        gAdminPairings.Reset();
+        gFabrics.Reset();
     }
 
-    AdminId admin                = gNextAvailableAdminId;
-    AdminPairingInfo * adminInfo = gAdminPairings.AssignAdminId(admin);
-    VerifyOrReturnError(adminInfo != nullptr, CHIP_ERROR_NO_MEMORY);
-    gNextAvailableAdminId++;
+    FabricIndex fabricIndex = gNextAvailableFabricIndex;
+    FabricInfo * fabricInfo = gFabrics.AssignFabricIndex(fabricIndex);
+    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_NO_MEMORY);
+    gNextAvailableFabricIndex++;
 
-    return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, adminInfo);
+    return gRendezvousServer.WaitForPairing(std::move(params), &gExchangeMgr, &gTransports, &gSessions, fabricInfo);
 }
 
 // The function will initialize datamodel handler and then start the server
@@ -474,7 +475,7 @@ void InitServer(AppDelegate * delegate)
 
     gAdvDelegate.SetDelegate(delegate);
 
-    err = gAdminPairings.Init(&gServerStorage);
+    err = gFabrics.Init(&gServerStorage);
     SuccessOrExit(err);
 
     // Init transport before operations with secure session mgr.
@@ -492,8 +493,7 @@ void InitServer(AppDelegate * delegate)
 
     SuccessOrExit(err);
 
-    err =
-        gSessions.Init(chip::kTestDeviceNodeId, &DeviceLayer::SystemLayer, &gTransports, &gAdminPairings, &gMessageCounterManager);
+    err = gSessions.Init(chip::kTestDeviceNodeId, &DeviceLayer::SystemLayer, &gTransports, &gFabrics, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeMgr.Init(&gSessions);
@@ -520,9 +520,9 @@ void InitServer(AppDelegate * delegate)
         ChipLogProgress(AppServer, "Network already provisioned. Disabling BLE advertisement");
         chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
 
-        // Restore any previous admin pairings
-        VerifyOrExit(CHIP_NO_ERROR == RestoreAllAdminPairingsFromKVS(gAdminPairings, gNextAvailableAdminId),
-                     ChipLogError(AppServer, "Could not restore admin table"));
+        // Restore any previous fabric pairings
+        VerifyOrExit(CHIP_NO_ERROR == RestoreAllFabricsFromKVS(gFabrics, gNextAvailableFabricIndex),
+                     ChipLogError(AppServer, "Could not restore fabric table"));
 
         VerifyOrExit(CHIP_NO_ERROR == RestoreAllSessionsFromKVS(gSessions),
                      ChipLogError(AppServer, "Could not restore previous sessions"));
@@ -530,7 +530,7 @@ void InitServer(AppDelegate * delegate)
     else
     {
 #if CHIP_DEVICE_CONFIG_ENABLE_PAIRING_AUTOSTART
-        SuccessOrExit(err = OpenDefaultPairingWindow(ResetAdmins::kYes));
+        SuccessOrExit(err = OpenDefaultPairingWindow(ResetFabrics::kYes));
 #endif
     }
 
@@ -549,7 +549,7 @@ void InitServer(AppDelegate * delegate)
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::ServiceProvisioning::Id, &gCallbacks);
     SuccessOrExit(err);
 
-    err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable(),
+    err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalFabricTable(),
                                                     &gSessionIDAllocator);
     SuccessOrExit(err);
 
@@ -566,26 +566,26 @@ exit:
 
 CHIP_ERROR AddTestPairing()
 {
-    CHIP_ERROR err               = CHIP_NO_ERROR;
-    AdminPairingInfo * adminInfo = nullptr;
-    PASESession * testSession    = nullptr;
+    CHIP_ERROR err            = CHIP_NO_ERROR;
+    FabricInfo * fabricInfo   = nullptr;
+    PASESession * testSession = nullptr;
     PASESessionSerializable serializedTestSession;
 
-    for (const AdminPairingInfo & admin : gAdminPairings)
-        if (admin.IsInitialized() && admin.GetNodeId() == chip::kTestDeviceNodeId)
+    for (const FabricInfo & fabric : gFabrics)
+        if (fabric.IsInitialized() && fabric.GetNodeId() == chip::kTestDeviceNodeId)
             ExitNow();
 
-    adminInfo = gAdminPairings.AssignAdminId(gNextAvailableAdminId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    fabricInfo = gFabrics.AssignFabricIndex(gNextAvailableFabricIndex);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    adminInfo->SetNodeId(chip::kTestDeviceNodeId);
+    fabricInfo->SetNodeId(chip::kTestDeviceNodeId);
     gTestPairing.ToSerializable(serializedTestSession);
 
     testSession = chip::Platform::New<PASESession>();
     testSession->FromSerializable(serializedTestSession);
     SuccessOrExit(err = gSessions.NewPairing(Optional<PeerAddress>{ PeerAddress::Uninitialized() }, chip::kTestControllerNodeId,
-                                             testSession, SecureSession::SessionRole::kResponder, gNextAvailableAdminId));
-    ++gNextAvailableAdminId;
+                                             testSession, SecureSession::SessionRole::kResponder, gNextAvailableFabricIndex));
+    ++gNextAvailableFabricIndex;
 
 exit:
     if (testSession)
@@ -594,13 +594,13 @@ exit:
         chip::Platform::Delete(testSession);
     }
 
-    if (err != CHIP_NO_ERROR && adminInfo != nullptr)
-        gAdminPairings.ReleaseAdminId(gNextAvailableAdminId);
+    if (err != CHIP_NO_ERROR && fabricInfo != nullptr)
+        gFabrics.ReleaseFabricIndex(gNextAvailableFabricIndex);
 
     return err;
 }
 
-AdminPairingTable & GetGlobalAdminPairingTable()
+FabricTable & GetGlobalFabricTable()
 {
-    return gAdminPairings;
+    return gFabrics;
 }

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -20,7 +20,7 @@
 #include <app/server/AppDelegate.h>
 #include <inet/InetConfig.h>
 #include <messaging/ExchangeMgr.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/BLE.h>
@@ -49,11 +49,11 @@ void InitServer(AppDelegate * delegate = nullptr);
 
 CHIP_ERROR AddTestPairing();
 
-chip::Transport::AdminPairingTable & GetGlobalAdminPairingTable();
+chip::Transport::FabricTable & GetGlobalFabricTable();
 
 namespace chip {
 
-enum class ResetAdmins
+enum class ResetFabrics
 {
     kYes,
     kNo,
@@ -69,5 +69,5 @@ enum class PairingWindowAdvertisement
 /**
  * Open the pairing window using default configured parameters.
  */
-CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins,
+CHIP_ERROR OpenDefaultPairingWindow(chip::ResetFabrics resetFabrics,
                                     chip::PairingWindowAdvertisement advertisementMode = chip::PairingWindowAdvertisement::kBle);

--- a/src/app/server/StorablePeerConnection.cpp
+++ b/src/app/server/StorablePeerConnection.cpp
@@ -21,11 +21,11 @@
 
 namespace chip {
 
-StorablePeerConnection::StorablePeerConnection(PASESession & session, Transport::AdminId admin)
+StorablePeerConnection::StorablePeerConnection(PASESession & session, FabricIndex fabric)
 {
     session.ToSerializable(mSession.mOpCreds);
-    mSession.mAdmin = Encoding::LittleEndian::HostSwap16(admin);
-    mKeyId          = session.GetLocalKeyId();
+    mSession.mFabric = fabric;
+    mKeyId           = session.GetLocalKeyId();
 }
 
 CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)

--- a/src/app/server/StorablePeerConnection.h
+++ b/src/app/server/StorablePeerConnection.h
@@ -32,7 +32,7 @@ class DLL_EXPORT StorablePeerConnection
 public:
     StorablePeerConnection() {}
 
-    StorablePeerConnection(PASESession & session, Transport::AdminId admin);
+    StorablePeerConnection(PASESession & session, FabricIndex fabric);
 
     virtual ~StorablePeerConnection() {}
 
@@ -44,7 +44,7 @@ public:
 
     void GetPASESession(PASESession * session) { session->FromSerializable(mSession.mOpCreds); }
 
-    Transport::AdminId GetAdminId() { return mSession.mAdmin; }
+    FabricIndex GetFabricIndex() { return mSession.mFabric; }
 
 private:
     static constexpr size_t KeySize();
@@ -54,7 +54,7 @@ private:
     struct StorableSession
     {
         PASESessionSerializable mOpCreds;
-        Transport::AdminId mAdmin; /* This field is serialized in LittleEndian byte order */
+        FabricIndex mFabric;
     };
 
     StorableSession mSession;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -53,8 +53,8 @@ static SecureSessionMgr gSessionManager;
 static Messaging::ExchangeManager gExchangeManager;
 static TransportMgr<Transport::UDP> gTransportManager;
 static secure_channel::MessageCounterManager gMessageCounterManager;
-static Transport::AdminId gAdminId = 0;
-static bool isCommandDispatched    = false;
+static FabricIndex gFabricIndex = 0;
+static bool isCommandDispatched = false;
 
 namespace {
 constexpr EndpointId kTestEndpointId = 1;
@@ -238,7 +238,7 @@ void TestCommandInteraction::TestCommandSenderWithWrongState(nlTestSuite * apSui
     err                            = commandSender.Init(&gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gAdminId);
+    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
 }
 
@@ -277,7 +277,7 @@ void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSu
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     AddCommandDataElement(apSuite, apContext, &commandSender, false);
-    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gAdminId);
+    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);
 
     GenerateReceivedCommand(apSuite, apContext, buf, true /*aNeedCommandData*/);
@@ -424,17 +424,17 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(chip::gFabricIndex, chip::kTestDeviceNodeId);
 
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+    NL_TEST_ASSERT(apSuite, fabricInfo != nullptr);
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     chip::gSystemLayer.Init();
 
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &fabrics,
                                      &chip::gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -54,7 +54,7 @@ static const chip::ClusterId kLivenessClusterId = 0x00000022;
 static const uint32_t kLivenessChangeEvent      = 1;
 static const chip::EndpointId kTestEndpointId   = 2;
 static const uint64_t kLivenessDeviceStatus     = chip::TLV::ContextTag(1);
-static const chip::Transport::AdminId gAdminId  = 0;
+static const chip::FabricIndex gFabricIndex     = 0;
 static chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 static chip::System::Layer gSystemLayer;
 
@@ -71,17 +71,17 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, kTestDeviceNodeId1);
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, kTestDeviceNodeId1);
 
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+    NL_TEST_ASSERT(apSuite, fabricInfo != nullptr);
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     gSystemLayer.Init();
 
-    err = gSessionManager.Init(kTestDeviceNodeId1, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
+    err = gSessionManager.Init(kTestDeviceNodeId1, &gSystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -48,7 +48,7 @@ static chip::SecureSessionMgr gSessionManager;
 static chip::Messaging::ExchangeManager gExchangeManager;
 static chip::secure_channel::MessageCounterManager gMessageCounterManager;
 static chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-static const chip::Transport::AdminId gAdminId = 0;
+static const chip::FabricIndex gFabricIndex = 0;
 } // namespace
 
 namespace chip {
@@ -109,17 +109,17 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, chip::kTestDeviceNodeId);
 
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+    NL_TEST_ASSERT(apSuite, fabricInfo != nullptr);
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     gSystemLayer.Init();
 
-    err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
+    err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -262,7 +262,7 @@ void TestReadInteraction::TestReadClient(nlTestSuite * apSuite, void * apContext
     err                            = readClient.Init(&ctx.GetExchangeManager(), &delegate, 0 /* application identifier */);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetAdminId(), &session, nullptr /*apEventPathParamsList*/,
+    err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session, nullptr /*apEventPathParamsList*/,
                                      0 /*aEventPathParamsListSize*/, nullptr /*apAttributePathParamsList*/,
                                      0 /*aAttributePathParamsListSize*/, eventNumber /*aEventNumber*/);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -389,7 +389,7 @@ void TestReadInteraction::TestReadClientInvalidReport(nlTestSuite * apSuite, voi
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetAdminId(), &session, nullptr /*apEventPathParamsList*/,
+    err = readClient.SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session, nullptr /*apEventPathParamsList*/,
                                      0 /*aEventPathParamsListSize*/, nullptr /*apAttributePathParamsList*/,
                                      0 /*aAttributePathParamsListSize*/, eventNumber /*aEventNumber*/);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -578,8 +578,8 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     eventPathParams[1].mEventId    = kTestEventIdCritical;
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetAdminId(), &session,
-                                                                            eventPathParams, 2, nullptr, 1, 0);
+    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(),
+                                                                            &session, eventPathParams, 2, nullptr, 1, 0);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().Run();

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -49,13 +49,13 @@ static SecureSessionMgr gSessionManager;
 static Messaging::ExchangeManager gExchangeManager;
 static TransportMgr<Transport::UDP> gTransportManager;
 static secure_channel::MessageCounterManager gMessageCounterManager;
-static const Transport::AdminId gAdminId = 0;
-constexpr ClusterId kTestClusterId       = 6;
-constexpr EndpointId kTestEndpointId     = 1;
-constexpr chip::FieldId kTestFieldId1    = 1;
-constexpr chip::FieldId kTestFieldId2    = 2;
-constexpr uint8_t kTestFieldValue1       = 1;
-constexpr uint8_t kTestFieldValue2       = 2;
+static const FabricIndex gFabricIndex = 0;
+constexpr ClusterId kTestClusterId    = 6;
+constexpr EndpointId kTestEndpointId  = 1;
+constexpr chip::FieldId kTestFieldId1 = 1;
+constexpr chip::FieldId kTestFieldId2 = 2;
+constexpr uint8_t kTestFieldValue1    = 1;
+constexpr uint8_t kTestFieldValue2    = 2;
 
 namespace app {
 CHIP_ERROR ReadSingleClusterData(AttributePathParams & aAttributePathParams, TLV::TLVWriter * apWriter, bool * apDataExists)
@@ -148,17 +148,17 @@ void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(chip::gFabricIndex, chip::kTestDeviceNodeId);
 
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+    NL_TEST_ASSERT(apSuite, fabricInfo != nullptr);
 
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     chip::gSystemLayer.Init();
 
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &fabrics,
                                      &chip::gMessageCounterManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -214,7 +214,7 @@ void TestWriteInteraction::TestWriteClient(nlTestSuite * apSuite, void * apConte
     AddAttributeDataElement(apSuite, apContext, writeClient);
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err                         = writeClient.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetAdminId(), &session);
+    err                         = writeClient.SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     GenerateWriteResponse(apSuite, apContext, buf);
@@ -304,7 +304,7 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
     NL_TEST_ASSERT(apSuite, !delegate.mGotResponse);
 
     SecureSessionHandle session = ctx.GetSessionLocalToPeer();
-    err                         = writeClient->SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetAdminId(), &session);
+    err                         = writeClient->SendWriteRequest(ctx.GetDestinationNodeId(), ctx.GetFabricIndex(), &session);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(apSuite, delegate.mGotResponse);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -49,7 +49,7 @@ constexpr size_t kTotalFailureCommandMessageCount = 1;
 constexpr size_t kMaxReadMessageCount             = 3;
 constexpr size_t kMaxWriteMessageCount            = 3;
 constexpr int32_t gMessageIntervalSeconds         = 1;
-constexpr chip::Transport::AdminId gAdminId       = 0;
+constexpr chip::FabricIndex gFabricIndex          = 0;
 
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::Inet::IPAddress gDestAddr;
@@ -125,7 +125,7 @@ CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);
+    err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gFabricIndex);
     SuccessOrExit(err);
 
 exit:
@@ -162,7 +162,7 @@ CHIP_ERROR SendBadCommandRequest(chip::app::CommandSender * commandSender)
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);
+    err = commandSender->SendCommandRequest(chip::kTestDeviceNodeId, gFabricIndex);
     SuccessOrExit(err);
 
 exit:
@@ -197,7 +197,7 @@ CHIP_ERROR SendReadRequest()
 
     printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(chip::kTestDeviceNodeId, gAdminId, nullptr,
+    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(chip::kTestDeviceNodeId, gFabricIndex, nullptr,
                                                                             eventPathParams, 2, &attributePathParams, 1, number);
     SuccessOrExit(err);
 
@@ -235,7 +235,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClient * apWriteClient)
 
     SuccessOrExit(err = writer->PutBoolean(chip::TLV::ContextTag(chip::app::AttributeDataElement::kCsTag_Data), true));
     SuccessOrExit(err = apWriteClient->FinishAttribute());
-    SuccessOrExit(err = apWriteClient->SendWriteRequest(chip::kTestDeviceNodeId, gAdminId, nullptr));
+    SuccessOrExit(err = apWriteClient->SendWriteRequest(chip::kTestDeviceNodeId, gFabricIndex, nullptr));
 
     gWriteCount++;
 
@@ -258,7 +258,7 @@ CHIP_ERROR EstablishSecureSession()
     err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
                                          chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID)),
                                      chip::kTestDeviceNodeId, testSecurePairingSecret, chip::SecureSession::SessionRole::kInitiator,
-                                     gAdminId);
+                                     gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -551,9 +551,9 @@ int main(int argc, char * argv[])
     std::mutex mutex;
     std::unique_lock<std::mutex> lock(mutex);
     MockInteractionModelApp mockDelegate;
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestControllerNodeId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, chip::kTestControllerNodeId);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     if (argc <= 1)
     {
@@ -574,7 +574,7 @@ int main(int argc, char * argv[])
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &admins,
+    err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &fabrics,
                                &gMessageCounterManager);
     SuccessOrExit(err);
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -168,11 +168,11 @@ int main(int argc, char * argv[])
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::app::InteractionModelDelegate mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    const chip::Transport::AdminId gAdminId = 0;
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
+    const chip::FabricIndex gFabricIndex = 0;
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, chip::kTestDeviceNodeId);
 
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     InitializeChip();
 
@@ -180,7 +180,7 @@ int main(int argc, char * argv[])
         chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &admins,
+    err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &fabrics,
                                &gMessageCounterManager);
     SuccessOrExit(err);
 
@@ -196,7 +196,7 @@ int main(int argc, char * argv[])
     InitializeEventLogging(&gExchangeManager);
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
-                                     gAdminId);
+                                     gFabricIndex);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -145,7 +145,7 @@ CHIP_ERROR Device::SendCommands(app::CommandSender * commandObj)
     bool loadedSecureSession = false;
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return commandObj->SendCommandRequest(mDeviceId, mAdminId, &mSecureSession);
+    return commandObj->SendCommandRequest(mDeviceId, mFabricIndex, &mSecureSession);
 }
 
 CHIP_ERROR Device::Serialize(SerializedDevice & output)
@@ -158,10 +158,10 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
     CHIP_ZERO_AT(serializable);
     CHIP_ZERO_AT(output);
 
-    serializable.mOpsCreds   = mPairing;
-    serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
-    serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDeviceAddress.GetPort());
-    serializable.mAdminId    = Encoding::LittleEndian::HostSwap16(mAdminId);
+    serializable.mOpsCreds    = mPairing;
+    serializable.mDeviceId    = Encoding::LittleEndian::HostSwap64(mDeviceId);
+    serializable.mDevicePort  = Encoding::LittleEndian::HostSwap16(mDeviceAddress.GetPort());
+    serializable.mFabricIndex = Encoding::LittleEndian::HostSwap16(mFabricIndex);
 
     Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
 
@@ -228,9 +228,12 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
     mPairing             = serializable.mOpsCreds;
     mDeviceId            = Encoding::LittleEndian::HostSwap64(serializable.mDeviceId);
     const uint16_t port  = Encoding::LittleEndian::HostSwap16(serializable.mDevicePort);
-    mAdminId             = Encoding::LittleEndian::HostSwap16(serializable.mAdminId);
+    const uint16_t index = Encoding::LittleEndian::HostSwap16(serializable.mFabricIndex);
     mLocalMessageCounter = Encoding::LittleEndian::HostSwap32(serializable.mLocalMessageCounter);
     mPeerMessageCounter  = Encoding::LittleEndian::HostSwap32(serializable.mPeerMessageCounter);
+
+    VerifyOrReturnError(CanCastTo<FabricIndex>(index), CHIP_ERROR_INVALID_ARGUMENT);
+    mFabricIndex = static_cast<FabricIndex>(index);
 
     // TODO - Remove the hack that's incrementing message counter while deserializing device
     // This hack was added as a quick workaround for TE3 testing. The commissioning code
@@ -481,7 +484,7 @@ CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
         SuccessOrExit(err);
 
         err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &pairingSession,
-                                          SecureSession::SessionRole::kInitiator, mAdminId);
+                                          SecureSession::SessionRole::kInitiator, mFabricIndex);
         SuccessOrExit(err);
     }
 
@@ -562,7 +565,7 @@ void Device::OnSessionEstablished()
     mCASESession.PeerConnection().SetPeerNodeId(mDeviceId);
 
     CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mCASESession,
-                                                 SecureSession::SessionRole::kInitiator, mAdminId);
+                                                 SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up CASE secure channel: err %s", ErrorStr(err));

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -172,16 +172,16 @@ public:
      *
      * @param[in] params       Wrapper object for transport manager etc.
      * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
-     * @param[in] admin        Local administrator that's initializing this device object
+     * @param[in] fabric        Local administrator that's initializing this device object
      */
-    void Init(ControllerDeviceInitParams params, uint16_t listenPort, Transport::AdminId admin)
+    void Init(ControllerDeviceInitParams params, uint16_t listenPort, FabricIndex fabric)
     {
         mTransportMgr    = params.transportMgr;
         mSessionManager  = params.sessionMgr;
         mExchangeMgr     = params.exchangeMgr;
         mInetLayer       = params.inetLayer;
         mListenPort      = listenPort;
-        mAdminId         = admin;
+        mFabricIndex     = fabric;
         mStorageDelegate = params.storageDelegate;
         mCredentials     = params.credentials;
         mIDAllocator     = params.idAllocator;
@@ -205,12 +205,12 @@ public:
      * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
      * @param[in] deviceId     Node ID of the device
      * @param[in] peerAddress  The location of the peer. MUST be of type Transport::Type::kUdp
-     * @param[in] admin        Local administrator that's initializing this device object
+     * @param[in] fabric        Local administrator that's initializing this device object
      */
     void Init(ControllerDeviceInitParams params, uint16_t listenPort, NodeId deviceId, const Transport::PeerAddress & peerAddress,
-              Transport::AdminId admin)
+              FabricIndex fabric)
     {
-        Init(params, mListenPort, admin);
+        Init(params, mListenPort, fabric);
         mDeviceId = deviceId;
         mState    = ConnectionState::Connecting;
 
@@ -470,7 +470,7 @@ private:
 
     uint16_t mListenPort;
 
-    Transport::AdminId mAdminId = Transport::kUndefinedAdminId;
+    FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
 
     bool mDeviceOperationalCertProvisioned = false;
 
@@ -534,8 +534,8 @@ typedef struct SerializableDevice
     PASESessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
-    uint16_t mDevicePort; /* This field is serialized in LittleEndian byte order */
-    uint16_t mAdminId;    /* This field is serialized in LittleEndian byte order */
+    uint16_t mDevicePort;  /* This field is serialized in LittleEndian byte order */
+    uint16_t mFabricIndex; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceTransport;
     uint8_t mDeviceOperationalCertProvisioned;
     uint8_t mInterfaceName[kMaxInterfaceName];

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -162,14 +162,14 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams par
 #endif
             ));
 
-    ReturnErrorOnFailure(mAdmins.Init(mStorageDelegate));
+    ReturnErrorOnFailure(mFabrics.Init(mStorageDelegate));
 
-    Transport::AdminPairingInfo * const admin = mAdmins.AssignAdminId(mAdminId, localDeviceId);
-    VerifyOrReturnError(admin != nullptr, CHIP_ERROR_NO_MEMORY);
+    Transport::FabricInfo * const fabric = mFabrics.AssignFabricIndex(mFabricIndex, localDeviceId);
+    VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    ReturnErrorOnFailure(mAdmins.LoadFromStorage(mAdminId));
+    ReturnErrorOnFailure(mFabrics.LoadFromStorage(mFabricIndex));
 
-    ReturnErrorOnFailure(mSessionMgr->Init(localDeviceId, mSystemLayer, mTransportMgr, &mAdmins, mMessageCounterManager));
+    ReturnErrorOnFailure(mSessionMgr->Init(localDeviceId, mSystemLayer, mTransportMgr, &mFabrics, mMessageCounterManager));
 
     ReturnErrorOnFailure(mExchangeMgr->Init(mSessionMgr));
 
@@ -205,7 +205,7 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams par
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mOperationalCredentialsDelegate = params.operationalCredentialsDelegate;
 
-    ReturnErrorOnFailure(LoadLocalCredentials(admin));
+    ReturnErrorOnFailure(LoadLocalCredentials(fabric));
 
     ReleaseAllDevices();
 
@@ -249,12 +249,12 @@ void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc)
 
     DeviceController * controller = static_cast<DeviceController *>(context);
 
-    Transport::AdminPairingInfo * const admin = controller->mAdmins.FindAdminWithId(controller->mAdminId);
+    Transport::FabricInfo * const fabric = controller->mFabrics.FindFabricWithIndex(controller->mFabricIndex);
 
     uint32_t chipCertAllocatedLen = kMaxCHIPCertLength * 2;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
 
-    VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(fabric != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(chipCert.Alloc(chipCertAllocatedLen), err = CHIP_ERROR_NO_MEMORY);
 
     {
@@ -262,7 +262,7 @@ void DeviceController::OnLocalNOCGenerated(void * context, const ByteSpan & noc)
         err = controller->GenerateOperationalCertificates(noc, chipCertSpan);
         SuccessOrExit(err);
 
-        err = admin->SetOperationalCertsFromCertArray(chipCertSpan);
+        err = fabric->SetOperationalCertsFromCertArray(chipCertSpan);
         SuccessOrExit(err);
     }
 
@@ -273,14 +273,14 @@ exit:
     }
 }
 
-CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * admin)
+CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::FabricInfo * fabric)
 {
     ChipLogProgress(Controller, "Getting operational keys");
-    Crypto::P256Keypair * keypair = admin->GetOperationalKey();
+    Crypto::P256Keypair * keypair = fabric->GetOperationalKey();
 
     ReturnErrorCodeIf(keypair == nullptr, CHIP_ERROR_NO_MEMORY);
 
-    if (!admin->AreCredentialsAvailable())
+    if (!fabric->AreCredentialsAvailable())
     {
         chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
         uint32_t chipCertAllocatedLen = kMaxCHIPCertLength * 2;
@@ -296,7 +296,7 @@ CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * 
             ReturnErrorOnFailure(mOperationalCredentialsDelegate->GetRootCACertificate(0, rootCertSpan));
             VerifyOrReturnError(CanCastTo<uint32_t>(rootCertSpan.size()), CHIP_ERROR_INVALID_ARGUMENT);
             ReturnErrorOnFailure(ConvertX509CertToChipCert(rootCertSpan, chipCert.Get(), chipCertAllocatedLen, chipCertLen));
-            ReturnErrorOnFailure(admin->SetRootCert(ByteSpan(chipCert.Get(), chipCertLen)));
+            ReturnErrorOnFailure(fabric->SetRootCert(ByteSpan(chipCert.Get(), chipCertLen)));
         }
 
         // Generate Operational Certificates (NOC and ICAC)
@@ -314,11 +314,11 @@ CHIP_ERROR DeviceController::LoadLocalCredentials(Transport::AdminPairingInfo * 
                 Optional<NodeId>(mLocalDeviceId), 0, ByteSpan(CSR.Get(), csrLength), ByteSpan(), &mLocalNOCCallback));
         }
 
-        ReturnErrorOnFailure(mAdmins.Store(admin->GetAdminId()));
+        ReturnErrorOnFailure(mFabrics.Store(fabric->GetFabricIndex()));
     }
 
     ChipLogProgress(Controller, "Generating credentials");
-    ReturnErrorOnFailure(admin->GetCredentials(mCredentials, mCertificates, mRootKeyId));
+    ReturnErrorOnFailure(fabric->GetCredentials(mCredentials, mCertificates, mRootKeyId));
 
     ChipLogProgress(Controller, "Loaded credentials successfully");
     return CHIP_NO_ERROR;
@@ -406,7 +406,7 @@ CHIP_ERROR DeviceController::Shutdown()
         mDefaultIMDelegate = nullptr;
     }
 
-    mAdmins.ReleaseAdminId(mAdminId);
+    mFabrics.ReleaseFabricIndex(mFabricIndex);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     Mdns::Resolver::Instance().SetResolverDelegate(nullptr);
@@ -463,7 +463,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
             err = device->Deserialize(deviceInfo);
             VerifyOrExit(err == CHIP_NO_ERROR, ReleaseDevice(device));
 
-            device->Init(GetControllerDeviceInitParams(), mListenPort, mAdminId);
+            device->Init(GetControllerDeviceInitParams(), mListenPort, mFabricIndex);
         }
     }
 
@@ -562,10 +562,10 @@ CHIP_ERROR DeviceController::ServiceEventSignal()
 
 CHIP_ERROR DeviceController::GetFabricId(uint64_t & fabricId)
 {
-    Transport::AdminPairingInfo * admin = mAdmins.FindAdminWithId(mAdminId);
-    VerifyOrReturnError(admin != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
+    VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    fabricId = admin->GetFabricId();
+    fabricId = fabric->GetFabricId();
 
     return CHIP_NO_ERROR;
 }
@@ -859,12 +859,12 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 
     uint16_t keyID = 0;
 
-    Transport::AdminPairingInfo * admin = mAdmins.FindAdminWithId(mAdminId);
+    Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
 
     VerifyOrExit(IsOperationalNodeId(remoteDeviceId), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mDeviceBeingPaired == kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(fabric != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err = InitializePairedDeviceList();
     SuccessOrExit(err);
@@ -912,7 +912,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     SuccessOrExit(err);
     mPairingSession.MessageDispatch().SetPeerAddress(params.GetPeerAddress());
 
-    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, admin->GetAdminId());
+    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, fabric->GetFabricIndex());
 
     mSystemLayer->StartTimer(kSessionEstablishmentTimeout, OnSessionEstablishmentTimeoutCallback, this);
     if (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle)
@@ -990,12 +990,12 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
 
     testSecurePairingSecret->ToSerializable(device->GetPairing());
 
-    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, mAdminId);
+    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, mFabricIndex);
 
     device->Serialize(serialized);
 
     err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(peerAddress), device->GetDeviceId(),
-                                  testSecurePairingSecret, SecureSession::SessionRole::kInitiator, mAdminId);
+                                  testSecurePairingSecret, SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
@@ -1147,7 +1147,7 @@ void DeviceCommissioner::OnSessionEstablished()
 
     CHIP_ERROR err = mSessionMgr->NewPairing(
         Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kInitiator, mAdminId);
+        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
@@ -1344,11 +1344,11 @@ CHIP_ERROR DeviceCommissioner::SendTrustedRootCertificate(Device * device)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    Transport::AdminPairingInfo * admin = mAdmins.FindAdminWithId(mAdminId);
-    VerifyOrReturnError(admin != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
+    VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     uint16_t rootCertLen     = 0;
-    const uint8_t * rootCert = admin->GetTrustedRoot(rootCertLen);
+    const uint8_t * rootCert = fabric->GetTrustedRoot(rootCertLen);
     VerifyOrReturnError(rootCert != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogProgress(Controller, "Sending root certificate to the device");

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -44,7 +44,7 @@
 #include <protocols/secure_channel/RendezvousParameters.h>
 #include <support/DLLUtil.h>
 #include <support/SerializableIntegerSet.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
@@ -333,8 +333,8 @@ protected:
 
     void PersistNextKeyId();
 
-    Transport::AdminId mAdminId = 0;
-    Transport::AdminPairingTable mAdmins;
+    FabricIndex mFabricIndex = 0;
+    Transport::FabricTable mFabrics;
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 
@@ -370,7 +370,7 @@ private:
 
     void ReleaseAllDevices();
 
-    CHIP_ERROR LoadLocalCredentials(Transport::AdminPairingInfo * admin);
+    CHIP_ERROR LoadLocalCredentials(Transport::FabricInfo * fabric);
 
     static void OnLocalNOCGenerated(void * context, const ByteSpan & noc);
     Callback::Callback<NOCGenerated> mLocalNOCCallback;

--- a/src/messaging/ExchangeACL.h
+++ b/src/messaging/ExchangeACL.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 
 namespace chip {
 namespace Messaging {
@@ -102,7 +102,7 @@ private:
 class DLL_EXPORT CASEExchangeACL : public ExchangeACL
 {
 public:
-    CASEExchangeACL(Transport::AdminPairingInfo * info) : mAdminInfo(info) {}
+    CASEExchangeACL(Transport::FabricInfo * info) : mFabricInfo(info) {}
     virtual ~CASEExchangeACL() {}
 
     PermissionLevel GetPermissionLevel(const ACLSubject & subject, const ACLTarget & target) override
@@ -110,13 +110,13 @@ public:
         // TODO: Lookup the ACL corresponding to the subject, and the target,
         //       and enforce it.
 
-        ReturnErrorCodeIf(mAdminInfo == nullptr, PermissionLevel::kNone);
+        ReturnErrorCodeIf(mFabricInfo == nullptr, PermissionLevel::kNone);
 
         return PermissionLevel::kOperate;
     }
 
 private:
-    Transport::AdminPairingInfo * mAdminInfo;
+    Transport::FabricInfo * mFabricInfo;
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -148,14 +148,14 @@ public:
 
     ExchangeMessageDispatch * GetMessageDispatch() { return mDispatch; }
 
-    ExchangeACL * GetExchangeACL(Transport::AdminPairingTable & table)
+    ExchangeACL * GetExchangeACL(Transport::FabricTable & table)
     {
         if (mExchangeACL == nullptr)
         {
-            Transport::AdminPairingInfo * admin = table.FindAdminWithId(mSecureSession.GetAdminId());
-            if (admin != nullptr)
+            Transport::FabricInfo * fabric = table.FindFabricWithIndex(mSecureSession.GetFabricIndex());
+            if (fabric != nullptr)
             {
-                mExchangeACL = chip::Platform::New<CASEExchangeACL>(admin);
+                mExchangeACL = chip::Platform::New<CASEExchangeACL>(fabric);
             }
         }
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -190,7 +190,7 @@ public:
 
     ReliableMessageMgr * GetReliableMessageMgr() { return &mReliableMessageMgr; };
 
-    Transport::AdminId GetAdminId() { return mAdminId; }
+    FabricIndex GetFabricIndex() { return mFabricIndex; }
 
     uint16_t GetNextKeyId() { return ++mNextKeyId; }
 
@@ -232,7 +232,7 @@ private:
 
     ApplicationExchangeDispatch mDefaultExchangeDispatch;
 
-    Transport::AdminId mAdminId = 0;
+    FabricIndex mFabricIndex = 0;
 
     BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> mContextPool;
 

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -27,25 +27,25 @@ CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transp
 {
     ReturnErrorOnFailure(IOContext::Init(suite));
 
-    mAdmins.Reset();
+    mFabrics.Reset();
 
-    chip::Transport::AdminPairingInfo * srcNodeAdmin = mAdmins.AssignAdminId(mSrcAdminId, GetSourceNodeId());
-    VerifyOrReturnError(srcNodeAdmin != nullptr, CHIP_ERROR_NO_MEMORY);
+    chip::Transport::FabricInfo * srcNodeFabric = mFabrics.AssignFabricIndex(mSrcFabricIndex, GetSourceNodeId());
+    VerifyOrReturnError(srcNodeFabric != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    chip::Transport::AdminPairingInfo * destNodeAdmin = mAdmins.AssignAdminId(mDestAdminId, GetDestinationNodeId());
-    VerifyOrReturnError(destNodeAdmin != nullptr, CHIP_ERROR_NO_MEMORY);
+    chip::Transport::FabricInfo * destNodeFabric = mFabrics.AssignFabricIndex(mDestFabricIndex, GetDestinationNodeId());
+    VerifyOrReturnError(destNodeFabric != nullptr, CHIP_ERROR_NO_MEMORY);
 
     ReturnErrorOnFailure(
-        mSecureSessionMgr.Init(GetSourceNodeId(), &GetSystemLayer(), transport, &mAdmins, &mMessageCounterManager));
+        mSecureSessionMgr.Init(GetSourceNodeId(), &GetSystemLayer(), transport, &mFabrics, &mMessageCounterManager));
 
     ReturnErrorOnFailure(mExchangeManager.Init(&mSecureSessionMgr));
     ReturnErrorOnFailure(mMessageCounterManager.Init(&mExchangeManager));
 
     ReturnErrorOnFailure(mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer,
-                                                      SecureSession::SessionRole::kInitiator, mSrcAdminId));
+                                                      SecureSession::SessionRole::kInitiator, mSrcFabricIndex));
 
     return mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal, SecureSession::SessionRole::kResponder,
-                                        mDestAdminId);
+                                        mDestFabricIndex);
 }
 
 // Shutdown all layers, finalize operations
@@ -58,13 +58,13 @@ CHIP_ERROR MessagingContext::Shutdown()
 SecureSessionHandle MessagingContext::GetSessionLocalToPeer()
 {
     // TODO: temporarily create a SecureSessionHandle from node id, will be fixed in PR 3602
-    return { GetDestinationNodeId(), GetPeerKeyId(), GetAdminId() };
+    return { GetDestinationNodeId(), GetPeerKeyId(), GetFabricIndex() };
 }
 
 SecureSessionHandle MessagingContext::GetSessionPeerToLocal()
 {
     // TODO: temporarily create a SecureSessionHandle from node id, will be fixed in PR 3602
-    return { GetSourceNodeId(), GetLocalKeyId(), mDestAdminId };
+    return { GetSourceNodeId(), GetLocalKeyId(), mDestFabricIndex };
 }
 
 Messaging::ExchangeContext * MessagingContext::NewExchangeToPeer(Messaging::ExchangeDelegate * delegate)

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -21,7 +21,7 @@
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/tests/NetworkTestHelpers.h>
@@ -65,11 +65,11 @@ public:
     void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
     void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
 
-    uint16_t GetAdminId() const { return mSrcAdminId; }
-    void SetAdminId(Transport::AdminId id)
+    FabricIndex GetFabricIndex() const { return mSrcFabricIndex; }
+    void SetFabricIndex(FabricIndex id)
     {
-        mSrcAdminId  = id;
-        mDestAdminId = id;
+        mSrcFabricIndex  = id;
+        mDestFabricIndex = id;
     }
 
     SecureSessionMgr & GetSecureSessionManager() { return mSecureSessionMgr; }
@@ -96,9 +96,9 @@ private:
     Optional<Transport::PeerAddress> mPeer;
     SecurePairingUsingTestSecret mPairingPeerToLocal;
     SecurePairingUsingTestSecret mPairingLocalToPeer;
-    Transport::AdminPairingTable mAdmins;
-    Transport::AdminId mSrcAdminId  = 0;
-    Transport::AdminId mDestAdminId = 1;
+    Transport::FabricTable mFabrics;
+    FabricIndex mSrcFabricIndex  = 0;
+    FabricIndex mDestFabricIndex = 1;
     Credentials::OperationalCredentialSet mOperationalCredentialSet;
 };
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -572,7 +572,7 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     ctx.SetDestinationNodeId(kPlaceholderNodeId);
     ctx.SetLocalKeyId(0);
     ctx.SetPeerKeyId(0);
-    ctx.SetAdminId(kUndefinedAdminId);
+    ctx.SetFabricIndex(kUndefinedFabricIndex);
 
     ctx.GetInetLayer().SystemLayer()->Init();
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -52,7 +52,7 @@ constexpr size_t kMaxEchoCount = 3;
 // The CHIP Echo interval time in milliseconds.
 constexpr int32_t gEchoInterval = 1000;
 
-constexpr chip::Transport::AdminId gAdminId = 0;
+constexpr chip::FabricIndex gFabricIndex = 0;
 
 // The EchoClient object.
 chip::Protocols::Echo::EchoClient gEchoClient;
@@ -167,7 +167,7 @@ CHIP_ERROR EstablishSecureSession()
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
-                                     chip::SecureSession::SessionRole::kInitiator, gAdminId);
+                                     chip::SecureSession::SessionRole::kInitiator, gFabricIndex);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -200,8 +200,8 @@ int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = nullptr;
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = nullptr;
 
     if (argc <= 1)
     {
@@ -228,8 +228,8 @@ int main(int argc, char * argv[])
 
     InitializeChip();
 
-    adminInfo = admins.AssignAdminId(gAdminId, chip::kTestControllerNodeId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, chip::kTestControllerNodeId);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     if (gUseTCP)
     {
@@ -238,7 +238,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &admins,
+        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &fabrics,
                                    &gMessageCounterManager);
         SuccessOrExit(err);
     }
@@ -249,7 +249,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &admins,
+        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &fabrics,
                                    &gMessageCounterManager);
         SuccessOrExit(err);
     }
@@ -265,7 +265,7 @@ int main(int argc, char * argv[])
     SuccessOrExit(err);
 
     // TODO: temprary create a SecureSessionHandle from node id to unblock end-to-end test. Complete solution is tracked in PR:4451
-    err = gEchoClient.Init(&gExchangeManager, { chip::kTestDeviceNodeId, 0, gAdminId });
+    err = gEchoClient.Init(&gExchangeManager, { chip::kTestDeviceNodeId, 0, gFabricIndex });
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -61,10 +61,10 @@ int main(int argc, char * argv[])
     bool useTCP      = false;
     bool disableEcho = false;
 
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = nullptr;
+    chip::Transport::FabricTable fabrics;
+    chip::Transport::FabricInfo * fabricInfo = nullptr;
 
-    const chip::Transport::AdminId gAdminId = 0;
+    const chip::FabricIndex gFabricIndex = 0;
 
     if (argc > 2)
     {
@@ -84,8 +84,8 @@ int main(int argc, char * argv[])
 
     InitializeChip();
 
-    adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
-    VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    fabricInfo = fabrics.AssignFabricIndex(gFabricIndex, chip::kTestDeviceNodeId);
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     if (useTCP)
     {
@@ -93,7 +93,7 @@ int main(int argc, char * argv[])
             chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &admins,
+        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &fabrics,
                                    &gMessageCounterManager);
         SuccessOrExit(err);
     }
@@ -103,7 +103,7 @@ int main(int argc, char * argv[])
             chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &admins,
+        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &fabrics,
                                    &gMessageCounterManager);
         SuccessOrExit(err);
     }
@@ -121,7 +121,7 @@ int main(int argc, char * argv[])
     }
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
-                                     gAdminId);
+                                     gFabricIndex);
     SuccessOrExit(err);
 
     if (!disableEcho)

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -39,7 +39,7 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins,
+                                             SecureSessionMgr * sessionMgr, Transport::FabricTable * fabrics,
                                              SessionIDAllocator * idAllocator);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
@@ -65,9 +65,9 @@ private:
     uint16_t mSessionKeyId         = 0;
     SecureSessionMgr * mSessionMgr = nullptr;
 
-    Transport::AdminId mAdminId = Transport::kUndefinedAdminId;
+    FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
 
-    Transport::AdminPairingTable * mAdmins = nullptr;
+    Transport::FabricTable * mFabrics = nullptr;
     Credentials::ChipCertificateSet mCertificates;
     Credentials::OperationalCredentialSet mCredentials;
     Credentials::CertificateKeyId mRootKeyId;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -392,7 +392,7 @@ int TestSecurePairing_Setup(void * inContext)
     ctx.SetDestinationNodeId(kPlaceholderNodeId);
     ctx.SetLocalKeyId(0);
     ctx.SetPeerKeyId(0);
-    ctx.SetAdminId(kUndefinedAdminId);
+    ctx.SetFabricIndex(kUndefinedFabricIndex);
 
     gTransportMgr.SetSecureSessionMgr(&ctx.GetSecureSessionManager());
 

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -20,8 +20,8 @@ static_library("transport") {
   output_name = "libTransportLayer"
 
   sources = [
-    "AdminPairingTable.cpp",
-    "AdminPairingTable.h",
+    "FabricTable.cpp",
+    "FabricTable.h",
     "MessageCounter.cpp",
     "MessageCounter.h",
     "PeerConnectionState.h",

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -16,13 +16,13 @@
  */
 
 /**
- * @brief Defines a table of admins that have provisioned the device.
+ * @brief Defines a table of fabrics that have provisioned the device.
  */
 
 #include <core/CHIPEncoding.h>
 #include <support/CHIPMem.h>
 #include <support/SafeInt.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #if CHIP_CRYPTO_HSM
 #include <crypto/hsm/CHIPCryptoPALHsm.h>
 #endif
@@ -33,7 +33,7 @@ using namespace Crypto;
 
 namespace Transport {
 
-CHIP_ERROR AdminPairingInfo::SetFabricLabel(const uint8_t * fabricLabel)
+CHIP_ERROR FabricInfo::SetFabricLabel(const uint8_t * fabricLabel)
 {
     const char * charFabricLabel = Uint8::to_const_char(fabricLabel);
     size_t stringLength          = strnlen(charFabricLabel, kFabricLabelMaxLengthInBytes);
@@ -43,18 +43,18 @@ CHIP_ERROR AdminPairingInfo::SetFabricLabel(const uint8_t * fabricLabel)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
+CHIP_ERROR FabricInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     char key[KeySize()];
-    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+    ReturnErrorOnFailure(GenerateKey(mFabric, key, sizeof(key)));
 
-    StorableAdminPairingInfo * info = chip::Platform::New<StorableAdminPairingInfo>();
+    StorableFabricInfo * info = chip::Platform::New<StorableFabricInfo>();
     ReturnErrorCodeIf(info == nullptr, CHIP_ERROR_NO_MEMORY);
 
     info->mNodeId   = Encoding::LittleEndian::HostSwap64(mNodeId);
-    info->mAdmin    = Encoding::LittleEndian::HostSwap16(mAdmin);
+    info->mFabric   = Encoding::LittleEndian::HostSwap16(mFabric);
     info->mFabricId = Encoding::LittleEndian::HostSwap64(mFabricId);
     info->mVendorId = Encoding::LittleEndian::HostSwap16(mVendorId);
 
@@ -103,7 +103,7 @@ CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
         memcpy(info->mNOCCert, mNOCCert, mNOCCertLen);
     }
 
-    err = kvs->SyncSetKeyValue(key, info, sizeof(StorableAdminPairingInfo));
+    err = kvs->SyncSetKeyValue(key, info, sizeof(StorableFabricInfo));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue: %s", chip::ErrorStr(err));
@@ -117,25 +117,25 @@ exit:
     return err;
 }
 
-CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
+CHIP_ERROR FabricInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     char key[KeySize()];
-    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+    ReturnErrorOnFailure(GenerateKey(mFabric, key, sizeof(key)));
 
-    StorableAdminPairingInfo * info = chip::Platform::New<StorableAdminPairingInfo>();
+    StorableFabricInfo * info = chip::Platform::New<StorableFabricInfo>();
     ReturnErrorCodeIf(info == nullptr, CHIP_ERROR_NO_MEMORY);
 
-    uint16_t infoSize = sizeof(StorableAdminPairingInfo);
+    uint16_t infoSize = sizeof(StorableFabricInfo);
 
-    AdminId id;
+    uint16_t id;
     uint16_t rootCertLen, icaCertLen, nocCertLen;
     size_t stringLength;
 
     SuccessOrExit(err = kvs->SyncGetKeyValue(key, info, infoSize));
 
     mNodeId     = Encoding::LittleEndian::HostSwap64(info->mNodeId);
-    id          = Encoding::LittleEndian::HostSwap16(info->mAdmin);
+    id          = Encoding::LittleEndian::HostSwap16(info->mFabric);
     mFabricId   = Encoding::LittleEndian::HostSwap64(info->mFabricId);
     mVendorId   = Encoding::LittleEndian::HostSwap16(info->mVendorId);
     rootCertLen = Encoding::LittleEndian::HostSwap16(info->mRootCertLen);
@@ -146,7 +146,7 @@ CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
     memcpy(mFabricLabel, info->mFabricLabel, stringLength);
     mFabricLabel[stringLength] = '\0'; // Set null terminator
 
-    VerifyOrExit(mAdmin == id, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mFabric == id, err = CHIP_ERROR_INCORRECT_STATE);
 
     if (mOperationalKey == nullptr)
     {
@@ -173,7 +173,7 @@ exit:
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, AdminId id)
+CHIP_ERROR FabricInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, FabricIndex id)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -188,21 +188,21 @@ CHIP_ERROR AdminPairingInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, Admi
     return err;
 }
 
-constexpr size_t AdminPairingInfo::KeySize()
+constexpr size_t FabricInfo::KeySize()
 {
-    return sizeof(kAdminTableKeyPrefix) + 2 * sizeof(AdminId);
+    return sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex);
 }
 
-CHIP_ERROR AdminPairingInfo::GenerateKey(AdminId id, char * key, size_t len)
+CHIP_ERROR FabricInfo::GenerateKey(FabricIndex id, char * key, size_t len)
 {
     VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
-    int keySize = snprintf(key, len, "%s%x", kAdminTableKeyPrefix, id);
+    int keySize = snprintf(key, len, "%s%x", kFabricTableKeyPrefix, id);
     VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingInfo::SetOperationalKey(const P256Keypair & key)
+CHIP_ERROR FabricInfo::SetOperationalKey(const P256Keypair & key)
 {
     P256SerializedKeypair serialized;
     ReturnErrorOnFailure(key.Serialize(serialized));
@@ -219,7 +219,7 @@ CHIP_ERROR AdminPairingInfo::SetOperationalKey(const P256Keypair & key)
     return mOperationalKey->Deserialize(serialized);
 }
 
-void AdminPairingInfo::ReleaseRootCert()
+void FabricInfo::ReleaseRootCert()
 {
     if (mRootCert != nullptr)
     {
@@ -230,7 +230,7 @@ void AdminPairingInfo::ReleaseRootCert()
     mRootCert             = nullptr;
 }
 
-CHIP_ERROR AdminPairingInfo::SetRootCert(const ByteSpan & cert)
+CHIP_ERROR FabricInfo::SetRootCert(const ByteSpan & cert)
 {
     if (cert.size() == 0)
     {
@@ -257,7 +257,7 @@ CHIP_ERROR AdminPairingInfo::SetRootCert(const ByteSpan & cert)
     return CHIP_NO_ERROR;
 }
 
-void AdminPairingInfo::ReleaseICACert()
+void FabricInfo::ReleaseICACert()
 {
     if (mICACert != nullptr)
     {
@@ -267,7 +267,7 @@ void AdminPairingInfo::ReleaseICACert()
     mICACert    = nullptr;
 }
 
-CHIP_ERROR AdminPairingInfo::SetICACert(const ByteSpan & cert)
+CHIP_ERROR FabricInfo::SetICACert(const ByteSpan & cert)
 {
     if (cert.size() == 0)
     {
@@ -293,7 +293,7 @@ CHIP_ERROR AdminPairingInfo::SetICACert(const ByteSpan & cert)
     return CHIP_NO_ERROR;
 }
 
-void AdminPairingInfo::ReleaseNOCCert()
+void FabricInfo::ReleaseNOCCert()
 {
     if (mNOCCert != nullptr)
     {
@@ -303,7 +303,7 @@ void AdminPairingInfo::ReleaseNOCCert()
     mNOCCert    = nullptr;
 }
 
-CHIP_ERROR AdminPairingInfo::SetNOCCert(const ByteSpan & cert)
+CHIP_ERROR FabricInfo::SetNOCCert(const ByteSpan & cert)
 {
     if (cert.size() == 0)
     {
@@ -329,7 +329,7 @@ CHIP_ERROR AdminPairingInfo::SetNOCCert(const ByteSpan & cert)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingInfo::SetOperationalCertsFromCertArray(const ByteSpan & certArray)
+CHIP_ERROR FabricInfo::SetOperationalCertsFromCertArray(const ByteSpan & certArray)
 {
     if (certArray.size() == 0)
     {
@@ -356,8 +356,8 @@ CHIP_ERROR AdminPairingInfo::SetOperationalCertsFromCertArray(const ByteSpan & c
     return err;
 }
 
-CHIP_ERROR AdminPairingInfo::GetCredentials(OperationalCredentialSet & credentials, ChipCertificateSet & certificates,
-                                            CertificateKeyId & rootKeyId)
+CHIP_ERROR FabricInfo::GetCredentials(OperationalCredentialSet & credentials, ChipCertificateSet & certificates,
+                                      CertificateKeyId & rootKeyId)
 {
     constexpr uint8_t kMaxNumCertsInOpCreds = 3;
     ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds));
@@ -383,13 +383,13 @@ CHIP_ERROR AdminPairingInfo::GetCredentials(OperationalCredentialSet & credentia
     return CHIP_NO_ERROR;
 }
 
-AdminPairingInfo * AdminPairingTable::AssignAdminId(AdminId adminId)
+FabricInfo * FabricTable::AssignFabricIndex(FabricIndex fabricIndex)
 {
     for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
     {
         if (!mStates[i].IsInitialized())
         {
-            mStates[i].SetAdminId(adminId);
+            mStates[i].SetFabricIndex(fabricIndex);
 
             return &mStates[i];
         }
@@ -398,32 +398,32 @@ AdminPairingInfo * AdminPairingTable::AssignAdminId(AdminId adminId)
     return nullptr;
 }
 
-AdminPairingInfo * AdminPairingTable::AssignAdminId(AdminId adminId, NodeId nodeId)
+FabricInfo * FabricTable::AssignFabricIndex(FabricIndex fabricIndex, NodeId nodeId)
 {
-    AdminPairingInfo * admin = AssignAdminId(adminId);
+    FabricInfo * fabric = AssignFabricIndex(fabricIndex);
 
-    if (admin != nullptr)
+    if (fabric != nullptr)
     {
-        admin->SetNodeId(nodeId);
+        fabric->SetNodeId(nodeId);
     }
 
-    return admin;
+    return fabric;
 }
 
-void AdminPairingTable::ReleaseAdminId(AdminId adminId)
+void FabricTable::ReleaseFabricIndex(FabricIndex fabricIndex)
 {
-    AdminPairingInfo * admin = FindAdminWithId(adminId);
-    if (admin != nullptr)
+    FabricInfo * fabric = FindFabricWithIndex(fabricIndex);
+    if (fabric != nullptr)
     {
-        admin->Reset();
+        fabric->Reset();
     }
 }
 
-AdminPairingInfo * AdminPairingTable::FindAdminWithId(AdminId adminId)
+FabricInfo * FabricTable::FindFabricWithIndex(FabricIndex fabricIndex)
 {
     for (auto & state : mStates)
     {
-        if (state.IsInitialized() && state.GetAdminId() == adminId)
+        if (state.IsInitialized() && state.GetFabricIndex() == fabricIndex)
         {
             return &state;
         }
@@ -432,7 +432,7 @@ AdminPairingInfo * AdminPairingTable::FindAdminWithId(AdminId adminId)
     return nullptr;
 }
 
-AdminPairingInfo * AdminPairingTable::FindAdminForNode(FabricId fabricId, NodeId nodeId, uint16_t vendorId)
+FabricInfo * FabricTable::FindFabricForNode(FabricId fabricId, NodeId nodeId, uint16_t vendorId)
 {
     uint32_t index = 0;
     for (auto & state : mStates)
@@ -459,7 +459,7 @@ AdminPairingInfo * AdminPairingTable::FindAdminForNode(FabricId fabricId, NodeId
     return nullptr;
 }
 
-void AdminPairingTable::Reset()
+void FabricTable::Reset()
 {
     for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
     {
@@ -467,92 +467,92 @@ void AdminPairingTable::Reset()
     }
 }
 
-CHIP_ERROR AdminPairingTable::Store(AdminId id)
+CHIP_ERROR FabricTable::Store(FabricIndex id)
 {
-    CHIP_ERROR err           = CHIP_NO_ERROR;
-    AdminPairingInfo * admin = nullptr;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    FabricInfo * fabric = nullptr;
 
     VerifyOrExit(mStorage != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    admin = FindAdminWithId(id);
-    VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    fabric = FindFabricWithIndex(id);
+    VerifyOrExit(fabric != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = admin->StoreIntoKVS(mStorage);
+    err = fabric->StoreIntoKVS(mStorage);
 exit:
     if (err == CHIP_NO_ERROR && mDelegate != nullptr)
     {
-        ChipLogProgress(Discovery, "Admin (%d) persisted to storage. Calling OnAdminPersistedToStorage", id);
-        mDelegate->OnAdminPersistedToStorage(admin);
+        ChipLogProgress(Discovery, "Fabric (%d) persisted to storage. Calling OnFabricPersistedToStorage", id);
+        mDelegate->OnFabricPersistedToStorage(fabric);
     }
     return err;
 }
 
-CHIP_ERROR AdminPairingTable::LoadFromStorage(AdminId id)
+CHIP_ERROR FabricTable::LoadFromStorage(FabricIndex id)
 {
-    CHIP_ERROR err           = CHIP_NO_ERROR;
-    AdminPairingInfo * admin = nullptr;
-    bool didCreateAdmin      = false;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    FabricInfo * fabric  = nullptr;
+    bool didCreateFabric = false;
     VerifyOrExit(mStorage != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    admin = FindAdminWithId(id);
-    if (admin == nullptr)
+    fabric = FindFabricWithIndex(id);
+    if (fabric == nullptr)
     {
-        admin          = AssignAdminId(id);
-        didCreateAdmin = true;
+        fabric          = AssignFabricIndex(id);
+        didCreateFabric = true;
     }
-    VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    err = admin->FetchFromKVS(mStorage);
+    VerifyOrExit(fabric != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    err = fabric->FetchFromKVS(mStorage);
 
 exit:
-    if (err != CHIP_NO_ERROR && didCreateAdmin)
+    if (err != CHIP_NO_ERROR && didCreateFabric)
     {
-        ReleaseAdminId(id);
+        ReleaseFabricIndex(id);
     }
     else if (err == CHIP_NO_ERROR && mDelegate != nullptr)
     {
-        ChipLogProgress(Discovery, "Admin (%d) loaded from storage. Calling OnAdminRetrievedFromStorage", id);
-        mDelegate->OnAdminRetrievedFromStorage(admin);
+        ChipLogProgress(Discovery, "Fabric (%d) loaded from storage. Calling OnFabricRetrievedFromStorage", id);
+        mDelegate->OnFabricRetrievedFromStorage(fabric);
     }
     return err;
 }
 
-CHIP_ERROR AdminPairingTable::Delete(AdminId id)
+CHIP_ERROR FabricTable::Delete(FabricIndex id)
 {
-    AdminPairingInfo * admin = nullptr;
+    FabricInfo * fabric      = nullptr;
     CHIP_ERROR err           = CHIP_NO_ERROR;
-    bool adminIsInitialized  = false;
+    bool fabricIsInitialized = false;
     VerifyOrExit(mStorage != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    admin              = FindAdminWithId(id);
-    adminIsInitialized = admin != nullptr && admin->IsInitialized();
-    err                = AdminPairingInfo::DeleteFromKVS(mStorage, id); // Delete from storage regardless
+    fabric              = FindFabricWithIndex(id);
+    fabricIsInitialized = fabric != nullptr && fabric->IsInitialized();
+    err                 = FabricInfo::DeleteFromKVS(mStorage, id); // Delete from storage regardless
 
 exit:
     if (err == CHIP_NO_ERROR)
     {
-        ReleaseAdminId(id);
-        if (mDelegate != nullptr && adminIsInitialized)
+        ReleaseFabricIndex(id);
+        if (mDelegate != nullptr && fabricIsInitialized)
         {
-            ChipLogProgress(Discovery, "Admin (%d) deleted. Calling OnAdminDeletedFromStorage", id);
-            mDelegate->OnAdminDeletedFromStorage(id);
+            ChipLogProgress(Discovery, "Fabric (%d) deleted. Calling OnFabricDeletedFromStorage", id);
+            mDelegate->OnFabricDeletedFromStorage(id);
         }
     }
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingTable::Init(PersistentStorageDelegate * storage)
+CHIP_ERROR FabricTable::Init(PersistentStorageDelegate * storage)
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mStorage = storage;
-    ChipLogDetail(Discovery, "Init admin pairing table with server storage");
+    ChipLogDetail(Discovery, "Init fabric pairing table with server storage");
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AdminPairingTable::SetAdminPairingDelegate(AdminPairingTableDelegate * delegate)
+CHIP_ERROR FabricTable::SetFabricDelegate(FabricTableDelegate * delegate)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mDelegate = delegate;
-    ChipLogDetail(Discovery, "Set the admin pairing table delegate");
+    ChipLogDetail(Discovery, "Set the fabric pairing table delegate");
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -46,8 +46,8 @@ static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 
 // KVS store is sensitive to length of key strings, based on the underlying
 // platform. Keeping them short.
-constexpr char kFabricTableKeyPrefix[] = "CHIPAdmin";
-constexpr char kFabricTableCountKey[]  = "CHIPAdminNextId";
+constexpr char kFabricTableKeyPrefix[] = "Fabric";
+constexpr char kFabricTableCountKey[]  = "NumFabrics";
 
 struct AccessControlList
 {
@@ -55,7 +55,7 @@ struct AccessControlList
 };
 
 /**
- * Defines state of a pairing established by an fabric.
+ * Defines state of a pairing established by a fabric.
  * ACL data can be mutated throughout the lifetime of the fabric pairing.
  * Node ID is only settable using the device operational credentials.
  *
@@ -228,17 +228,17 @@ class DLL_EXPORT FabricTableDelegate
 public:
     virtual ~FabricTableDelegate() {}
     /**
-     * Gets called when an fabric is deleted from KVS store.
+     * Gets called when a fabric is deleted from KVS store.
      **/
     virtual void OnFabricDeletedFromStorage(FabricIndex fabricId) = 0;
 
     /**
-     * Gets called when an fabric is loaded into Fabric Table from KVS store.
+     * Gets called when a fabric is loaded into Fabric Table from KVS store.
      **/
     virtual void OnFabricRetrievedFromStorage(FabricInfo * fabricInfo) = 0;
 
     /**
-     * Gets called when an fabric in Fabric Table is persisted to KVS store.
+     * Gets called when a fabric in Fabric Table is persisted to KVS store.
      **/
     virtual void OnFabricPersistedToStorage(FabricInfo * fabricInfo) = 0;
 };

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -16,7 +16,7 @@
  */
 
 /**
- * @brief Defines a table of admins that have provisioned the device.
+ * @brief Defines a table of fabrics that have provisioned the device.
  */
 
 #pragma once
@@ -41,14 +41,13 @@
 namespace chip {
 namespace Transport {
 
-typedef uint16_t AdminId;
-static constexpr AdminId kUndefinedAdminId            = UINT16_MAX;
+static constexpr FabricIndex kUndefinedFabricIndex    = UINT8_MAX;
 static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 
 // KVS store is sensitive to length of key strings, based on the underlying
 // platform. Keeping them short.
-constexpr char kAdminTableKeyPrefix[] = "CHIPAdmin";
-constexpr char kAdminTableCountKey[]  = "CHIPAdminNextId";
+constexpr char kFabricTableKeyPrefix[] = "CHIPAdmin";
+constexpr char kFabricTableCountKey[]  = "CHIPAdminNextId";
 
 struct AccessControlList
 {
@@ -56,22 +55,22 @@ struct AccessControlList
 };
 
 /**
- * Defines state of a pairing established by an admin.
- * ACL data can be mutated throughout the lifetime of the admin pairing.
+ * Defines state of a pairing established by an fabric.
+ * ACL data can be mutated throughout the lifetime of the fabric pairing.
  * Node ID is only settable using the device operational credentials.
  *
  * Information contained within the state:
- *   - Admin identification
- *   - Node Id assigned by the admin to the device
+ *   - Fabric identification
+ *   - Node Id assigned by the fabric to the device
  *   - Vendor Id
  *   - Fabric Id
  *   - Device operational credentials
  *   - Access control list
  */
-class DLL_EXPORT AdminPairingInfo
+class DLL_EXPORT FabricInfo
 {
 public:
-    AdminPairingInfo() { Reset(); }
+    FabricInfo() { Reset(); }
 
     // Returns a pointer to a null terminated char array
     const uint8_t * GetFabricLabel() const { return Uint8::from_const_char(mFabricLabel); };
@@ -79,7 +78,7 @@ public:
     // Expects a pointer to a null terminated char array
     CHIP_ERROR SetFabricLabel(const uint8_t * fabricLabel);
 
-    ~AdminPairingInfo()
+    ~FabricInfo()
     {
         if (mOperationalKey != nullptr)
         {
@@ -96,8 +95,8 @@ public:
     FabricId GetFabricId() const { return mFabricId; }
     void SetFabricId(FabricId fabricId) { mFabricId = fabricId; }
 
-    AdminId GetAdminId() const { return mAdmin; }
-    void SetAdminId(AdminId adminId) { mAdmin = adminId; }
+    FabricIndex GetFabricIndex() const { return mFabric; }
+    void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 
     uint16_t GetVendorId() const { return mVendorId; }
     void SetVendorId(uint16_t vendorId) { mVendorId = vendorId; }
@@ -143,7 +142,7 @@ public:
     AccessControlList & GetACL() { return mACL; }
     void SetACL(const AccessControlList & acl) { mACL = acl; }
 
-    bool IsInitialized() const { return (mAdmin != kUndefinedAdminId); }
+    bool IsInitialized() const { return (mFabric != kUndefinedFabricIndex); }
 
     /**
      *  Reset the state to a completely uninitialized status.
@@ -151,7 +150,7 @@ public:
     void Reset()
     {
         mNodeId         = kUndefinedNodeId;
-        mAdmin          = kUndefinedAdminId;
+        mFabric         = kUndefinedFabricIndex;
         mFabricId       = kUndefinedFabricId;
         mVendorId       = kUndefinedVendorId;
         mFabricLabel[0] = '\0';
@@ -165,12 +164,12 @@ public:
         ReleaseNOCCert();
     }
 
-    friend class AdminPairingTable;
+    friend class FabricTable;
 
 private:
     NodeId mNodeId                                      = kUndefinedNodeId;
     FabricId mFabricId                                  = kUndefinedFabricId;
-    AdminId mAdmin                                      = kUndefinedAdminId;
+    FabricIndex mFabric                                 = kUndefinedFabricIndex;
     uint16_t mVendorId                                  = kUndefinedVendorId;
     char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
 
@@ -192,19 +191,19 @@ private:
 
     static constexpr size_t KeySize();
 
-    static CHIP_ERROR GenerateKey(AdminId id, char * key, size_t len);
+    static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 
     CHIP_ERROR StoreIntoKVS(PersistentStorageDelegate * kvs);
     CHIP_ERROR FetchFromKVS(PersistentStorageDelegate * kvs);
-    static CHIP_ERROR DeleteFromKVS(PersistentStorageDelegate * kvs, AdminId id);
+    static CHIP_ERROR DeleteFromKVS(PersistentStorageDelegate * kvs, FabricIndex id);
 
     void ReleaseNOCCert();
     void ReleaseICACert();
     void ReleaseRootCert();
 
-    struct StorableAdminPairingInfo
+    struct StorableFabricInfo
     {
-        uint16_t mAdmin;    /* This field is serialized in LittleEndian byte order */
+        uint16_t mFabric;   /* This field is serialized in LittleEndian byte order */
         uint64_t mNodeId;   /* This field is serialized in LittleEndian byte order */
         uint64_t mFabricId; /* This field is serialized in LittleEndian byte order */
         uint16_t mVendorId; /* This field is serialized in LittleEndian byte order */
@@ -221,41 +220,40 @@ private:
     };
 };
 
-// Once attribute store has persistence implemented, AdminPairingTable shoud be backed using
+// Once attribute store has persistence implemented, FabricTable shoud be backed using
 // attribute store so no need for this Delegate API anymore
-// TODO: Reimplement AdminPairingTable to only have one backing store.
-class DLL_EXPORT AdminPairingTableDelegate
+// TODO: Reimplement FabricTable to only have one backing store.
+class DLL_EXPORT FabricTableDelegate
 {
 public:
-    virtual ~AdminPairingTableDelegate() {}
+    virtual ~FabricTableDelegate() {}
     /**
-     * Gets called when an admin is deleted from KVS store.
+     * Gets called when an fabric is deleted from KVS store.
      **/
-    virtual void OnAdminDeletedFromStorage(AdminId adminId) = 0;
+    virtual void OnFabricDeletedFromStorage(FabricIndex fabricId) = 0;
 
     /**
-     * Gets called when an admin is loaded into Admin Pairing Table from KVS store.
+     * Gets called when an fabric is loaded into Fabric Table from KVS store.
      **/
-    virtual void OnAdminRetrievedFromStorage(AdminPairingInfo * adminInfo) = 0;
+    virtual void OnFabricRetrievedFromStorage(FabricInfo * fabricInfo) = 0;
 
     /**
-     * Gets called when an admin in Admin Pairing Table is persisted to KVS store.
+     * Gets called when an fabric in Fabric Table is persisted to KVS store.
      **/
-    virtual void OnAdminPersistedToStorage(AdminPairingInfo * adminInfo) = 0;
+    virtual void OnFabricPersistedToStorage(FabricInfo * fabricInfo) = 0;
 };
 
 /**
- * Iterates over valid admins within a list
+ * Iterates over valid fabrics within a list
  */
-class ConstAdminIterator
+class ConstFabricIterator
 {
 public:
-    using value_type = AdminPairingInfo;
-    using pointer    = AdminPairingInfo *;
-    using reference  = AdminPairingInfo &;
+    using value_type = FabricInfo;
+    using pointer    = FabricInfo *;
+    using reference  = FabricInfo &;
 
-    ConstAdminIterator(const AdminPairingInfo * start, size_t index, size_t maxSize) :
-        mStart(start), mIndex(index), mMaxSize(maxSize)
+    ConstFabricIterator(const FabricInfo * start, size_t index, size_t maxSize) : mStart(start), mIndex(index), mMaxSize(maxSize)
     {
         if (mIndex >= maxSize)
         {
@@ -266,21 +264,21 @@ public:
             Advance();
         }
     }
-    ConstAdminIterator(const ConstAdminIterator &) = default;
-    ConstAdminIterator & operator=(const ConstAdminIterator &) = default;
+    ConstFabricIterator(const ConstFabricIterator &) = default;
+    ConstFabricIterator & operator=(const ConstFabricIterator &) = default;
 
-    ConstAdminIterator & operator++() { return Advance(); }
-    ConstAdminIterator operator++(int)
+    ConstFabricIterator & operator++() { return Advance(); }
+    ConstFabricIterator operator++(int)
     {
-        ConstAdminIterator other(*this);
+        ConstFabricIterator other(*this);
         Advance();
         return other;
     }
 
-    const AdminPairingInfo & operator*() const { return mStart[mIndex]; }
-    const AdminPairingInfo * operator->() const { return mStart + mIndex; }
+    const FabricInfo & operator*() const { return mStart[mIndex]; }
+    const FabricInfo * operator->() const { return mStart + mIndex; }
 
-    bool operator==(const ConstAdminIterator & other)
+    bool operator==(const ConstFabricIterator & other)
     {
         if (IsAtEnd())
         {
@@ -289,16 +287,16 @@ public:
 
         return (mStart == other.mStart) && (mIndex == other.mIndex) && (mMaxSize == other.mMaxSize);
     }
-    bool operator!=(const ConstAdminIterator & other) { return !(*this == other); }
+    bool operator!=(const ConstFabricIterator & other) { return !(*this == other); }
 
     bool IsAtEnd() const { return (mIndex == mMaxSize); }
 
 private:
-    const AdminPairingInfo * mStart;
+    const FabricInfo * mStart;
     size_t mIndex;
     size_t mMaxSize;
 
-    ConstAdminIterator & Advance()
+    ConstFabricIterator & Advance()
     {
         do
         {
@@ -312,43 +310,42 @@ private:
     }
 };
 
-class DLL_EXPORT AdminPairingTable
+class DLL_EXPORT FabricTable
 {
 public:
-    CHIP_ERROR Store(AdminId id);
-    CHIP_ERROR LoadFromStorage(AdminId id);
-    CHIP_ERROR Delete(AdminId id);
+    CHIP_ERROR Store(FabricIndex id);
+    CHIP_ERROR LoadFromStorage(FabricIndex id);
+    CHIP_ERROR Delete(FabricIndex id);
 
-    AdminPairingInfo * AssignAdminId(AdminId adminId);
+    FabricInfo * AssignFabricIndex(FabricIndex fabricId);
 
-    AdminPairingInfo * AssignAdminId(AdminId adminId, NodeId nodeId);
+    FabricInfo * AssignFabricIndex(FabricIndex fabricId, NodeId nodeId);
 
-    void ReleaseAdminId(AdminId adminId);
+    void ReleaseFabricIndex(FabricIndex fabricId);
 
-    AdminPairingInfo * FindAdminWithId(AdminId adminId);
+    FabricInfo * FindFabricWithIndex(FabricIndex fabricId);
 
-    AdminPairingInfo * FindAdminForNode(FabricId fabricId, NodeId nodeId = kUndefinedNodeId,
-                                        uint16_t vendorId = kUndefinedVendorId);
+    FabricInfo * FindFabricForNode(FabricId fabricId, NodeId nodeId = kUndefinedNodeId, uint16_t vendorId = kUndefinedVendorId);
 
     void Reset();
 
     CHIP_ERROR Init(PersistentStorageDelegate * storage);
-    CHIP_ERROR SetAdminPairingDelegate(AdminPairingTableDelegate * delegate);
+    CHIP_ERROR SetFabricDelegate(FabricTableDelegate * delegate);
 
-    ConstAdminIterator cbegin() const { return ConstAdminIterator(mStates, 0, CHIP_CONFIG_MAX_DEVICE_ADMINS); }
-    ConstAdminIterator cend() const
+    ConstFabricIterator cbegin() const { return ConstFabricIterator(mStates, 0, CHIP_CONFIG_MAX_DEVICE_ADMINS); }
+    ConstFabricIterator cend() const
     {
-        return ConstAdminIterator(mStates, CHIP_CONFIG_MAX_DEVICE_ADMINS, CHIP_CONFIG_MAX_DEVICE_ADMINS);
+        return ConstFabricIterator(mStates, CHIP_CONFIG_MAX_DEVICE_ADMINS, CHIP_CONFIG_MAX_DEVICE_ADMINS);
     }
-    ConstAdminIterator begin() const { return cbegin(); }
-    ConstAdminIterator end() const { return cend(); }
+    ConstFabricIterator begin() const { return cbegin(); }
+    ConstFabricIterator end() const { return cend(); }
 
 private:
-    AdminPairingInfo mStates[CHIP_CONFIG_MAX_DEVICE_ADMINS];
+    FabricInfo mStates[CHIP_CONFIG_MAX_DEVICE_ADMINS];
     PersistentStorageDelegate * mStorage = nullptr;
 
-    // TODO: Admin Pairing table should be backed by a single backing store (attribute store), remove delegate callbacks #6419
-    AdminPairingTableDelegate * mDelegate = nullptr;
+    // TODO: Fabric table should be backed by a single backing store (attribute store), remove delegate callbacks #6419
+    FabricTableDelegate * mDelegate = nullptr;
 };
 
 } // namespace Transport

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureSession.h>
 #include <transport/SessionMessageCounter.h>
 #include <transport/raw/Base.h>
@@ -76,8 +76,8 @@ public:
 
     SecureSession & GetSecureSession() { return mSecureSession; }
 
-    Transport::AdminId GetAdminId() const { return mAdmin; }
-    void SetAdminId(Transport::AdminId admin) { mAdmin = admin; }
+    FabricIndex GetFabricIndex() const { return mFabric; }
+    void SetFabricIndex(FabricIndex fabricIndex) { mFabric = fabricIndex; }
 
     bool IsInitialized()
     {
@@ -119,7 +119,7 @@ private:
     uint64_t mLastActivityTimeMs = 0;
     SecureSession mSecureSession;
     SessionMessageCounter mSessionMessageCounter;
-    Transport::AdminId mAdmin = kUndefinedAdminId;
+    FabricIndex mFabric = kUndefinedFabricIndex;
 };
 
 } // namespace Transport

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -19,7 +19,7 @@
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
 #include <system/TimeSource.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/PeerConnectionState.h>
 
 namespace chip {

--- a/src/transport/SecureSessionHandle.h
+++ b/src/transport/SecureSessionHandle.h
@@ -24,18 +24,18 @@ class SecureSessionMgr;
 class SecureSessionHandle
 {
 public:
-    SecureSessionHandle() : mPeerNodeId(kPlaceholderNodeId), mPeerKeyId(0), mAdmin(Transport::kUndefinedAdminId) {}
-    SecureSessionHandle(NodeId peerNodeId, uint16_t peerKeyId, Transport::AdminId admin) :
-        mPeerNodeId(peerNodeId), mPeerKeyId(peerKeyId), mAdmin(admin)
+    SecureSessionHandle() : mPeerNodeId(kPlaceholderNodeId), mPeerKeyId(0), mFabric(Transport::kUndefinedFabricIndex) {}
+    SecureSessionHandle(NodeId peerNodeId, uint16_t peerKeyId, FabricIndex fabric) :
+        mPeerNodeId(peerNodeId), mPeerKeyId(peerKeyId), mFabric(fabric)
     {}
 
-    bool HasAdminId() const { return (mAdmin != Transport::kUndefinedAdminId); }
-    Transport::AdminId GetAdminId() const { return mAdmin; }
-    void SetAdminId(Transport::AdminId adminId) { mAdmin = adminId; }
+    bool HasFabricIndex() const { return (mFabric != Transport::kUndefinedFabricIndex); }
+    FabricIndex GetFabricIndex() const { return mFabric; }
+    void SetFabricIndex(FabricIndex fabricId) { mFabric = fabricId; }
 
     bool operator==(const SecureSessionHandle & that) const
     {
-        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId && mAdmin == that.mAdmin;
+        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId && mFabric == that.mFabric;
     }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
@@ -45,11 +45,11 @@ private:
     friend class SecureSessionMgr;
     NodeId mPeerNodeId;
     uint16_t mPeerKeyId;
-    // TODO: Re-evaluate the storing of Admin ID in SecureSessionHandle
-    //       The Admin ID will not be available for PASE and group sessions. So need
+    // TODO: Re-evaluate the storing of Fabric ID in SecureSessionHandle
+    //       The Fabric ID will not be available for PASE and group sessions. So need
     //       to identify an approach that'll allow looking up the corresponding information for
     //       such sessions.
-    Transport::AdminId mAdmin;
+    FabricIndex mFabric;
 };
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -435,7 +435,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     }
 
     // See operational-credentials-server.cpp for explanation as to why fabricId is being set to commissioner node id
-    // This is temporary code until AddOptCert is implemented through which an fabric will be correctly added with the correct
+    // This is temporary code until AddOptCert is implemented through which a fabric will be correctly added with the correct
     // fields.
     // TODO: Remove temporary code once AddOptCert is implemented
     if (packetHeader.GetSourceNodeId().HasValue())

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -36,7 +36,7 @@
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/SecureMessageCodec.h>
 #include <transport/TransportMgr.h>
 
@@ -72,7 +72,7 @@ SecureSessionMgr::~SecureSessionMgr()
 }
 
 CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, System::Layer * systemLayer, TransportMgrBase * transportMgr,
-                                  Transport::AdminPairingTable * admins,
+                                  Transport::FabricTable * fabrics,
                                   Transport::MessageCounterManagerInterface * messageCounterManager)
 {
     VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
@@ -82,7 +82,7 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, System::Layer * systemLaye
     mLocalNodeId           = localNodeId;
     mSystemLayer           = systemLayer;
     mTransportMgr          = transportMgr;
-    mAdmins                = admins;
+    mFabrics               = fabrics;
     mMessageCounterManager = messageCounterManager;
 
     mGlobalEncryptedMessageCounter.Init();
@@ -106,7 +106,7 @@ void SecureSessionMgr::Shutdown()
     mLocalNodeId  = kUndefinedNodeId;
     mSystemLayer  = nullptr;
     mTransportMgr = nullptr;
-    mAdmins       = nullptr;
+    mFabrics      = nullptr;
     mCB           = nullptr;
 }
 
@@ -126,13 +126,13 @@ CHIP_ERROR SecureSessionMgr::BuildEncryptedMessagePayload(SecureSessionHandle se
         return CHIP_ERROR_NOT_CONNECTED;
     }
 
-    Transport::AdminPairingInfo * admin = mAdmins->FindAdminWithId(state->GetAdminId());
-    if (admin == nullptr)
+    Transport::FabricInfo * fabric = mFabrics->FindFabricWithIndex(state->GetFabricIndex());
+    if (fabric == nullptr)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    NodeId localNodeId       = admin->GetNodeId();
+    NodeId localNodeId       = fabric->GetNodeId();
     MessageCounter & counter = GetSendCounterForPacket(payloadHeader, *state);
     ReturnErrorOnFailure(SecureMessageCodec::Encode(localNodeId, state, payloadHeader, packetHeader, msgBuf, counter));
 
@@ -207,12 +207,12 @@ void SecureSessionMgr::ExpirePairing(SecureSessionHandle session)
     }
 }
 
-void SecureSessionMgr::ExpireAllPairings(NodeId peerNodeId, Transport::AdminId admin)
+void SecureSessionMgr::ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric)
 {
     PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(peerNodeId, nullptr);
     while (state != nullptr)
     {
-        if (admin == state->GetAdminId())
+        if (fabric == state->GetFabricIndex())
         {
             mPeerConnections.MarkConnectionExpired(
                 state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
@@ -226,14 +226,14 @@ void SecureSessionMgr::ExpireAllPairings(NodeId peerNodeId, Transport::AdminId a
 }
 
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                                        PairingSession * pairing, SecureSession::SessionRole direction, Transport::AdminId admin)
+                                        PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
 {
     uint16_t peerKeyId          = pairing->GetPeerKeyId();
     uint16_t localKeyId         = pairing->GetLocalKeyId();
     PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, nullptr);
 
     // Find any existing connection with the same node and key ID
-    if (state && (state->GetAdminId() == Transport::kUndefinedAdminId || state->GetAdminId() == admin))
+    if (state && (state->GetFabricIndex() == Transport::kUndefinedFabricIndex || state->GetFabricIndex() == fabric))
     {
         mPeerConnections.MarkConnectionExpired(
             state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
@@ -246,7 +246,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
         mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
     ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
-    state->SetAdminId(admin);
+    state->SetFabricIndex(fabric);
 
     if (peerAddr.HasValue() && peerAddr.Value().GetIPAddress() != Inet::IPAddress::Any)
     {
@@ -268,7 +268,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     if (mCB != nullptr)
     {
         state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-        mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), admin });
+        mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), fabric });
     }
 
     return CHIP_NO_ERROR;
@@ -327,9 +327,9 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     PayloadHeader payloadHeader;
 
-    Transport::AdminPairingInfo * admin = nullptr;
+    Transport::FabricInfo * fabric = nullptr;
 
-    bool modifiedAdmin = false;
+    bool modifiedFabric = false;
     NodeId localNodeId;
     FabricId fabricId;
 
@@ -354,7 +354,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         {
             // Queue and start message sync procedure
             err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
-                packetHeader, { state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId() }, state, peerAddress,
+                packetHeader, { state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex() }, state, peerAddress,
                 std::move(msg));
 
             if (err != CHIP_NO_ERROR)
@@ -386,30 +386,30 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         SuccessOrExit(err);
     }
 
-    admin = mAdmins->FindAdminWithId(state->GetAdminId());
-    VerifyOrExit(admin != nullptr,
-                 ChipLogError(Inet, "Secure transport received packet for unknown admin (%p, %d) pairing, discarding", state,
-                              state->GetAdminId()));
-    if (packetHeader.GetDestinationNodeId().HasValue() && admin->GetNodeId() != kUndefinedNodeId)
+    fabric = mFabrics->FindFabricWithIndex(state->GetFabricIndex());
+    VerifyOrExit(fabric != nullptr,
+                 ChipLogError(Inet, "Secure transport received packet for unknown fabric (%p, %d) pairing, discarding", state,
+                              state->GetFabricIndex()));
+    if (packetHeader.GetDestinationNodeId().HasValue() && fabric->GetNodeId() != kUndefinedNodeId)
     {
-        VerifyOrExit(admin->GetNodeId() == packetHeader.GetDestinationNodeId().Value(),
+        VerifyOrExit(fabric->GetNodeId() == packetHeader.GetDestinationNodeId().Value(),
                      ChipLogError(Inet,
                                   "Secure transport received message, but destination node ID (0x" ChipLogFormatX64
                                   ") doesn't match our node ID (0x" ChipLogFormatX64 "), discarding",
                                   ChipLogValueX64(packetHeader.GetDestinationNodeId().Value()),
-                                  ChipLogValueX64(admin->GetNodeId())));
+                                  ChipLogValueX64(fabric->GetNodeId())));
     }
 
     if (packetHeader.GetDestinationNodeId().HasValue())
     {
         ChipLogProgress(Inet, "Secure transport received message destined to fabric %d, node 0x" ChipLogFormatX64 ". Key ID %d",
-                        static_cast<int>(state->GetAdminId()), ChipLogValueX64(packetHeader.GetDestinationNodeId().Value()),
+                        static_cast<int>(state->GetFabricIndex()), ChipLogValueX64(packetHeader.GetDestinationNodeId().Value()),
                         packetHeader.GetEncryptionKeyID());
     }
     else
     {
         ChipLogProgress(Inet, "Secure transport received message for fabric %d without node ID. Key ID %d",
-                        static_cast<int>(state->GetAdminId()), packetHeader.GetEncryptionKeyID());
+                        static_cast<int>(state->GetFabricIndex()), packetHeader.GetEncryptionKeyID());
     }
 
     mPeerConnections.MarkConnectionActive(state);
@@ -435,7 +435,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     }
 
     // See operational-credentials-server.cpp for explanation as to why fabricId is being set to commissioner node id
-    // This is temporary code until AddOptCert is implemented through which an admin will be correctly added with the correct
+    // This is temporary code until AddOptCert is implemented through which an fabric will be correctly added with the correct
     // fields.
     // TODO: Remove temporary code once AddOptCert is implemented
     if (packetHeader.GetSourceNodeId().HasValue())
@@ -450,11 +450,11 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     if (packetHeader.GetDestinationNodeId().HasValue())
     {
         localNodeId = packetHeader.GetDestinationNodeId().Value();
-        if (localNodeId != kUndefinedNodeId && admin->GetNodeId() != localNodeId)
+        if (localNodeId != kUndefinedNodeId && fabric->GetNodeId() != localNodeId)
         {
-            admin->SetNodeId(localNodeId);
-            ChipLogProgress(Inet, "Setting nodeID %" PRIX64 " on admin.", admin->GetNodeId());
-            modifiedAdmin = true;
+            fabric->SetNodeId(localNodeId);
+            ChipLogProgress(Inet, "Setting nodeID %" PRIX64 " on fabric.", fabric->GetNodeId());
+            modifiedFabric = true;
         }
     }
 
@@ -462,19 +462,19 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
     if (packetHeader.GetSourceNodeId().HasValue())
     {
         fabricId = packetHeader.GetSourceNodeId().Value();
-        if (fabricId != kUndefinedFabricId && admin->GetFabricId() != fabricId)
+        if (fabricId != kUndefinedFabricId && fabric->GetFabricId() != fabricId)
         {
-            admin->SetFabricId(packetHeader.GetSourceNodeId().Value());
-            ChipLogProgress(Inet, "Setting fabricID %" PRIX64 " on admin.", admin->GetFabricId());
-            modifiedAdmin = true;
+            fabric->SetFabricId(packetHeader.GetSourceNodeId().Value());
+            ChipLogProgress(Inet, "Setting fabricID %" PRIX64 " on fabric.", fabric->GetFabricId());
+            modifiedFabric = true;
         }
     }
 
     // TODO: Remove temporary code once AddOptCert is implemented
-    if (modifiedAdmin)
+    if (modifiedFabric)
     {
-        ChipLogProgress(Inet, "Since admin was modified, persisting changes to KVS");
-        mAdmins->Store(admin->GetAdminId());
+        ChipLogProgress(Inet, "Since fabric was modified, persisting changes to KVS");
+        mFabrics->Store(fabric->GetFabricIndex());
     }
 
     // TODO: once mDNS address resolution is available reconsider if this is required
@@ -487,7 +487,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (mCB != nullptr)
     {
-        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId());
+        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetFabricIndex());
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
     }
 
@@ -505,7 +505,7 @@ void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionSt
 
     if (mCB != nullptr)
     {
-        mCB->OnConnectionExpired({ state.GetPeerNodeId(), state.GetPeerKeyID(), state.GetAdminId() });
+        mCB->OnConnectionExpired({ state.GetPeerNodeId(), state.GetPeerKeyID(), state.GetFabricIndex() });
     }
 
     mTransportMgr->Disconnect(state.GetPeerAddress());

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -33,7 +33,7 @@
 #include <protocols/secure_channel/Constants.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/MessageCounterManagerInterface.h>
 #include <transport/PairingSession.h>
 #include <transport/PeerConnections.h>
@@ -221,10 +221,10 @@ public:
      *   peer node.
      */
     CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PairingSession * pairing,
-                          SecureSession::SessionRole direction, Transport::AdminId admin);
+                          SecureSession::SessionRole direction, FabricIndex fabric);
 
     void ExpirePairing(SecureSessionHandle session);
-    void ExpireAllPairings(NodeId peerNodeId, Transport::AdminId admin);
+    void ExpireAllPairings(NodeId peerNodeId, FabricIndex fabric);
 
     /**
      * @brief
@@ -239,11 +239,11 @@ public:
      * @param localNodeId           Node id for the current node
      * @param systemLayer           System, layer to use
      * @param transportMgr          Transport to use
-     * @param admins                A table of device administrators
+     * @param fabrics                A table of device administrators
      * @param messageCounterManager The message counter manager
      */
     CHIP_ERROR Init(NodeId localNodeId, System::Layer * systemLayer, TransportMgrBase * transportMgr,
-                    Transport::AdminPairingTable * admins, Transport::MessageCounterManagerInterface * messageCounterManager);
+                    Transport::FabricTable * fabrics, Transport::MessageCounterManagerInterface * messageCounterManager);
 
     /**
      * @brief
@@ -296,7 +296,7 @@ private:
 
     SecureSessionMgrDelegate * mCB                                     = nullptr;
     TransportMgrBase * mTransportMgr                                   = nullptr;
-    Transport::AdminPairingTable * mAdmins                             = nullptr;
+    Transport::FabricTable * mFabrics                                  = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;
 
     GlobalUnencryptedMessageCounter mGlobalUnencryptedMessageCounter;

--- a/src/transport/SessionMessageCounter.h
+++ b/src/transport/SessionMessageCounter.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 #include <transport/MessageCounter.h>
 #include <transport/PeerMessageCounter.h>
 #include <transport/SecureSession.h>

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -123,8 +123,8 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::AdminPairingTable admins;
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &admins, &gMessageCounterManager);
+    Transport::FabricTable fabrics;
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
@@ -152,8 +152,8 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::AdminPairingTable admins;
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &admins, &gMessageCounterManager);
+    Transport::FabricTable fabrics;
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -162,11 +162,11 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    Transport::AdminPairingInfo * admin = admins.AssignAdminId(0, kSourceNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    Transport::FabricInfo * fabric = fabrics.AssignFabricIndex(0, kSourceNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
-    admin = admins.AssignAdminId(1, kDestinationNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    fabric = fabrics.AssignFabricIndex(1, kDestinationNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);
@@ -250,8 +250,8 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::AdminPairingTable admins;
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &admins, &gMessageCounterManager);
+    Transport::FabricTable fabrics;
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -260,11 +260,11 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    Transport::AdminPairingInfo * admin = admins.AssignAdminId(0, kSourceNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    Transport::FabricInfo * fabric = fabrics.AssignFabricIndex(0, kSourceNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
-    admin = admins.AssignAdminId(1, kDestinationNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    fabric = fabrics.AssignFabricIndex(1, kDestinationNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);
@@ -332,8 +332,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = transportMgr.Init("LOOPBACK");
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    Transport::AdminPairingTable admins;
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &admins, &gMessageCounterManager);
+    Transport::FabricTable fabrics;
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &fabrics, &gMessageCounterManager);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     callback.mSuite = inSuite;
@@ -342,11 +342,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    Transport::AdminPairingInfo * admin = admins.AssignAdminId(0, kSourceNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    Transport::FabricInfo * fabric = fabrics.AssignFabricIndex(0, kSourceNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
-    admin = admins.AssignAdminId(1, kDestinationNodeId);
-    NL_TEST_ASSERT(inSuite, admin != nullptr);
+    fabric = fabrics.AssignFabricIndex(1, kDestinationNodeId);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);


### PR DESCRIPTION
#### Problem
AdminPairingTable and AdminPairingInfo should be renamed to Fabric to match latest specifications.

#### Change overview
Update the class and its usage.
Note: more changes are needed in the class to bring it up to the spec. This PR is specifically only renaming the class and its usage, to prevent mixing the large rename change with more specific logic change in the class.

#### Testing
Existing unit tests, and pairing using chip-tool, Python controller, and iOS controller apps.