### PR TITLE
Add meeting notes 2021-06-14 Threading and Synchronization

### DIFF
--- a/docs/dated/20210614_thread_races_in_matter.md
+++ b/docs/dated/20210614_thread_races_in_matter.md
@@ -1,0 +1,184 @@
+# Thread Races in Matter
+
+## Current Situation:
+
+-   Data races cause lots of issues in the SDK:
+
+    -   [_\#7297 - Crashes in chip-tool client after PR 7060_](https://github.com/project-chip/connectedhomeip/issues/7297)
+
+    -   [_\#7493 - Handling of mTestIndex in chip-tool tests is racy_](https://github.com/project-chip/connectedhomeip/issues/7493)
+
+    -   [_\#7498 - Crash due to exchange timing out a packet before it ever gets a chance to be sent_](https://github.com/project-chip/connectedhomeip/issues/7498)
+
+    -   [_\#7623 - Linux test suite errors out due to failure to rename tmp file_](https://github.com/project-chip/connectedhomeip/issues/7623)
+
+    -   [_\#7574 - chip-tool segfault on Darwin_](https://github.com/project-chip/connectedhomeip/issues/7574)
+
+-   Recently added support for tsan that provides an empirical, measurable way
+    to detect and validate the ‘race-free’-ness of our stack.
+
+-   Need to really come together as a development team and figure out how to
+    address these systemically, rather than applying incremental patches.
+
+-   [_\#7478_](https://github.com/project-chip/connectedhomeip/pull/7478) using
+    tsan as a validator to see how **one** particular systemic approach to
+    fixing these data races would look like.
+
+-   In chip-tool,
+
+    -   Lots of concurrent access to global state from multiple threads of
+        execution across all phases of the lifetime of an application
+        (initialization, steady state operation and shutdown).
+
+-   \#7478 took **one** particular approach to solving that specifically with
+    chip-tool, which is to:
+
+    -   Provide a number of options within
+        [_PlatformManager’s API_](https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/PlatformManager.h#L79)
+        set that empowers applications to compose in the right patterns that
+        fits their needs:
+
+        -   A: Run the stack on a separate threading context from the
+            ‘application’, and use the stack lock to serialize access to global
+            state in the SDK
+
+            -   chip-tool, im-initiator, minimal mdns client, im-responder
+                mostly take this approach.
+
+        -   B: Run the stack on the same threading context as the application,
+            and avoid the need to use the stack lock to serialize access to
+            global state in the SDK
+
+            -   All the server-side example applications mostly take this
+                approach
+
+        -   C: Run the stack on a separate threading context from the
+            ‘application’, but make it the application’s responsibility to
+            handle messaging between the different threading queues in a
+            platform-specific manner.
+
+            -   Any darwin example apps perhaps?
+
+    -   Ensure consistent impleme km ntations of the PlatformManager API on all
+        platforms (targeted POSIX to start with to establish a baseline)
+
+    -   Selected B) as the basis for the fixes to chip-tool given it was best
+        aligned with how it was structured today.
+
+    -   Doesn’t mean that that’s how we **have** to do it.
+
+## Q1: Should the SDK be opinionated and take a particular stance on how threading and synchronization should be achieved by applications? Or should it be left to applications to decide?
+
+-   When it comes to the SDK, achieving true concurrency is less important than
+    ensuring serialized, safe access to the global state in the SDK.
+-   What are the guidelines for how applications should interact with the SDK
+    from a synchronization perspective?
+
+## Q2: Should PlatformManager APIs be consistently implemented on all
+
+platforms? Which subsets of it should be?
+
+-   E.g POSIX’s implementation of PlatformManager API varies quite a bit from
+    the Darwin implementation, which varies quite a bit from the FreeRTOS
+    version.
+
+    -   See
+        [_this_](https://github.com/project-chip/connectedhomeip/issues/7557#issuecomment-860271069)
+        issue for analysis on Darwin’s version.
+
+## Q3: How do we support common tools like chip-tool (client), all-clusters-app (server) that work correctly/reliably across different platforms?\*\*
+
+-   Option A and B have the most portability, leverage APIs in PlatformManager
+    that can be implemented on most platforms.
+
+-   Option C has the least portability but maximum concurrency, requires highly
+    custom APIs for each platform:
+
+    -   > Dispatching blocks on dispatch queues on Darwin
+
+    -   > Dispatching generic closures on an std::queue on POSIX
+
+    -   > Dispatching highly constrained closures onto a FreeRTOS queue on
+        > FreeRTOS
+
+-   Should avoid needing to sprinkle \#ifdefs in application code based on
+    platform-impl specific API
+
+## Meeting Minutes (June 15th)
+
+Attendees: Jerry, Michael Spang, Michael Sandstedt, Tennessee, Andrei, Vivien,
+Yufeng
+
+-   Consensus that applications should be responsible for managing the
+    threading, dispatch and queueing of SDK events and API calls, deciding the
+    models that are most appropriate to their needs.
+
+-   chip-tool shouldn’t really have been designed from the onset to have a
+    separate ‘main’ thread, which doesn’t do much beyond just blocking waiting
+    for a result. Instead, it could have been folded into the same threading
+    context as that running the SDK core. This could have minimized the issues
+    we have seen so far.
+
+-   General consensus that the PlatformManager part of the Device Layer
+    shouldn’t really be part of the SDK, and is ‘external’ to the SDK
+
+-   Need to design out a new, more minimal ‘threading/dispatch’ interface that
+    the SDK expects to be provided:
+
+    -   A call to post an event
+
+    -   A call to add an event handler for a particular type of event
+
+-   This interface would replace the existing PlatformManager APIs and Impls
+
+-   Q: What about the various \#ifdefs in Inet endpoint logic that selects
+    between LWIP and Socket file handles?
+
+    -   This effort does not affect that logic - that still needs a separate
+        conversation.
+
+-   With this new operating model, it means there is now not a trivial way to
+    write portable, client logic that is reusable across different platforms.
+    Notably, this includes tools like chip-tool, clusters-app, etc… Needs more
+    discussion.
+
+## Meeting Minutes (June 16th)
+
+Attendees: Jerry, Michael Spang, Michael Sandstedt, Andrei, Vivien, Yufeng,
+Boris, Kevin
+
+-   Spent some time clarifying the original rationale for the device layer and
+    its design.
+
+-   Acknowledgement however that the device layer today imbues too much policy
+
+-   If application is responsible for managing the threading model, then the
+    question of building portable tools like chip-tool surfaces (and a means to
+    avoid \#ifdef hell)
+
+-   Suggestion to actually use chip-tool as a means to exemplify different
+    threading pattern variants, using it as an example app of sorts AND a
+    proving ground for this model
+
+-   Still can keep the various implementations of threading/synchronization
+    around in the device layer as possible options, but it is ‘external’ to the
+    core SDK. THese implementations would provide an implementation for the
+    narrower, ‘Threading and Dispatch’ interface that is mentioned above.
+
+-   Application can use some of these reference examples in their applications
+    if it provides them value
+
+-   Side discussion on whether CRTP is still the right pattern to go forward
+    with.
+
+    -   Acknowledgement that pure virtual interfaces are used fairly broadly in
+        the code, and make it more testable
+
+    -   However, not sure if the testability wins there justify the performance
+        losses
+
+-   Kevin to spearhead these changes, Yufeng to assist.
+
+-   See
+    [_https://github.com/project-chip/connectedhomeip/issues/7725_](https://github.com/project-chip/connectedhomeip/issues/7725)
+    for more details.

--- a/docs/dated/20210614_threading_and_synchronization.md
+++ b/docs/dated/20210614_threading_and_synchronization.md
@@ -1,0 +1,93 @@
+# Threading & Synchronization
+
+Meeting notes 2021-06-14
+
+-   Two overall schools of thought around how SDK should approach
+    synchronization:
+
+    1.  **Make SDK Public/External APIs thread-safe.**
+
+        Two variations in approaches here:
+
+        1.  Async: Make the APIs Post to the CHIP thread and complete the work
+            on that thread. This is the approach outlined in
+            [_Yufeng’s PR_](https://github.com/project-chip/connectedhomeip/pull/7117).
+
+            -   The approach currently resident in the OpenThread stack.
+            -   Requires SDK to be designed in a very async-friendly manner, and
+                requires applications to maintain state machines to handle
+                bottom half-handlers.
+
+        2.  Sync: Make the APIs grab narrowly-scoped locks that protect very
+            specific critical sections.
+
+            -   e.g. One lock to protect ExchangeMgr’s singleton state, another
+                to protect the InteractionModelEngine singleton’s state, etc.
+
+    2.  **Not Thread-safe APIs, rely on external synchronization**
+
+        Unless marked otherwise, APIs will be deemed ‘not thread-safe’, and
+        require applications embedding the SDK to guarantee thread-safety when
+        calling into the SDK
+
+        Couple of options available to applications:
+
+        1.  Run their application logic that calls into the SDK APIs on the same
+            threading context as the SDK itself. This requires no further
+            synchronization
+
+        2.  Run their application logic on a separate thread, and if so, grab
+            the CHIP lock before calling any of the SDK APIs
+
+        3.  Run their application logic on a separate thread, and provide custom
+            ‘Posted’ versions of the SDK APIs as they see fit to their consumers
+            to safely call into the SDK API on the CHIP thread.
+
+            1.  They’ll also be responsible for handling responses when handling
+                the events and routing them back to the originating calling
+                thread.
+            2.  The SDK will **not** provide the ‘Posted’ versions of these APIs
+
+        When dispatching callbacks from the SDK, applications can call back into
+        the SDK safely without grabbing the CHIP lock. Applications however may
+        not make any assumptions about the specific threading context on that
+        callback (i.e whether it’s running on the CHIP thread or not).
+
+-   In a pure greenfield development model, most agree that 1a) would have been
+    ideal. It places the onus of ensuring thread safety on SDK developers to
+    solve, leaving application developers unencumbered and unlikely to make
+    mistakes across arguably, a wide swatch of developer capabilities.
+
+-   However:
+
+    -   Switching to an async, event-post model pervasively requires a lot of
+        changes to the implementation to provide appropriate callbacks + add
+        state machines. The stack is just not designed in this way today
+
+    -   Can potentially entail a lot of flash cost (\~150 bytes / call-site in
+        the IM
+        [_PR_](https://github.com/project-chip/connectedhomeip/pull/7117#issuecomment-849999350)
+        that Yufeng put out), which can eventually end up costing a lot (needs
+        to be ratified with some analysis though).
+
+    -   Switching to a narrowly-scoped lock model requires a lot of up-front
+        analysis (which we should do anyways) as to the critical sections
+        involved, and whether there can be potential to have races/deadlocks in
+        certain call-paths
+
+-   **Recommendation:**
+
+    -   Go with 2 (use external synchronization rather than thread-safe APIs)
+        for now, with well-written documentation that stipulates the
+        expectations of application developers, as well as example applications
+        that are updated to showcase the different approaches available to them.
+
+        -   On Linux, example apps could use the post-event using lambdas +
+            closures, or grab the lock.
+        -   On embedded, example apps could just run on the CHIP thread
+
+    -   Easiest to deploy today.
+
+    -   Continue to investigate whether we can incrementally move to 1
+        (thread-safe APIs) in the future, including doing the critical section
+        analysis (which we should do anyways).

--- a/docs/dated/README.md
+++ b/docs/dated/README.md
@@ -1,0 +1,3 @@
+This directory contains documents that may aid in understanding, but do not
+necessarily correspond to the current code, such as design proposals and meeting
+notes.


### PR DESCRIPTION
#### Problem

There is not enough documentation in tree.

#### Change overview

* Create a directory contains documents that may aid in understanding, but do not
necessarily correspond to the current code, such as design proposals and meeting
notes.
* Add meeting notes related to threading and synchronization from mid-June 2021.
