### PR TITLE
Re-enable the TestCluster bits of the Tests job.

### DIFF
--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -27,7 +27,7 @@ usage() {
     echo "  -a APPLICATION: runs chip-tool against 'chip-<APPLICATION>-app' (default: all-clusters)"
     echo "  -i ITERATIONS: number of iterations to run (default: $iterations)"
     echo "  -h: this help message"
-    echo "  -s CASE_NAME: runs single test case name (e.g. TC_OO_2_2"
+    echo "  -s CASE_NAME: runs single test case name (e.g. Test_TC_OO_2_2"
     echo "                for Test_TC_OO_2_2.yaml) (by default, all are run)"
     echo "  -w COMMAND: prefix all instantiations with a command (e.g. valgrind) (default: '')"
     echo ""
@@ -46,16 +46,15 @@ while getopts a:i:hs:w: flag; do
 done
 
 if [[ $application == "tv" ]]; then
-    declare test_filenames="TV_${single_case-*}.yaml"
-    declare -a test_array="($(find src/app/tests/suites -type f -name "$test_filenames" -exec basename {} .yaml \;))"
+    declare test_filenames="${single_case-TV_*}.yaml"
     cp examples/tv-app/linux/include/endpoint-configuration/chip_tv_config.ini /tmp/chip_tv_config.ini
 # in case there's no application argument
 # always default to all-cluters app
 else
     application="all-clusters"
-    declare test_filenames="Test_${single_case-*}.yaml"
-    declare -a test_array="($(find src/app/tests/suites -type f -name "$test_filenames" -exec basename {} .yaml \;))"
+    declare test_filenames="${single_case-Test*}.yaml"
 fi
+declare -a test_array="($(find src/app/tests/suites -type f -name "$test_filenames" -exec basename {} .yaml \;))"
 
 if [[ $iterations == 0 ]]; then
     echo "Invalid iteration count: '$1'"


### PR DESCRIPTION
These got disabled by accident because that filename does not have a '_' in it.

#### Problem
We no longer run TestCluster tests in the "Tests" CI (we do still run it in the Darwin CI).

#### Change overview
Run TestCluster tests again.

#### Testing
Manually verified that if I add a failing TestCluster test the job still passes without this PR and fails with it.