### PR TITLE
Reduce default iteration counts for the test_suites script to 2.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,7 +87,6 @@ jobs:
             - name: Run Tests
               timeout-minutes: 10
               run: |
-                  ifconfig -a
                   scripts/tests/test_suites.sh
             - name: Run TV Tests
               timeout-minutes: 10

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -18,7 +18,7 @@
 
 set -e
 
-declare -i iterations=20
+declare -i iterations=2
 declare -i background_pid=0
 declare test_case_wrapper=()
 


### PR DESCRIPTION
This should help with CI load and is probably also better for local
testing now that we have more tests and a single iteration takes a few
seconds instead of hundreds of ms.

#### Problem
Tests are starting to take a long time as we add more of them.

#### Change overview
Reduce iteration count to speed things up.

#### Testing
Ran script manually, observed only 2 iterations happen.