### PR TITLE
Fix for fabric renaming

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -420,7 +420,6 @@ SecurePairingUsingTestSecret gTestPairing;
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
 chip::Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient gUDCClient;
-constexpr chip::Transport::AdminId gAdminId = 0;
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -20,7 +20,6 @@
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
 #include <system/TimeSource.h>
-#include <transport/FabricTable.h>
 
 namespace chip {
 namespace Protocols {

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -20,7 +20,7 @@
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
 #include <system/TimeSource.h>
-#include <transport/AdminPairingTable.h>
+#include <transport/FabricTable.h>
 
 namespace chip {
 namespace Protocols {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Removed problematic header since it is not used anymore
* Removed unused variable
(relating to this commit 2a633091dce6a2dd5a05d4c4457a896dc110c49c)

#### Change overview
Removed include
Removed variable

#### Testing
How was this tested? (at least one bullet point required)
Example app, python controller and linux standalone were locally built to validated change.
