### PR TITLE
Increase discover timeout for connect on controller

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -445,18 +445,10 @@ class DeviceMgrCmd(Cmd):
             print("Waiting for device responses...")
             strlen = 100;
             addrStrStorage = ctypes.create_string_buffer(strlen)
-            count = 0
             # If this device is on the network and we're looking specifically for 1 device,
             # expect a quick response.
-            maxWaitTime = 1
-            ok = False
-            while count < maxWaitTime:
-                ok = self.devCtrl.GetIPForDiscoveredDevice(0, addrStrStorage, strlen)
-                if ok:
-                    break
-                time.sleep(0.2)
-                count = count + 0.2
-            if ok:
+            if self.wait_for_one_discovered_device():
+                self.devCtrl.GetIPForDiscoveredDevice(0, addrStrStorage, strlen)
                 addrStr = addrStrStorage.value.decode('utf-8')
                 print("Connecting to device at " + addrStr)
                 pincode = ctypes.c_uint32(int(setupPayload.attributes['SetUpPINCode']))
@@ -558,6 +550,7 @@ class DeviceMgrCmd(Cmd):
         while (not self.devCtrl.GetIPForDiscoveredDevice(0, addrStrStorage, strlen) and count < maxWaitTime):
             time.sleep(0.2)
             count = count + 0.2
+        return count != maxWaitTime
 
     def wait_for_many_discovered_devices(self):
         # Discovery happens through mdns, which means we need to wait for responses to come back.

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -550,7 +550,7 @@ class DeviceMgrCmd(Cmd):
         while (not self.devCtrl.GetIPForDiscoveredDevice(0, addrStrStorage, strlen) and count < maxWaitTime):
             time.sleep(0.2)
             count = count + 0.2
-        return count != maxWaitTime
+        return count < maxWaitTime
 
     def wait_for_many_discovered_devices(self):
         # Discovery happens through mdns, which means we need to wait for responses to come back.


### PR DESCRIPTION
Normally the connect timeout is sufficient, but it looks like the
platform mdns impl changed. Increasing the timeout and just using
the wait function that discover uses.

#### Problem
Connect -qr fails to find the device by ip when using the platform mdns impl. Looks like the platform mdns impl changed when the event loop changes went in and the startup time is longer now. 

#### Change overview
Increases the timeout to 2 seconds and uses the wait_ function used by discovery (less code duplication)

#### Testing
ran discover -all, discover -l and connect -qr using both platform and minimal compiles of the python controller.