### PR TITLE
Looks like the changes to other clusters didn't make it to the

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat.cpp
+++ b/src/app/clusters/thermostat-server/thermostat.cpp
@@ -56,13 +56,16 @@ bool emberAfThermostatClusterGetRelayStatusLogCallback(chip::app::CommandHandler
     return false;
 }
 
-bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t daysToReturn, uint8_t modeToReturn)
+bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t daysToReturn,
+                                                       uint8_t modeToReturn)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t numberOfTransitionsForSequence, uint8_t daysOfWeekForSequence, uint8_t modeForSequence, uint8_t * payload)
+bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj,
+                                                       uint8_t numberOfTransitionsForSequence, uint8_t daysOfWeekForSequence,
+                                                       uint8_t modeForSequence, uint8_t * payload)
 {
     // TODO
     return false;

--- a/src/app/clusters/thermostat-server/thermostat.cpp
+++ b/src/app/clusters/thermostat-server/thermostat.cpp
@@ -20,10 +20,12 @@
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 
-#include "gen/attribute-id.h"
-#include "gen/attribute-type.h"
-#include "gen/cluster-id.h"
-#include "gen/enums.h"
+#include <app/CommandHandler.h>
+#include <app/common/gen/attribute-id.h>
+#include <app/common/gen/attribute-type.h>
+#include <app/common/gen/cluster-id.h>
+#include <app/common/gen/command-id.h>
+#include <app/common/gen/enums.h>
 
 using namespace chip;
 
@@ -43,36 +45,35 @@ void emberAfThermostatClusterServerInitCallback(void)
     // or should this just be the responsibility of the thermostat application?
 }
 
-bool emberAfThermostatClusterClearWeeklyScheduleCallback()
+bool emberAfThermostatClusterClearWeeklyScheduleCallback(chip::app::CommandHandler * commandObj)
 {
     // TODO
     return false;
 }
-bool emberAfThermostatClusterGetRelayStatusLogCallback()
-{
-    // TODO
-    return false;
-}
-
-bool emberAfThermostatClusterGetWeeklyScheduleCallback(uint8_t daysToReturn, uint8_t modeToReturn)
+bool emberAfThermostatClusterGetRelayStatusLogCallback(chip::app::CommandHandler * commandObj)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterSetWeeklyScheduleCallback(uint8_t numberOfTransitionsForSequence, uint8_t daysOfWeekForSequence,
-                                                       uint8_t modeForSequence, uint8_t * payload)
+bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t daysToReturn, uint8_t modeToReturn)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterSetpointRaiseLowerCallback(uint8_t mode, int8_t amount)
+bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t numberOfTransitionsForSequence, uint8_t daysOfWeekForSequence, uint8_t modeForSequence, uint8_t * payload)
+{
+    // TODO
+    return false;
+}
+
+bool emberAfThermostatClusterSetpointRaiseLowerCallback(chip::app::CommandHandler * commandObj, uint8_t mode, int8_t amount)
 {
     bool result             = false;
     EndpointId endpoint     = 1;                            // Hard code to 1 for now/
     int32_t HeatingSetpoint = 2000, CoolingSetpoint = 2600; // Set to defaults to be safe
-    EmberAfStatus status;
+    EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
     switch (mode)
     {
     case EMBER_ZCL_SETPOINT_ADJUST_MODE_HEAT_AND_COOL_SETPOINTS: {


### PR DESCRIPTION
thermostat cluster.  These changes allow it to compile again

#### Problem
When including this source file in a project that uses the matter SDK this file fails to compile.  Looks like it's been overlooked in some recent refactors.

#### Change overview
Fixed up location of headers that are being included, fixed up the function signatures to match the signatures generated by zap, and initialized the status variable since that was also triggering a compiler failure on our project.

#### Testing
Not functionally tested as there were no functional changes.  This is purely to get things compiling once again.

Tested compiling using our devices project.