### PR TITLE
Fix build error due to undefined kAnyNodeId

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -25,6 +25,7 @@
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <core/CHIPError.h>
+#include <core/NodeId.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/CHIPMem.h>
@@ -165,7 +166,7 @@ ExampleOperationalCredentialsIssuer gOpCredsIssuer;
 
 CHIP_ERROR InitCommissioner()
 {
-    NodeId localId = chip::kAnyNodeId;
+    NodeId localId = chip::kPlaceholderNodeId;
 
     chip::Controller::CommissionerInitParams params;
 


### PR DESCRIPTION
#### Problem
ToT fails due to #8465 and #8084 merged around the same time.

#### Change overview
Replace `kAnyNodeId` with `kPlaceholderNodeId`.

#### Testing
Tested build of the tv-app for Linux. Both constants have the same value, so there should be no functional difference.