### PR TITLE
Add *.egg-info to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ TAGS
 # Python bytecodes
 __pycache__
 *.pyc
+*.egg-info
 
 # Doxygen outputs
 docs/html


### PR DESCRIPTION
These are python binary bits that should not get checked in.

#### Problem
`scripts/build/build_examples.egg-info` keeps showing up as modified.

#### Change overview
Add it to .gitignore.

#### Testing
Ran `git status` and was happy.