### PR TITLE
Fix CASE warmup on address update

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -392,6 +392,8 @@ CHIP_ERROR Device::UpdateAddress(const Transport::PeerAddress & addr)
 {
     bool didLoad;
 
+    mDeviceAddress = addr;
+
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(didLoad));
 
     Transport::PeerConnectionState * connectionState = mSessionManager->GetPeerConnectionState(mSecureSession);
@@ -404,7 +406,6 @@ CHIP_ERROR Device::UpdateAddress(const Transport::PeerAddress & addr)
         return CHIP_NO_ERROR;
     }
 
-    mDeviceAddress = addr;
     connectionState->SetPeerAddress(addr);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem

When addresses change CASE uses the previous address and fails.

#### Change overview

Assign the address earlier so we get the correct value in WarmupCASESession().

Note this still uses a cached address when it really should resolve the address during session establishment, but at least the cached address updates now.

fixes #8622

#### Testing

- chip-tool pairing ble-wifi <ssid> <password> 112233 20202021 3840
- rotate statically assigned address
- chip-tool onoff toggle 1