### PR TITLE
[android] Use common DNS-SD code

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -27,9 +27,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import chip.devicecontroller.ChipDeviceController
+import chip.devicecontroller.NsdManagerServiceResolver
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
 import com.google.chip.chiptool.attestation.AttestationTestFragment
-import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.echoclient.EchoClientFragment
 import com.google.chip.chiptool.provisioning.DeviceProvisioningFragment
 import com.google.chip.chiptool.provisioning.ProvisionNetworkType
@@ -39,6 +39,7 @@ import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
 import chip.devicecontroller.PreferencesKeyValueStoreManager
 import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
+import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 
 class CHIPToolActivity :
     AppCompatActivity(),
@@ -54,6 +55,7 @@ class CHIPToolActivity :
 
     if (savedInstanceState == null) {
       ChipDeviceController.setKeyValueStoreManager(PreferencesKeyValueStoreManager(this))
+      ChipDeviceController.setServiceResolver(NsdManagerServiceResolver(this))
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
           .beginTransaction()

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -1,8 +1,5 @@
 package com.google.chip.chiptool.clusterclient
 
-import android.content.Context
-import android.net.nsd.NsdManager
-import android.net.nsd.NsdServiceInfo
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -110,39 +107,11 @@ class OnOffClientFragment : Fragment() {
   }
 
   private fun updateAddressClick() {
-    val serviceInfo = NsdServiceInfo().apply {
-      serviceName = "%016X-%016X".format(
-        fabricIdEd.text.toString().toLong(),
-        deviceIdEd.text.toString().toLong()
-      )
-      serviceType = "_matter._tcp"
-    }
-
-    // TODO: implement the common CHIP mDNS interface for Android and make CHIP stack call the resolver
-    val resolverListener = object : NsdManager.ResolveListener {
-      override fun onResolveFailed(serviceInfo: NsdServiceInfo?, errorCode: Int) {
-        showMessage("Address resolution failed: $errorCode")
-      }
-
-      override fun onServiceResolved(serviceInfo: NsdServiceInfo?) {
-        val hostAddress = serviceInfo?.host?.hostAddress ?: ""
-        val port = serviceInfo?.port ?: 0
-
-        showMessage("Address: ${hostAddress}:${port}")
-
-        if (hostAddress == "" || port == 0)
-          return
-
-        try {
-          deviceController.updateAddress(deviceIdEd.text.toString().toLong(), hostAddress, port)
-        } catch (e: ChipDeviceControllerException) {
-          showMessage(e.toString())
-        }
-      }
-    }
-
-    (requireContext().getSystemService(Context.NSD_SERVICE) as NsdManager).apply {
-      resolveService(serviceInfo, resolverListener)
+    try{
+      deviceController.updateDevice(fabricIdEd.text.toString().toLong(), deviceIdEd.text.toString().toLong())
+      showMessage("Address update started")
+    } catch (e: ChipDeviceControllerException) {
+      showMessage(e.toString())
     }
   }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -108,10 +108,13 @@ class OnOffClientFragment : Fragment() {
 
   private fun updateAddressClick() {
     try{
-      deviceController.updateDevice(fabricIdEd.text.toString().toLong(), deviceIdEd.text.toString().toLong())
+      deviceController.updateDevice(
+          fabricIdEd.text.toString().toULong().toLong(),
+          deviceIdEd.text.toString().toULong().toLong()
+      )
       showMessage("Address update started")
-    } catch (e: ChipDeviceControllerException) {
-      showMessage(e.toString())
+    } catch (ex: Exception) {
+      showMessage("Address update failed: $ex")
     }
   }
 

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -37,6 +37,8 @@ shared_library("jni") {
     "JniReferences.cpp",
     "JniReferences.h",
     "JniTypeWrappers.h",
+    "MdnsImpl.cpp",
+    "MdnsImpl.h",
     "StackLock.h",
     "gen/CHIPClusters-JNI.cpp",
   ]
@@ -67,7 +69,9 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceController.java",
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/KeyValueStoreManager.java",
+    "src/chip/devicecontroller/NsdManagerServiceResolver.java",
     "src/chip/devicecontroller/PreferencesKeyValueStoreManager.java",
+    "src/chip/devicecontroller/ServiceResolver.java",
   ]
 
   javac_flags = [ "-Xlint:deprecation" ]

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -29,6 +29,7 @@
 #include "CHIPJNIError.h"
 #include "JniReferences.h"
 #include "JniTypeWrappers.h"
+#include "MdnsImpl.h"
 #include "StackLock.h"
 
 #include <app/chip-zcl-zpro-codec.h>
@@ -261,6 +262,19 @@ JNI_METHOD(void, setKeyValueStoreManager)(JNIEnv * env, jclass self, jobject man
     chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(manager);
 }
 
+JNI_METHOD(void, setServiceResolver)(JNIEnv * env, jclass self, jobject resolver)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    chip::Mdns::InitializeWithObject(resolver);
+}
+
+JNI_METHOD(void, handleServiceResolve)
+(JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    chip::Mdns::HandleResolve(instanceName, serviceType, address, port, callback, context);
+}
+
 JNI_METHOD(void, pairDevice)
 (JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint connObj, jlong pinCode, jbyteArray csrNonce)
 {
@@ -421,25 +435,16 @@ JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlon
     return env->NewStringUTF(addrStr);
 }
 
-JNI_METHOD(void, updateAddress)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring address, jint port)
+JNI_METHOD(void, updateDevice)(JNIEnv * env, jobject self, jlong handle, jlong fabricId, jlong deviceId)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    Device * chipDevice = nullptr;
-    CHIP_ERROR err      = CHIP_NO_ERROR;
 
-    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    CHIP_ERROR err                           = wrapper->Controller()->UpdateDevice(deviceId, fabricId);
 
-    Inet::IPAddress ipAddress = {};
-    JniUtfString addressAccessor(env, address);
-    VerifyOrExit(Inet::IPAddress::FromString(addressAccessor.c_str(), ipAddress), err = CHIP_ERROR_INVALID_ADDRESS);
-    VerifyOrExit(CanCastTo<uint16_t>(port), err = CHIP_ERROR_INVALID_ADDRESS);
-
-    err = chipDevice->UpdateAddress(Transport::PeerAddress::UDP(ipAddress, port));
-
-exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to update address");
+        ChipLogError(Controller, "Failed to update device");
         ThrowError(env, err);
     }
 }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -264,15 +264,17 @@ JNI_METHOD(void, setKeyValueStoreManager)(JNIEnv * env, jclass self, jobject man
 
 JNI_METHOD(void, setServiceResolver)(JNIEnv * env, jclass self, jobject resolver)
 {
+    using namespace chip::Mdns;
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    chip::Mdns::InitializeWithObject(resolver);
+    InitializeWithObject(resolver);
 }
 
 JNI_METHOD(void, handleServiceResolve)
 (JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context)
 {
+    using namespace chip::Mdns;
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    chip::Mdns::HandleResolve(instanceName, serviceType, address, port, callback, context);
+    HandleResolve(instanceName, serviceType, address, port, callback, context);
 }
 
 JNI_METHOD(void, pairDevice)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -270,11 +270,12 @@ JNI_METHOD(void, setServiceResolver)(JNIEnv * env, jclass self, jobject resolver
 }
 
 JNI_METHOD(void, handleServiceResolve)
-(JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context)
+(JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callbackHandle,
+ jlong contextHandle)
 {
     using namespace chip::Mdns;
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    HandleResolve(instanceName, serviceType, address, port, callback, context);
+    HandleResolve(instanceName, serviceType, address, port, callbackHandle, contextHandle);
 }
 
 JNI_METHOD(void, pairDevice)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -443,7 +443,7 @@ JNI_METHOD(void, updateDevice)(JNIEnv * env, jobject self, jlong handle, jlong f
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    CHIP_ERROR err                           = wrapper->Controller()->UpdateDevice(deviceId, fabricId);
+    CHIP_ERROR err = wrapper->Controller()->UpdateDevice(static_cast<chip::NodeId>(deviceId), static_cast<uint64_t>(fabricId));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/MdnsImpl.cpp
+++ b/src/controller/java/MdnsImpl.cpp
@@ -65,6 +65,7 @@ CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, Inet::IPAddressType addressType,
                           Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
 {
+    // TODO: Implement DNS-SD browse for Android
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -119,16 +120,16 @@ void InitializeWithObject(jobject resolverObject)
     }
 }
 
-void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context)
+void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callbackHandle, jlong contextHandle)
 {
-    VerifyOrReturn(callback != 0, ChipLogError(Discovery, "HandleResolve called with callback equal to nullptr"));
+    VerifyOrReturn(callbackHandle != 0, ChipLogError(Discovery, "HandleResolve called with callback equal to nullptr"));
 
-    const auto dispatch = [callback, context](CHIP_ERROR error, MdnsService * service = nullptr) {
-        MdnsResolveCallback resolveCallback = reinterpret_cast<MdnsResolveCallback>(callback);
-        resolveCallback(reinterpret_cast<void *>(context), service, error);
+    const auto dispatch = [callbackHandle, contextHandle](CHIP_ERROR error, MdnsService * service = nullptr) {
+        MdnsResolveCallback callback = reinterpret_cast<MdnsResolveCallback>(callbackHandle);
+        callback(reinterpret_cast<void *>(contextHandle), service, error);
     };
 
-    VerifyOrReturn(address != 0 && port != 0, dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
+    VerifyOrReturn(address != nullptr && port != 0, dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     JniUtfString jniInstanceName(env, instanceName);

--- a/src/controller/java/MdnsImpl.cpp
+++ b/src/controller/java/MdnsImpl.cpp
@@ -1,0 +1,154 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "MdnsImpl.h"
+
+#include "CHIPJNIError.h"
+#include "JniReferences.h"
+#include "JniTypeWrappers.h"
+
+#include <lib/mdns/platform/Mdns.h>
+#include <support/CHIPMemString.h>
+#include <support/CodeUtils.h>
+#include <support/SafeInt.h>
+#include <support/logging/CHIPLogging.h>
+
+#include <string>
+
+namespace chip {
+namespace Mdns {
+
+using namespace chip::Controller;
+using namespace chip::Platform;
+
+namespace {
+jobject sResolverObject  = nullptr;
+jmethodID sResolveMethod = nullptr;
+} // namespace
+
+// Implemention of functions declared in lib/mdns/platform/Mdns.h
+
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsStopPublish()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, Inet::IPAddressType addressType,
+                          Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsResolve(MdnsService * service, Inet::InterfaceId interface, MdnsResolveCallback callback, void * context)
+{
+    VerifyOrReturnError(service != nullptr && callback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(sResolverObject != nullptr && sResolveMethod != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    std::string serviceType = service->mType;
+    serviceType += '.';
+    serviceType += (service->mProtocol == MdnsServiceProtocol::kMdnsProtocolUdp ? "_udp" : "_tcp");
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    UtfString jniInstanceName(env, service->mName);
+    UtfString jniServiceType(env, serviceType.c_str());
+
+    env->CallVoidMethod(sResolverObject, sResolveMethod, jniInstanceName.jniValue(), jniServiceType.jniValue(),
+                        reinterpret_cast<jlong>(callback), reinterpret_cast<jlong>(context));
+
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(Discovery, "Java exception in ChipMdnsResolve");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return CHIP_JNI_ERROR_EXCEPTION_THROWN;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+// Implementation of other methods required by the CHIP stack
+
+void GetMdnsTimeout(timeval & timeout) {}
+void HandleMdnsTimeout() {}
+
+// Implemention of Java-specific functions
+
+void InitializeWithObject(jobject resolverObject)
+{
+    JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
+    sResolverObject      = env->NewGlobalRef(resolverObject);
+    jclass resolverClass = env->GetObjectClass(sResolverObject);
+
+    VerifyOrReturn(resolverClass != nullptr, ChipLogError(Discovery, "Failed to get Resolver Java class"));
+
+    sResolveMethod = env->GetMethodID(resolverClass, "resolve", "(Ljava/lang/String;Ljava/lang/String;JJ)V");
+
+    if (sResolveMethod == nullptr)
+    {
+        ChipLogError(Discovery, "Failed to access Resolver 'resolve' method");
+        env->ExceptionClear();
+    }
+}
+
+void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context)
+{
+    VerifyOrReturn(callback != 0, ChipLogError(Discovery, "HandleResolve called with callback equal to nullptr"));
+
+    const auto dispatch = [callback, context](CHIP_ERROR error, MdnsService * service = nullptr) {
+        MdnsResolveCallback resolveCallback = reinterpret_cast<MdnsResolveCallback>(callback);
+        resolveCallback(reinterpret_cast<void *>(context), service, error);
+    };
+
+    VerifyOrReturn(address != 0 && port != 0, dispatch(CHIP_ERROR_UNKNOWN_RESOURCE_ID));
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    JniUtfString jniInstanceName(env, instanceName);
+    JniUtfString jniServiceType(env, serviceType);
+    JniUtfString jniAddress(env, address);
+    Inet::IPAddress ipAddress;
+
+    VerifyOrReturn(strlen(jniInstanceName.c_str()) <= kMdnsInstanceNameMaxSize, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturn(strlen(jniServiceType.c_str()) <= kMdnsTypeAndProtocolMaxSize, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturn(CanCastTo<uint16_t>(port), dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturn(Inet::IPAddress::FromString(jniAddress.c_str(), ipAddress), dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+
+    MdnsService service = {};
+    CopyString(service.mName, jniInstanceName.c_str());
+    CopyString(service.mType, jniServiceType.c_str());
+    service.mAddress.SetValue(ipAddress);
+    service.mPort = static_cast<uint16_t>(port);
+
+    dispatch(CHIP_NO_ERROR, &service);
+}
+
+} // namespace Mdns
+} // namespace chip

--- a/src/controller/java/MdnsImpl.h
+++ b/src/controller/java/MdnsImpl.h
@@ -31,7 +31,8 @@ void InitializeWithObject(jobject resolverObject);
 /**
  * Pass results of the service resolution to the CHIP stack.
  */
-void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context);
+void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callbackHandle,
+                   jlong contextHandle);
 
 } // namespace Mdns
 } // namespace chip

--- a/src/controller/java/MdnsImpl.h
+++ b/src/controller/java/MdnsImpl.h
@@ -1,0 +1,37 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+
+namespace chip {
+namespace Mdns {
+
+/**
+ * Initialize DNS-SD implementation for Android with an object of a class
+ * that implements chip.devicecontroller.ServiceResolver interface.
+ */
+void InitializeWithObject(jobject resolverObject);
+
+/**
+ * Pass results of the service resolution to the CHIP stack.
+ */
+void HandleResolve(jstring instanceName, jstring serviceType, jstring address, jint port, jlong callback, jlong context);
+
+} // namespace Mdns
+} // namespace chip

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -248,8 +248,8 @@ public class ChipDeviceController {
       String serviceType,
       String address,
       int port,
-      long callback,
-      long context);
+      long callbackHandle,
+      long contextHandle);
 
   static {
     System.loadLibrary("CHIPController");

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -184,8 +184,8 @@ public class ChipDeviceController {
     return getIpAddress(deviceControllerPtr, deviceId);
   }
 
-  public void updateAddress(long deviceId, String address, int port) {
-    updateAddress(deviceControllerPtr, deviceId, address, port);
+  public void updateDevice(long fabricId, long deviceId) {
+    updateDevice(deviceControllerPtr, fabricId, deviceId);
   }
 
   public void sendMessage(long deviceId, String message) {
@@ -225,8 +225,7 @@ public class ChipDeviceController {
 
   private native String getIpAddress(long deviceControllerPtr, long deviceId);
 
-  private native void updateAddress(
-      long deviceControllerPtr, long deviceId, String address, int port);
+  private native void updateDevice(long deviceControllerPtr, long fabricId, long deviceId);
 
   private native void sendMessage(long deviceControllerPtr, long deviceId, String message);
 
@@ -241,6 +240,16 @@ public class ChipDeviceController {
   private native boolean isActive(long deviceControllerPtr, long deviceId);
 
   public static native void setKeyValueStoreManager(KeyValueStoreManager manager);
+
+  public static native void setServiceResolver(ServiceResolver resolver);
+
+  public static native void handleServiceResolve(
+      String instanceName,
+      String serviceType,
+      String address,
+      int port,
+      long callback,
+      long context);
 
   static {
     System.loadLibrary("CHIPController");

--- a/src/controller/java/src/chip/devicecontroller/NsdManagerServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/NsdManagerServiceResolver.java
@@ -60,6 +60,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
                     + serviceInfo.getServiceName()
                     + "' to "
                     + serviceInfo.getHost());
+            // TODO: Find out if DNS-SD results for Android should contain interface ID
             ChipDeviceController.handleServiceResolve(
                 instanceName,
                 serviceType,

--- a/src/controller/java/src/chip/devicecontroller/NsdManagerServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/NsdManagerServiceResolver.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+
+public class NsdManagerServiceResolver implements ServiceResolver {
+  private final String TAG = NsdManagerServiceResolver.class.getSimpleName();
+  private final NsdManager nsdManager;
+
+  public NsdManagerServiceResolver(Context context) {
+    this.nsdManager = (NsdManager) context.getSystemService(Context.NSD_SERVICE);
+  }
+
+  @Override
+  public void resolve(
+      final String instanceName,
+      final String serviceType,
+      final long callbackHandle,
+      final long contextHandle) {
+    NsdServiceInfo serviceInfo = new NsdServiceInfo();
+    serviceInfo.setServiceName(instanceName);
+    serviceInfo.setServiceType(serviceType);
+
+    this.nsdManager.resolveService(
+        serviceInfo,
+        new NsdManager.ResolveListener() {
+          @Override
+          public void onResolveFailed(NsdServiceInfo serviceInfo, int errorCode) {
+            Log.w(
+                TAG,
+                "Failed to resolve service '" + serviceInfo.getServiceName() + "': " + errorCode);
+            ChipDeviceController.handleServiceResolve(
+                instanceName, serviceType, null, 0, callbackHandle, contextHandle);
+          }
+
+          @Override
+          public void onServiceResolved(NsdServiceInfo serviceInfo) {
+            Log.i(
+                TAG,
+                "Resolved service '"
+                    + serviceInfo.getServiceName()
+                    + "' to "
+                    + serviceInfo.getHost());
+            ChipDeviceController.handleServiceResolve(
+                instanceName,
+                serviceType,
+                serviceInfo.getHost().getHostAddress(),
+                serviceInfo.getPort(),
+                callbackHandle,
+                contextHandle);
+          }
+        });
+  }
+}

--- a/src/controller/java/src/chip/devicecontroller/ServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/ServiceResolver.java
@@ -1,0 +1,23 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller;
+
+public interface ServiceResolver {
+  public void resolve(
+      String instanceName, String serviceType, long callbackHandle, long contextHandle);
+}

--- a/src/controller/java/src/chip/devicecontroller/ServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/ServiceResolver.java
@@ -18,6 +18,5 @@
 package chip.devicecontroller;
 
 public interface ServiceResolver {
-  public void resolve(
-      String instanceName, String serviceType, long callbackHandle, long contextHandle);
+  void resolve(String instanceName, String serviceType, long callbackHandle, long contextHandle);
 }

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -177,6 +177,8 @@ if (chip_device_platform != "none") {
     }
   }
 } else {
+  chip_device_config_enable_mdns = chip_mdns != "none"
+
   buildconfig_header("platform_buildconfig") {
     header = "CHIPDeviceBuildConfig.h"
     header_dir = "platform"
@@ -187,7 +189,10 @@ if (chip_device_platform != "none") {
     ]
 
     if (current_os == "android") {
-      defines += [ "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"" ]
+      defines += [
+        "CHIP_DEVICE_CONFIG_ENABLE_MDNS=${chip_device_config_enable_mdns}",
+        "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"",
+      ]
     }
   }
 }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -53,7 +53,7 @@ declare_args() {
       chip_device_platform == "mbed") {
     chip_mdns = "minimal"
   } else if (chip_device_platform == "darwin" ||
-             chip_device_platform == "cc13x2_26x2") {
+             chip_device_platform == "cc13x2_26x2" || current_os == "android") {
     chip_mdns = "platform"
   } else {
     chip_mdns = "none"


### PR DESCRIPTION
#### Problem
Currently, Android contains temporary code for resolving a node ID to an IP address. The temporary code was added to unblock testing CHIP on Android platform, but eventually CHIP stack must get access to Android DNS-SD capabilities if DNS-SD queries are to be generated automatically in various cases.

#### Change overview
Rewrite this piece to use common CHIP DNS-SD layer by providing an adapter between Discovery_ImplPlatform and NsdManager from the Android library. 
Fixes #7331.

#### Testing
Tested using CHIPTool on Android 8.1, OTBR on Raspberry Pi and nRF Connect Lock Example that after commissioning, updating a device address still works correctly. Note that making CASE work on Android requires some fixes form #8447.