### PR TITLE
Make CHIP_ERROR a class type on Darwin

### DIFF
--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -33,6 +33,10 @@
 #define CHIP_CONFIG_TIME_ENABLE_CLIENT 1
 #define CHIP_CONFIG_TIME_ENABLE_SERVER 0
 
+#define CHIP_CONFIG_ERROR_CLASS 1
+#define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
+#define CHIP_CONFIG_ERROR_SOURCE 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0


### PR DESCRIPTION
#### Problem
CHIP_ERROR is not a class type on Darwin, so we can't get nice location tracking for errors.

#### Change overview
Make it a class type.

#### Testing
Compiled the tree on Darwin.  Ran some tests that should log errors and saw that those errors had file/line info.