### PR TITLE
CHIPDevice: get new ExchangeContext on existing SecureSession

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -681,6 +681,19 @@ CHIP_ERROR Device::SendReadAttributeRequest(app::AttributePathParams aPath, Call
     return err;
 }
 
+Messaging::ExchangeContext * Device::GetNewExchangeContext(Messaging::ExchangeDelegate * delegate)
+{
+    if (mExchangeMgr == nullptr || delegate == nullptr)
+    {
+        return nullptr;
+    }
+
+    bool didLoad = false;
+    LoadSecureSessionParametersIfNeeded(didLoad);
+
+    return mExchangeMgr->NewContext(mSecureSession, delegate);
+}
+
 Device::~Device()
 {
     if (mExchangeMgr)

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -376,6 +376,13 @@ public:
 
     ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
 
+    /** @brief Generate a new ExchangeContext on the SecureSession with the option of using a different ExchangeDelegate than this
+     *         class.
+     *
+     * @return Returns a pointer to an ExchangeContext or nullptr if no object can be allocated or is available.
+     **/
+    Messaging::ExchangeContext * GetNewExchangeContext(Messaging::ExchangeDelegate * delegate);
+
     /*
      * This function can be called to establish a secure session with the device.
      *


### PR DESCRIPTION
#### Problem
The `Device` API hides access to the `ExchangeContext` that it creates, and currently only handles IM or SecureSession protocol messages. This means other protocols such as BDX cannot use the `Device` API to send and receive messages.

#### Change overview
- add a public method `GetNewExchangeContext` that generates a new context on the existing `SecureSession` using the provided `ExchangeDelegate`.

#### Testing
- tested manually using custom local BDX applications