### PR TITLE
Update the log format of ExchangeMgr when a message a received to use…

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -202,9 +202,9 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     CHIP_ERROR err                          = CHIP_NO_ERROR;
     UnsolicitedMessageHandler * matchingUMH = nullptr;
 
-    ChipLogProgress(ExchangeManager, "Received message of type %d and protocolId %" PRIu32 " on exchange %d",
-                    payloadHeader.GetMessageType(), payloadHeader.GetProtocolID().ToFullyQualifiedSpecForm(),
-                    payloadHeader.GetExchangeID());
+    ChipLogProgress(ExchangeManager, "Received message of type 0x%02x with vendorId 0x%04x and protocolId 0x%04x on exchange %d",
+                    payloadHeader.GetMessageType(), payloadHeader.GetProtocolID().GetVendorId(),
+                    payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetExchangeID());
 
     MessageFlags msgFlags;
     if (isDuplicate == DuplicateMessage::Yes)


### PR DESCRIPTION
… hex notation instead of decimal, as it matches up the source code and makes it easier to understand

#### Problem

When a message is received, there is some logging related to `ExchangeMgr`, notably logging showing the message type. This logging uses decimal notation, which makes it hard to correlates with the source code that uses hex notation. 

#### Change overview
 * Use hex notation for the message type instead of decimal

#### Testing
 * Just some small logging fixes that likely does not require any specific testing besides logging at the log.