### PR TITLE
Make CHIP_ERROR a class type on nrfconnect

### DIFF
--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -21,6 +21,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
+#include <system/SystemError.h>
 
 #include <kernel.h>
 
@@ -40,58 +41,64 @@ int main(void)
     chip::rpc::Init();
 #endif
 
-    int ret = 0;
+    int ret        = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
 #ifdef CONFIG_USB
     ret = usb_enable(nullptr);
     if (ret)
     {
         LOG_ERR("Failed to initialize USB device");
+        err = chip::System::MapErrorZephyr(ret);
         goto exit;
     }
 #endif
 
-    ret = chip::Platform::MemoryInit();
-    if (ret != CHIP_NO_ERROR)
+    err = chip::Platform::MemoryInit();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("Platform::MemoryInit() failed");
         goto exit;
     }
 
     LOG_INF("Init CHIP stack");
-    ret = PlatformMgr().InitChipStack();
-    if (ret != CHIP_NO_ERROR)
+    err = PlatformMgr().InitChipStack();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("PlatformMgr().InitChipStack() failed");
         goto exit;
     }
 
     LOG_INF("Starting CHIP task");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
         goto exit;
     }
 
     LOG_INF("Init Thread stack");
-    ret = ThreadStackMgr().InitThreadStack();
-    if (ret != CHIP_NO_ERROR)
+    err = ThreadStackMgr().InitThreadStack();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
         goto exit;
     }
 
-    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-    if (ret != CHIP_NO_ERROR)
+    err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         goto exit;
     }
 
     ret = GetAppTask().StartApp();
+    if (ret != 0)
+    {
+        err = chip::System::MapErrorZephyr(ret);
+    }
 
 exit:
-    LOG_ERR("Exited with code %d", ret);
-    return ret;
+    LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, chip::ChipError::FormatError(err));
+    return err == CHIP_NO_ERROR ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/lock-app/nrfconnect/main/main.cpp
+++ b/examples/lock-app/nrfconnect/main/main.cpp
@@ -32,49 +32,54 @@ using namespace ::chip::DeviceLayer;
 
 int main()
 {
-    int ret = 0;
+    int ret        = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ret = chip::Platform::MemoryInit();
-    if (ret != CHIP_NO_ERROR)
+    err = chip::Platform::MemoryInit();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("Platform::MemoryInit() failed");
         goto exit;
     }
 
     LOG_INF("Init CHIP stack");
-    ret = PlatformMgr().InitChipStack();
-    if (ret != CHIP_NO_ERROR)
+    err = PlatformMgr().InitChipStack();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("PlatformMgr().InitChipStack() failed");
         goto exit;
     }
 
     LOG_INF("Starting CHIP task");
-    ret = PlatformMgr().StartEventLoopTask();
-    if (ret != CHIP_NO_ERROR)
+    err = PlatformMgr().StartEventLoopTask();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
         goto exit;
     }
 
     LOG_INF("Init Thread stack");
-    ret = ThreadStackMgr().InitThreadStack();
-    if (ret != CHIP_NO_ERROR)
+    err = ThreadStackMgr().InitThreadStack();
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
         goto exit;
     }
 
-    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-    if (ret != CHIP_NO_ERROR)
+    err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+    if (err != CHIP_NO_ERROR)
     {
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         goto exit;
     }
 
     ret = GetAppTask().StartApp();
+    if (ret != 0)
+    {
+        err = chip::System::MapErrorZephyr(ret);
+    }
 
 exit:
-    LOG_ERR("Exited with code %d", ret);
-    return ret;
+    LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, chip::ChipError::FormatError(err));
+    return err == CHIP_NO_ERROR ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -164,7 +164,7 @@ static const shell_command_t cmds_otcli_root = { &cmd_otcli_dispatch, "otcli", "
 static int OnOtCliOutput(void * aContext, const char * aFormat, va_list aArguments)
 {
     int rval = vsnprintf(sTxBuffer, sTxLength, aFormat, aArguments);
-    VerifyOrExit(rval >= 0 && rval < sTxLength, rval = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrExit(rval >= 0 && rval < sTxLength, rval = ChipError::AsInteger(CHIP_ERROR_BUFFER_TOO_SMALL));
     return streamer_write(streamer_get(), (const char *) sTxBuffer, rval);
 exit:
     return rval;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1429,7 +1429,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_DnsBrowse(const
     char fullServiceName[chip::Mdns::kMdnsTypeAndProtocolMaxSize + 1 + SrpClient::kDefaultDomainNameSize + 1];
     snprintf(fullServiceName, sizeof(fullServiceName), "%s.%s", aServiceName, SrpClient::kDefaultDomainName);
 
-    error = otDnsClientBrowse(mOTInst, fullServiceName, OnDnsBrowseResult, aContext, defaultConfig);
+    error = MapOpenThreadError(otDnsClientBrowse(mOTInst, fullServiceName, OnDnsBrowseResult, aContext, defaultConfig));
 
 exit:
 
@@ -1503,7 +1503,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_DnsResolve(cons
     char fullServiceName[chip::Mdns::kMdnsTypeAndProtocolMaxSize + 1 + SrpClient::kDefaultDomainNameSize + 1];
     snprintf(fullServiceName, sizeof(fullServiceName), "%s.%s", aServiceName, SrpClient::kDefaultDomainName);
 
-    error = otDnsClientResolveService(mOTInst, aInstanceName, fullServiceName, OnDnsResolveResult, aContext, defaultConfig);
+    error = MapOpenThreadError(
+        otDnsClientResolveService(mOTInst, aInstanceName, fullServiceName, OnDnsResolveResult, aContext, defaultConfig));
 
 exit:
 

--- a/src/platform/nrfconnect/CHIPPlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPPlatformConfig.h
@@ -36,6 +36,8 @@
 #define CHIP_CONFIG_TIME_ENABLE_CLIENT 1
 #define CHIP_CONFIG_TIME_ENABLE_SERVER 0
 
+#define CHIP_CONFIG_ERROR_CLASS 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0


### PR DESCRIPTION
#### Problem

Having CHIP_ERROR be a class type would provide (a) type safety,
and (b) the ability to trace the source of errors (issue #8340).

Recent changes have made CHIP_ERROR a class on Linux (#8383),
cc13x2_26x2, EFR32, QPG (#8446), and ESP32 (#8469).

#### Change overview

- Enable `CHIP_CONFIG_ERROR_CLASS` on nrfconnect.

#### Testing

Existing tests should confirm no change to functionality.
