### PR TITLE
CHIPCert Code Cleanups

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -40,6 +40,7 @@
 #include <protocols/Protocols.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#include <support/SafeInt.h>
 #include <support/ScopedBuffer.h>
 #include <support/TimeUtils.h>
 
@@ -289,10 +290,8 @@ CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<CertDecode
             err = LoadCert(reader, decodeFlags);
             SuccessOrExit(err);
         }
-        if (err != CHIP_END_OF_TLV)
-        {
-            ExitNow();
-        }
+        err = reader.VerifyEndOfContainer();
+        SuccessOrExit(err);
 
         err = reader.ExitContainer(containerType);
         SuccessOrExit(err);
@@ -348,11 +347,11 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
 }
 
 CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId,
-                                             ValidationContext & context, ChipCertificateData *& cert)
+                                             ValidationContext & context, const ChipCertificateData ** certData)
 {
     context.mTrustAnchor = nullptr;
 
-    return FindValidCert(subjectDN, subjectKeyId, context, context.mValidateFlags, 0, cert);
+    return FindValidCert(subjectDN, subjectKeyId, context, context.mValidateFlags, 0, certData);
 }
 
 CHIP_ERROR ChipCertificateSet::VerifySignature(const ChipCertificateData * cert, const ChipCertificateData * caCert)
@@ -374,8 +373,8 @@ CHIP_ERROR ChipCertificateSet::VerifySignature(const ChipCertificateData * cert,
 CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, ValidationContext & context,
                                             BitFlags<CertValidateFlags> validateFlags, uint8_t depth)
 {
-    CHIP_ERROR err               = CHIP_NO_ERROR;
-    ChipCertificateData * caCert = nullptr;
+    CHIP_ERROR err                     = CHIP_NO_ERROR;
+    const ChipCertificateData * caCert = nullptr;
     uint8_t certType;
 
     err = cert->mSubjectDN.GetCertType(certType);
@@ -478,7 +477,7 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
 
     // Search for a valid CA certificate that matches the Issuer DN and Authority Key Id of the current certificate.
     // Fail if no acceptable certificate is found.
-    err = FindValidCert(cert->mIssuerDN, cert->mAuthKeyId, context, validateFlags, static_cast<uint8_t>(depth + 1), caCert);
+    err = FindValidCert(cert->mIssuerDN, cert->mAuthKeyId, context, validateFlags, static_cast<uint8_t>(depth + 1), &caCert);
     if (err != CHIP_NO_ERROR)
     {
         ExitNow(err = CHIP_ERROR_CA_CERT_NOT_FOUND);
@@ -495,9 +494,11 @@ exit:
 
 CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId,
                                              ValidationContext & context, BitFlags<CertValidateFlags> validateFlags, uint8_t depth,
-                                             ChipCertificateData *& cert)
+                                             const ChipCertificateData ** certData)
 {
     CHIP_ERROR err;
+
+    *certData = nullptr;
 
     // Default error if we don't find any matching cert.
     err = (depth > 0) ? CHIP_ERROR_CA_CERT_NOT_FOUND : CHIP_ERROR_CERT_NOT_FOUND;
@@ -529,12 +530,10 @@ CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const Cer
         err = ValidateCert(candidateCert, context, validateFlags, depth);
         if (err == CHIP_NO_ERROR)
         {
-            cert = candidateCert;
+            *certData = candidateCert;
             ExitNow();
         }
     }
-
-    cert = nullptr;
 
 exit:
     return err;
@@ -582,7 +581,6 @@ void ValidationContext::Reset()
 {
     mEffectiveTime = 0;
     mTrustAnchor   = nullptr;
-    mSigningCert   = nullptr;
     mRequiredKeyUsages.ClearAll();
     mRequiredKeyPurposes.ClearAll();
     mValidateFlags.ClearAll();
@@ -642,7 +640,7 @@ CHIP_ERROR ChipDN::AddAttribute(chip::ASN1::OID oid, uint64_t val)
 
     if (IsChip32bitDNAttr(oid))
     {
-        VerifyOrReturnError(val <= UINT32_MAX, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(CanCastTo<uint32_t>(val), CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     rdn[rdnCount].mAttrOID = oid;

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -334,8 +334,10 @@ struct ChipCertificateData
 struct ValidationContext
 {
     uint32_t mEffectiveTime;                        /**< Current CHIP Epoch UTC time. */
-    const ChipCertificateData * mTrustAnchor;       /**< Pointer to the Trust Anchor Certificate data structure. */
-    const ChipCertificateData * mSigningCert;       /**< Pointer to the Signing Certificate data structure. */
+    const ChipCertificateData * mTrustAnchor;       /**< Pointer to the Trust Anchor Certificate data structure.
+                                                       This value is set during certificate validation process
+                                                       to indicate to the caller the trust anchor of the
+                                                       validated certificate. */
     BitFlags<KeyUsageFlags> mRequiredKeyUsages;     /**< Key usage extensions that should be present in the
                                                        validated certificate. */
     BitFlags<KeyPurposeFlags> mRequiredKeyPurposes; /**< Extended Key usage extensions that should be present
@@ -497,7 +499,7 @@ public:
     /**
      * @brief Validate CHIP certificate.
      *
-     * @param cert     Pointer to the CHIP certificiate to be validated. The certificate is
+     * @param cert     Pointer to the CHIP certificate to be validated. The certificate is
      *                 required to be in this set, otherwise this function returns error.
      * @param context  Certificate validation context.
      *
@@ -508,20 +510,20 @@ public:
     /**
      * @brief Find and validate CHIP certificate.
      *
-     * @param subjectDN     Subject distinguished name to use as certificate search parameter.
-     * @param subjectKeyId  Subject key identifier to use as certificate search parameter.
-     * @param context       Certificate validation context.
-     * @param cert          A pointer to the valid CHIP certificate that matches search criteria.
+     * @param[in]  subjectDN     Subject distinguished name to use as certificate search parameter.
+     * @param[in]  subjectKeyId  Subject key identifier to use as certificate search parameter.
+     * @param[in]  context       Certificate validation context.
+     * @param[out] certData      A pointer to a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId, ValidationContext & context,
-                             ChipCertificateData *& cert);
+                             const ChipCertificateData ** certData);
 
     /**
      * @brief Verify CHIP certificate signature.
      *
-     * @param cert    Pointer to the CHIP certificiate which signature should be validated.
+     * @param cert    Pointer to the CHIP certificate which signature should be validated.
      * @param caCert  Pointer to the CA certificate of the verified certificate.
      *
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
@@ -543,22 +545,22 @@ private:
     /**
      * @brief Find and validate CHIP certificate.
      *
-     * @param subjectDN      Subject distinguished name to use as certificate search parameter.
-     * @param subjectKeyId   Subject key identifier to use as certificate search parameter.
-     * @param context        Certificate validation context.
-     * @param validateFlags  Certificate validation flags.
-     * @param depth          Depth of the current certificate in the certificate validation chain.
-     * @param cert           A pointer to the valid CHIP certificate that matches search criteria.
+     * @param[in]  subjectDN      Subject distinguished name to use as certificate search parameter.
+     * @param[in]  subjectKeyId   Subject key identifier to use as certificate search parameter.
+     * @param[in]  context        Certificate validation context.
+     * @param[in]  validateFlags  Certificate validation flags.
+     * @param[in]  depth          Depth of the current certificate in the certificate validation chain.
+     * @param[out] certData       A pointer to a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId, ValidationContext & context,
-                             BitFlags<CertValidateFlags> validateFlags, uint8_t depth, ChipCertificateData *& cert);
+                             BitFlags<CertValidateFlags> validateFlags, uint8_t depth, const ChipCertificateData ** certData);
 
     /**
      * @brief Validate CHIP certificate.
      *
-     * @param cert           Pointer to the CHIP certificiate to be validated.
+     * @param cert           Pointer to the CHIP certificate to be validated.
      * @param context        Certificate validation context.
      * @param validateFlags  Certificate validation flags.
      * @param depth          Depth of the current certificate in the certificate validation chain.

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -513,7 +513,7 @@ public:
      * @param[in]  subjectDN     Subject distinguished name to use as certificate search parameter.
      * @param[in]  subjectKeyId  Subject key identifier to use as certificate search parameter.
      * @param[in]  context       Certificate validation context.
-     * @param[out] certData      A pointer to a pointer to the CHIP certificate data that matches search criteria.
+     * @param[out] certData      A slot to write a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
@@ -550,7 +550,7 @@ private:
      * @param[in]  context        Certificate validation context.
      * @param[in]  validateFlags  Certificate validation flags.
      * @param[in]  depth          Depth of the current certificate in the certificate validation chain.
-     * @param[out] certData       A pointer to a pointer to the CHIP certificate data that matches search criteria.
+     * @param[out] certData       A slot to write a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -393,7 +393,7 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                 uint32_t keyUsageBits;
                 err = reader.GetBitString(keyUsageBits);
                 SuccessOrExit(err);
-                VerifyOrExit(keyUsageBits <= UINT16_MAX, err = ASN1_ERROR_INVALID_ENCODING);
+                VerifyOrExit(CanCastTo<uint16_t>(keyUsageBits), err = ASN1_ERROR_INVALID_ENCODING);
 
                 // Check that only supported flags are set.
                 BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
@@ -435,8 +435,7 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                     {
                         ASN1_GET_INTEGER(pathLenConstraint);
 
-                        VerifyOrExit(pathLenConstraint <= UINT8_MAX, err = ASN1_ERROR_INVALID_ENCODING);
-                        VerifyOrExit(pathLenConstraint >= 0, err = ASN1_ERROR_INVALID_ENCODING);
+                        VerifyOrExit(CanCastTo<uint8_t>(pathLenConstraint), err = ASN1_ERROR_INVALID_ENCODING);
 
                         // pathLenConstraint is present only when cA is TRUE
                         VerifyOrExit(isCA, err = ASN1_ERROR_INVALID_ENCODING);

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -119,7 +119,7 @@ static CHIP_ERROR DecodeConvertDN(TLVReader & reader, ASN1Writer & writer, ChipD
                     }
                     else
                     {
-                        VerifyOrExit(chipAttr <= UINT32_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+                        VerifyOrExit(CanCastTo<uint32_t>(chipAttr), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
                         // For CHIP 32-bit attribute the string representation is 8 uppercase hex characters.
                         snprintf(reinterpret_cast<char *>(chipAttrStr), sizeof(chipAttrStr), "%08" PRIX32,
@@ -181,6 +181,8 @@ static CHIP_ERROR DecodeConvertDN(TLVReader & reader, ASN1Writer & writer, ChipD
             }
             ASN1_END_SET;
         }
+        err = reader.VerifyEndOfContainer();
+        SuccessOrExit(err);
     }
     ASN1_END_SEQUENCE;
 
@@ -208,7 +210,7 @@ static CHIP_ERROR DecodeConvertValidity(TLVReader & reader, ASN1Writer & writer,
         err = reader.Get(chipEpochTime);
         SuccessOrExit(err);
 
-        VerifyOrExit(chipEpochTime <= UINT32_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+        VerifyOrExit(CanCastTo<uint32_t>(chipEpochTime), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
         certData.mNotBeforeTime = static_cast<uint32_t>(chipEpochTime);
 
         err = ChipEpochToASN1Time(static_cast<uint32_t>(chipEpochTime), asn1Time);
@@ -222,7 +224,7 @@ static CHIP_ERROR DecodeConvertValidity(TLVReader & reader, ASN1Writer & writer,
         err = reader.Get(chipEpochTime);
         SuccessOrExit(err);
 
-        VerifyOrExit(chipEpochTime <= UINT32_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+        VerifyOrExit(CanCastTo<uint32_t>(chipEpochTime), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
         certData.mNotAfterTime = static_cast<uint32_t>(chipEpochTime);
 
         err = ChipEpochToASN1Time(static_cast<uint32_t>(chipEpochTime), asn1Time);
@@ -246,7 +248,7 @@ static CHIP_ERROR DecodeConvertSubjectPublicKeyInfo(TLVReader & reader, ASN1Writ
     SuccessOrExit(err);
     err = reader.Get(pubKeyAlgoId);
     SuccessOrExit(err);
-    VerifyOrExit(pubKeyAlgoId <= UINT8_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+    VerifyOrExit(CanCastTo<uint8_t>(pubKeyAlgoId), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
     pubKeyAlgoOID           = GetOID(kOIDCategory_PubKeyAlgo, static_cast<uint8_t>(pubKeyAlgoId));
     certData.mPubKeyAlgoOID = pubKeyAlgoOID;
@@ -257,7 +259,7 @@ static CHIP_ERROR DecodeConvertSubjectPublicKeyInfo(TLVReader & reader, ASN1Writ
     SuccessOrExit(err);
     err = reader.Get(pubKeyCurveId);
     SuccessOrExit(err);
-    VerifyOrExit(pubKeyCurveId <= UINT8_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+    VerifyOrExit(CanCastTo<uint8_t>(pubKeyCurveId), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
     certData.mPubKeyCurveOID = GetOID(kOIDCategory_EllipticCurve, static_cast<uint8_t>(pubKeyCurveId));
 
@@ -372,7 +374,7 @@ static CHIP_ERROR DecodeConvertKeyUsageExtension(TLVReader & reader, ASN1Writer 
     err = reader.Get(keyUsageBits);
     SuccessOrExit(err);
 
-    VerifyOrExit(keyUsageBits <= UINT16_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+    VerifyOrExit(CanCastTo<uint16_t>(keyUsageBits), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
     {
         BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
@@ -437,7 +439,7 @@ static CHIP_ERROR DecodeConvertBasicConstraintsExtension(TLVReader & reader, ASN
             err = reader.Get(pathLenConstraint);
             SuccessOrExit(err);
 
-            VerifyOrExit(pathLenConstraint <= UINT8_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+            VerifyOrExit(CanCastTo<uint8_t>(pathLenConstraint), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
             ASN1_ENCODE_INTEGER(static_cast<int64_t>(pathLenConstraint));
 
@@ -445,7 +447,8 @@ static CHIP_ERROR DecodeConvertBasicConstraintsExtension(TLVReader & reader, ASN
 
             certData.mCertFlags.Set(CertFlags::kPathLenConstraintPresent);
 
-            reader.Next();
+            nextRes = reader.Next();
+            VerifyOrExit(nextRes == CHIP_END_OF_TLV, err = nextRes);
         }
 
         err = reader.VerifyEndOfContainer();
@@ -462,7 +465,7 @@ exit:
 
 static CHIP_ERROR DecodeConvertExtendedKeyUsageExtension(TLVReader & reader, ASN1Writer & writer, ChipCertificateData & certData)
 {
-    CHIP_ERROR err, nextRes;
+    CHIP_ERROR err;
     TLVType outerContainer;
 
     certData.mCertFlags.Set(CertFlags::kExtPresent_ExtendedKeyUsage);
@@ -476,7 +479,7 @@ static CHIP_ERROR DecodeConvertExtendedKeyUsageExtension(TLVReader & reader, ASN
         err = reader.EnterContainer(outerContainer);
         SuccessOrExit(err);
 
-        while ((nextRes = reader.Next(kTLVType_UnsignedInteger, AnonymousTag)) == CHIP_NO_ERROR)
+        while ((err = reader.Next(kTLVType_UnsignedInteger, AnonymousTag)) == CHIP_NO_ERROR)
         {
             uint64_t keyPurposeId;
             OID keyPurposeOID;
@@ -484,7 +487,7 @@ static CHIP_ERROR DecodeConvertExtendedKeyUsageExtension(TLVReader & reader, ASN
             err = reader.Get(keyPurposeId);
             SuccessOrExit(err);
 
-            VerifyOrExit(keyPurposeId <= UINT8_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+            VerifyOrExit(CanCastTo<uint8_t>(keyPurposeId), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
             keyPurposeOID = GetOID(kOIDCategory_KeyPurpose, static_cast<uint8_t>(keyPurposeId));
 
@@ -493,8 +496,8 @@ static CHIP_ERROR DecodeConvertExtendedKeyUsageExtension(TLVReader & reader, ASN
 
             certData.mKeyPurposeFlags.Set(static_cast<KeyPurposeFlags>(0x01 << (keyPurposeId - 1)));
         }
-
-        VerifyOrExit(nextRes == CHIP_END_OF_TLV, err = nextRes);
+        err = reader.VerifyEndOfContainer();
+        SuccessOrExit(err);
 
         err = reader.ExitContainer(outerContainer);
         SuccessOrExit(err);
@@ -548,7 +551,7 @@ static CHIP_ERROR DecodeConvertFutureExtension(TLVReader & tlvReader, ASN1Writer
     }
     ASN1_EXIT_SEQUENCE;
 
-    VerifyOrExit(extensionSequenceLen <= UINT16_MAX, err = ASN1_ERROR_INVALID_ENCODING);
+    VerifyOrExit(CanCastTo<uint16_t>(extensionSequenceLen), err = ASN1_ERROR_INVALID_ENCODING);
 
     // FutureExtension SEQUENCE
     err = writer.PutConstructedType(extensionSequence, static_cast<uint16_t>(extensionSequenceLen));
@@ -650,6 +653,8 @@ static CHIP_ERROR DecodeConvertExtensions(TLVReader & reader, ASN1Writer & write
                 err = DecodeConvertExtension(reader, writer, certData);
                 SuccessOrExit(err);
             }
+            err = reader.VerifyEndOfContainer();
+            SuccessOrExit(err);
         }
         ASN1_END_SEQUENCE;
     }
@@ -743,7 +748,7 @@ CHIP_ERROR DecodeConvertTBSCert(TLVReader & reader, ASN1Writer & writer, ChipCer
             err = reader.Get(sigAlgoId);
             SuccessOrExit(err);
 
-            VerifyOrExit(sigAlgoId <= UINT8_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+            VerifyOrExit(CanCastTo<uint8_t>(sigAlgoId), err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
             sigAlgoOID = GetOID(kOIDCategory_SigAlgo, static_cast<uint8_t>(sigAlgoId));
             ASN1_ENCODE_OBJECT_ID(sigAlgoOID);

--- a/src/credentials/CHIPOperationalCredentials.cpp
+++ b/src/credentials/CHIPOperationalCredentials.cpp
@@ -191,14 +191,14 @@ CHIP_ERROR OperationalCredentialSet::ValidateCert(const CertificateKeyId & trust
 
 CHIP_ERROR OperationalCredentialSet::FindValidCert(const CertificateKeyId & trustedRootId, const ChipDN & subjectDN,
                                                    const CertificateKeyId & subjectKeyId, ValidationContext & context,
-                                                   ChipCertificateData *& cert)
+                                                   const ChipCertificateData ** certData)
 {
     ChipCertificateSet * chipCertificateSet;
 
     chipCertificateSet = FindCertSet(trustedRootId);
     VerifyOrReturnError(chipCertificateSet != nullptr, CHIP_ERROR_CERT_NOT_FOUND);
 
-    return chipCertificateSet->FindValidCert(subjectDN, subjectKeyId, context, cert);
+    return chipCertificateSet->FindValidCert(subjectDN, subjectKeyId, context, certData);
 }
 
 CHIP_ERROR OperationalCredentialSet::SignMsg(const CertificateKeyId & trustedRootId, const uint8_t * msg, const size_t msg_length,

--- a/src/credentials/CHIPOperationalCredentials.h
+++ b/src/credentials/CHIPOperationalCredentials.h
@@ -186,7 +186,7 @@ public:
      *
      * @param trustedRootId     Reference to the Trusted Root ID for the Certificate Set to be used
      *                          for validation
-     * @param cert              Pointer to the CHIP certificiate to be validated. The certificate is
+     * @param cert              Pointer to the CHIP certificate to be validated. The certificate is
      *                          required to be in this set, otherwise this function returns error.
      * @param context           Certificate validation context.
      *
@@ -197,17 +197,18 @@ public:
     /**
      * @brief Find and validate CHIP certificate.
      *
-     * @param trustedRootId     Reference to the Trusted Root ID for the Certificate Set to be used
-     *                          for validation
-     * @param subjectDN         Subject distinguished name to use as certificate search parameter.
-     * @param subjectKeyId      Subject key identifier to use as certificate search parameter.
-     * @param context           Certificate validation context.
-     * @param cert              A pointer to the valid CHIP certificate that matches search criteria.
+     * @param[in]  trustedRootId Reference to the Trusted Root ID for the Certificate Set to be used
+     *                           for validation.
+     * @param[in]  subjectDN     Subject distinguished name to use as certificate search parameter.
+     * @param[in]  subjectKeyId  Subject key identifier to use as certificate search parameter.
+     * @param[in]  context       Certificate validation context.
+     * @param[out] certData      A pointer to a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR if no valid certificate could be found
      **/
     CHIP_ERROR FindValidCert(const CertificateKeyId & trustedRootId, const ChipDN & subjectDN,
-                             const CertificateKeyId & subjectKeyId, ValidationContext & context, ChipCertificateData *& cert);
+                             const CertificateKeyId & subjectKeyId, ValidationContext & context,
+                             const ChipCertificateData ** certData);
 
     /**
      * @brief A function to sign a msg using ECDSA and the respective device credentials keypair.

--- a/src/credentials/CHIPOperationalCredentials.h
+++ b/src/credentials/CHIPOperationalCredentials.h
@@ -202,7 +202,7 @@ public:
      * @param[in]  subjectDN     Subject distinguished name to use as certificate search parameter.
      * @param[in]  subjectKeyId  Subject key identifier to use as certificate search parameter.
      * @param[in]  context       Certificate validation context.
-     * @param[out] certData      A pointer to a pointer to the CHIP certificate data that matches search criteria.
+     * @param[out] certData      A slot to write a pointer to the CHIP certificate data that matches search criteria.
      *
      * @return Returns a CHIP_ERROR if no valid certificate could be found
      **/

--- a/src/credentials/tests/CHIPCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPCert_test_vectors.cpp
@@ -131,7 +131,7 @@ const char * GetTestCertName(uint8_t certType)
     return nullptr;
 }
 
-CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t *& certPubkey, uint32_t & certPubkeyLen)
+CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t ** certPubkey, uint32_t & certPubkeyLen)
 {
     CHIP_ERROR err;
 
@@ -140,7 +140,7 @@ CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t *& certPubkey, uint
     {                                                                                                                              \
         if (certType == TestCert::k##NAME)                                                                                         \
         {                                                                                                                          \
-            certPubkey    = sTestCert_##NAME##_PublicKey;                                                                          \
+            *certPubkey   = sTestCert_##NAME##_PublicKey;                                                                          \
             certPubkeyLen = sTestCert_##NAME##_PublicKey_Len;                                                                      \
             ExitNow(err = CHIP_NO_ERROR);                                                                                          \
         }                                                                                                                          \

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -70,7 +70,7 @@ enum class TestCertLoadFlags : uint8_t
 
 extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, ByteSpan & cert);
 extern const char * GetTestCertName(uint8_t certType);
-extern CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t *& certPubkey, uint32_t & certPubkeyLen);
+extern CHIP_ERROR GetTestCertPubkey(uint8_t certType, const uint8_t ** certPubkey, uint32_t & certPubkeyLen);
 extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,
                                BitFlags<CertDecodeFlags> decodeFlags);
 

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -347,8 +347,8 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
 
     for (unsigned i = 0; i < sNumValidationTestCases; i++)
     {
-        ChipCertificateData * resultCert    = nullptr;
-        const ValidationTestCase & testCase = sValidationTestCases[i];
+        const ChipCertificateData * resultCert = nullptr;
+        const ValidationTestCase & testCase    = sValidationTestCases[i];
 
         err = certSet.Init(kMaxCertsPerTestCase);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -386,7 +386,7 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
         const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[testCase.mSubjectCertIndex].mSubjectKeyId;
 
         // Invoke the FindValidCert() method (the method being tested).
-        err = certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert);
+        err = certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert);
         NL_TEST_ASSERT(inSuite, err == testCase.mExpectedResult);
 
         // If the test case is expected to be successful...
@@ -978,8 +978,8 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     const ChipDN & subjectDN              = certSet.GetCertSet()[2].mSubjectDN;
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[2].mSubjectKeyId;
 
-    ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+    const ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
 }
 
 static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext)
@@ -1049,8 +1049,8 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
     const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
-    ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+    const ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
 }
 
 static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inContext)
@@ -1108,8 +1108,8 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
-    ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+    const ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
 }
 
 static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, void * inContext)
@@ -1243,8 +1243,8 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
     const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
-    ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+    const ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
 }
 
 static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void * inContext)
@@ -1307,8 +1307,8 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
     const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
-    ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, resultCert) == CHIP_NO_ERROR);
+    const ChipCertificateData * resultCert = nullptr;
+    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
 }
 
 static void TestChipCert_ExtractPeerId(nlTestSuite * inSuite, void * inContext)

--- a/src/credentials/tests/TestChipOperationalCredentials.cpp
+++ b/src/credentials/tests/TestChipOperationalCredentials.cpp
@@ -118,8 +118,8 @@ static void TestChipOperationalCredentials_CertValidation(nlTestSuite * inSuite,
 
     for (unsigned i = 0; i < sNumValidationTestCases; i++)
     {
-        ChipCertificateData * resultCert    = nullptr;
-        const ValidationTestCase & testCase = sValidationTestCases[i];
+        const ChipCertificateData * resultCert = nullptr;
+        const ValidationTestCase & testCase    = sValidationTestCases[i];
 
         err = certSet.Init(kMaxCertsPerTestCase);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -160,7 +160,7 @@ static void TestChipOperationalCredentials_CertValidation(nlTestSuite * inSuite,
         const CertificateKeyId & trustedRootId = certSet.GetCertSet()[testCase.mExpectedTrustAnchorIndex].mAuthKeyId;
 
         // Invoke the FindValidCert() method (the method being tested).
-        err = opCredSet.FindValidCert(trustedRootId, subjectDN, subjectKeyId, validContext, resultCert);
+        err = opCredSet.FindValidCert(trustedRootId, subjectDN, subjectKeyId, validContext, &resultCert);
         NL_TEST_ASSERT(inSuite, err == testCase.mExpectedResult);
 
         // If the test case is expected to be successful...

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1725,7 +1725,7 @@ static void TestPubkey_x509Extraction(nlTestSuite * inSuite, void * inContext)
 
         err = GetTestCert(certType, TestCertLoadFlags::kDERForm, cert);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        err = GetTestCertPubkey(certType, certPubkey, certPubkeyLen);
+        err = GetTestCertPubkey(certType, &certPubkey, certPubkeyLen);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = ExtractPubkeyFromX509Cert(cert, publicKey);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1197,7 +1197,7 @@ CHIP_ERROR CASESession::ConstructSaltSigmaR3(const uint8_t * ipk, size_t ipkLen,
 CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t * responderOpCert, uint16_t responderOpCertLen,
                                                          P256PublicKey & responderID)
 {
-    ChipCertificateData * resultCert = nullptr;
+    const ChipCertificateData * resultCert = nullptr;
 
     ChipCertificateSet certSet;
     // Certificate set can contain up to 3 certs (NOC, ICA cert, and Root CA cert)
@@ -1222,7 +1222,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const uint8_t * respond
         const ChipDN & subjectDN              = certSet.GetCertSet()[0].mSubjectDN;
         const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[0].mSubjectKeyId;
 
-        ReturnErrorOnFailure(mOpCredSet->FindValidCert(mTrustedRootId, subjectDN, subjectKeyId, mValidContext, resultCert));
+        ReturnErrorOnFailure(mOpCredSet->FindValidCert(mTrustedRootId, subjectDN, subjectKeyId, mValidContext, &resultCert));
 
         // Now that we have verified that this is a valid cert, try to get the
         // peer's operational identity from it.

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -143,8 +143,8 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     bool res       = true;
     CHIP_ERROR err = CHIP_NO_ERROR;
     ChipCertificateSet certSet;
-    const ChipCertificateData * certToBeValidated;
-    ChipCertificateData * validatedCert;
+    const ChipCertificateData * certToBeValidated = nullptr;
+    const ChipCertificateData * validatedCert     = nullptr;
     ValidationContext context;
     uint8_t certsBuf[kMaxCerts * kMaxCHIPCertLength];
 
@@ -182,7 +182,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     res = chip::UnixEpochToChipEpochTime(static_cast<uint32_t>(time(nullptr)), context.mEffectiveTime);
     VerifyTrueOrExit(res);
 
-    err = certSet.FindValidCert(certToBeValidated->mSubjectDN, certToBeValidated->mSubjectKeyId, context, validatedCert);
+    err = certSet.FindValidCert(certToBeValidated->mSubjectDN, certToBeValidated->mSubjectKeyId, context, &validatedCert);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Failed certificate chain validation: %s\n", chip::ErrorStr(err));


### PR DESCRIPTION
#### Problem
Ticket: #4695

#### Change overview
-- Changed reference-to-pointer to pointer-to-pointer parameter to make it clearer
   at caller site that it's being written to.
-- Removed unused legacy member mSigningCert from the ValidationContext class
-- Added use of CanCastTo check before casting
-- Added end of container checks while parsing TLV containers
-- other minor cleanups and typo fixes

#### Testing
Unit tests for CHIP Certs and secure session protocols