### PR TITLE
Stop redefining CHIP_ERROR in Darwin headers.

### DIFF
--- a/examples/chip-tool-darwin/main.m
+++ b/examples/chip-tool-darwin/main.m
@@ -19,7 +19,6 @@
 #import <CHIP/CHIPDevice.h>
 #import <CHIP/CHIPDeviceController.h>
 #import <CHIP/CHIPDevicePairingDelegate.h>
-#import <CHIP/CHIPError.h>
 #import <CHIP/CHIPManualSetupPayloadParser.h>
 #import <CHIP/CHIPPersistentStorageDelegate.h>
 #import <CHIP/CHIPQRCodeSetupPayloadParser.h>

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */; };
 		2CB7163F252F731E0026E2BB /* CHIPDevicePairingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FD775552695557E00FF4B12 /* error-mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2FD775542695557E00FF4B12 /* error-mapping.cpp */; };
+		5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* CHIPError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991DC0842475F45400C13860 /* CHIPDeviceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC0822475F45400C13860 /* CHIPDeviceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
@@ -63,7 +64,7 @@
 		B2E0D7B1245B0B5C003C5B48 /* CHIP.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A8245B0B5C003C5B48 /* CHIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E0D7B2245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A9245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */; };
-		B2E0D7B4245B0B5C003C5B48 /* CHIPError.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AB245B0B5C003C5B48 /* CHIPError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2E0D7B4245B0B5C003C5B48 /* CHIPError_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AB245B0B5C003C5B48 /* CHIPError_Internal.h */; };
 		B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AC245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E0D7B6245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AD245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm */; };
 		B2E0D7B7245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AE245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm */; };
@@ -126,6 +127,7 @@
 		2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDevicePairingDelegateBridge.mm; sourceTree = "<group>"; };
 		2CB7163E252F731E0026E2BB /* CHIPDevicePairingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevicePairingDelegate.h; sourceTree = "<group>"; };
 		2FD775542695557E00FF4B12 /* error-mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "error-mapping.cpp"; path = "../../../app/util/error-mapping.cpp"; sourceTree = "<group>"; };
+		5129BCFC26A9EE3300122DDF /* CHIPError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CHIPError.h; path = CHIP/CHIPError.h; sourceTree = "<group>"; };
 		991DC0822475F45400C13860 /* CHIPDeviceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceController.h; sourceTree = "<group>"; };
 		991DC0872475F47D00C13860 /* CHIPDeviceController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceController.mm; sourceTree = "<group>"; };
 		991DC08A247704DC00C13860 /* CHIPLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPLogging.h; sourceTree = "<group>"; };
@@ -143,7 +145,7 @@
 		B2E0D7A8245B0B5C003C5B48 /* CHIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIP.h; sourceTree = "<group>"; };
 		B2E0D7A9245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPManualSetupPayloadParser.h; sourceTree = "<group>"; };
 		B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPError.mm; sourceTree = "<group>"; };
-		B2E0D7AB245B0B5C003C5B48 /* CHIPError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPError.h; sourceTree = "<group>"; };
+		B2E0D7AB245B0B5C003C5B48 /* CHIPError_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPError_Internal.h; sourceTree = "<group>"; };
 		B2E0D7AC245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPQRCodeSetupPayloadParser.h; sourceTree = "<group>"; };
 		B2E0D7AD245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPManualSetupPayloadParser.mm; sourceTree = "<group>"; };
 		B2E0D7AE245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPQRCodeSetupPayloadParser.mm; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 		B20252832459E34F00F97062 = {
 			isa = PBXGroup;
 			children = (
+				5129BCFC26A9EE3300122DDF /* CHIPError.h */,
 				BA107AEE2470CFBB004287EB /* chip_xcode_build_connector.sh */,
 				B202528F2459E34F00F97062 /* CHIP */,
 				B202529A2459E34F00F97062 /* CHIPTests */,
@@ -257,7 +260,7 @@
 				2CB71638252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h */,
 				2CB71639252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.mm */,
 				B2E0D7A8245B0B5C003C5B48 /* CHIP.h */,
-				B2E0D7AB245B0B5C003C5B48 /* CHIPError.h */,
+				B2E0D7AB245B0B5C003C5B48 /* CHIPError_Internal.h */,
 				B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */,
 				991DC08A247704DC00C13860 /* CHIPLogging.h */,
 				B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */,
@@ -315,6 +318,7 @@
 				B2E0D7B8245B0B5C003C5B48 /* CHIPSetupPayload.h in Headers */,
 				997DED182695344800975E97 /* CHIPThreadOperationalDataset.h in Headers */,
 				9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */,
+				5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */,
 				2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
 				1EC4CE6425CC276600D7304F /* CHIPClustersObjc.h in Headers */,
@@ -322,7 +326,7 @@
 				2C8C8FC0253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* CHIPDevice_Internal.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
-				B2E0D7B4245B0B5C003C5B48 /* CHIPError.h in Headers */,
+				B2E0D7B4245B0B5C003C5B48 /* CHIPError_Internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -39,6 +39,7 @@ static_library("framework") {
     "CHIPDevice_Internal.h",
     "CHIPError.h",
     "CHIPError.mm",
+    "CHIPError_Internal.h",
     "CHIPLogging.h",
     "CHIPManualSetupPayloadParser.h",
     "CHIPManualSetupPayloadParser.mm",

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -16,8 +16,8 @@
  */
 
 #import "CHIPDevice_Internal.h"
+#import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
-#import <CHIP/CHIPError.h>
 #import <setup_payload/ManualSetupPayloadGenerator.h>
 #import <setup_payload/SetupPayload.h>
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceConnectionBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceConnectionBridge.mm
@@ -17,7 +17,7 @@
 
 #import "CHIPDeviceConnectionBridge.h"
 #import "CHIPDevice_Internal.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 
 void CHIPDeviceConnectionBridge::OnConnected(void * context, chip::Controller::Device * device)
 {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -18,7 +18,7 @@
 
 #import "CHIPDevicePairingDelegateBridge.h"
 #import "CHIPDevice_Internal.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
 #import "CHIPOperationalCredentialsDelegate.h"
 #import "CHIPPersistentStorageDelegateBridge.h"

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -16,7 +16,7 @@
  */
 
 #import "CHIPDevicePairingDelegateBridge.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 
 CHIPDevicePairingDelegateBridge::CHIPDevicePairingDelegateBridge(void)
     : mDelegate(nil)

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -16,9 +16,9 @@
  */
 
 #import "CHIPError.h"
+#import "CHIPError_Internal.h"
 
 #import <app/util/af-enums.h>
-#import <core/CHIPError.h>
 #import <inet/InetError.h>
 
 NSString * const CHIPErrorDomain = @"CHIPErrorDomain";

--- a/src/darwin/Framework/CHIP/CHIPError_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPError_Internal.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,21 +17,13 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-FOUNDATION_EXPORT NSErrorDomain const CHIPErrorDomain;
+#include <core/CHIPError.h>
 
-typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode){
-    CHIPSuccess                       = 0,
-    CHIPErrorCodeUndefinedError       = 1,
-    CHIPErrorCodeInvalidStringLength  = 2,
-    CHIPErrorCodeInvalidIntegerValue  = 3,
-    CHIPErrorCodeInvalidArgument      = 4,
-    CHIPErrorCodeInvalidMessageLength = 5,
-    CHIPErrorCodeInvalidState         = 6,
-    CHIPErrorCodeWrongAddressType     = 7,
-    CHIPErrorCodeIntegrityCheckFailed = 8,
-    CHIPErrorCodeDuplicateExists      = 9,
-    CHIPErrorCodeUnsupportedAttribute = 10,
-};
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CHIPError : NSObject
++ (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
++ (CHIP_ERROR)errorToCHIPErrorCode:(NSError *)errorCode;
+@end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -16,7 +16,7 @@
  */
 #import "CHIPManualSetupPayloadParser.h"
 
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
 #import "CHIPSetupPayload_Internal.h"
 

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -18,7 +18,7 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPPersistentStorageDelegateBridge.h"
 
 #include <controller/OperationalCredentialsDelegate.h>

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -17,7 +17,7 @@
 
 #import "CHIPPersistentStorageDelegate.h"
 
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #include <core/CHIPPersistentStorageDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -16,7 +16,7 @@
  */
 
 #import "CHIPQRCodeSetupPayloadParser.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPLogging.h"
 #import "CHIPSetupPayload_Internal.h"
 

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -16,6 +16,7 @@
  */
 
 #import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "CHIPSetupPayload_Internal.h"
 #import <setup_payload/SetupPayload.h>
 

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -21,7 +21,7 @@
 
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "app/util/af.h"
 #import "gen/CHIPClientCallbacks.h"
 #import "gen/CHIPClusters.h"

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -5,7 +5,7 @@
 
 #import "CHIPDevice.h"
 #import "CHIPDevice_Internal.h"
-#import "CHIPError.h"
+#import "CHIPError_Internal.h"
 #import "gen/CHIPClusters.h"
 #import "gen/CHIPClustersObjc.h"
 #import "gen/CHIPClientCallbacks.h"

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -6,9 +6,6 @@
 // module headers
 #import <CHIP/CHIP.h>
 
-// additional includes
-#import "CHIPError.h"
-
 // system dependencies
 #import <XCTest/XCTest.h>
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -23,9 +23,6 @@
 // module headers
 #import <CHIP/CHIP.h>
 
-// additional includes
-#import "CHIPError.h"
-
 // system dependencies
 #import <XCTest/XCTest.h>
 


### PR DESCRIPTION
That gets in the way of making it a class on Darwin.

#### Problem
Darwin headers redefine CHIP_ERROR, which makes it hard to turn on CHIP_CONFIG_ERROR_CLASS.

#### Change overview
Remove the CHIP_ERROR redefinition.

#### Testing
Compiled iOS CHIPTool, ran Darwin tests locally.