### PR TITLE
Remove public Shutdown method on WriteHandler.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -103,10 +103,7 @@ void InteractionModelEngine::Shutdown()
 
     for (auto & writeHandler : mWriteHandlers)
     {
-        if (!writeHandler.IsFree())
-        {
-            writeHandler.Shutdown();
-        }
+        VerifyOrDie(writeHandler.IsFree());
     }
 
     for (uint32_t index = 0; index < IM_SERVER_MAX_NUM_PATH_GROUPS; index++)

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -54,11 +54,6 @@ public:
     CHIP_ERROR Init(InteractionModelDelegate * apDelegate);
 
     /**
-     *  Shut down the ReadHandler. This terminates this instance
-     *  of the object and releases all held resources.
-     */
-    void Shutdown();
-    /**
      *  Process a write request.  Parts of the processing may end up being asynchronous, but the WriteHandler
      *  guarantees that it will call Shutdown on itself when processing is done (including if OnWriteRequest
      *  returns an error).
@@ -99,6 +94,10 @@ private:
     void MoveToState(const State aTargetState);
     void ClearState();
     const char * GetStateStr() const;
+    /**
+     *  Clean up state when we are done sending the write response.
+     */
+    void Shutdown();
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponse::Builder mWriteResponseBuilder;


### PR DESCRIPTION
We don't ever have long-lived WriteHandler instances, so don't need
external shutdown on them.

Fixes https://github.com/project-chip/connectedhomeip/issues/8651

#### Problem
Exposed method that can be misused.

#### Change overview
Stop exposing it.

#### Testing
Code compiles; there were no consumers of this method outside this class.