### PR TITLE
Fix chip-tool to never use the stored node id when doing a new pairing.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -21,6 +21,7 @@
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <protocols/secure_channel/PASESession.h>
 #include <support/logging/CHIPLogging.h>
 
 #include <setup_payload/ManualSetupPayloadParser.h>
@@ -45,14 +46,16 @@ CHIP_ERROR PairingCommand::Run()
     // TODO: Ideally we'd just ask for an operational cert for the commissionnee
     // and get the node from that, but the APIs are not set up that way yet.
     NodeId randomId;
-    if (Controller::ExampleOperationalCredentialsIssuer::GetRandomOperationalNodeId(&randomId) == CHIP_NO_ERROR)
-    {
-        ChipLogProgress(Controller, "Generated random node id: 0x" ChipLogFormatX64, ChipLogValueX64(randomId));
-        if (GetExecContext()->storage->SetRemoteNodeId(randomId) == CHIP_NO_ERROR)
-        {
-            GetExecContext()->remoteId = randomId;
-        }
-    }
+    ReturnErrorOnFailure(Controller::ExampleOperationalCredentialsIssuer::GetRandomOperationalNodeId(&randomId));
+
+    ChipLogProgress(Controller, "Generated random node id: 0x" ChipLogFormatX64, ChipLogValueX64(randomId));
+
+    ReturnErrorOnFailure(GetExecContext()->storage->SetRemoteNodeId(randomId));
+    GetExecContext()->remoteId = randomId;
+#else  // CONFIG_PAIR_WITH_RANDOM_ID
+    // Use the default id, not whatever happens to be in our storage, since this
+    // is a new pairing.
+    GetExecContext()->remoteId = kTestDeviceNodeId;
 #endif // CONFIG_PAIR_WITH_RANDOM_ID
 
     err = RunInternal(GetExecContext()->remoteId);


### PR DESCRIPTION
We should use the default test id if we are not told to generate a
random one.

#### Problem
See https://github.com/project-chip/connectedhomeip/pull/8450#issuecomment-886545124

#### Change overview
Use the default test device id if we are not generating a random id, instead of digging our whatever we have in storage (for a different device, probably!).

#### Testing
Made sure both variants compile.  CI coverage exists for the non-random case, but it always has a clean storage, so would not have caught this problem.