### PR TITLE
Update Telink docker image version to :latest in workflows example .yaml file

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:0.4.30
+            image: connectedhomeip/chip-build-telink:latest
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
#### Problem
As https://github.com/project-chip/connectedhomeip/issues/8640 issue has been fixed
in this PR: https://github.com/project-chip/connectedhomeip/pull/8660
it is time go back to the latest version of Telink docker image 

#### Change overview
This PR updated docker image to :latest version in .github/workflows/examples-telink.yaml

#### Testing
Tested manually. Steps:
1. **$ docker pull connectedhomeip/chip-build-telink**
2. run **$ ./scripts/examples/telink_example.sh lighting-app tlsr9518adk80d** in the docker container
3. check that build was successful
