### PR TITLE
Fix for device side log for EnhancedHue attribute under color control cluster.

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1782,10 +1782,16 @@ void emberAfPluginColorControlServerHueSatTransitionEventHandler(void)
     }
 
     writeSaturation(colorSaturationTransitionState.endpoint, (uint8_t) colorSaturationTransitionState.currentValue);
-
-    emberAfColorControlClusterPrintln("Hue %d Saturation %d endpoint %d", colorHueTransitionState.currentHue,
-                                      colorSaturationTransitionState.currentValue, endpoint);
-
+    if (colorHueTransitionState.isEnhancedHue)
+    {
+        emberAfColorControlClusterPrintln("Enhanced Hue %d Saturation %d endpoint %d", colorHueTransitionState.currentEnhancedHue,
+                                          colorSaturationTransitionState.currentValue, endpoint);
+    }
+    else
+    {
+        emberAfColorControlClusterPrintln("Hue %d Saturation %d endpoint %d", colorHueTransitionState.currentHue,
+                                          colorSaturationTransitionState.currentValue, endpoint);
+    }
     emberAfPluginColorControlServerComputePwmFromHsvCallback(endpoint);
 }
 


### PR DESCRIPTION
#### Problem
* Device log displays the old value of Hue attribute when the commands for EnhancedHue attributes are used.
* Controller command
```
chip-device-ctrl > zcl ColorControl EnhancedMoveHue 12344321 1 0 moveMode=0 rate=100 optionsMask=0 optionsOverride=0
```
* Device side log
```
I (5656383) chip[ZCL]: Hue 171 Saturation 254 endpoint 1
```
#### Change overview
* Added the fix for the display log.

#### Testing
* Build, flash and commissioned all-clusters-app
* Sent EnhancedHue commands 
* Observed the logs
**Device log**
```
I (124713) chip[ZCL]: Enhanced Hue 910 Saturation 0 endpoint 1
```