### PR TITLE
[Android] Rename onOpCSRGenerationComplete() parameter

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
@@ -39,7 +39,7 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
-  override fun onOpCSRGenerationComplete(errorCode: ByteArray) {
+  override fun onOpCSRGenerationComplete(csr: ByteArray) {
     // No op
   }
 }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -135,8 +135,8 @@ class DeviceProvisioningFragment : Fragment() {
       }
     }
 
-    override fun onOpCSRGenerationComplete(errorCode: ByteArray) {
-      Log.d(TAG,String(errorCode))
+    override fun onOpCSRGenerationComplete(csr: ByteArray) {
+      Log.d(TAG, String(csr))
     }
 
     override fun onPairingDeleted(code: Int) {

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -197,11 +197,11 @@ AndroidDeviceControllerWrapper::GenerateNodeOperationalCertificate(const Optiona
 
     onNOCGenerated->mCall(onNOCGenerated->mContext, ByteSpan(noc.Get(), nocLen));
 
-    jbyteArray argument;
+    jbyteArray javaCsr;
     JniReferences::GetInstance().GetEnvForCurrentThread()->ExceptionClear();
     JniReferences::GetInstance().N2J_ByteArray(JniReferences::GetInstance().GetEnvForCurrentThread(), csr.data(), csr.size(),
-                                               argument);
-    JniReferences::GetInstance().GetEnvForCurrentThread()->CallVoidMethod(mJavaObjectRef, method, argument);
+                                               javaCsr);
+    JniReferences::GetInstance().GetEnvForCurrentThread()->CallVoidMethod(mJavaObjectRef, method, javaCsr);
     return generateCert;
 }
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -118,9 +118,9 @@ public class ChipDeviceController {
     }
   }
 
-  public void onOpCSRGenerationComplete(byte[] errorCode) {
+  public void onOpCSRGenerationComplete(byte[] csr) {
     if (completionListener != null) {
-      completionListener.onOpCSRGenerationComplete(errorCode);
+      completionListener.onOpCSRGenerationComplete(csr);
     }
   }
 
@@ -287,6 +287,6 @@ public class ChipDeviceController {
     void onError(Throwable error);
 
     /** Notifies the Commissioner when the OpCSR for the Comissionee is generated. */
-    void onOpCSRGenerationComplete(byte[] errorCode);
+    void onOpCSRGenerationComplete(byte[] csr);
   }
 }


### PR DESCRIPTION
#### Problem
* In #7696, a callback for the CSR was added, but the parameter was mistakenly named `errorCode`.

#### Change overview
* Rename `errorCode` to `csr`.

#### Testing
* No functional changes, variable rename only
