### PR TITLE
Implement ResetCounts command for Network Diagnostics Cluster

### DIFF
--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -16,12 +16,29 @@
  */
 
 #include <app/CommandHandler.h>
+#include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
+
+using namespace chip::app::Clusters;
 
 bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
 {
-    // TODO: Implement the ResetCounts in the platform layer.
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::SetPacketRxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));
+
+    status = EthernetNetworkDiagnostics::Attributes::SetPacketTxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketTxCount attribute"));
+
+    status = EthernetNetworkDiagnostics::Attributes::SetTxErrCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset TxErrCount attribute"));
+
+    status = EthernetNetworkDiagnostics::Attributes::SetCollisionCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset CollisionCount attribute"));
+
+    status = EthernetNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
+
+exit:
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -16,12 +16,19 @@
  */
 
 #include <app/CommandHandler.h>
+#include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
+
+using namespace chip::app::Clusters;
 
 bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
 {
-    // TODO: Implement the ResetCounts in the platform layer.
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    EmberAfStatus status = ThreadNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        ChipLogError(Zcl, "Failed to reset OverrunCount attribute");
+    }
+
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -16,12 +16,36 @@
  */
 
 #include <app/CommandHandler.h>
+#include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
+
+using namespace chip::app::Clusters;
 
 bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
 {
-    // TODO: Implement the ResetCounts in the platform layer.
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    EmberAfStatus status = WiFiNetworkDiagnostics::Attributes::SetBeaconLostCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconLostCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetBeaconRxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconRxCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetPacketMulticastRxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastRxCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetPacketMulticastTxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastTxCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetPacketUnicastRxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastRxCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetPacketUnicastTxCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastTxCount attribute"));
+
+    status = WiFiNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
+
+exit:
     emberAfSendImmediateDefaultResponse(status);
+
     return true;
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
*Attribute Accessory helper APIs have been merged, now we can implement the missing ResetCounts command for Thread/WiFi/Ethernet Network Diagnostics Cluster

* Fixes #8397

#### Change overview
Implement ResetCounts command for Thread/WiFi/Ethernet Network Diagnostics Cluster

#### Testing
How was this tested? (at least one bullet point required)
1. Reset thread network diagnostic counts
./chip-tool threadnetworkdiagnostics reset-counts 0
Confirm attribute OverrunCount is set to 0

2. Reset wifi network diagnostic counts
./chip-tool wifinetworkdiagnostics reset-counts 0
Confirm reception of this command SHALL reset the following attributes to 0:
• BeaconLostCount
• BeaconRxCount
• PacketMulticastRxCount
• PacketMulticastTxCount
• PacketUnicastRxCount
• PacketUnicastTxCount
• OverrunCount

3. Reset ethernet network diagnostic counts
./chip-tool ethernetnetworkdiagnostics reset-counts 0
Confirm reception of this command SHALL reset the following attributes to 0:
• PacketRxCount
• PacketTxCount
• TxErrCount
• CollisionCount
• OverrunCount
