### PR TITLE
Add nrf support  for scripts/build/build_examples.py

### DIFF
--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 from typing import Set

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -7,6 +7,7 @@ from builders.linux import LinuxBuilder
 from builders.qpg import QpgBuilder
 from builders.esp32 import Esp32Builder, Esp32Board, Esp32App
 from builders.efr32 import Efr32Builder, Efr32App, Efr32Board
+from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 
 from .targets import Application, Board, Platform
 
@@ -68,6 +69,7 @@ _MATCHERS = {
     Platform.ESP32: Matcher(Esp32Builder),
     Platform.QPG: Matcher(QpgBuilder),
     Platform.EFR32: Matcher(Efr32Builder),
+    Platform.NRF: Matcher(NrfConnectBuilder),
 }
 
 # Matrix of what can be compiled and what build options are required
@@ -92,6 +94,12 @@ _MATCHERS[Platform.EFR32].AcceptApplication(Application.LOCK, app=Efr32App.LOCK)
 _MATCHERS[Platform.EFR32].AcceptApplication(
     Application.WINDOW_COVERING, app=Efr32App.WINDOW_COVERING)
 
+
+_MATCHERS[Platform.NRF].AcceptBoard(Board.NRF5340, board=NrfBoard.NRF5340)
+_MATCHERS[Platform.NRF].AcceptBoard(Board.NRF52840, board=NrfBoard.NRF52840)
+_MATCHERS[Platform.NRF].AcceptApplication(Application.LOCK, app=NrfApp.LOCK)
+_MATCHERS[Platform.NRF].AcceptApplication(Application.LIGHT, app=NrfApp.LIGHT)
+_MATCHERS[Platform.NRF].AcceptApplication(Application.SHELL, app=NrfApp.SHELL)
 
 class BuilderFactory:
   """Creates application builders."""

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -11,6 +11,7 @@ class Platform(IntEnum):
   QPG = auto()
   ESP32 = auto()
   EFR32 = auto()
+  NRF = auto()
 
   @property
   def ArgName(self):
@@ -39,6 +40,10 @@ class Board(IntEnum):
   # EFR32 platform
   BRD4161A = auto()
 
+  # NRF platform
+  NRF52840 = auto()
+  NRF5340 = auto()
+
   @property
   def ArgName(self):
     return self.name.lower()
@@ -57,6 +62,7 @@ class Application(IntEnum):
   LIGHT = auto()
   LOCK = auto()
   WINDOW_COVERING = auto()
+  SHELL = auto()
 
   @property
   def ArgName(self):

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import shutil

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env -S python3 -B
 
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import coloredlogs
 import click
 import logging

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -1,4 +1,16 @@
-#!/usr/bin/env python3
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 import os

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 from enum import Enum, auto

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -100,7 +100,6 @@ class Esp32Builder(Builder):
   def build(self):
     logging.info('Compiling Esp32 at %s', self.output_dir)
 
-    self.generate()
     self._IdfEnvExecute(
         "ninja -C '%s'" % self.output_dir, title='Building ' + self.identifier)
 

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import shlex

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -47,6 +47,5 @@ class GnBuilder(Builder):
       self._Execute(cmd, title='Generating ' + self.identifier)
 
   def build(self):
-    self.generate()
     self._Execute(['ninja', '-C', self.output_dir],
                   title='Building ' + self.identifier)

--- a/scripts/build/builders/linux.py
+++ b/scripts/build/builders/linux.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -112,7 +112,6 @@ west build --cmake-only -d {outdir} -b {board} {sourcedir}
   def build(self):
     logging.info('Compiling NrfConnect at %s', self.output_dir)
 
-    self.generate()
     self._Execute(['ninja', '-C', self.output_dir], title='Building ' + self.identifier)
 
   def outputs(self):

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -75,7 +75,7 @@ class NrfConnectBuilder(Builder):
   def generate(self):
     if not os.path.exists(self.output_dir):
         # NRF does a in-place update  of SDK tools
-        if not self.runner.dry_run:
+        if not self._runner.dry_run:
           if 'ZEPHYR_BASE' not in os.environ:
               raise Exception("NRF builds require ZEPHYR_BASE to be set")
 

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -75,16 +75,17 @@ class NrfConnectBuilder(Builder):
   def generate(self):
     if not os.path.exists(self.output_dir):
         # NRF does a in-place update  of SDK tools
-        if 'ZEPHYR_BASE' not in os.environ:
-            raise Exception("NRF builds require ZEPHYR_BASE to be set")
+        if not self.runner.dry_run:
+          if 'ZEPHYR_BASE' not in os.environ:
+              raise Exception("NRF builds require ZEPHYR_BASE to be set")
 
-        zephyr_base = os.environ['ZEPHYR_BASE']
-        nrfconnect_sdk = os.path.dirname(zephyr_base)
+          zephyr_base = os.environ['ZEPHYR_BASE']
+          nrfconnect_sdk = os.path.dirname(zephyr_base)
 
-        # NRF builds will both try to change .west/config in nrfconnect and 
-        # overall perform a git fetch on that location
-        if not os.access(nrfconnect_sdk, os.W_OK):
-            raise Exception("Directory %s not writable. NRFConnect builds require updates to this directory." % nrfconnect_sdk)
+          # NRF builds will both try to change .west/config in nrfconnect and 
+          # overall perform a git fetch on that location
+          if not os.access(nrfconnect_sdk, os.W_OK):
+              raise Exception("Directory %s not writable. NRFConnect builds require updates to this directory." % nrfconnect_sdk)
 
         # NOTE: update_ncs is available but SHOULD NOT be needed on docker builds.
         # We are specifically NOT adding to below:

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -1,0 +1,107 @@
+import logging
+import os
+import shlex
+
+from enum import Enum, auto
+
+from .builder import Builder
+
+
+class NrfApp(Enum):
+  LIGHT = auto()
+  LOCK = auto()
+  SHELL=auto()
+
+  def ExampleName(self):
+    if self == NrfApp.LIGHT:
+      return 'lighting-app'
+    elif self == NrfApp.LOCK:
+      return 'lock-app'
+    elif self == NrfApp.SHELL:
+      return 'shell'
+    else:
+      raise Exception('Unknown app type: %r' % self)
+
+  def AppNamePrefix(self):
+    if self == NrfApp.LIGHT:
+      return 'chip-nrf-lighting-example'
+    elif self == NrfApp.LOCK:
+      return 'chip-nrf-lock-example'
+    elif self == NrfApp.SHELL:
+      return 'chip-nrf-shell'
+    else:
+      raise Exception('Unknown app type: %r' % self)
+
+
+class NrfBoard(Enum):
+  NRF52840 = auto()
+  NRF5340 = auto()
+
+  def GnArgName(self):
+    if self == NrfBoard.NRF52840:
+      return 'nrf52840dk_nrf52840'
+    elif self == NrfBoard.NRF5340:
+      return 'nrf5340dk_nrf5340_cpuapp'
+    else:
+      raise Exception('Unknown board type: %r' % self)
+
+
+class NrfConnectBuilder(Builder):
+
+  def __init__(self,
+               root,
+               runner,
+               output_dir: str,
+               app: NrfApp = NrfApp.LIGHT,
+               board: NrfBoard = NrfBoard.NRF52840):
+    super(NrfConnectBuilder, self).__init__(root, runner, output_dir)
+    self.app = app
+    self.board = board
+
+  def generate(self):
+    if not os.path.exists(self.output_dir):
+        # NRF does a in-place update  of SDK tools
+        if 'ZEPHYR_BASE' not in os.environ:
+            raise Exception("NRF builds require ZEPHYR_BASE to be set")
+
+        zephyr_base = os.environ['ZEPHYR_BASE']
+        nrfconnect_sdk = os.path.dirname(zephyr_base)
+
+        # NRF builds will both try to change .west/config in nrfconnect and 
+        # overall perform a git fetch on that location
+        if not os.access(nrfconnect_sdk, os.W_OK):
+            raise Exception("Directory %s not writable. NRFConnect builds require updates to this directory." % nrfconnect_sdk)
+
+        # NOTE: update_ncs is available but SHOULD NOT be needed on docker builds.
+        # We are specifically NOT adding to below:
+        #
+        #   python3 scripts/setup/nrfconnect/update_ncs.py --update --shallow
+        #
+        # ZEPHYR_BASE is assumed already updated to the correct version
+        #
+        # TODO: can this 'correct version' be checked by the build script?
+
+        cmd = '''
+[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {outdir} -b {board} {sourcedir}
+        '''.format(
+            outdir = shlex.quote(self.output_dir),
+            board = self.board.GnArgName(),
+            sourcedir=shlex.quote(os.path.join(self.root, 'examples', self.app.ExampleName(), 'nrfconnect'))
+        ).strip()
+
+        self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
+
+
+  def build(self):
+    logging.info('Compiling NrfConnect at %s', self.output_dir)
+
+    self.generate()
+    self._Execute(['ninja', '-C', self.output_dir], title='Building ' + self.identifier)
+
+  def outputs(self):
+    return {
+        '%s.elf' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),
+        '%s.map' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.map'),
+    }

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import shlex

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -1,4 +1,16 @@
-#!/usr/bin/env python3
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 import os

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -28,6 +28,36 @@ gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--ar
 # Generating efr32-brd4161a-window_covering
 gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window_covering
 
+# Generating nrf-nrf52840-light
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect'
+
+# Generating nrf-nrf52840-lock
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
+
+# Generating nrf-nrf52840-shell
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root}/examples/shell/nrfconnect'
+
+# Generating nrf-nrf5340-light
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
+
+# Generating nrf-nrf5340-lock
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {root}/examples/lock-app/nrfconnect'
+
+# Generating nrf-nrf5340-shell
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
+
 # Generating linux-native-all_clusters
 gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux {out}/linux-native-all_clusters
 
@@ -81,5 +111,53 @@ gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--
 
 # Building efr32-brd4161a-window_covering
 ninja -C {out}/efr32-brd4161a-window_covering
+
+# Generating nrf-nrf52840-light
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect'
+
+# Building nrf-nrf52840-light
+ninja -C {out}/nrf-nrf52840-light
+
+# Generating nrf-nrf52840-lock
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
+
+# Building nrf-nrf52840-lock
+ninja -C {out}/nrf-nrf52840-lock
+
+# Generating nrf-nrf52840-shell
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root}/examples/shell/nrfconnect'
+
+# Building nrf-nrf52840-shell
+ninja -C {out}/nrf-nrf52840-shell
+
+# Generating nrf-nrf5340-light
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
+
+# Building nrf-nrf5340-light
+ninja -C {out}/nrf-nrf5340-light
+
+# Generating nrf-nrf5340-lock
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {root}/examples/lock-app/nrfconnect'
+
+# Building nrf-nrf5340-lock
+ninja -C {out}/nrf-nrf5340-lock
+
+# Generating nrf-nrf5340-shell
+bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
+west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
+
+# Building nrf-nrf5340-shell
+ninja -C {out}/nrf-nrf5340-shell
 
 

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -58,104 +58,44 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
-# Generating linux-native-all_clusters
-gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/linux {out}/linux-native-all_clusters
-
 # Building linux-native-all_clusters
 ninja -C {out}/linux-native-all_clusters
-
-# Generating qpg-qpg6100-lock
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/qpg {out}/qpg-qpg6100-lock
 
 # Building qpg-qpg6100-lock
 ninja -C {out}/qpg-qpg6100-lock
 
-# Generating esp32-m5stack-all_clusters
-cd "{root}"
-bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig_m5stack.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all_clusters reconfigure'
-cd -
-
 # Building esp32-m5stack-all_clusters
 bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-m5stack-all_clusters'"'"''
-
-# Generating esp32-devkitc-all_clusters
-cd "{root}"
-bash -c 'source $IDF_PATH/export.sh; idf.py -D SDKCONFIG_DEFAULTS='"'"'sdkconfig.defaults'"'"' -C examples/all-clusters-app/esp32 -B {out}/esp32-devkitc-all_clusters reconfigure'
-cd -
 
 # Building esp32-devkitc-all_clusters
 bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-devkitc-all_clusters'"'"''
 
-# Generating esp32-devkitc-lock
-cd "{root}"
-bash -c 'source $IDF_PATH/export.sh; idf.py -C examples/lock-app/esp32 -B {out}/esp32-devkitc-lock reconfigure'
-cd -
-
 # Building esp32-devkitc-lock
 bash -c 'source $IDF_PATH/export.sh; ninja -C '"'"'{out}/esp32-devkitc-lock'"'"''
-
-# Generating efr32-brd4161a-light
-gn gen --check --fail-on-unused-args --root={root}/examples/lighting-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-light
 
 # Building efr32-brd4161a-light
 ninja -C {out}/efr32-brd4161a-light
 
-# Generating efr32-brd4161a-lock
-gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-lock
-
 # Building efr32-brd4161a-lock
 ninja -C {out}/efr32-brd4161a-lock
-
-# Generating efr32-brd4161a-window_covering
-gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window_covering
 
 # Building efr32-brd4161a-window_covering
 ninja -C {out}/efr32-brd4161a-window_covering
 
-# Generating nrf-nrf52840-light
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect'
-
 # Building nrf-nrf52840-light
 ninja -C {out}/nrf-nrf52840-light
-
-# Generating nrf-nrf52840-lock
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
 
 # Building nrf-nrf52840-lock
 ninja -C {out}/nrf-nrf52840-lock
 
-# Generating nrf-nrf52840-shell
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root}/examples/shell/nrfconnect'
-
 # Building nrf-nrf52840-shell
 ninja -C {out}/nrf-nrf52840-shell
-
-# Generating nrf-nrf5340-light
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
 
 # Building nrf-nrf5340-light
 ninja -C {out}/nrf-nrf5340-light
 
-# Generating nrf-nrf5340-lock
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {root}/examples/lock-app/nrfconnect'
-
 # Building nrf-nrf5340-lock
 ninja -C {out}/nrf-nrf5340-lock
-
-# Generating nrf-nrf5340-shell
-bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
 # Building nrf-nrf5340-shell
 ninja -C {out}/nrf-nrf5340-shell

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -29,32 +29,32 @@ gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/efr32 '--ar
 gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--args=efr32_board="BRD4161A"' {out}/efr32-brd4161a-window_covering
 
 # Generating nrf-nrf52840-light
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect'
 
 # Generating nrf-nrf52840-lock
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
 
 # Generating nrf-nrf52840-shell
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root}/examples/shell/nrfconnect'
 
 # Generating nrf-nrf5340-light
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
 
 # Generating nrf-nrf5340-lock
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {root}/examples/lock-app/nrfconnect'
 
 # Generating nrf-nrf5340-shell
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
@@ -113,7 +113,7 @@ gn gen --check --fail-on-unused-args --root={root}/examples/window-app/efr32 '--
 ninja -C {out}/efr32-brd4161a-window_covering
 
 # Generating nrf-nrf52840-light
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root}/examples/lighting-app/nrfconnect'
 
@@ -121,7 +121,7 @@ west build --cmake-only -d {out}/nrf-nrf52840-light -b nrf52840dk_nrf52840 {root
 ninja -C {out}/nrf-nrf52840-light
 
 # Generating nrf-nrf52840-lock
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}/examples/lock-app/nrfconnect'
 
@@ -129,7 +129,7 @@ west build --cmake-only -d {out}/nrf-nrf52840-lock -b nrf52840dk_nrf52840 {root}
 ninja -C {out}/nrf-nrf52840-lock
 
 # Generating nrf-nrf52840-shell
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root}/examples/shell/nrfconnect'
 
@@ -137,7 +137,7 @@ west build --cmake-only -d {out}/nrf-nrf52840-shell -b nrf52840dk_nrf52840 {root
 ninja -C {out}/nrf-nrf52840-shell
 
 # Generating nrf-nrf5340-light
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {root}/examples/lighting-app/nrfconnect'
 
@@ -145,7 +145,7 @@ west build --cmake-only -d {out}/nrf-nrf5340-light -b nrf5340dk_nrf5340_cpuapp {
 ninja -C {out}/nrf-nrf5340-light
 
 # Generating nrf-nrf5340-lock
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {root}/examples/lock-app/nrfconnect'
 
@@ -153,7 +153,7 @@ west build --cmake-only -d {out}/nrf-nrf5340-lock -b nrf5340dk_nrf5340_cpuapp {r
 ninja -C {out}/nrf-nrf5340-lock
 
 # Generating nrf-nrf5340-shell
-bash -c '[[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh";
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 

--- a/scripts/build/runner/printonly.py
+++ b/scripts/build/runner/printonly.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import shlex
 
 

--- a/scripts/build/runner/printonly.py
+++ b/scripts/build/runner/printonly.py
@@ -18,6 +18,7 @@ import shlex
 class PrintOnlyRunner:
   def __init__(self, output_file):
     self.output_file = output_file
+    self.dry_run = True
 
   def Run(self, cmd, cwd=None, title=None):
     if title:

--- a/scripts/build/runner/shell.py
+++ b/scripts/build/runner/shell.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import subprocess

--- a/scripts/build/runner/shell.py
+++ b/scripts/build/runner/shell.py
@@ -50,6 +50,9 @@ class LogPipe(threading.Thread):
 
 class ShellRunner:
 
+  def __init__(self):
+    self.dry_run = False
+
   def Run(self, cmd, cwd=None, title=None):
     outpipe = LogPipe(logging.INFO)
     errpipe = LogPipe(logging.WARN)

--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import click
 import coloredlogs
 import difflib


### PR DESCRIPTION
#### Problem
Need to migrate builds to a unified build script:
  - allows faster command-line builds hiding away gn/idf.py/west/other small differences
  - final goal is to allow a single builder to compile any number of needed example applications - both for developer testing and for speeding up CI

#### Change overview

- Adds nrf build support in build_examples.py with 3 apps covered
- Adds license comment blurb to scripts/build python files

#### Testing

Unit test updated

Manually ran `./scripts/build/build_examples.py --platform nrf build` for full test and `./scripts/build/build_examples.py --app shell build` for partial test
