### PR TITLE
Don't run MbedOS jobs on restyled PRs.

### DIFF
--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -17,6 +17,7 @@ name: Build example - Mbed OS
 on:
     push:
     pull_request:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -37,6 +38,7 @@ jobs:
             EXAMPLE_PROFILE: release
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
 
         container:
             image: connectedhomeip/chip-build-mbed-os:latest


### PR DESCRIPTION
We generally don't want to run CI on those.

#### Problem
MbedOS CI runs on restyled PRs.

#### Change overview
Skip it for restyled PRs, like our other CI.

#### Testing
No testing so far, but I will watch CI after this merges to see if it does what I expect.  The exact line I added was copied from another workflow file, so I am pretty confident this will do the right thing.