### PR TITLE
Remove leftover troubleshooting printf()

### DIFF
--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -2737,7 +2737,6 @@ void TestCHIPTLVWriterErrorHandling(nlTestSuite * inSuite)
 
     // CloseContainer() for non-container
     err = writer.CloseContainer(writer2);
-    printf("%s\n", ErrorStr(err));
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     // OpenContainer() failure


### PR DESCRIPTION
#### Problem

PR #8470 accidentally included a `printf()` added to troubleshoot a
flaky unit test.

#### Change overview

Remove it.

#### Testing

I heard you like tests, so I ran the test to test the test so you can
test while you test.
