### PR TITLE
Fix for scripts/build test failure

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -138,7 +138,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   group("check") {
     if (chip_link_tests) {
-      deps = [ "//src:tests_run" ]
+      deps = [
+        "//scripts/build:build_examples.tests",
+        "//src:tests_run",
+      ]
     }
   }
 

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -11,7 +11,7 @@ cd -
 
 # Generating esp32-devkitc-all_clusters
 cd "{root}"
-bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig_devkit.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-devkitc-all_clusters reconfigure'
+bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-devkitc-all_clusters reconfigure'
 cd -
 
 # Generating esp32-devkitc-lock
@@ -50,7 +50,7 @@ bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-m5stack-all_clust
 
 # Generating esp32-devkitc-all_clusters
 cd "{root}"
-bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig_devkit.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-devkitc-all_clusters reconfigure'
+bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-devkitc-all_clusters reconfigure'
 cd -
 
 # Building esp32-devkitc-all_clusters


### PR DESCRIPTION
#### Problem
* `scripts/build/expected_all_platform_commands.txt` uses `sdkconfig_devkitc.defaults`, which is now deprecated here (#8409)

#### Change overview
Replace the occurrence of `sdkconfig_devkitc.defaults` with `skdconfig.defaults`

#### Testing
Ran `gn_build.sh`
