### PR TITLE
Fix session leaks in CHIPDevice

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -383,7 +383,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption optio
 
 CHIP_ERROR Device::CloseSession()
 {
-    ReturnErrorCodeIf(mState != ConnectionState::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorCodeIf(!mSecureSession, CHIP_ERROR_NOT_CONNECTED);
     mSessionManager->ExpirePairing(mSecureSession);
     mState = ConnectionState::NotConnected;
     return CHIP_NO_ERROR;
@@ -426,6 +426,8 @@ void Device::Reset()
 
     SetActive(false);
     mCASESession.Clear();
+
+    CloseSession();
 
     mState          = ConnectionState::NotConnected;
     mSessionManager = nullptr;

--- a/src/transport/SecureSessionHandle.h
+++ b/src/transport/SecureSessionHandle.h
@@ -38,6 +38,8 @@ public:
         return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId && mFabric == that.mFabric;
     }
 
+    explicit operator bool() const { return !(*this == SecureSessionHandle()); }
+
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     uint16_t GetPeerKeyId() const { return mPeerKeyId; }
 


### PR DESCRIPTION
#### Problem

CHIPDevice leaks its session when being released and in various error paths.

#### Change overview

Change all state transitions to NotConnected to actually release the
session.

#### Testing

- Confirmed chip-tool release PeerConnectionState before exiting

fixes #8741
