### PR TITLE
Use not_first and not_last in templates.

### DIFF
--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -475,7 +475,7 @@ class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}Attribute
 
                 jobject attributeObj = env->NewObject(attributeClass, attributeCtor,
                     {{#chip_attribute_list_entryTypes}}
-                    {{asCamelCased name true}}{{#unless (isLastElement index count)}}, {{/unless}}
+                    {{asCamelCased name true}}{{#not_last}}, {{/not_last}}
                     {{/chip_attribute_list_entryTypes}}
                 );
                 VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create {{asCamelCased name false}}Attribute object"));
@@ -530,7 +530,7 @@ JNI_METHOD(jlong, {{asCamelCased name false}}Cluster, initWithDevice)(JNIEnv * e
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_server_cluster_command_arguments}}{{asJniBasicType type}} {{asCamelCased label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/chip_server_cluster_command_arguments}})
+JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_server_cluster_command_arguments}}{{asJniBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}})
 {{else}}
 JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {{/if}}

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -72,12 +72,12 @@ public class ChipClusters {
   {{#chip_server_cluster_commands}}
 
   {{#if (zcl_command_arguments_count this.id)}}
-    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/chip_server_cluster_command_arguments}}) {
+    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}}) {
   {{else}}
     public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback) {
   {{/if}}
   {{#if (zcl_command_arguments_count this.id)}}
-      {{asCamelCased name}}(chipClusterPtr, callback, {{#chip_server_cluster_command_arguments}}{{asCamelCased label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/chip_server_cluster_command_arguments}});
+      {{asCamelCased name}}(chipClusterPtr, callback, {{#chip_server_cluster_command_arguments}}{{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}});
   {{else}}
       {{asCamelCased name}}(chipClusterPtr, callback);
   {{/if}}    
@@ -86,7 +86,7 @@ public class ChipClusters {
   {{/chip_server_cluster_commands}}
   {{#chip_server_cluster_commands}}
   {{#if (zcl_command_arguments_count this.id)}}
-    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/chip_server_cluster_command_arguments}});
+    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}});
   {{else}}
     private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback);
   {{/if}}
@@ -133,11 +133,11 @@ public class ChipClusters {
       public {{asCamelCased name false}}Attribute(
         {{#chip_attribute_list_entryTypes}}
         {{#if (isOctetString type)}}
-        byte[] {{asCamelCased name true}}{{#unless (isLastElement index count)}},{{/unless}}
+        byte[] {{asCamelCased name true}}{{#not_last}},{{/not_last}}
         {{else if (isCharString type)}}
         // Add String field here after ByteSpan is properly emitted in C++ layer
         {{else}}
-        {{asJavaBasicType label type}} {{asCamelCased name true}}{{#unless (isLastElement index count)}},{{/unless}}
+        {{asJavaBasicType label type}} {{asCamelCased name true}}{{#not_last}},{{/not_last}}
         {{/if}}
         {{/chip_attribute_list_entryTypes}}
       ) {
@@ -199,9 +199,9 @@ public class ChipClusters {
   {{/if}}
   {{/chip_server_cluster_attributes}}
   }
-  {{#unless (isLastElement index count)}}
+  {{#not_last}}
 
-  {{/unless}}
+  {{/not_last}}
   {{/chip_client_clusters}}
 }
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -584,7 +584,7 @@ private:
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asLowerCamelCase label}}:{{/if}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
+- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#chip_server_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#if index includeZero=false}}{{asLowerCamelCase label}}:{{/if}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
+- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler;
 {{/if}}


### PR DESCRIPTION
It's more readable and intuitive than messing with the index

#### Problem
We are using things like `{{#unless (isLastElement index count)}}` when we mean `{{not_last}}`.

#### Change overview
Use `not_first` and `not_last`.

#### Testing
Regenerated and verified that there are no changes to the generated code.