### PR TITLE
Fix ESP32 storage

### DIFF
--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -404,6 +404,7 @@ CHIP_ERROR ESP32Config::EnsureNamespace(const char * ns)
     {
         ReturnErrorOnFailure(handle.Open(ns, NVS_READWRITE));
         ReturnMappedErrorOnFailure(nvs_commit(handle));
+        return CHIP_NO_ERROR;
     }
     return err;
 }

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -315,7 +315,7 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
 }
 
 /**
- * Given a CHP error value that represents an ESP32 error, returns a
+ * Given a CHIP error value that represents an ESP32 error, returns a
  * human-readable NULL-terminated C string describing the error.
  *
  * @param[in] buf                   Buffer into which the error string will be placed.

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -313,3 +313,43 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
     }
     return ChipError::Encapsulate(ChipError::Range::kPlatform, error);
 }
+
+/**
+ * Given an OpenChip error value that represents an OpenThread error, returns a
+ * human-readable NULL-terminated C string describing the error.
+ *
+ * @param[in] buf                   Buffer into which the error string will be placed.
+ * @param[in] bufSize               Size of the supplied buffer in bytes.
+ * @param[in] err                   The error to be described.
+ *
+ * @return true                     If a description string was written into the supplied buffer.
+ * @return false                    If the supplied error was not an OpenThread error.
+ *
+ */
+bool ESP32Utils::FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err)
+{
+    if (!ChipError::IsRange(ChipError::Range::kPlatform, err))
+    {
+        return false;
+    }
+
+#if CHIP_CONFIG_SHORT_ERROR_STR
+    const char * desc = NULL;
+#else  // CHIP_CONFIG_SHORT_ERROR_STR
+    const char * desc = esp_err_to_name((esp_err_t) ChipError::GetValue(err));
+#endif // CHIP_CONFIG_SHORT_ERROR_STR
+
+    chip::FormatError(buf, bufSize, "OpenThread", err, desc);
+
+    return true;
+}
+
+/**
+ * Register a text error formatter for OpenThread errors.
+ */
+void ESP32Utils::RegisterESP32ErrorFormatter()
+{
+    static ErrorFormatter sErrorFormatter = { ESP32Utils::FormatError, NULL };
+
+    RegisterErrorFormatter(&sErrorFormatter);
+}

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -315,7 +315,7 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
 }
 
 /**
- * Given an OpenChip error value that represents an OpenThread error, returns a
+ * Given a CHP error value that represents an ESP32 error, returns a
  * human-readable NULL-terminated C string describing the error.
  *
  * @param[in] buf                   Buffer into which the error string will be placed.
@@ -323,7 +323,7 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
  * @param[in] err                   The error to be described.
  *
  * @return true                     If a description string was written into the supplied buffer.
- * @return false                    If the supplied error was not an OpenThread error.
+ * @return false                    If the supplied error was not an ESP32 error.
  *
  */
 bool ESP32Utils::FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err)
@@ -339,13 +339,13 @@ bool ESP32Utils::FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     const char * desc = esp_err_to_name((esp_err_t) ChipError::GetValue(err));
 #endif // CHIP_CONFIG_SHORT_ERROR_STR
 
-    chip::FormatError(buf, bufSize, "OpenThread", err, desc);
+    chip::FormatError(buf, bufSize, "ESP32", err, desc);
 
     return true;
 }
 
 /**
- * Register a text error formatter for OpenThread errors.
+ * Register a text error formatter for ESP32 errors.
  */
 void ESP32Utils::RegisterESP32ErrorFormatter()
 {

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -47,6 +47,8 @@ public:
     static CHIP_ERROR ClearWiFiStationProvision(void);
 
     static CHIP_ERROR MapError(esp_err_t error);
+    static void RegisterESP32ErrorFormatter();
+    static bool FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err);
 };
 
 #define ReturnMappedErrorOnFailure(expr)                                                                                           \

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     VerifyOrReturnError(value, CHIP_ERROR_INVALID_ARGUMENT);
 
     Internal::ScopedNvsHandle handle;
-    ReturnErrorOnFailure(handle.Open(kNamespace, NVS_READONLY));
+    ReturnErrorOnFailure(handle.Open(kNamespace, NVS_READWRITE));
 
     ReturnMappedErrorOnFailure(nvs_set_blob(handle, key, value, value_size));
 

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -61,6 +61,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     uint8_t ap_mac[6];
     wifi_mode_t mode;
 
+    // Arrange for CHIP-encapsulated ESP32 errors to be translated to text
+    Internal::ESP32Utils::RegisterESP32ErrorFormatter();
+
     // Make sure the LwIP core lock has been initialized
     ReturnErrorOnFailure(Internal::InitLwIPCoreLock());
 

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -38,7 +38,7 @@ namespace DeviceLayer {
 namespace Internal {
 
 /**
- * Map an OpenThread error into the OpenChip error space.
+ * Map an OpenThread error into the CHIP error space.
  */
 CHIP_ERROR MapOpenThreadError(otError otErr)
 {
@@ -47,7 +47,7 @@ CHIP_ERROR MapOpenThreadError(otError otErr)
 }
 
 /**
- * Given an OpenChip error value that represents an OpenThread error, returns a
+ * Given an CHIP error value that represents an OpenThread error, returns a
  * human-readable NULL-terminated C string describing the error.
  *
  * @param[in] buf                   Buffer into which the error string will be placed.


### PR DESCRIPTION
#### Problem

Commit 162366f0 (#8469) broke persistent storage on ESP32.

#### Change overview

- Fixed return value of `ESP32Config::EnsureNamespace()`.
- Fixed a copy-paste mistake (`NVS_READONLY` for `NVS_READWRITE`)
  in `KeyValueStoreManagerImpl::_Put()`.
- Added string presentation of ESP32 errors to aid troubleshooting.

Fixes #8572 _ESP32 storage probably broken_
Fixes #8569 _ESP32: All clusters app fails to boot up._

#### Testing

Manual on M5Stack
