### PR TITLE
[OpenThread] Optimize memory usage of DNS client

### DIFF
--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -107,6 +107,7 @@ public:
     static constexpr uint8_t kTxtMaxNumber     = 2;
     static constexpr uint8_t kTxtMaxKeySize    = MaxStringLength("CRI", "CRA"); // possible keys
     static constexpr uint8_t kTxtMaxValueSize  = std::max({ kTxtRetryIntervalIdleMaxLength, kTxtRetryIntervalActiveMaxLength });
+    static constexpr size_t kTxtTotalKeySize   = TotalStringLength("CRI", "CRA"); // possible keys
     static constexpr size_t kTxtTotalValueSize = kTxtRetryIntervalIdleMaxLength + kTxtRetryIntervalActiveMaxLength;
 
     OperationalAdvertisingParameters & SetPeerId(const PeerId & peerId)
@@ -143,6 +144,7 @@ public:
         std::max({ kKeyDiscriminatorMaxLength, kKeyVendorProductMaxLength, kKeyAdditionalPairingMaxLength,
                    kKeyCommissioningModeMaxLength, kKeyDeviceTypeMaxLength, kKeyDeviceNameMaxLength, kKeyRotatingIdMaxLength,
                    kKeyPairingInstructionMaxLength, kKeyPairingHintMaxLength });
+    static constexpr size_t kTxtTotalKeySize   = TotalStringLength("D", "VP", "CM", "DT", "DN", "RI", "PI", "PH"); // possible keys
     static constexpr size_t kTxtTotalValueSize = kKeyDiscriminatorMaxLength + kKeyVendorProductMaxLength +
         kKeyAdditionalPairingMaxLength + kKeyCommissioningModeMaxLength + kKeyDeviceTypeMaxLength + kKeyDeviceNameMaxLength +
         kKeyRotatingIdMaxLength + kKeyPairingInstructionMaxLength + kKeyPairingHintMaxLength;

--- a/src/lib/support/SafeString.h
+++ b/src/lib/support/SafeString.h
@@ -51,4 +51,27 @@ constexpr size_t MaxStringLength(const char (&)[FirstLength], RestOfTypes &&... 
     return max(FirstLength - 1, MaxStringLength(std::forward<RestOfTypes>(aArgs)...));
 }
 
+/**
+ * A function that determines, at compile time, the total length (not
+ * counting the null terminator) of a list of literal C strings. Suitable for
+ * determining sizes of buffers that might need to hold all of the given
+ * strings.
+ *
+ * Do NOT pass things that are not string literals to this function.
+ *
+ * Use like:
+ *   constexpr size_t totalLen = TotalStringLength("abc", "defhij", "something");
+ */
+constexpr size_t TotalStringLength()
+{
+    return 0;
+}
+
+template <size_t FirstLength, typename... RestOfTypes>
+constexpr size_t TotalStringLength(const char (&)[FirstLength], RestOfTypes &&... aArgs)
+{
+    // Subtract 1 because we are not counting the null-terminator.
+    return FirstLength - 1 + TotalStringLength(std::forward<RestOfTypes>(aArgs)...);
+}
+
 } // namespace chip

--- a/src/lib/support/tests/TestSafeString.cpp
+++ b/src/lib/support/tests/TestSafeString.cpp
@@ -41,11 +41,18 @@ static void TestMaxStringLength(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MaxStringLength("") == 0);
 }
 
+static void TestTotalStringLength(nlTestSuite * inSuite, void * inContext)
+{
+    NL_TEST_ASSERT(inSuite, TotalStringLength("") == 0);
+    NL_TEST_ASSERT(inSuite, TotalStringLength("a") == 1);
+    NL_TEST_ASSERT(inSuite, TotalStringLength("def", "bc", "a") == 6);
+}
+
 #define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestMaxStringLength), NL_TEST_SENTINEL() };
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestMaxStringLength), NL_TEST_DEF_FN(TestTotalStringLength), NL_TEST_SENTINEL() };
 
 int TestSafeString(void)
 {

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -182,25 +182,28 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_COMMISSIONABLE_DISCOVERY
     // Thread supports both operational and commissionable discovery, so buffers sizes must be worst case.
-    static constexpr uint8_t kMaxDnsServiceTxtEntriesNumber = Mdns::CommissionAdvertisingParameters::kTxtMaxNumber;
-    static constexpr uint8_t kMaxDnsServiceTxtValueSize     = Mdns::CommissionAdvertisingParameters::kTxtMaxValueSize;
-    // TODO: Switch to max(commissionable TXT key size, operational TXT key size) after optimizing memory usage
-    static constexpr uint8_t kMaxDnsServiceTxtKeySize = Mdns::OperationalAdvertisingParameters::kTxtMaxKeySize;
+    static constexpr uint8_t kMaxDnsServiceTxtEntriesNumber =
+        std::max(Mdns::CommissionAdvertisingParameters::kTxtMaxNumber, Mdns::OperationalAdvertisingParameters::kTxtMaxNumber);
+    static constexpr size_t kTotalDnsServiceTxtValueSize = std::max(Mdns::CommissionAdvertisingParameters::kTxtTotalValueSize,
+                                                                    Mdns::OperationalAdvertisingParameters::kTxtTotalValueSize);
+    static constexpr size_t kTotalDnsServiceTxtKeySize =
+        std::max(Mdns::CommissionAdvertisingParameters::kTxtTotalKeySize, Mdns::OperationalAdvertisingParameters::kTxtTotalKeySize);
 #else
     // Thread only supports operational discovery.
     static constexpr uint8_t kMaxDnsServiceTxtEntriesNumber = Mdns::OperationalAdvertisingParameters::kTxtMaxNumber;
-    static constexpr uint8_t kMaxDnsServiceTxtValueSize     = Mdns::OperationalAdvertisingParameters::kTxtMaxValueSize;
-    static constexpr uint8_t kMaxDnsServiceTxtKeySize       = Mdns::OperationalAdvertisingParameters::kTxtMaxKeySize;
+    static constexpr size_t kTotalDnsServiceTxtValueSize    = Mdns::OperationalAdvertisingParameters::kTxtTotalValueSize;
+    static constexpr size_t kTotalDnsServiceTxtKeySize      = Mdns::OperationalAdvertisingParameters::kTxtTotalKeySize;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_COMMISSIONABLE_DISCOVERY
+    static constexpr size_t kTotalDnsServiceTxtBufferSize =
+        kTotalDnsServiceTxtKeySize + kMaxDnsServiceTxtEntriesNumber + kTotalDnsServiceTxtValueSize;
 
     DnsBrowseCallback mDnsBrowseCallback;
     DnsResolveCallback mDnsResolveCallback;
 
     struct DnsServiceTxtEntries
     {
+        uint8_t mBuffer[kTotalDnsServiceTxtBufferSize];
         chip::Mdns::TextEntry mTxtEntries[kMaxDnsServiceTxtEntriesNumber];
-        uint8_t mTxtValueBuffers[kMaxDnsServiceTxtEntriesNumber][kMaxDnsServiceTxtValueSize];
-        char mTxtKeyBuffers[kMaxDnsServiceTxtEntriesNumber][kMaxDnsServiceTxtKeySize + 1];
     };
 
     struct DnsResult


### PR DESCRIPTION
#### Problem
In the worst-case scenario, the DNS client must correctly handle a commissionable node service which contains
a TXT entry with key "PI" and a pairing instruction up to 128 characters. Current DNS client implementation for OpenThread does not support such long TXT entries to limit the stack usage.

#### Change overview
Change the method of allocating memory for the resolved/discovered services to allow long TXT entries, yet not to consume too much memory on stack.
Fixes #8467.

#### Testing
Tested along with #8454 that nRF Connect Lock can both advertise and discover (with `matter dns browse` shell command) a node with the longest possible pairing instruction.
