### PR TITLE
[hotfix] Temporary fix for Telink builds

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:latest
+            image: connectedhomeip/chip-build-telink:0.4.30
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
#### Problem
Something is wrong with the new Telink Docker image and Telink CI jobs are failing preventing other PRs to be
merged. 

#### Change overview
Switch back to the previous image version until the problem is found.

#### Testing
No testing required.
