### PR TITLE
[Darwin] Fix incorrect Thread panID generation

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.h
+++ b/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.h
@@ -74,6 +74,12 @@ extern size_t const CHIPSizeThreadPSKc;
                                        panID:(NSData *)panID;
 
 /**
+ *  Create a Thread Operational Dataset object with a RCP formatted active operational dataset.
+ *  This initializer will return nil if the input data cannot be parsed correctly
+ */
+- (nullable instancetype)initWithData:(NSData *)data;
+
+/**
  * Get the underlying data that represents the Thread Active Operational Dataset
  */
 - (NSData *)asData;

--- a/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
@@ -96,7 +96,8 @@ size_t const CHIPSizeThreadPSKc = chip::Thread::kSizePSKc;
     if (valuePtr == nullptr) {
         return NO;
     }
-    _cppThreadOperationalDataset.SetPanId(*valuePtr);
+    // The underlying CPP class assumes Big Endianness for the panID
+    _cppThreadOperationalDataset.SetPanId(CFSwapInt16HostToBig(*valuePtr));
 
     return YES;
 }
@@ -108,6 +109,40 @@ size_t const CHIPSizeThreadPSKc = chip::Thread::kSizePSKc;
         return NO;
     }
     return YES;
+}
+
+
+- (nullable instancetype)initWithData:(NSData *)data
+{
+    chip::ByteSpan span = chip::ByteSpan((uint8_t *)data.bytes, data.length);
+    auto dataset = chip::Thread::OperationalDataset();
+    CHIP_ERROR error = dataset.Init(span);
+    if (error != CHIP_NO_ERROR)
+    {
+        CHIP_LOG_ERROR("Failed to parse data, cannot construct Operational Dataset. %d", error);
+        return nil;
+    }
+    // len+1 for null termination
+    char networkName[CHIPSizeThreadNetworkName + 1];
+    uint8_t pskc[CHIPSizeThreadPSKc];
+    uint8_t extendedPANID[CHIPSizeThreadExtendedPanId];
+    uint8_t masterKey[CHIPSizeThreadMasterKey];
+    uint16_t panID;
+    uint16_t channel;
+    dataset.GetNetworkName(networkName);
+    dataset.GetExtendedPanId(extendedPANID);
+    dataset.GetMasterKey(masterKey);
+    dataset.GetPSKc(pskc);
+    dataset.GetPanId(panID);
+    dataset.GetChannel(channel);
+    panID = CFSwapInt16BigToHost(panID);
+
+    return [self initWithNetworkName:[NSString stringWithUTF8String:networkName]
+                       extendedPANID:[NSData dataWithBytes:extendedPANID length:CHIPSizeThreadExtendedPanId]
+                           masterKey:[NSData dataWithBytes:masterKey length:CHIPSizeThreadMasterKey]
+                                PSKc:[NSData dataWithBytes:pskc length:CHIPSizeThreadPSKc]
+                             channel:channel
+                               panID:[NSData dataWithBytes:&panID length:sizeof(uint16_t)]];
 }
 
 - (NSData *)asData

--- a/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
@@ -111,14 +111,12 @@ size_t const CHIPSizeThreadPSKc = chip::Thread::kSizePSKc;
     return YES;
 }
 
-
 - (nullable instancetype)initWithData:(NSData *)data
 {
-    chip::ByteSpan span = chip::ByteSpan((uint8_t *)data.bytes, data.length);
+    chip::ByteSpan span = chip::ByteSpan((uint8_t *) data.bytes, data.length);
     auto dataset = chip::Thread::OperationalDataset();
     CHIP_ERROR error = dataset.Init(span);
-    if (error != CHIP_NO_ERROR)
-    {
+    if (error != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("Failed to parse data, cannot construct Operational Dataset. %d", error);
         return nil;
     }

--- a/src/darwin/Framework/CHIPTests/CHIPThreadOperationalDatasetTests.mm
+++ b/src/darwin/Framework/CHIPTests/CHIPThreadOperationalDatasetTests.mm
@@ -46,6 +46,16 @@
     XCTAssertNotNil(dataset);
     NSData * data = [dataset asData];
     XCTAssertNotNil(data);
+
+    CHIPThreadOperationalDataset * reconstructed = [[CHIPThreadOperationalDataset alloc] initWithData:data];
+    XCTAssertNotNil(reconstructed);
+    XCTAssertEqualObjects(reconstructed.networkName, dataset.networkName);
+    XCTAssertEqualObjects(reconstructed.panID, dataset.panID);
+    XCTAssertEqualObjects(reconstructed.masterKey, dataset.masterKey);
+    XCTAssertEqualObjects(reconstructed.PSKc, dataset.PSKc);
+    XCTAssertEqualObjects(reconstructed.extendedPANID, dataset.extendedPANID);
+    XCTAssertEqual(reconstructed.channel, dataset.channel);
+
 }
 
 - (void)testThreadOperationalDatasetInvalid

--- a/src/darwin/Framework/CHIPTests/CHIPThreadOperationalDatasetTests.mm
+++ b/src/darwin/Framework/CHIPTests/CHIPThreadOperationalDatasetTests.mm
@@ -55,7 +55,6 @@
     XCTAssertEqualObjects(reconstructed.PSKc, dataset.PSKc);
     XCTAssertEqualObjects(reconstructed.extendedPANID, dataset.extendedPANID);
     XCTAssertEqual(reconstructed.channel, dataset.channel);
-
 }
 
 - (void)testThreadOperationalDatasetInvalid


### PR DESCRIPTION
#### Problem
The underlying cpp implementation assumes(with no documentation) that the input panID is meant to be in Big-Endian. 

#### Change overview
Explicitly convert from Host order to BE when constructing the underlying cpp structure. And make sure to convert back into Host order when pulling information out of a buffer again.

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
Added a unit test to convert individual fields to a data buffer and then reconstruct the individual fields from that data buffer