### PR TITLE
Remove one kind of Timer

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -69,7 +69,7 @@ class BLEManagerImpl final : public BLEManager,
                              private Ble::BleApplicationDelegate
 {
 public:
-    BLEManagerImpl();
+    BLEManagerImpl() {}
 
 private:
     // Allow the BLEManager interface class to delegate method calls to
@@ -199,8 +199,6 @@ private:
     static constexpr uint32_t kAdvertiseTimeout     = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT;
     static constexpr uint32_t kFastAdvertiseTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     uint64_t mAdvertiseStartTime;
-    System::Layer::TimerCompleteFunct mAdvertiseTimerCallback;
-    System::Layer::TimerCompleteFunct mFastAdvertiseTimerCallback;
 
     static void HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError);
     void HandleFastAdvertisementTimer();

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -199,12 +199,12 @@ private:
     static constexpr uint32_t kAdvertiseTimeout     = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT;
     static constexpr uint32_t kFastAdvertiseTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     uint64_t mAdvertiseStartTime;
-    chip::Callback::Callback<> mAdvertiseTimerCallback;
-    chip::Callback::Callback<> mFastAdvertiseTimerCallback;
+    System::Layer::TimerCompleteFunct mAdvertiseTimerCallback;
+    System::Layer::TimerCompleteFunct mFastAdvertiseTimerCallback;
 
-    static void HandleFastAdvertisementTimer(void * context);
+    static void HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError);
     void HandleFastAdvertisementTimer();
-    static void HandleAdvertisementTimer(void * context);
+    static void HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError);
     void HandleAdvertisementTimer();
 
 #if CONFIG_BT_BLUEDROID_ENABLED

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -126,10 +126,6 @@ const uint16_t CHIPoBLEGATTAttrCount = sizeof(CHIPoBLEGATTAttrs) / sizeof(CHIPoB
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
-BLEManagerImpl::BLEManagerImpl() :
-    mAdvertiseTimerCallback(HandleAdvertisementTimer), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer)
-{}
-
 CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err;
@@ -181,8 +177,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.StartTimer(kAdvertiseTimeout, mAdvertiseTimerCallback, this);
-        SystemLayer.StartTimer(kFastAdvertiseTimeout, mFastAdvertiseTimerCallback, this);
+        ReturnErrorOnFailure(SystemLayer.StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
+        ReturnErrorOnFailure(SystemLayer.StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
     }
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);
     mFlags.Set(Flags::kAdvertisingRefreshNeeded, 1);

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -127,7 +127,7 @@ const uint16_t CHIPoBLEGATTAttrCount = sizeof(CHIPoBLEGATTAttrs) / sizeof(CHIPoB
 BLEManagerImpl BLEManagerImpl::sInstance;
 
 BLEManagerImpl::BLEManagerImpl() :
-    mAdvertiseTimerCallback(HandleAdvertisementTimer, this), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer, this)
+    mAdvertiseTimerCallback(HandleAdvertisementTimer), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer)
 {}
 
 CHIP_ERROR BLEManagerImpl::_Init()
@@ -181,8 +181,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.StartTimer(kAdvertiseTimeout, &mAdvertiseTimerCallback);
-        SystemLayer.StartTimer(kFastAdvertiseTimeout, &mFastAdvertiseTimerCallback);
+        SystemLayer.StartTimer(kAdvertiseTimeout, mAdvertiseTimerCallback, this);
+        SystemLayer.StartTimer(kFastAdvertiseTimeout, mFastAdvertiseTimerCallback, this);
     }
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);
     mFlags.Set(Flags::kAdvertisingRefreshNeeded, 1);
@@ -192,7 +192,7 @@ exit:
     return err;
 }
 
-void BLEManagerImpl::HandleAdvertisementTimer(void * context)
+void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
 {
     static_cast<BLEManagerImpl *>(context)->HandleAdvertisementTimer();
 }
@@ -208,7 +208,7 @@ void BLEManagerImpl::HandleAdvertisementTimer()
     }
 }
 
-void BLEManagerImpl::HandleFastAdvertisementTimer(void * context)
+void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
 {
     static_cast<BLEManagerImpl *>(context)->HandleFastAdvertisementTimer();
 }

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -94,10 +94,6 @@ const ble_uuid128_t UUID_CHIPoBLEChar_TX   = {
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
-BLEManagerImpl::BLEManagerImpl() :
-    mAdvertiseTimerCallback(HandleAdvertisementTimer), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer)
-{}
-
 const struct ble_gatt_svc_def BLEManagerImpl::CHIPoBLEGATTAttrs[] = {
     { .type = BLE_GATT_SVC_TYPE_PRIMARY,
       .uuid = (ble_uuid_t *) (&ShortUUID_CHIPoBLEService),
@@ -174,8 +170,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.StartTimer(kAdvertiseTimeout, mAdvertiseTimerCallback, this);
-        SystemLayer.StartTimer(kFastAdvertiseTimeout, mFastAdvertiseTimerCallback, this);
+        ReturnErrorOnFailure(SystemLayer.StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
+        ReturnErrorOnFailure(SystemLayer.StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
     }
 
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -95,7 +95,7 @@ const ble_uuid128_t UUID_CHIPoBLEChar_TX   = {
 BLEManagerImpl BLEManagerImpl::sInstance;
 
 BLEManagerImpl::BLEManagerImpl() :
-    mAdvertiseTimerCallback(HandleAdvertisementTimer, this), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer, this)
+    mAdvertiseTimerCallback(HandleAdvertisementTimer), mFastAdvertiseTimerCallback(HandleFastAdvertisementTimer)
 {}
 
 const struct ble_gatt_svc_def BLEManagerImpl::CHIPoBLEGATTAttrs[] = {
@@ -174,8 +174,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.StartTimer(kAdvertiseTimeout, &mAdvertiseTimerCallback);
-        SystemLayer.StartTimer(kFastAdvertiseTimeout, &mFastAdvertiseTimerCallback);
+        SystemLayer.StartTimer(kAdvertiseTimeout, mAdvertiseTimerCallback, this);
+        SystemLayer.StartTimer(kFastAdvertiseTimeout, mFastAdvertiseTimerCallback, this);
     }
 
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);
@@ -187,7 +187,7 @@ exit:
     return err;
 }
 
-void BLEManagerImpl::HandleAdvertisementTimer(void * context)
+void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
 {
     static_cast<BLEManagerImpl *>(context)->HandleAdvertisementTimer();
 }
@@ -203,7 +203,7 @@ void BLEManagerImpl::HandleAdvertisementTimer()
     }
 }
 
-void BLEManagerImpl::HandleFastAdvertisementTimer(void * context)
+void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
 {
     static_cast<BLEManagerImpl *>(context)->HandleFastAdvertisementTimer();
 }

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -125,9 +125,6 @@ public:
 
     CHIP_ERROR NewTimer(Timer *& aTimerPtr);
 
-    void StartTimer(uint32_t aMilliseconds, chip::Callback::Callback<> * aCallback);
-    void DispatchTimerCallbacks(Clock::MonotonicMilliseconds aCurrentTime);
-
     using TimerCompleteFunct = Timer::OnCompleteFunct;
     // typedef void (*TimerCompleteFunct)(Layer * aLayer, void * aAppState, CHIP_ERROR aError);
     CHIP_ERROR StartTimer(uint32_t aMilliseconds, TimerCompleteFunct aComplete, void * aAppState);
@@ -165,7 +162,6 @@ public:
 private:
     LayerState mLayerState;
     void * mPlatformData;
-    chip::Callback::CallbackDeque mTimerCallbacks;
     Clock mClock;
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -88,7 +88,6 @@ public:
             return;
         }
 
-        mLayer->StartTimer(0, &mGreedyTimer);
         mNumTimersHandled++;
     }
     static void GreedyTimer(void * p)
@@ -127,7 +126,6 @@ void HandleTimer10Success(Layer * inetLayer, void * aState, CHIP_ERROR aError)
 static void CheckOverflow(nlTestSuite * inSuite, void * aContext)
 {
     uint32_t timeout_overflow_0ms = 652835029;
-    uint32_t timeout_overflow_1ms = 1958505088;
     uint32_t timeout_10ms         = 10;
 
     TestContext & lContext = *static_cast<TestContext *>(aContext);
@@ -136,8 +134,6 @@ static void CheckOverflow(nlTestSuite * inSuite, void * aContext)
     sOverflowTestDone = false;
 
     lSys.StartTimer(timeout_overflow_0ms, HandleTimerFailed, aContext);
-    chip::Callback::Callback<> cb(TimerFailed, aContext);
-    lSys.StartTimer(timeout_overflow_1ms, &cb);
     lSys.StartTimer(timeout_10ms, HandleTimer10Success, aContext);
 
     while (!sOverflowTestDone)
@@ -175,7 +171,6 @@ static void CheckStarvation(nlTestSuite * inSuite, void * aContext)
     struct timeval sleepTime;
 
     lSys.StartTimer(0, HandleGreedyTimer, aContext);
-    lSys.StartTimer(0, &lContext.mGreedyTimer);
 
     sleepTime.tv_sec  = 0;
     sleepTime.tv_usec = 1000; // 1 ms tick


### PR DESCRIPTION
#### Problem

`System::Layer` has two functionally equivalent kinds of timer,
which is a maintenance burden. One of them is very little
used, and not currently supported on all platforms.

#### Change overview

Remove the kind of timer that takes a `Callback<>`.

#### Testing

Revised the unit test. The changed calls are both in ESP32,
which is tested in CI using QEMU.
