### PR TITLE
[ChipTool] Remove a check for the RendezvousInformation inside manual…

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -103,6 +103,10 @@ CHIP_ERROR PairingCommand::PairWithQRCode(NodeId remoteId)
 {
     SetupPayload payload;
     ReturnErrorOnFailure(QRCodeSetupPayloadParser(mOnboardingPayload).populatePayload(payload));
+
+    chip::RendezvousInformationFlags rendezvousInformation = payload.rendezvousInformation;
+    ReturnErrorCodeIf(rendezvousInformation != RendezvousInformationFlag::kBLE, CHIP_ERROR_INVALID_ARGUMENT);
+
     return PairWithCode(remoteId, payload);
 }
 
@@ -115,9 +119,6 @@ CHIP_ERROR PairingCommand::PairWithManualCode(NodeId remoteId)
 
 CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId, SetupPayload payload)
 {
-    chip::RendezvousInformationFlags rendezvousInformation = payload.rendezvousInformation;
-    ReturnErrorCodeIf(rendezvousInformation != RendezvousInformationFlag::kBLE, CHIP_ERROR_INVALID_ARGUMENT);
-
     RendezvousParameters params = RendezvousParameters()
                                       .SetSetupPINCode(payload.setUpPINCode)
                                       .SetDiscriminator(payload.discriminator)


### PR DESCRIPTION
… code since it does not contains such information

#### Problem

`chip-tool pairing manualcode` does not work because manual code does not contains anything related to `Rendezvous`.

This is only a stopgap solution to get it working over BLE at the moment. In theory the controller should then scan over all network interfaces but mdns discovery for commissionable nodes is not properly supported at the moment. So the code will just assume BLE at the moment.

#### Change overview
 * Remove the check for `RendezvousInformation` from the manual code use case.

#### Testing
 * It was tested by using a manual code with `chip-tool`.