### PR TITLE
Update to node.js 14 for the ZAP test.

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -35,10 +35,10 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
-            - name: Use Node.js 12.x
+            - name: Use Node.js 14.x
               uses: actions/setup-node@v1
               with:
-                node-version: '12.x'
+                node-version: '14.x'
             - name: Use Java 
               uses: actions/setup-java@v2
               with:


### PR DESCRIPTION
At some point in the recent past ZAP dropped support for node.js 12.
Going forward we need to use node.js 14 or later with ZAP.

#### Problem
If we update ZAP to tip, ZAP CI fails because ZAP now relies on packages that don't work with node.js 12

#### Change overview
Use node.js 14 for the CI.

#### Testing
Verified via our CI that CI passes with a ZAP updated to tip and this change.