### PR TITLE
Implement command ResetWatermarks for Software Diagnostics Cluster

### DIFF
--- a/examples/lighting-app/mbed/CMakeLists.txt
+++ b/examples/lighting-app/mbed/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(${APP_TARGET} PRIVATE
                ${APP_ROOT}/lighting-common/gen/callback-stub.cpp
                ${LIGHTING_COMMON}/gen/IMClusterCommandHandler.cpp
                ${MBED_COMMON}/util/LEDWidget.cpp
+               ${CHIP_ROOT}/src/app/common/gen/attributes/Accessors.cpp
                ${CHIP_ROOT}/src/app/util/DataModelHandler.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting.cpp

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(app PRIVATE
                ${LIGHTING_COMMON}/gen/IMClusterCommandHandler.cpp
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
                ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
+               ${CHIP_ROOT}/src/app/common/gen/attributes/Accessors.cpp
                ${CHIP_ROOT}/src/app/util/DataModelHandler.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting.cpp

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/util/src/LEDWidget.cpp
                ${TELINK_COMMON}/util/src/ButtonManager.cpp
                ${TELINK_COMMON}/util/src/ThreadUtil.cpp
+               ${CHIP_ROOT}/src/app/common/gen/attributes/Accessors.cpp               
                ${CHIP_ROOT}/src/app/util/DataModelHandler.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
                ${CHIP_ROOT}/src/app/reporting/reporting.cpp

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -16,12 +16,27 @@
  */
 
 #include <app/CommandHandler.h>
+#include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
+
+using namespace chip::app::Clusters;
 
 bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
 {
-    // TODO: Implement the ResetWatermarks in the platform layer.
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    uint64_t currentHeapUsed;
+
+    EmberAfStatus status = SoftwareDiagnostics::Attributes::GetCurrentHeapUsed(endpoint, &currentHeapUsed);
+    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to get the value of the CurrentHeapUsed attribute"));
+
+    status = SoftwareDiagnostics::Attributes::SetCurrentHeapHighWatermark(endpoint, currentHeapUsed);
+    VerifyOrExit(
+        status == EMBER_ZCL_STATUS_SUCCESS,
+        ChipLogError(
+            Zcl,
+            "Failed to reset the value of the CurrentHeapHighWaterMark attribute to the value of the CurrentHeapUsed attribute"));
+
+exit:
     emberAfSendImmediateDefaultResponse(status);
+
     return true;
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Attribute Accessory helper APIs have been merged, now we can implement the missing ResetWatermarks command for Software Diagnostics Cluster

* Fixes #8608

TODO: Reset the value of the StackFreeMinimum field for every thread to the value of the corresponding thread’s StackFreeCurrent field when accessory helper APIs for list and struct are ready.

#### Change overview
On receipt of command ResetWatermarks, the Node SHALL set the value of the CurrentHeapHighWaterMark attribute to
the value of the CurrentHeapUsed attribute.

#### Testing
How was this tested? (at least one bullet point required)
Reset Software diagnostic counts
./chip-tool softwarediagnostics reset-watermarks 0
Confirm  the value of the CurrentHeapHighWaterMark attribute is set to the value of the CurrentHeapUsed attribute.
