### PR TITLE
Chip add wifi rpcs all-clusters-app

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -33,7 +33,24 @@ elseif(${IDF_TARGET} STREQUAL "esp32c3")
 endif()
 
 project(chip-all-clusters-app)
-idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
 flashing_script()
+
+if (CONFIG_ENABLE_PW_RPC)
+get_filename_component(CHIP_ROOT ./third_party/connectedhomeip REALPATH)
+include(third_party/connectedhomeip/third_party/pigweed/repo/pw_build/pigweed.cmake)
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert pw_assert_log)
+pw_set_backend(pw_sys_io pw_sys_io.esp32)
+
+add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
+add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
+add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
+
+get_target_property(_target_cxx_flags pw_build.cpp17 INTERFACE_COMPILE_OPTIONS)
+list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
+list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
+set_target_properties(pw_build.cpp17 PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
+endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -257,3 +257,27 @@ If you wish to see the actual effect of the commands on `ESP32-DevKitC`,
 `ESP32-WROVER-KIT_V4.1`, you will have to connect an external LED to GPIO
 `STATUS_LED_GPIO_NUM`. For `ESP32C3-DevKitM`, the on-board LED will show the
 actual effect of the commands.
+
+## Using the RPC console
+
+Enable RPCs in the build using menuconfig:
+
+    $ idf.py menuconfig
+
+Enable the RPC library:
+
+    Component config → CHIP Core → General Options → Enable Pigweed PRC library
+
+After flashing a build with RPCs enabled you can use the rpc console to send
+commands to the device.
+
+Build or install the [rpc console](../../common/pigweed/rpc_console/README.md)
+
+Start the console
+
+    python -m chip_rpc.console --device /dev/ttyUSB0
+
+From within the console you can then invoke rpcs:
+
+    rpcs.chip.rpc.Wifi.Connect(ssid=b"MySSID", secret=b"MyPASSWORD")
+    rpcs.chip.rpc.Wifi.GetIP6Address()

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -73,6 +73,22 @@ set(SRC_DIRS_LIST
                       #${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ias-zone-client
 )
 
+if (CONFIG_ENABLE_PW_RPC)
+# Append additional directories for RPC build
+set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${IDF_PATH}/components/freertos/include/freertos"
+)
+set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+)
+endif (CONFIG_ENABLE_PW_RPC)
+
 if(("${CONFIG_DEVICE_TYPE_ESP32_DEVKITC}" STREQUAL "y") OR ("${CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM}" STREQUAL "y"))
     list(APPEND PRIV_INCLUDE_DIRS_LIST
                 "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/screen-framework/include")
@@ -89,5 +105,74 @@ idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
                        SRC_DIRS ${SRC_DIRS_LIST}
                        PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
 
-set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 17)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
+
+if (CONFIG_ENABLE_PW_RPC)
+
+idf_component_get_property(chip_lib chip COMPONENT_LIB)
+
+set(WRAP_FUNCTIONS esp_log_write)
+target_link_libraries(${chip_lib} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
+
+get_filename_component(CHIP_ROOT ../third_party/connectedhomeip REALPATH)
+
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
+include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
+set(dir_pw_third_party_nanopb "${CHIP_ROOT}/third_party/nanopb/repo" CACHE STRING "" FORCE)
+
+pw_proto_library(button_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/button_service.proto
+  PREFIX
+    button_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(device_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.options
+  PREFIX
+    device_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(wifi_service
+  SOURCES
+    ${CHIP_ROOT}/examples/ipv6only-app/common/wifi_service/wifi_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/ipv6only-app/common/wifi_service/wifi_service.options
+  PREFIX
+    wifi_service
+  DEPS
+    pw_protobuf.common_protos
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/ipv6only-app/common/wifi_service
+)
+
+target_link_libraries(${COMPONENT_LIB} PUBLIC
+  button_service.nanopb_rpc
+  device_service.nanopb_rpc
+  wifi_service.nanopb_rpc
+  pw_checksum
+  pw_hdlc
+  pw_log
+  pw_rpc.server
+)
+
+set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})
+target_include_directories(${chip_lib} PUBLIC
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb")
+
+endif (CONFIG_ENABLE_PW_RPC)

--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -101,3 +101,37 @@ menu "Demo"
 
 
 endmenu
+
+menu "PW RPC Debug channel"
+    config EXAMPLE_UART_PORT_NUM
+        int "UART port number"
+        range 0 2 if IDF_TARGET_ESP32
+        default 0 if IDF_TARGET_ESP32
+        help
+            UART communication port number for the example.
+            See UART documentation for available port numbers.
+
+    config EXAMPLE_UART_BAUD_RATE
+        int "UART communication speed"
+        range 1200 115200
+        default 115200
+        help
+            UART communication speed for Modbus example.
+
+    config EXAMPLE_UART_RXD
+        int "UART RXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        default 3
+        help
+            GPIO number for UART RX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+    config EXAMPLE_UART_TXD
+        int "UART TXD pin number"
+        range 0 34 if IDF_TARGET_ESP32
+        default 1
+        help
+            GPIO number for UART TX pin. See UART documentation for more information
+            about available pin numbers for UART.
+
+endmenu

--- a/examples/all-clusters-app/esp32/main/Rpc.cpp
+++ b/examples/all-clusters-app/esp32/main/Rpc.cpp
@@ -1,0 +1,332 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "sdkconfig.h"
+#if CONFIG_ENABLE_PW_RPC
+#include "PigweedLoggerMutex.h"
+#include "RpcService.h"
+#include "button_service/button_service.rpc.pb.h"
+#include "device_service/device_service.rpc.pb.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "pw_log/log.h"
+#include "pw_rpc/server.h"
+#include "pw_sys_io/sys_io.h"
+#include <support/logging/CHIPLogging.h>
+
+#include "ScreenManager.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "pw_containers/flat_map.h"
+#include "pw_status/status.h"
+#include "pw_status/try.h"
+#include "wifi_service/wifi_service.rpc.pb.h"
+
+#include "ServiceProvisioning.h"
+
+#include "ESP32Utils.h"
+
+static const char * TAG = "RPC";
+
+namespace chip {
+namespace rpc {
+namespace {
+
+constexpr pw::containers::FlatMap<uint8_t, uint32_t, 73> kChannelToFreqMap({ {
+    { 1, 2412 },   { 2, 2417 },   { 3, 2422 },   { 4, 2427 },   { 5, 2432 },   { 6, 2437 },   { 7, 2442 },   { 8, 2447 },
+    { 9, 2452 },   { 10, 2457 },  { 11, 2462 },  { 12, 2467 },  { 13, 2472 },  { 14, 2484 },  { 32, 5160 },  { 34, 5170 },
+    { 36, 5180 },  { 38, 5190 },  { 40, 5200 },  { 42, 5210 },  { 44, 5220 },  { 46, 5230 },  { 48, 5240 },  { 50, 5250 },
+    { 52, 5260 },  { 54, 5270 },  { 56, 5280 },  { 58, 5290 },  { 60, 5300 },  { 62, 5310 },  { 64, 5320 },  { 68, 5340 },
+    { 96, 5480 },  { 100, 5500 }, { 102, 5510 }, { 104, 5520 }, { 106, 5530 }, { 108, 5540 }, { 110, 5550 }, { 112, 5560 },
+    { 114, 5570 }, { 116, 5580 }, { 118, 5590 }, { 120, 5600 }, { 122, 5610 }, { 124, 5620 }, { 126, 5630 }, { 128, 5640 },
+    { 132, 5660 }, { 134, 5670 }, { 136, 5680 }, { 138, 5690 }, { 140, 5700 }, { 142, 5710 }, { 144, 5720 }, { 149, 5745 },
+    { 151, 5755 }, { 153, 5765 }, { 155, 5775 }, { 157, 5785 }, { 159, 5795 }, { 161, 5805 }, { 165, 5825 }, { 169, 5845 },
+    { 173, 5865 }, { 183, 4915 }, { 184, 4920 }, { 185, 4925 }, { 187, 4935 }, { 188, 4940 }, { 189, 4945 }, { 192, 4960 },
+    { 196, 4980 },
+} });
+
+// These are potentially large objects for the scan results.
+constexpr size_t kScanRecordsMax = sizeof(chip_rpc_ScanResults().aps) / sizeof(chip_rpc_ScanResult);
+chip_rpc_ScanResults out_scan_records;
+wifi_ap_record_t scan_records[kScanRecordsMax];
+
+class Device final : public generated::Device<Device>
+{
+public:
+    pw::Status FactoryReset(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        chip::DeviceLayer::ConfigurationMgr().InitiateFactoryReset();
+        return pw::OkStatus();
+    }
+    pw::Status Reboot(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        return pw::Status::Unimplemented();
+    }
+    pw::Status TriggerOta(ServerContext & ctx, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        return pw::Status::Unimplemented();
+    }
+    pw::Status GetDeviceInfo(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_DeviceInfo & response)
+    {
+        response.vendor_id        = 1234;
+        response.product_id       = 5678;
+        response.software_version = 0;
+        return pw::OkStatus();
+    }
+};
+
+class Button final : public generated::Button<Button>
+{
+public:
+    pw::Status Event(ServerContext &, const chip_rpc_ButtonEvent & request, pw_protobuf_Empty & response)
+    {
+#if CONFIG_DEVICE_TYPE_M5STACK
+        if (request.pushed)
+        {
+            ScreenManager::ButtonPressed(1 + request.idx);
+        }
+        return pw::OkStatus();
+#else  // CONFIG_DEVICE_TYPE_M5STACK
+        return pw::Status::Unimplemented();
+#endif // CONFIG_DEVICE_TYPE_M5STACK
+    }
+};
+
+class Wifi final : public generated::Wifi<Wifi>
+{
+public:
+    pw::Status GetChannel(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_Channel & response)
+    {
+        uint8_t channel = 0;
+        wifi_second_chan_t second;
+        PW_TRY(EspToPwStatus(esp_wifi_get_channel(&channel, &second)));
+        response.channel = channel;
+        return pw::OkStatus();
+    }
+
+    pw::Status GetSsid(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_Ssid & response)
+    {
+        wifi_config_t config;
+        PW_TRY(EspToPwStatus(esp_wifi_get_config(WIFI_IF_STA, &config)));
+        size_t size = std::min(sizeof(response.ssid.bytes), sizeof(config.sta.ssid));
+        memcpy(response.ssid.bytes, config.sta.ssid, size);
+        response.ssid.size = size;
+        return pw::OkStatus();
+    }
+
+    pw::Status GetState(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_State & response)
+    {
+        wifi_ap_record_t ap_info;
+        esp_err_t err = esp_wifi_sta_get_ap_info(&ap_info);
+        PW_TRY(EspToPwStatus(err));
+        response.connected = (err != ESP_ERR_WIFI_NOT_CONNECT);
+        return pw::OkStatus();
+    }
+
+    pw::Status GetMacAddress(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_MacAddress & response)
+    {
+        uint8_t mac[6];
+        PW_TRY(EspToPwStatus(esp_wifi_get_mac(WIFI_IF_STA, mac)));
+        snprintf(response.mac_address, sizeof(response.mac_address), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2],
+                 mac[3], mac[4], mac[5]);
+        return pw::OkStatus();
+    }
+
+    pw::Status GetWiFiInterface(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_WiFiInterface & response)
+    {
+        wifi_ap_record_t ap_info;
+        PW_TRY(EspToPwStatus(esp_wifi_sta_get_ap_info(&ap_info)));
+        snprintf(response.interface, sizeof(response.interface), "STA");
+        return pw::OkStatus();
+    }
+
+    pw::Status GetIP4Address(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_IP4Address & response)
+    {
+        esp_netif_ip_info_t ip_info;
+        PW_TRY(EspToPwStatus(esp_netif_get_ip_info(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip_info)));
+        snprintf(response.address, sizeof(response.address), IPSTR, IP2STR(&ip_info.ip));
+        return pw::OkStatus();
+    }
+
+    pw::Status GetIP6Address(ServerContext &, const pw_protobuf_Empty & request, chip_rpc_IP6Address & response)
+    {
+        esp_ip6_addr_t ip6;
+        PW_TRY(EspToPwStatus(esp_netif_get_ip6_linklocal(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"), &ip6)));
+        snprintf(response.address, sizeof(response.address), IPV6STR, IPV62STR(ip6));
+        return pw::OkStatus();
+    }
+
+    // NOTE: Currently this is blocking, it can be made non-blocking if needed
+    //       but would require another worker thread to handle the scanning.
+    void StartScan(ServerContext &, const chip_rpc_ScanConfig & request, ServerWriter<chip_rpc_ScanResults> & writer)
+    {
+        wifi_scan_config_t scan_config;
+        if (request.ssid_count != 0)
+        {
+            scan_config.ssid = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(request.ssid[0].bytes));
+        }
+        if (request.bssid_count != 0)
+        {
+            scan_config.bssid = const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(request.bssid[0].bytes));
+        }
+        scan_config.channel     = request.channel;
+        scan_config.show_hidden = request.show_hidden;
+        scan_config.scan_type   = static_cast<wifi_scan_type_t>(request.active_scan);
+        if (request.active_scan)
+        {
+            scan_config.scan_time.active.min = request.scan_time_min_ms;
+            scan_config.scan_time.active.max = request.scan_time_max_ms;
+        }
+        else
+        {
+            scan_config.scan_time.passive = request.scan_time_min_ms;
+        }
+
+        auto err = esp_wifi_scan_start(&scan_config, true /* block */);
+        if (ESP_OK != err)
+        {
+            ESP_LOGI(TAG, "Error starting scan: %d", err);
+            return;
+        }
+
+        // Output scan results
+        uint16_t num_scan_records = kScanRecordsMax;
+        err                       = esp_wifi_scan_get_ap_records(&num_scan_records, scan_records);
+        if (ESP_OK != err)
+        {
+            ESP_LOGI(TAG, "Error getting scanned APs: %d", err);
+            num_scan_records = 0;
+        }
+        ESP_LOGI(TAG, "%d", num_scan_records);
+        out_scan_records.aps_count = num_scan_records;
+
+        for (size_t i = 0; i < num_scan_records; ++i)
+        {
+            out_scan_records.aps[i].ssid.size = std::min(sizeof(scan_records[i].ssid), sizeof(out_scan_records.aps[i].ssid.bytes));
+            memcpy(out_scan_records.aps[i].ssid.bytes, scan_records[i].ssid, out_scan_records.aps[i].ssid.size);
+            out_scan_records.aps[i].bssid.size =
+                std::min(sizeof(scan_records[i].bssid), sizeof(out_scan_records.aps[i].bssid.bytes));
+            memcpy(out_scan_records.aps[i].bssid.bytes, scan_records[i].bssid, out_scan_records.aps[i].bssid.size);
+            out_scan_records.aps[i].security_type = static_cast<chip_rpc_WIFI_SECURITY_TYPE>(scan_records[i].authmode);
+            out_scan_records.aps[i].channel       = scan_records[i].primary;
+            auto found_channel                    = kChannelToFreqMap.find(scan_records[i].primary);
+            out_scan_records.aps[i].frequency     = (found_channel ? found_channel->second : 0);
+            out_scan_records.aps[i].signal        = scan_records[i].rssi;
+        }
+        writer.Write(out_scan_records);
+        writer.Finish();
+    }
+
+    pw::Status StopScan(ServerContext &, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        esp_wifi_scan_stop();
+        return pw::OkStatus();
+    }
+
+    pw::Status Connect(ServerContext &, const chip_rpc_ConnectionData & request, chip_rpc_ConnectionResult & response)
+    {
+        char ssid[sizeof(wifi_config_t().sta.ssid)];
+        char password[sizeof(wifi_config_t().sta.password)];
+        size_t ssid_size = std::min(sizeof(ssid) - 1, static_cast<size_t>(request.ssid.size));
+        memcpy(ssid, request.ssid.bytes, ssid_size);
+        ssid[ssid_size]      = '\0';
+        size_t password_size = std::min(sizeof(password) - 1, static_cast<size_t>(request.secret.size));
+        memcpy(password, request.secret.bytes, password_size);
+        password[password_size] = '\0';
+        return SetWiFiStationProvisioning(ssid, password) == CHIP_NO_ERROR ? pw::OkStatus() : pw::Status::Unknown();
+    }
+
+    pw::Status Disconnect(ServerContext &, const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
+    {
+        chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
+        chip::DeviceLayer::ConnectivityMgr().SetWiFiStationMode(chip::DeviceLayer::ConnectivityManager::kWiFiStationMode_Disabled);
+        return pw::OkStatus();
+    }
+
+private:
+    static constexpr pw::Status EspToPwStatus(esp_err_t err)
+    {
+        switch (err)
+        {
+        case ESP_OK:
+            return pw::OkStatus();
+        case ESP_ERR_WIFI_NOT_INIT:
+            return pw::Status::FailedPrecondition();
+        case ESP_ERR_INVALID_ARG:
+            return pw::Status::InvalidArgument();
+        case ESP_ERR_ESP_NETIF_INVALID_PARAMS:
+            return pw::Status::InvalidArgument();
+        case ESP_ERR_WIFI_IF:
+            return pw::Status::NotFound();
+        case ESP_ERR_WIFI_NOT_CONNECT:
+            return pw::Status::FailedPrecondition();
+        case ESP_ERR_WIFI_NOT_STARTED:
+            return pw::Status::FailedPrecondition();
+        case ESP_ERR_WIFI_CONN:
+            return pw::Status::Internal();
+        case ESP_FAIL:
+            return pw::Status::Internal();
+        default:
+            return pw::Status::Unknown();
+        }
+    }
+};
+
+constexpr size_t kRpcStackSizeBytes = (8 * 1024);
+constexpr uint8_t kRpcTaskPriority  = 5;
+
+TaskHandle_t rpcTaskHandle;
+
+Button button_service;
+Device device_service;
+Wifi wifi_service;
+
+void RegisterServices(pw::rpc::Server & server)
+{
+    server.RegisterService(button_service);
+    server.RegisterService(device_service);
+    server.RegisterService(wifi_service);
+}
+
+void RunRpcService(void *)
+{
+    Start(RegisterServices, &logger_mutex);
+}
+
+} // namespace
+
+void Init()
+{
+    PigweedLogger::init();
+
+    ESP_LOGI(TAG, "----------- esp32-rpc-service starting -----------");
+
+    xTaskCreate(RunRpcService, "RPC", kRpcStackSizeBytes / sizeof(StackType_t), nullptr, kRpcTaskPriority, &rpcTaskHandle);
+}
+
+} // namespace rpc
+} // namespace chip
+
+#endif // CONFIG_ENABLE_PW_RPC

--- a/examples/all-clusters-app/esp32/main/include/Rpc.h
+++ b/examples/all-clusters-app/esp32/main/include/Rpc.h
@@ -1,0 +1,26 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace rpc {
+
+void Init();
+
+} // namespace rpc
+} // namespace chip

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -64,6 +64,10 @@
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/clusters/temperature-measurement-server/temperature-measurement-server.h>
 
+#if CONFIG_ENABLE_PW_RPC
+#include "Rpc.h"
+#endif
+
 using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
@@ -593,6 +597,9 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
         return;
     }
+#if CONFIG_ENABLE_PW_RPC
+    chip::rpc::Init();
+#endif
 
 #if CONFIG_ENABLE_CHIP_SHELL
     chip::LaunchShell();

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -199,6 +199,17 @@ connect an external LED to GPIO.
 
 ## Using the RPC console
 
+Enable RPCs in the build using menuconfig:
+
+    $ idf.py menuconfig
+
+Enable the RPC library:
+
+    Component config → CHIP Core → General Options → Enable Pigweed PRC library
+
+After flashing a build with RPCs enabled you can use the rpc console to send
+commands to the device.
+
 Build or install the [rpc console](../../common/pigweed/rpc_console/README.md)
 
 Start the console


### PR DESCRIPTION
#### Problem
Need an automated way to connect to WIFI to support testing.

#### Change overview
Add the ability to optionally include the RPCs into the all-clusters app for ESP32. This includes the services for Button, Device, and Wifi. Wifi RPCs can be used to automate both scanning and connecting.

#### Testing
Tested using chip-rpc.console:
- Verified Device Service RPCs behaved as expected (Some still return Unimplemented, which is expected).
- Button Service RPCs could move through menus when triggered.
- Wifi RPCs could scan, connect, and get the IP address. 
