### PR TITLE
[Darwin] Set the Progress Log level to DEFAULT instead of INFO

### DIFF
--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -55,7 +55,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
         break;
 
     case kLogCategory_Progress:
-        os_log_with_type(log, OS_LOG_TYPE_INFO, "🔵 %{public}s", formattedMsg);
+        os_log_with_type(log, OS_LOG_TYPE_DEFAULT, "🔵 %{public}s", formattedMsg);
 #if TARGET_OS_MAC && TARGET_OS_IPHONE == 0
         fprintf(stdout, "\033[0;32m");
 #endif


### PR DESCRIPTION
#### Problem
Progress Logs are being logged as "OS_LOG_TYPE_ INFO", INFO logs are not persisted to disk and so they are lost after some time. We should use "OS_LOG_TYPE_DEFAULT" instead since we want these logs to be persisted in sysdiagnoses 

#### Change overview
Change the Progress Log Level to DEFAULT instead of INFO
#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
Change to the priority of logging. No logical changes. 
