### PR TITLE
Stop assuming CHIP_ERROR is an integer in Darwin code.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -71,7 +71,7 @@
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
-        CHIP_LOG_ERROR("Error(%d): %@, Open Pairing Window failed", err, [CHIPError errorForCHIPErrorCode:err]);
+        CHIP_LOG_ERROR("Error(%s): Open Pairing Window failed", chip::ErrorStr(err));
         if (error) {
             *error = [CHIPError errorForCHIPErrorCode:err];
         }
@@ -117,7 +117,7 @@
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
-        CHIP_LOG_ERROR("Error(%d): %@, Open Pairing Window failed", err, [CHIPError errorForCHIPErrorCode:err]);
+        CHIP_LOG_ERROR("Error(%s): Open Pairing Window failed", chip::ErrorStr(err));
         if (error) {
             *error = [CHIPError errorForCHIPErrorCode:err];
         }

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -441,7 +441,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     dispatch_sync(_chipWorkQueue, ^{
         if ([self isRunning]) {
             errorCode = self.cppCommissioner->UpdateDevice(deviceID, fabricId);
-            CHIP_LOG_ERROR("Update device address returned: %d", errorCode);
+            CHIP_LOG_ERROR("Update device address returned: %s", chip::ErrorStr(errorCode));
         }
     });
 }
@@ -501,7 +501,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         return NO;
     }
 
-    CHIP_LOG_ERROR("Error(%d): %@, %@", errorCode, [CHIPError errorForCHIPErrorCode:errorCode], logMsg);
+    CHIP_LOG_ERROR("Error(%s): %s", chip::ErrorStr(errorCode), [logMsg UTF8String]);
     if (error) {
         *error = [CHIPError errorForCHIPErrorCode:errorCode];
     }

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -67,7 +67,7 @@ void CHIPDevicePairingDelegateBridge::OnStatusUpdate(chip::Controller::DevicePai
 
 void CHIPDevicePairingDelegateBridge::OnPairingComplete(CHIP_ERROR error)
 {
-    NSLog(@"DevicePairingDelegate Pairing complete. Status %d", error);
+    NSLog(@"DevicePairingDelegate Pairing complete. Status %s", chip::ErrorStr(error));
 
     id<CHIPDevicePairingDelegate> strongDelegate = mDelegate;
     if ([strongDelegate respondsToSelector:@selector(onPairingComplete:)]) {
@@ -82,7 +82,7 @@ void CHIPDevicePairingDelegateBridge::OnPairingComplete(CHIP_ERROR error)
 
 void CHIPDevicePairingDelegateBridge::OnPairingDeleted(CHIP_ERROR error)
 {
-    NSLog(@"DevicePairingDelegate Pairing deleted. Status %d", error);
+    NSLog(@"DevicePairingDelegate Pairing deleted. Status %s", chip::ErrorStr(error));
 
     id<CHIPDevicePairingDelegate> strongDelegate = mDelegate;
     if ([strongDelegate respondsToSelector:@selector(onPairingDeleted:)]) {
@@ -97,7 +97,7 @@ void CHIPDevicePairingDelegateBridge::OnPairingDeleted(CHIP_ERROR error)
 
 void CHIPDevicePairingDelegateBridge::OnAddressUpdateComplete(chip::NodeId nodeId, CHIP_ERROR error)
 {
-    NSLog(@"OnAddressUpdateComplete. Status %d", error);
+    NSLog(@"OnAddressUpdateComplete. Status %s", chip::ErrorStr(error));
 
     id<CHIPDevicePairingDelegate> strongDelegate = mDelegate;
     if ([strongDelegate respondsToSelector:@selector(onAddressUpdated:)]) {

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -27,31 +27,61 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
 
 + (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
 {
-    switch (errorCode) {
-    case CHIP_ERROR_INVALID_STRING_LENGTH:
+    if (errorCode == CHIP_ERROR_INVALID_STRING_LENGTH) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeInvalidStringLength
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A list length is invalid.", nil) }];
-    case CHIP_ERROR_INVALID_INTEGER_VALUE:
+    }
+
+    if (errorCode == CHIP_ERROR_INVALID_INTEGER_VALUE) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeInvalidIntegerValue
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Unexpected integer value.", nil) }];
-    case CHIP_ERROR_INVALID_ARGUMENT:
+    }
+
+    if (errorCode == CHIP_ERROR_INVALID_ARGUMENT) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeInvalidArgument
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"An argument is invalid.", nil) }];
-    case CHIP_ERROR_INVALID_MESSAGE_LENGTH:
+    }
+
+    if (errorCode == CHIP_ERROR_INVALID_MESSAGE_LENGTH) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeInvalidMessageLength
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A message length is invalid.", nil) }];
-    case CHIP_ERROR_INCORRECT_STATE:
+    }
+
+    if (errorCode == CHIP_ERROR_INCORRECT_STATE) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeInvalidState
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid object state.", nil) }];
-    case CHIP_ERROR_INTEGRITY_CHECK_FAILED:
+    }
+
+    if (errorCode == CHIP_ERROR_INTEGRITY_CHECK_FAILED) {
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeIntegrityCheckFailed
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
+    }
+
+    if (errorCode == CHIP_NO_ERROR) {
+        return [NSError errorWithDomain:CHIPErrorDomain
+                                   code:CHIPSuccess
+                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Success.", nil) }];
+    }
+
+    return
+        [NSError errorWithDomain:CHIPErrorDomain
+                            code:CHIPErrorCodeUndefinedError
+                        userInfo:@{
+                            NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Undefined error:%u.", nil),
+                                                                  chip::ChipError::AsInteger(errorCode)]
+                        }];
+    ;
+}
+
++ (NSError *)errorForZCLErrorCode:(uint8_t)errorCode
+{
+    switch (errorCode) {
     case EMBER_ZCL_STATUS_DUPLICATE_EXISTS:
         return [NSError
             errorWithDomain:CHIPErrorDomain
@@ -61,18 +91,13 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeUnsupportedAttribute
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Attribute is not supported.", nil) }];
-    case CHIP_NO_ERROR:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPSuccess
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Success.", nil) }];
     default:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeUndefinedError
                                userInfo:@{
-                                   NSLocalizedDescriptionKey :
-                                       [NSString stringWithFormat:NSLocalizedString(@"Undefined error:%d.", nil), errorCode]
+                                   NSLocalizedDescriptionKey : [NSString
+                                       stringWithFormat:NSLocalizedString(@"Undefined data model error:%u.", nil), errorCode]
                                }];
-        ;
     }
 }
 
@@ -83,10 +108,6 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
     }
 
     switch (error.code) {
-    case CHIPErrorCodeUnsupportedAttribute:
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
-    case CHIPErrorCodeDuplicateExists:
-        return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
     case CHIPErrorCodeInvalidStringLength:
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     case CHIPErrorCodeInvalidIntegerValue:

--- a/src/darwin/Framework/CHIP/CHIPError_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPError_Internal.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPError : NSObject
 + (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
++ (nullable NSError *)errorForZCLErrorCode:(uint8_t)errorCode;
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError *)errorCode;
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -50,7 +50,7 @@
     if (_chipManualSetupPayloadParser) {
         CHIP_ERROR chipError = _chipManualSetupPayloadParser->populatePayload(cPlusPluspayload);
 
-        if (chipError == 0) {
+        if (chipError == CHIP_NO_ERROR) {
             payload = [[CHIPSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
         } else if (error) {
             *error = [CHIPError errorForCHIPErrorCode:chipError];

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -61,7 +61,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
         // err = SetIssuerID(storage);
     }
 
-    CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate::init returning %d", err);
+    CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate::init returning %s", chip::ErrorStr(err));
     return err;
 }
 

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -50,7 +50,7 @@
     if (_chipQRCodeSetupPayloadParser) {
         CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
 
-        if (chipError == 0) {
+        if (chipError == CHIP_NO_ERROR) {
             payload = [[CHIPSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
         } else if (error) {
             *error = [CHIPError errorForCHIPErrorCode:chipError];

--- a/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/CHIPThreadOperationalDataset.mm
@@ -117,7 +117,7 @@ size_t const CHIPSizeThreadPSKc = chip::Thread::kSizePSKc;
     auto dataset = chip::Thread::OperationalDataset();
     CHIP_ERROR error = dataset.Init(span);
     if (error != CHIP_NO_ERROR) {
-        CHIP_LOG_ERROR("Failed to parse data, cannot construct Operational Dataset. %d", error);
+        CHIP_LOG_ERROR("Failed to parse data, cannot construct Operational Dataset. %s", chip::ErrorStr(error));
         return nil;
     }
     // len+1 for null termination

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -76,7 +76,7 @@ public:
         CHIPDefaultFailureCallbackBridge * callback = reinterpret_cast<CHIPDefaultFailureCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                NSError * error = [CHIPError errorForCHIPErrorCode:status];
+                NSError * error = [CHIPError errorForZCLErrorCode:status];
                 callback->mHandler(error, nil);
                 callback->Cancel();
                 delete callback;

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -60,7 +60,7 @@ public:
         CHIPDefaultFailureCallbackBridge * callback = reinterpret_cast<CHIPDefaultFailureCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                NSError * error = [CHIPError errorForCHIPErrorCode:status];
+                NSError * error = [CHIPError errorForZCLErrorCode:status];
                 callback->mHandler(error, nil);
                 callback->Cancel();
                 delete callback;


### PR DESCRIPTION
Some of the fixes have to do with the fact that %@ is not a format
ChipLogging supports, not strictly with the CHIP_ERROR changes.

#### Problem
Various Darwin-specific code assumes that a CHIP_ERROR is an int.

#### Change overview
Stop making those assumptions.

#### Testing
Compiled code, locally ran Darwin tests.