### PR TITLE
[linux] Fix example apps crash when run with version or help options

### DIFF
--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -88,8 +88,13 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 
 int main(int argc, char * argv[])
 {
-    VerifyOrDie(ChipLinuxAppInit(argc, argv) == 0);
+    if (ChipLinuxAppInit(argc, argv) != 0)
+    {
+        return -1;
+    }
+
     LightingMgr().Init();
     ChipLinuxAppMainLoop();
+
     return 0;
 }

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -37,6 +37,8 @@ enum
     kDeviceOption_Thread    = 0x1002,
 };
 
+constexpr unsigned kAppUsageLength = 64;
+
 OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
                                   { "wifi", kNoArgument, kDeviceOption_WiFi },
@@ -94,11 +96,17 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
 OptionSet sDeviceOptions = { HandleOption, sDeviceOptionDefs, "GENERAL OPTIONS", sDeviceOptionHelp };
 
-OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr };
+OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr, nullptr };
 } // namespace
 
 CHIP_ERROR ParseArguments(int argc, char * argv[])
 {
+    char usage[kAppUsageLength];
+    snprintf(usage, kAppUsageLength, "Usage: %s [options]", argv[0]);
+
+    HelpOptions helpOptions(argv[0], usage, "1.0");
+    sLinuxDeviceOptionSets[1] = &helpOptions;
+
     if (!ParseArgs(argv[0], argc, argv, sLinuxDeviceOptionSets))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
example app crash when run with help, version options or invalid options.
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app -h
./chip-lighting-app: Unknown option: -h
[1626760099.710514][362943:362943] CHIP:-: Failed to run Linux Lighting App: Error 0x0000002F
Aborted (core dumped)

* Fixes #8498

#### Change overview
Construct HelpOptions and add to sLinuxDeviceOptionSets. 

#### Testing
How was this tested? (at least one bullet point required)
* Run with help option
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app -h
```
Usage: ./chip-lighting-app [options]

GENERAL OPTIONS

  --ble-device <number>
       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.

  --wifi
       Enable WiFi management via wpa_supplicant.

  --thread
       Enable Thread management via ot-agent.

HELP OPTIONS

  -h, --help
       Print this output and then exit.

  -v, --version
       Print the version and then exit.
```

* Run with version option
```
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app -v
./chip-lighting-app 1.0

```
* Run with invalid option
```
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app -k
./chip-lighting-app: Unknown option: -k
yujuan: CHIP_ERROR_INVALID_ARGUMENT
[1626761197.616845][364931:364931] CHIP:-: Failed to run Linux Lighting App: Error 0x0000002F 
```
