### PR TITLE
Fix build with logging disabled

### DIFF
--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -31,6 +31,7 @@ using namespace chip::Logging;
 
 void emberAfPrint(int category, const char * format, ...)
 {
+#if _CHIP_USE_LOGGING
     if (format != nullptr)
     {
         va_list args;
@@ -38,10 +39,12 @@ void emberAfPrint(int category, const char * format, ...)
         chip::Logging::LogV(chip::Logging::kLogModule_Zcl, chip::Logging::kLogCategory_Progress, format, args);
         va_end(args);
     }
+#endif
 }
 
 void emberAfPrintln(int category, const char * format, ...)
 {
+#if _CHIP_USE_LOGGING
     if (format != nullptr)
     {
         va_list args;
@@ -49,6 +52,7 @@ void emberAfPrintln(int category, const char * format, ...)
         chip::Logging::LogV(chip::Logging::kLogModule_Zcl, chip::Logging::kLogCategory_Progress, format, args);
         va_end(args);
     }
+#endif
 }
 
 // TODO: add unit tests.

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -113,7 +113,7 @@ void SetLogFilter(uint8_t category);
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Error, MSG, ##__VA_ARGS__)
 #endif
 #else
-#define ChipLogError(MOD, MSG, ...)
+#define ChipLogError(MOD, MSG, ...) ((void) 0)
 #endif
 
 #ifndef CHIP_PROGRESS_LOGGING
@@ -134,7 +134,7 @@ void SetLogFilter(uint8_t category);
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Progress, MSG, ##__VA_ARGS__)
 #endif
 #else
-#define ChipLogProgress(MOD, MSG, ...)
+#define ChipLogProgress(MOD, MSG, ...) ((void) 0)
 #endif
 
 #ifndef CHIP_DETAIL_LOGGING
@@ -155,7 +155,7 @@ void SetLogFilter(uint8_t category);
     chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Detail, MSG, ##__VA_ARGS__)
 #endif
 #else
-#define ChipLogDetail(MOD, MSG, ...)
+#define ChipLogDetail(MOD, MSG, ...) ((void) 0)
 #endif
 
 #if CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING


### PR DESCRIPTION
#### Problem
CHIP does not compile with logs disabled.

#### Change overview
Instead of fixing all the places where ChipLogXXX macros are used without curly braces, define them as NO-OP in case
they are disabled. Also fix ember code assuming that logging is enabled.

#### Testing
Built a random example with `chip_logging=false`.
