### PR TITLE
[android] Add sensor clusters screen

### DIFF
--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.work:work-runtime:2.3.3"
     implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.jjoe64:graphview:4.2.2'
 }
 repositories {
     mavenCentral()

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -40,6 +40,7 @@ import chip.devicecontroller.PreferencesKeyValueStoreManager
 import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
+import com.google.chip.chiptool.clusterclient.SensorClientFragment
 
 class CHIPToolActivity :
     AppCompatActivity(),
@@ -112,6 +113,10 @@ class CHIPToolActivity :
 
   override fun handleOnOffClicked() {
     showFragment(OnOffClientFragment.newInstance())
+  }
+
+  override fun handleSensorClicked() {
+    showFragment(SensorClientFragment.newInstance())
   }
 
   override fun handleAttestationTestClicked() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -52,6 +52,7 @@ class SelectActionFragment : Fragment() {
       }
       echoClientBtn.setOnClickListener { getCallback()?.handleEchoClientClicked() }
       onOffClusterBtn.setOnClickListener { getCallback()?.handleOnOffClicked() }
+      sensorClustersBtn.setOnClickListener{ getCallback()?.handleSensorClicked() }
       attestationTestBtn.setOnClickListener { getCallback()?.handleAttestationTestClicked() }
     }
   }
@@ -107,8 +108,10 @@ class SelectActionFragment : Fragment() {
     fun onProvisionThreadCredentialsClicked()
     /** Notifies listener of Echo client button click. */
     fun handleEchoClientClicked()
-    /** Notifies listener of send command button click. */
+    /** Notifies listener of Light On/Off & Level Cluster button click. */
     fun handleOnOffClicked()
+    /** Notifies listener of Sensor Clusters button click. */
+    fun handleSensorClicked()
     /** Notifies listener of attestation command button clicked. */
     fun handleAttestationTestClicked()
   }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -1,0 +1,207 @@
+package com.google.chip.chiptool.clusterclient
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import chip.devicecontroller.ChipClusters
+import com.google.chip.chiptool.ChipClient
+import com.google.chip.chiptool.R
+import com.google.chip.chiptool.util.DeviceIdUtil
+import com.jjoe64.graphview.LabelFormatter
+import com.jjoe64.graphview.Viewport
+import com.jjoe64.graphview.series.DataPoint
+import com.jjoe64.graphview.series.LineGraphSeries
+import kotlinx.android.synthetic.main.sensor_client_fragment.*
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.*
+import kotlinx.coroutines.*
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.concurrent.schedule
+
+private typealias ReadCallback = ChipClusters.IntegerAttributeCallback
+
+class SensorClientFragment : Fragment() {
+  private val scope = CoroutineScope(Dispatchers.Main + Job())
+
+  // Timer to send periodic sensor read requests
+  private var sensorWatchTimer: Timer? = null
+
+  // History of sensor values
+  private val sensorData = LineGraphSeries<DataPoint>()
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
+  ): View {
+    return inflater.inflate(R.layout.sensor_client_fragment, container, false).apply {
+      clusterNameSpinner.adapter = makeClusterNamesAdapter()
+      clusterNameSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+          resetSensorGraph() // reset the graph on cluster change
+        }
+      }
+      readSensorBtn.setOnClickListener { scope.launch { readSensorButtonClick() } }
+      watchSensorBtn.setOnCheckedChangeListener { _, isChecked ->
+        if (isChecked) {
+          watchSensorButtonChecked()
+        } else {
+          watchSensorButtonUnchecked()
+        }
+      }
+      sensorGraph.addSeries(sensorData)
+      sensorGraph.gridLabelRenderer.padding = 30
+      sensorGraph.gridLabelRenderer.numHorizontalLabels = 4
+      sensorGraph.gridLabelRenderer.labelFormatter = object : LabelFormatter {
+        override fun setViewport(viewport: Viewport?) = Unit
+        override fun formatLabel(value: Double, isValueX: Boolean): String {
+          if (!isValueX)
+            return value.toString()
+          return SimpleDateFormat("H:m:s").format(Date(value.toLong())).toString()
+        }
+      }
+    }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    deviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
+  }
+
+  override fun onStop() {
+    super.onStop()
+    scope.cancel()
+    resetSensorGraph() // reset the graph on fragment exit
+  }
+
+  private fun resetSensorGraph() {
+    watchSensorBtn.isChecked = false
+    sensorGraph.visibility = View.INVISIBLE
+    sensorData.resetData(emptyArray())
+  }
+
+  private fun makeClusterNamesAdapter(): ArrayAdapter<String> {
+    return ArrayAdapter(
+        requireContext(),
+        android.R.layout.simple_spinner_dropdown_item,
+        CLUSTERS.keys.toList()
+    ).apply {
+      setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+    }
+  }
+
+  private suspend fun readSensorButtonClick() {
+    try {
+      readSensorCluster(clusterNameSpinner.selectedItem.toString(), false)
+    } catch (ex: Exception) {
+      showMessage(R.string.sensor_client_read_error_text, ex.toString())
+    }
+  }
+
+  private fun watchSensorButtonChecked() {
+    sensorWatchTimer = Timer("SensorWatchTimer", false).apply {
+      schedule(REFRESH_PERIOD_MS, REFRESH_PERIOD_MS) {
+        scope.launch {
+          try {
+            readSensorCluster(clusterNameSpinner.selectedItem.toString(), true)
+          } catch (ex: Exception) {
+            showMessage(R.string.sensor_client_read_error_text, ex.toString())
+          }
+        }
+      }
+    }
+  }
+
+  private fun watchSensorButtonUnchecked() {
+    sensorWatchTimer?.cancel()
+    sensorWatchTimer = null
+  }
+
+  private suspend fun readSensorCluster(clusterName: String, addToGraph: Boolean) {
+    val deviceId = deviceIdEd.text.toString().toULong().toLong()
+    val endpointId = endpointIdEd.text.toString().toInt()
+    val clusterConfig = CLUSTERS[clusterName]
+    val clusterRead = clusterConfig!!["read"] as (Long, Int, ReadCallback) -> Unit
+
+    val device = ChipClient.getConnectedDevicePointer(deviceId)
+
+    clusterRead(device, endpointId, object : ReadCallback {
+      override fun onSuccess(value: Int) {
+        val unitValue = clusterConfig["unitValue"] as Double
+        val unitSymbol = clusterConfig["unitSymbol"] as String
+        consumeSensorValue(value * unitValue, unitSymbol, addToGraph)
+      }
+
+      override fun onError(ex: Exception) {
+        showMessage(R.string.sensor_client_read_error_text, ex.toString())
+      }
+    })
+  }
+
+  private fun consumeSensorValue(value: Double, unitSymbol: String, addToGraph: Boolean) {
+    requireActivity().runOnUiThread {
+      lastValueTv.text = requireContext().getString(
+          R.string.sensor_client_last_value_text, value, unitSymbol
+      )
+
+      if (addToGraph) {
+        // Make the graph visible on the first sample
+        if (sensorData.isEmpty)
+          sensorGraph.visibility = View.VISIBLE
+        val dataPoint = DataPoint(Calendar.getInstance().time, value)
+        sensorData.appendData(dataPoint, false, MAX_DATA_POINTS)
+      }
+    }
+  }
+
+  private fun showMessage(msgResId: Int, stringArgs: String? = null) {
+    requireActivity().runOnUiThread {
+      val context = requireContext()
+      val message = context.getString(msgResId, stringArgs)
+      Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+      Log.i(TAG, message)
+    }
+  }
+
+  companion object {
+    private const val TAG = "SensorClientFragment"
+    private const val REFRESH_PERIOD_MS = 3000L
+    private const val MAX_DATA_POINTS = 60
+    private val CLUSTERS = mapOf(
+        "Temperature" to mapOf(
+            "read" to { device: Long, endpointId: Int, callback: ReadCallback ->
+              val cluster = ChipClusters.TemperatureMeasurementCluster(device, endpointId)
+              cluster.readMeasuredValueAttribute(callback)
+            },
+            "unitValue" to 0.01,
+            "unitSymbol" to "\u00B0C"
+        ),
+        "Pressure" to mapOf(
+            "read" to { device: Long, endpointId: Int, callback: ReadCallback ->
+              val cluster = ChipClusters.PressureMeasurementCluster(device, endpointId)
+              cluster.readMeasuredValueAttribute(callback)
+            },
+            "unitValue" to 1.0,
+            "unitSymbol" to "hPa"
+        ),
+        "Relative Humidity" to mapOf(
+            "read" to { device: Long, endpointId: Int, callback: ReadCallback ->
+              val cluster = ChipClusters.RelativeHumidityMeasurementCluster(device, endpointId)
+              cluster.readMeasuredValueAttribute(callback)
+            },
+            "unitValue" to 0.01,
+            "unitSymbol" to "%"
+        )
+    )
+
+    fun newInstance(): SensorClientFragment = SensorClientFragment()
+  }
+}
+

--- a/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
@@ -44,6 +44,14 @@
         android:text="@string/on_off_level_btn_text" />
 
     <Button
+        android:id="@+id/sensorClustersBtn"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/sensor_client_btn_text" />
+
+    <Button
         android:id="@+id/attestationTestBtn"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/layout/sensor_client_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/sensor_client_fragment.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/deviceEndpointLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@+id/deviceIdEd"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:hint="@string/enter_device_id_hint_text"
+                android:inputType="number"
+                android:textSize="16sp" />
+
+            <EditText
+                android:id="@+id/endpointIdEd"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:hint="@string/enter_endpoint_id_hint_text"
+                android:inputType="number"
+                android:text="1"
+                android:textSize="16sp" />
+        </LinearLayout>
+
+        <Spinner
+            android:id="@+id/clusterNameSpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/deviceEndpointLayout"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:spinnerMode="dialog"></Spinner>
+
+        <LinearLayout
+            android:id="@+id/buttonsLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/clusterNameSpinner"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/readSensorBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:padding="16dp"
+                android:text="@string/sensor_client_read_btn_text"
+                android:textAllCaps="true"
+                android:textSize="16sp" />
+
+            <ToggleButton
+                android:id="@+id/watchSensorBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:padding="16dp"
+                android:textAllCaps="true"
+                android:textOff="@string/sensor_client_watch_btn_text"
+                android:textOn="@string/sensor_client_watch_btn_text"
+                android:textSize="16sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/lastValueTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/buttonsLayout"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:padding="8dp"
+            android:textSize="16dp"
+            android:textAlignment="center"/>
+
+        <com.jjoe64.graphview.GraphView
+            android:id="@+id/sensorGraph"
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:layout_below="@+id/lastValueTv"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:padding="8dp"/>
+
+    </RelativeLayout>
+</ScrollView>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="enter_ip_address_hint_text">Enter IP Address (eg. 192.168.10.2)</string>
     <string name="enter_fabric_id_hint_text">Enter Fabric ID</string>
     <string name="enter_device_id_hint_text">Enter Device ID</string>
+    <string name="enter_endpoint_id_hint_text">Enter Endpoint ID</string>
     <string name="echo_input_hint_text">Enter message for device</string>
     <string name="update_device_address_btn_text">Update address</string>
 
@@ -74,5 +75,11 @@
     <string name="nfc_tag_action_show">Show device information</string>
     <string name="nfc_tag_action_wifi">Provision into Wi-Fi network</string>
     <string name="nfc_tag_action_thread">Provision into Thread network</string>
+
+    <string name="sensor_client_btn_text">Sensor clusters</string>
+    <string name="sensor_client_read_btn_text">Read</string>
+    <string name="sensor_client_watch_btn_text">Watch</string>
+    <string name="sensor_client_last_value_text">Last value: %1$.1f %2$s</string>
+    <string name="sensor_client_read_error_text">Failed to read the sensor: %1$s</string>
 
 </resources>


### PR DESCRIPTION
#### Problem
Android CHIPTool does not provide any UI for reading sensors.

#### Change overview
* Add a new screen for reading sensors: Temperature, Relative Humidity and Pressure. More can be easily configured when needed.
* The UI allows to send a single read request and display the last sample, as well as to watch the sensor and display a history of configurable number of samples:
![image](https://user-images.githubusercontent.com/66667989/127024044-b2bc4d37-6565-44a7-a884-f8f1a119b102.png)
(the screenshot is based on fake data generated on the sensor device, it's not so cold over here ;))

#### Testing
Tested manually with a not yet contributed sensor app based on nRF Connect platform.
