### PR TITLE
Use {{chip_tests}} instead of manually adding class names for the tes…

### DIFF
--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -181,3 +181,16 @@ class {{filename}}: public TestCommand
 };
 
 {{/chip_tests}}
+
+void registerCommandsTests(Commands & commands)
+{
+    const char * clusterName = "Tests";
+
+    commands_list clusterCommands = {
+      {{#chip_tests tests}}
+        make_unique<{{filename}}>(),
+      {{/chip_tests}}
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}

--- a/examples/chip-tool/templates/tests-commands.zapt
+++ b/examples/chip-tool/templates/tests-commands.zapt
@@ -5,36 +5,3 @@
 #include "TestCommand.h"
 
 {{>test_cluster tests="TV_TargetNavigatorCluster, TV_AudioOutputCluster, TV_ApplicationLauncherCluster, TV_KeypadInputCluster, TV_AccountLoginCluster, TV_ApplicationBasicCluster, TV_MediaPlaybackCluster, TV_TvChannelCluster, TV_LowPowerCluster, TV_MediaInputCluster, TestCluster, Test_TC_OO_1_1, Test_TC_OO_2_1, Test_TC_OO_2_2, Test_TC_DM_1_1, Test_TC_DM_3_1, Test_TC_CC_3_4, Test_TC_CC_5, Test_TC_CC_6, Test_TC_CC_7, Test_TC_WNCV_1_1, Test_TC_WNCV_2_1, Test_TC_BI_1_1"}}
-
-void registerCommandsTests(Commands & commands)
-{
-    const char * clusterName = "Tests";
-
-    commands_list clusterCommands = {
-        make_unique<TV_TargetNavigatorCluster>(),
-        make_unique<TV_AudioOutputCluster>(),
-        make_unique<TV_ApplicationLauncherCluster>(),
-        make_unique<TV_KeypadInputCluster>(),
-        make_unique<TV_AccountLoginCluster>(),
-        make_unique<TV_ApplicationBasicCluster>(),
-        make_unique<TV_MediaPlaybackCluster>(),
-        make_unique<TV_TvChannelCluster>(),
-        make_unique<TV_LowPowerCluster>(),
-        make_unique<TV_MediaInputCluster>(),
-        make_unique<TestCluster>(),
-        make_unique<Test_TC_OO_1_1>(),
-        make_unique<Test_TC_OO_2_1>(),
-        make_unique<Test_TC_OO_2_2>(),
-        make_unique<Test_TC_DM_1_1>(),
-        make_unique<Test_TC_DM_3_1>(),
-        make_unique<Test_TC_CC_3_4>(),
-        make_unique<Test_TC_CC_5>(),
-        make_unique<Test_TC_CC_6>(),
-        make_unique<Test_TC_CC_7>(),
-        make_unique<Test_TC_WNCV_1_1>(),
-        make_unique<Test_TC_WNCV_2_1>(),
-        make_unique<Test_TC_BI_1_1>(),
-    };
-
-    commands.Register(clusterName, clusterCommands);
-}


### PR DESCRIPTION
…ts command

#### Problem
 `examples/chip-tool/templates/tests-commands.zapt` contains twice the same list. This is annoying.

#### Change overview
 * Update the template so it is needed only once.

#### Testing
 * Tested by trying to regenerate the code and observe that there is no differences