### PR TITLE
[hotfix] Fix regression / crash caused by #7873 (#8054)

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -883,7 +883,7 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
 
     if (emberAfFindClusterWithMfgCode(endpoint, clusterId, mask, manufacturerCode) == NULL)
     {
-        return 0xFF;
+        return 0xFFFF;
     }
 
     for (i = 0; i < emberAfEndpointCount(); i++)
@@ -913,7 +913,7 @@ static uint16_t findIndexFromEndpoint(EndpointId endpoint, bool ignoreDisabledEn
             return epi;
         }
     }
-    return 0xFF;
+    return 0xFFFF;
 }
 
 bool emberAfEndpointIsEnabled(EndpointId endpoint)

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <app/InteractionModelDelegate.h>
 #include <controller/CHIPDeviceController.h>
 

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -24,12 +24,14 @@ import chip.exceptions
 import typing
 from dataclasses import dataclass
 
+# The type should match CommandStatus in interaction_model/Delegate.h
+# CommandStatus should not contain padding
 IMCommandStatus = Struct(
     "ProtocolId" /  Int32ul,
     "ProtocolCode" / Int16ul,
-    "EndpointId" / Int8ul,
-    "ClusterId" / Int16ul,
-    "CommandId" / Int8ul,
+    "EndpointId" / Int16ul,
+    "ClusterId" / Int32ul,
+    "CommandId" / Int32ul,
     "CommandIndex" / Int8ul,
 )
 


### PR DESCRIPTION
* [python] Add static_assert to CommandStatus

* Change EndpointId to uint16 in Python delegate

* Fix findIndexFromEndpoint

* Add more static_asserts

* Update src/controller/python/chip/interaction_model/Delegate.h

Co-authored-by: Boris Zbarsky <bzbarsky@apple.com>

Co-authored-by: Boris Zbarsky <bzbarsky@apple.com>

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
