### PR TITLE
TLV reader: Fix `float` support and remove union UB

### DIFF
--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -211,26 +211,18 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, float v)
+CHIP_ERROR TLVWriter::Put(uint64_t tag, const float v)
 {
-    union
-    {
-        float f;
-        uint32_t u32;
-    } cvt;
-    cvt.f = v;
-    return WriteElementHead(TLVElementType::FloatingPointNumber32, tag, cvt.u32);
+    uint32_t u32;
+    memcpy(&u32, &v, sizeof(u32));
+    return WriteElementHead(TLVElementType::FloatingPointNumber32, tag, u32);
 }
 
-CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
+CHIP_ERROR TLVWriter::Put(uint64_t tag, const double v)
 {
-    union
-    {
-        double d;
-        uint64_t u64;
-    } cvt;
-    cvt.d = v;
-    return WriteElementHead(TLVElementType::FloatingPointNumber64, tag, cvt.u64);
+    uint64_t u64;
+    memcpy(&u64, &v, sizeof(u64));
+    return WriteElementHead(TLVElementType::FloatingPointNumber64, tag, u64);
 }
 
 CHIP_ERROR TLVWriter::Put(uint64_t tag, ByteSpan data)


### PR DESCRIPTION
1. For some reason the Get(float&) signature was declared in the .h file
   but never defined. Define it as well, extracting a helper function
   for both Get(float&) and Get(double&).
2. It is undefined behaviour to use unions for type-punning in C++. Use
   raw memcpy calls instead, which is well-defined (std::bit_cast is not
   available). Compilers will generally be able to optimize this away
   unless a freestanding implementation (with possibly non-standard
   memcpy) is used.

#### Problem
Various improvements to `TLVReader` floating point code.

#### Change overview
1. Implement `TLVReader::Get(float&)`
1. Use `memcpy` instead of type-punning for bit conversions from integer to floating-point

#### Testing
* Updated TLVReader tests by copy-pasting the existing test cases for `double`
