### PR TITLE
[linux] Enable setup code options for linux example apps

### DIFF
--- a/examples/bridge-app/linux/include/Options.h
+++ b/examples/bridge-app/linux/include/Options.h
@@ -27,9 +27,11 @@
 #include <cstdint>
 
 #include <core/CHIPError.h>
+#include <setup_payload/SetupPayload.h>
 
 struct LinuxDeviceOptions
 {
+    chip::SetupPayload payload;
     uint32_t mBleDevice = 0;
 
     static LinuxDeviceOptions & GetInstance();

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -72,9 +72,17 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
 
 int ChipLinuxAppInit(int argc, char ** argv)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    chip::RendezvousInformationFlags rendezvousFlags = chip::RendezvousInformationFlag::kBLE;
+
+#ifdef CONFIG_RENDEZVOUS_MODE
+    rendezvousFlags = static_cast<chip::RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
+#endif
 
     err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
+
+    err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
     SuccessOrExit(err);
 
     err = ParseArguments(argc, argv);
@@ -84,11 +92,8 @@ int ChipLinuxAppInit(int argc, char ** argv)
     SuccessOrExit(err);
 
     ConfigurationMgr().LogDeviceConfig();
-#ifdef CONFIG_RENDEZVOUS_MODE
-    PrintOnboardingCodes(static_cast<chip::RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE));
-#else
-    PrintOnboardingCodes(chip::RendezvousInformationFlag::kBLE);
-#endif
+
+    PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
 #if defined(PW_RPC_ENABLED)
     chip::rpc::Init();

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -18,6 +18,7 @@
 
 #include "Options.h"
 
+#include <app/server/OnboardingCodesUtil.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #include <core/CHIPError.h>
@@ -32,9 +33,16 @@ LinuxDeviceOptions gDeviceOptions;
 // Follow the code style of command line arguments in case we need to add more options in the future.
 enum
 {
-    kDeviceOption_BleDevice = 0x1000,
-    kDeviceOption_WiFi      = 0x1001,
-    kDeviceOption_Thread    = 0x1002,
+    kDeviceOption_BleDevice     = 0x1000,
+    kDeviceOption_WiFi          = 0x1001,
+    kDeviceOption_Thread        = 0x1002,
+    kDeviceOption_Version       = 0x1003,
+    kDeviceOption_VendorID      = 0x1004,
+    kDeviceOption_ProductID     = 0x1005,
+    kDeviceOption_CustomFlow    = 0x1006,
+    kDeviceOption_Capabilities  = 0x1007,
+    kDeviceOption_Discriminator = 0x1008,
+    kDeviceOption_Passcode      = 0x1009
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -46,21 +54,50 @@ OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOpti
 #if CHIP_ENABLE_OPENTHREAD
                                   { "thread", kNoArgument, kDeviceOption_Thread },
 #endif // CHIP_ENABLE_OPENTHREAD
+                                  { "version", kArgumentRequired, kDeviceOption_Version },
+                                  { "vendor-id", kArgumentRequired, kDeviceOption_VendorID },
+                                  { "product-id", kArgumentRequired, kDeviceOption_ProductID },
+                                  { "custom-flow", kArgumentRequired, kDeviceOption_CustomFlow },
+                                  { "capabilities", kArgumentRequired, kDeviceOption_Capabilities },
+                                  { "discriminator", kArgumentRequired, kDeviceOption_Discriminator },
+                                  { "passcode", kArgumentRequired, kDeviceOption_Passcode },
                                   {} };
 
-const char * sDeviceOptionHelp = "  --ble-device <number>\n"
-                                 "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
+const char * sDeviceOptionHelp =
+    "  --ble-device <number>\n"
+    "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-                                 "\n"
-                                 "  --wifi\n"
-                                 "       Enable WiFi management via wpa_supplicant.\n"
+    "\n"
+    "  --wifi\n"
+    "       Enable WiFi management via wpa_supplicant.\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_ENABLE_OPENTHREAD
-                                 "\n"
-                                 "  --thread\n"
-                                 "       Enable Thread management via ot-agent.\n"
+    "\n"
+    "  --thread\n"
+    "       Enable Thread management via ot-agent.\n"
 #endif // CHIP_ENABLE_OPENTHREAD
-                                 "\n";
+    "\n"
+    "  --version <version>\n"
+    "       The version indication provides versioning of the setup payload.\n"
+    "\n"
+    "  --vendor-id <id>\n"
+    "       The Vendor ID is assigned by the Connectivity Standards Alliance.\n"
+    "\n"
+    "  --product-id <id>\n"
+    "       The Product ID is specified by vendor.\n"
+    "\n"
+    "  --custom-flow <Standard = 0 | UserActionRequired = 1 | Custom = 2>\n"
+    "       A 2-bit unsigned enumeration specifying manufacturer-specific custom flow options.\n"
+    "\n"
+    "  --capabilities <None = 0, SoftAP = 1 << 0, BLE = 1 << 1, OnNetwork = 1 << 2>\n"
+    "       Discovery Capabilities Bitmask which contains information about Device’s available technologies for device discovery.\n"
+    "\n"
+    "  --discriminator <discriminator>\n"
+    "       A 12-bit unsigned integer match the value which a device advertises during commissioning.\n"
+    "\n"
+    "  --passcode <passcode>\n"
+    "       A 27-bit unsigned integer, which serves as proof of possession during commissioning.\n"
+    "\n";
 
 bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
@@ -83,6 +120,34 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_Thread:
         LinuxDeviceOptions::GetInstance().mThread = true;
+        break;
+
+    case kDeviceOption_Version:
+        LinuxDeviceOptions::GetInstance().payload.version = static_cast<uint8_t>(atoi(aValue));
+        break;
+
+    case kDeviceOption_VendorID:
+        LinuxDeviceOptions::GetInstance().payload.vendorID = static_cast<uint16_t>(atoi(aValue));
+        break;
+
+    case kDeviceOption_ProductID:
+        LinuxDeviceOptions::GetInstance().payload.productID = static_cast<uint16_t>(atoi(aValue));
+        break;
+
+    case kDeviceOption_CustomFlow:
+        LinuxDeviceOptions::GetInstance().payload.commissioningFlow = static_cast<CommissioningFlow>(atoi(aValue));
+        break;
+
+    case kDeviceOption_Capabilities:
+        LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.SetRaw(static_cast<uint8_t>(atoi(aValue)));
+        break;
+
+    case kDeviceOption_Discriminator:
+        LinuxDeviceOptions::GetInstance().payload.discriminator = static_cast<uint16_t>(atoi(aValue));
+        break;
+
+    case kDeviceOption_Passcode:
+        LinuxDeviceOptions::GetInstance().payload.setUpPINCode = static_cast<uint32_t>(atoi(aValue));
         break;
 
     default:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -27,9 +27,11 @@
 #include <cstdint>
 
 #include <core/CHIPError.h>
+#include <setup_payload/SetupPayload.h>
 
 struct LinuxDeviceOptions
 {
+    chip::SetupPayload payload;
     uint32_t mBleDevice = 0;
     bool mWiFi          = false;
     bool mThread        = false;

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -36,17 +36,17 @@ using namespace ::chip::DeviceLayer;
 
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    std::string QRCode;
+    std::string qrCode;
     std::string manualPairingCode;
 
-    if (GetQRCode(QRCode, aRendezvousFlags) == CHIP_NO_ERROR)
+    if (GetQRCode(qrCode, aRendezvousFlags) == CHIP_NO_ERROR)
     {
         chip::Platform::ScopedMemoryBuffer<char> qrCodeBuffer;
-        const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * QRCode.size() + 1;
+        const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * qrCode.size() + 1;
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
-        ChipLogProgress(AppServer, "SetupQRCode: [%s]", QRCode.c_str());
-        if (GetQRCodeUrl(&qrCodeBuffer[0], qrCodeBufferMaxSize, QRCode) == CHIP_NO_ERROR)
+        ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
+        if (GetQRCodeUrl(&qrCodeBuffer[0], qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
             ChipLogProgress(AppServer, "%s", &qrCodeBuffer[0]);
@@ -69,17 +69,17 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
 
 void PrintOnboardingCodes(const chip::SetupPayload & payload)
 {
-    std::string QRCode;
+    std::string qrCode;
     std::string manualPairingCode;
 
-    if (GetQRCode(QRCode, payload) == CHIP_NO_ERROR)
+    if (GetQRCode(qrCode, payload) == CHIP_NO_ERROR)
     {
         chip::Platform::ScopedMemoryBuffer<char> qrCodeBuffer;
-        const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * QRCode.size() + 1;
+        const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * qrCode.size() + 1;
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
-        ChipLogProgress(AppServer, "SetupQRCode: [%s]", QRCode.c_str());
-        if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, QRCode) == CHIP_NO_ERROR)
+        ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
+        if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
             ChipLogProgress(AppServer, "%s", qrCodeBuffer.Get());
@@ -104,10 +104,10 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags)
 {
     // Get QR Code and emulate its content using NFC tag
-    std::string QRCode;
-    ReturnOnFailure(GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));
+    std::string qrCode;
+    ReturnOnFailure(GetQRCode(qrCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));
 
-    ReturnOnFailure(NFCMgr().StartTagEmulation(QRCode.c_str(), QRCode.size()));
+    ReturnOnFailure(NFCMgr().StartTagEmulation(qrCode.c_str(), qrCode.size()));
 }
 #endif
 

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -46,10 +46,10 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
         ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
-        if (GetQRCodeUrl(&qrCodeBuffer[0], qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
+        if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
-            ChipLogProgress(AppServer, "%s", &qrCodeBuffer[0]);
+            ChipLogProgress(AppServer, "%s", qrCodeBuffer.Get());
         }
     }
     else

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -82,7 +82,7 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
         if (GetQRCodeUrl(&qrCodeBuffer[0], qrCodeBufferMaxSize, QRCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
-            ChipLogProgress(AppServer, "%s", &qrCodeBuffer[0]);
+            ChipLogProgress(AppServer, "%s", qrCodeBuffer.Get());
         }
     }
     else

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -79,7 +79,7 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
         ChipLogProgress(AppServer, "SetupQRCode: [%s]", QRCode.c_str());
-        if (GetQRCodeUrl(&qrCodeBuffer[0], qrCodeBufferMaxSize, QRCode) == CHIP_NO_ERROR)
+        if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, QRCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
             ChipLogProgress(AppServer, "%s", qrCodeBuffer.Get());

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -22,8 +22,8 @@
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags);
 void PrintOnboardingCodes(const chip::SetupPayload & payload);
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetQRCode(std::string & QRCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetQRCode(std::string & QRCode, const chip::SetupPayload & payload);
+CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -20,10 +20,13 @@
 #include <setup_payload/SetupPayload.h>
 
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags);
+void PrintOnboardingCodes(const chip::SetupPayload & payload);
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags);
 CHIP_ERROR GetQRCode(std::string & QRCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetQRCode(std::string & QRCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
 CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
 CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* currently, example app always generate setup code with default Device Configuration, CSG would like to add options to allow configure QRcode/setup code with linux example apps for CSG tests validation.

* Fixes #8404 

#### Change overview
Enable setup code options for linux example apps

#### Testing
How was this tested? (at least one bullet point required)
1. Run chip-lighting-app -h to show new options for Setup Payload.
```
yufengw@yufengw-SEi:~/Workspace/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app -h
Usage: ./chip-lighting-app [options]

GENERAL OPTIONS

  --ble-device <number>
       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.

  --wifi
       Enable WiFi management via wpa_supplicant.

  --thread
       Enable Thread management via ot-agent.

  --version <version>
       The version indication provides versioning of the setup payload.

  --vendor-id <id>
       The Vendor ID is assigned by the Connectivity Standards Alliance.

  --product-id <id>
       The Product ID is specified by vendor.

  --custom-flow <Standard = 0 | UserActionRequired = 1 | Custom = 2>
       A 2-bit unsigned enumeration specifying manufacturer-specific custom flow options.

  --capabilities <None = 0, SoftAP = 1 << 0, BLE = 1 << 1, OnNetwork = 1 << 2>
       Discovery Capabilities Bitmask which contains information about Device’s available technologies for device discovery.

  --discriminator <discriminator>
       A 12-bit unsigned integer match the value which a device advertises during commissioning.

  --passcode <passcode>
       A 27-bit unsigned integer, which serves as proof of possession during commissioning.

HELP OPTIONS

  -h, --help
       Print this output and then exit.

  -v, --version
       Print the version and then exit.
```
2. Run ./chip-lighting-app with customized setup payload  
```
./chip-lighting-app --version 1 --vendor-id 1234 --product-id 1234 --custom-flow 2 --capabilities 3 --discriminator 1234 --passcode 1234 

[1626884897.552607][453003:453003] CHIP:SVR: SetupQRCode: [MT:TA6K4-J-02MOJB00000]
[1626884897.552637][453003:453003] CHIP:SVR: Manual pairing code: [501234000001234012341]
```
