### PR TITLE
[Darwin] Fix log level for CHIP Detail logging so that all logs are persisted

### DIFF
--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -62,7 +62,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
         break;
 
     case kLogCategory_Detail:
-        os_log_with_type(log, OS_LOG_TYPE_DEBUG, "🟢 %{public}s", formattedMsg);
+        os_log_with_type(log, OS_LOG_TYPE_DEFAULT, "🟢 %{public}s", formattedMsg);
 #if TARGET_OS_MAC && TARGET_OS_IPHONE == 0
         fprintf(stdout, "\033[0;34m");
 #endif


### PR DESCRIPTION
#### Problem
On iOS Debug logs are not always enabled, and even when they are, they are not persisted to disk. This results in missing information in sysdiagnoses. 

CHIP is already controlling whether or not detailed logs need to be enabled, we don't need to further gate them by letting the platform decide if Debug logs are needed or not. 

#### Change overview
Make CHIP Detail logging print as "Default" log category. If the build configuration decides to have Detailed logging enabled, then the platform should honor it and not treat it differently than a regular log statement.

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not?
Not a logical change
