### PR TITLE
Update the yaml parser to be stricter regarding response configuration

### DIFF
--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -1016,15 +1016,6 @@ public:
         case 3:
             err = TestSendClusterApplicationBasicCommandReadAttribute_3();
             break;
-        case 4:
-            err = TestSendClusterApplicationBasicCommandReadAttribute_4();
-            break;
-        case 5:
-            err = TestSendClusterApplicationBasicCommandReadAttribute_5();
-            break;
-        case 6:
-            err = TestSendClusterApplicationBasicCommandReadAttribute_6();
-            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -1036,7 +1027,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 7;
+    const uint16_t mTestCount = 4;
 
     //
     // Tests methods
@@ -1099,8 +1090,8 @@ private:
         runner->NextTest();
     }
 
-    // Test Read attribute vendor name
-    using SuccessCallback_1 = void (*)(void * context, chip::ByteSpan vendorName);
+    // Test Read attribute vendor id
+    using SuccessCallback_1 = void (*)(void * context, uint16_t vendorId);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{
         OnTestSendClusterApplicationBasicCommandReadAttribute_1_SuccessResponse, this
     };
@@ -1111,21 +1102,21 @@ private:
 
     CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_1()
     {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor name: Sending command...");
+        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor id: Sending command...");
 
         chip::Controller::ApplicationBasicCluster cluster;
         cluster.Associate(mDevice, 3);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeVendorName(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        err = cluster.ReadAttributeVendorId(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
 
         return err;
     }
 
     static void OnTestSendClusterApplicationBasicCommandReadAttribute_1_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor name: Failure Response");
+        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor id: Failure Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
@@ -1139,69 +1130,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_1_SuccessResponse(void * context, chip::ByteSpan vendorName)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor name: Success Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_1 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Read attribute vendor id
-    using SuccessCallback_2 = void (*)(void * context, uint16_t vendorId);
-    chip::Callback::Callback<SuccessCallback_2> mOnSuccessCallback_2{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_2_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_2{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_2_FailureResponse, this
-    };
-    bool mIsFailureExpected_2 = 0;
-
-    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_2()
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor id: Sending command...");
-
-        chip::Controller::ApplicationBasicCluster cluster;
-        cluster.Associate(mDevice, 3);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeVendorId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_2_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute vendor id: Failure Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_2 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_2_SuccessResponse(void * context, uint16_t vendorId)
+    static void OnTestSendClusterApplicationBasicCommandReadAttribute_1_SuccessResponse(void * context, uint16_t vendorId)
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute vendor id: Success Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
-        if (runner->mIsFailureExpected_2 == true)
+        if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -1218,74 +1153,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Read attribute name
-    using SuccessCallback_3 = void (*)(void * context, chip::ByteSpan applicationName);
-    chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_3_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_3_FailureResponse, this
-    };
-    bool mIsFailureExpected_3 = 0;
-
-    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_3()
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute name: Sending command...");
-
-        chip::Controller::ApplicationBasicCluster cluster;
-        cluster.Associate(mDevice, 3);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeApplicationName(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_3_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute name: Failure Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_3 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_3_SuccessResponse(void * context,
-                                                                                        chip::ByteSpan applicationName)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute name: Success Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_3 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
     // Test Read attribute product id
-    using SuccessCallback_4 = void (*)(void * context, uint16_t productId);
-    chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_4_SuccessResponse, this
+    using SuccessCallback_2 = void (*)(void * context, uint16_t productId);
+    chip::Callback::Callback<SuccessCallback_2> mOnSuccessCallback_2{
+        OnTestSendClusterApplicationBasicCommandReadAttribute_2_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_4_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_2{
+        OnTestSendClusterApplicationBasicCommandReadAttribute_2_FailureResponse, this
     };
-    bool mIsFailureExpected_4 = 0;
+    bool mIsFailureExpected_2 = 0;
 
-    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_4()
+    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_2()
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute product id: Sending command...");
 
@@ -1294,18 +1172,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeProductId(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        err = cluster.ReadAttributeProductId(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_4_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterApplicationBasicCommandReadAttribute_2_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute product id: Failure Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
-        if (runner->mIsFailureExpected_4 == false)
+        if (runner->mIsFailureExpected_2 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -1315,13 +1193,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_4_SuccessResponse(void * context, uint16_t productId)
+    static void OnTestSendClusterApplicationBasicCommandReadAttribute_2_SuccessResponse(void * context, uint16_t productId)
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute product id: Success Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
-        if (runner->mIsFailureExpected_4 == true)
+        if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -1338,74 +1216,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Read attribute id
-    using SuccessCallback_5 = void (*)(void * context, chip::ByteSpan applicationId);
-    chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_5_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_5{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_5_FailureResponse, this
-    };
-    bool mIsFailureExpected_5 = 0;
-
-    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_5()
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute id: Sending command...");
-
-        chip::Controller::ApplicationBasicCluster cluster;
-        cluster.Associate(mDevice, 3);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeApplicationId(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_5_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute id: Failure Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_5 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_5_SuccessResponse(void * context,
-                                                                                        chip::ByteSpan applicationId)
-    {
-        ChipLogProgress(chipTool, "Application Basic - Read attribute id: Success Response");
-
-        TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
-
-        if (runner->mIsFailureExpected_5 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
     // Test Read attribute catalog vendor id
-    using SuccessCallback_6 = void (*)(void * context, uint16_t catalogVendorId);
-    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_6_SuccessResponse, this
+    using SuccessCallback_3 = void (*)(void * context, uint16_t catalogVendorId);
+    chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{
+        OnTestSendClusterApplicationBasicCommandReadAttribute_3_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
-        OnTestSendClusterApplicationBasicCommandReadAttribute_6_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
+        OnTestSendClusterApplicationBasicCommandReadAttribute_3_FailureResponse, this
     };
-    bool mIsFailureExpected_6 = 0;
+    bool mIsFailureExpected_3 = 0;
 
-    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_6()
+    CHIP_ERROR TestSendClusterApplicationBasicCommandReadAttribute_3()
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute catalog vendor id: Sending command...");
 
@@ -1414,18 +1235,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
+        err = cluster.ReadAttributeCatalogVendorId(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_6_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterApplicationBasicCommandReadAttribute_3_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute catalog vendor id: Failure Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
-        if (runner->mIsFailureExpected_6 == false)
+        if (runner->mIsFailureExpected_3 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -1435,13 +1256,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterApplicationBasicCommandReadAttribute_6_SuccessResponse(void * context, uint16_t catalogVendorId)
+    static void OnTestSendClusterApplicationBasicCommandReadAttribute_3_SuccessResponse(void * context, uint16_t catalogVendorId)
     {
         ChipLogProgress(chipTool, "Application Basic - Read attribute catalog vendor id: Success Response");
 
         TV_ApplicationBasicCluster * runner = reinterpret_cast<TV_ApplicationBasicCluster *>(context);
 
-        if (runner->mIsFailureExpected_6 == true)
+        if (runner->mIsFailureExpected_3 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -13528,109 +13349,55 @@ public:
             err = TestSendClusterColorControlCommandMoveToHue_2();
             break;
         case 3:
-            err = TestSendClusterColorControlCommandReadAttribute_3();
+            err = TestSendClusterColorControlCommandMoveToHue_3();
             break;
         case 4:
             err = TestSendClusterColorControlCommandMoveToHue_4();
             break;
         case 5:
-            err = TestSendClusterColorControlCommandReadAttribute_5();
+            err = TestSendClusterColorControlCommandMoveToHue_5();
             break;
         case 6:
-            err = TestSendClusterColorControlCommandMoveToHue_6();
+            err = TestSendClusterColorControlCommandMoveHue_6();
             break;
         case 7:
-            err = TestSendClusterColorControlCommandReadAttribute_7();
+            err = TestSendClusterColorControlCommandMoveHue_7();
             break;
         case 8:
-            err = TestSendClusterColorControlCommandMoveToHue_8();
+            err = TestSendClusterColorControlCommandMoveHue_8();
             break;
         case 9:
-            err = TestSendClusterColorControlCommandReadAttribute_9();
+            err = TestSendClusterColorControlCommandMoveHue_9();
             break;
         case 10:
-            err = TestSendClusterColorControlCommandMoveHue_10();
+            err = TestSendClusterColorControlCommandStepHue_10();
             break;
         case 11:
-            err = TestSendClusterColorControlCommandReadAttribute_11();
+            err = TestSendClusterColorControlCommandStepHue_11();
             break;
         case 12:
-            err = TestSendClusterColorControlCommandMoveHue_12();
+            err = TestSendClusterColorControlCommandMoveToSaturation_12();
             break;
         case 13:
-            err = TestSendClusterColorControlCommandReadAttribute_13();
+            err = TestSendClusterColorControlCommandMoveSaturation_13();
             break;
         case 14:
-            err = TestSendClusterColorControlCommandMoveHue_14();
+            err = TestSendClusterColorControlCommandMoveSaturation_14();
             break;
         case 15:
-            err = TestSendClusterColorControlCommandReadAttribute_15();
+            err = TestSendClusterColorControlCommandStepSaturation_15();
             break;
         case 16:
-            err = TestSendClusterColorControlCommandMoveHue_16();
+            err = TestSendClusterColorControlCommandStepSaturation_16();
             break;
         case 17:
-            err = TestSendClusterColorControlCommandReadAttribute_17();
+            err = TestSendClusterColorControlCommandMoveToHueAndSaturation_17();
             break;
         case 18:
-            err = TestSendClusterColorControlCommandStepHue_18();
+            err = TestSendClusterOnOffCommandOff_18();
             break;
         case 19:
-            err = TestSendClusterColorControlCommandReadAttribute_19();
-            break;
-        case 20:
-            err = TestSendClusterColorControlCommandStepHue_20();
-            break;
-        case 21:
-            err = TestSendClusterColorControlCommandReadAttribute_21();
-            break;
-        case 22:
-            err = TestSendClusterColorControlCommandReadAttribute_22();
-            break;
-        case 23:
-            err = TestSendClusterColorControlCommandMoveToSaturation_23();
-            break;
-        case 24:
-            err = TestSendClusterColorControlCommandReadAttribute_24();
-            break;
-        case 25:
-            err = TestSendClusterColorControlCommandMoveSaturation_25();
-            break;
-        case 26:
-            err = TestSendClusterColorControlCommandReadAttribute_26();
-            break;
-        case 27:
-            err = TestSendClusterColorControlCommandMoveSaturation_27();
-            break;
-        case 28:
-            err = TestSendClusterColorControlCommandReadAttribute_28();
-            break;
-        case 29:
-            err = TestSendClusterColorControlCommandStepSaturation_29();
-            break;
-        case 30:
-            err = TestSendClusterColorControlCommandReadAttribute_30();
-            break;
-        case 31:
-            err = TestSendClusterColorControlCommandStepSaturation_31();
-            break;
-        case 32:
-            err = TestSendClusterColorControlCommandReadAttribute_32();
-            break;
-        case 33:
-            err = TestSendClusterColorControlCommandMoveToHueAndSaturation_33();
-            break;
-        case 34:
-            err = TestSendClusterColorControlCommandReadAttribute_34();
-            break;
-        case 35:
-            err = TestSendClusterColorControlCommandReadAttribute_35();
-            break;
-        case 36:
-            err = TestSendClusterOnOffCommandOff_36();
-            break;
-        case 37:
-            err = TestSendClusterOnOffCommandReadAttribute_37();
+            err = TestSendClusterOnOffCommandReadAttribute_19();
             break;
         }
 
@@ -13643,7 +13410,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 38;
+    const uint16_t mTestCount = 20;
 
     //
     // Tests methods
@@ -13826,79 +13593,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_3 = void (*)(void * context, uint8_t currentHue);
+    // Test Move to hue longest distance command
+    using SuccessCallback_3 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse, this
+        OnTestSendClusterColorControlCommandMoveToHue_3_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveToHue_3_FailureResponse, this
     };
     bool mIsFailureExpected_3 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_3()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_3 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_3 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move to hue longest distance command
-    using SuccessCallback_4 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
-        OnTestSendClusterColorControlCommandMoveToHue_4_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
-        OnTestSendClusterColorControlCommandMoveToHue_4_FailureResponse, this
-    };
-    bool mIsFailureExpected_4 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_4()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_3()
     {
         ChipLogProgress(chipTool, "Color Control - Move to hue longest distance command: Sending command...");
 
@@ -13912,6 +13617,68 @@ private:
         uint16_t transitionTimeArgument = 100U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveToHue(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel(), hueArgument, directionArgument,
+                                transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveToHue_3_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move to hue longest distance command: Failure Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_3 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveToHue_3_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move to hue longest distance command: Success Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_3 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Move to hue up command
+    using SuccessCallback_4 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
+        OnTestSendClusterColorControlCommandMoveToHue_4_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
+        OnTestSendClusterColorControlCommandMoveToHue_4_FailureResponse, this
+    };
+    bool mIsFailureExpected_4 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_4()
+    {
+        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t hueArgument             = 250;
+        uint8_t directionArgument       = 2;
+        uint16_t transitionTimeArgument = 100U;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
         err = cluster.MoveToHue(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel(), hueArgument, directionArgument,
                                 transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
@@ -13920,7 +13687,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandMoveToHue_4_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Move to hue longest distance command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -13936,7 +13703,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandMoveToHue_4_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Move to hue longest distance command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -13950,203 +13717,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_5 = void (*)(void * context, uint8_t currentHue);
+    // Test Move to hue down command
+    using SuccessCallback_5 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
-        OnTestSendClusterColorControlCommandReadAttribute_5_SuccessResponse, this
+        OnTestSendClusterColorControlCommandMoveToHue_5_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_5{
-        OnTestSendClusterColorControlCommandReadAttribute_5_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveToHue_5_FailureResponse, this
     };
     bool mIsFailureExpected_5 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_5()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_5_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_5 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_5_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_5 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move to hue up command
-    using SuccessCallback_6 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
-        OnTestSendClusterColorControlCommandMoveToHue_6_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
-        OnTestSendClusterColorControlCommandMoveToHue_6_FailureResponse, this
-    };
-    bool mIsFailureExpected_6 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_6()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t hueArgument             = 250;
-        uint8_t directionArgument       = 2;
-        uint16_t transitionTimeArgument = 100U;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveToHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), hueArgument, directionArgument,
-                                transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveToHue_6_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_6 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveToHue_6_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move to hue up command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_6 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_7 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse, this
-    };
-    bool mIsFailureExpected_7 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_7()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_7 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_7 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move to hue down command
-    using SuccessCallback_8 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{
-        OnTestSendClusterColorControlCommandMoveToHue_8_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{
-        OnTestSendClusterColorControlCommandMoveToHue_8_FailureResponse, this
-    };
-    bool mIsFailureExpected_8 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_8()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveToHue_5()
     {
         ChipLogProgress(chipTool, "Color Control - Move to hue down command: Sending command...");
 
@@ -14160,15 +13741,195 @@ private:
         uint16_t transitionTimeArgument = 100U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveToHue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), hueArgument, directionArgument,
+        err = cluster.MoveToHue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel(), hueArgument, directionArgument,
                                 transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToHue_8_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveToHue_5_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move to hue down command: Failure Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_5 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveToHue_5_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move to hue down command: Success Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_5 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Move hue up command
+    using SuccessCallback_6 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{ OnTestSendClusterColorControlCommandMoveHue_6_SuccessResponse,
+                                                                      this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
+        OnTestSendClusterColorControlCommandMoveHue_6_FailureResponse, this
+    };
+    bool mIsFailureExpected_6 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_6()
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue up command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t moveModeArgument        = 1;
+        uint8_t rateArgument            = 50;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), moveModeArgument, rateArgument,
+                              optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveHue_6_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue up command: Failure Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_6 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveHue_6_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue up command: Success Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_6 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Move hue stop command
+    using SuccessCallback_7 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{ OnTestSendClusterColorControlCommandMoveHue_7_SuccessResponse,
+                                                                      this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
+        OnTestSendClusterColorControlCommandMoveHue_7_FailureResponse, this
+    };
+    bool mIsFailureExpected_7 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_7()
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t moveModeArgument        = 0;
+        uint8_t rateArgument            = 50;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveHue(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel(), moveModeArgument, rateArgument,
+                              optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveHue_7_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Failure Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_7 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveHue_7_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Success Response");
+
+        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
+
+        if (runner->mIsFailureExpected_7 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Move hue down command
+    using SuccessCallback_8 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{ OnTestSendClusterColorControlCommandMoveHue_8_SuccessResponse,
+                                                                      this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{
+        OnTestSendClusterColorControlCommandMoveHue_8_FailureResponse, this
+    };
+    bool mIsFailureExpected_8 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_8()
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue down command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t moveModeArgument        = 3;
+        uint8_t rateArgument            = 50;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveHue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), moveModeArgument, rateArgument,
+                              optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveHue_8_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move hue down command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -14182,9 +13943,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToHue_8_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveHue_8_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Move to hue down command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Move hue down command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -14198,37 +13959,37 @@ private:
         runner->NextTest();
     }
 
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_9 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse, this
-    };
+    // Test Move hue stop command
+    using SuccessCallback_9 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{ OnTestSendClusterColorControlCommandMoveHue_9_SuccessResponse,
+                                                                      this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveHue_9_FailureResponse, this
     };
     bool mIsFailureExpected_9 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_9()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_9()
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
+        uint8_t moveModeArgument        = 0;
+        uint8_t rateArgument            = 50;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveHue(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel(), moveModeArgument, rateArgument,
+                              optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveHue_9_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -14242,11 +14003,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse(void * context, uint8_t currentHue)
+    static void OnTestSendClusterColorControlCommandMoveHue_9_SuccessResponse(void * context)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
@@ -14260,509 +14019,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Move hue up command
+    // Test Step hue up command
     using SuccessCallback_10 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_10> mOnSuccessCallback_10{
-        OnTestSendClusterColorControlCommandMoveHue_10_SuccessResponse, this
+        OnTestSendClusterColorControlCommandStepHue_10_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_10{
-        OnTestSendClusterColorControlCommandMoveHue_10_FailureResponse, this
+        OnTestSendClusterColorControlCommandStepHue_10_FailureResponse, this
     };
     bool mIsFailureExpected_10 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_10()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue up command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument        = 1;
-        uint8_t rateArgument            = 50;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveHue(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel(), moveModeArgument, rateArgument,
-                              optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_10_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue up command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_10 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_10_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue up command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_10 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_11 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
-        OnTestSendClusterColorControlCommandReadAttribute_11_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{
-        OnTestSendClusterColorControlCommandReadAttribute_11_FailureResponse, this
-    };
-    bool mIsFailureExpected_11 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_11()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_11_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_11 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_11_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_11 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move hue stop command
-    using SuccessCallback_12 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
-        OnTestSendClusterColorControlCommandMoveHue_12_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_12{
-        OnTestSendClusterColorControlCommandMoveHue_12_FailureResponse, this
-    };
-    bool mIsFailureExpected_12 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_12()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument        = 0;
-        uint8_t rateArgument            = 50;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveHue(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel(), moveModeArgument, rateArgument,
-                              optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_12_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_12 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_12_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_12 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_13 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse, this
-    };
-    bool mIsFailureExpected_13 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_13()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_13 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_13 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move hue down command
-    using SuccessCallback_14 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_14> mOnSuccessCallback_14{
-        OnTestSendClusterColorControlCommandMoveHue_14_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_14{
-        OnTestSendClusterColorControlCommandMoveHue_14_FailureResponse, this
-    };
-    bool mIsFailureExpected_14 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_14()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue down command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument        = 3;
-        uint8_t rateArgument            = 50;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveHue(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel(), moveModeArgument, rateArgument,
-                              optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_14_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue down command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_14 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_14_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue down command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_14 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_15 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_15> mOnSuccessCallback_15{
-        OnTestSendClusterColorControlCommandReadAttribute_15_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_15{
-        OnTestSendClusterColorControlCommandReadAttribute_15_FailureResponse, this
-    };
-    bool mIsFailureExpected_15 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_15()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_15_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_15 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_15_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_15 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move hue stop command
-    using SuccessCallback_16 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_16> mOnSuccessCallback_16{
-        OnTestSendClusterColorControlCommandMoveHue_16_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_16{
-        OnTestSendClusterColorControlCommandMoveHue_16_FailureResponse, this
-    };
-    bool mIsFailureExpected_16 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveHue_16()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument        = 0;
-        uint8_t rateArgument            = 50;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveHue(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel(), moveModeArgument, rateArgument,
-                              optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_16_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_16 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveHue_16_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move hue stop command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_16 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_17 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_17> mOnSuccessCallback_17{
-        OnTestSendClusterColorControlCommandReadAttribute_17_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_17{
-        OnTestSendClusterColorControlCommandReadAttribute_17_FailureResponse, this
-    };
-    bool mIsFailureExpected_17 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_17()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_17_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_17 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_17_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_17 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Step hue up command
-    using SuccessCallback_18 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_18> mOnSuccessCallback_18{
-        OnTestSendClusterColorControlCommandStepHue_18_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_18{
-        OnTestSendClusterColorControlCommandStepHue_18_FailureResponse, this
-    };
-    bool mIsFailureExpected_18 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandStepHue_18()
+    CHIP_ERROR TestSendClusterColorControlCommandStepHue_10()
     {
         ChipLogProgress(chipTool, "Color Control - Step hue up command: Sending command...");
 
@@ -14776,19 +14043,19 @@ private:
         uint8_t transitionTimeArgument  = 25;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.StepHue(mOnSuccessCallback_18.Cancel(), mOnFailureCallback_18.Cancel(), stepModeArgument, stepSizeArgument,
+        err = cluster.StepHue(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel(), stepModeArgument, stepSizeArgument,
                               transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepHue_18_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepHue_10_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step hue up command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_18 == false)
+        if (runner->mIsFailureExpected_10 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -14798,75 +14065,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepHue_18_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepHue_10_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step hue up command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_18 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_19 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_19> mOnSuccessCallback_19{
-        OnTestSendClusterColorControlCommandReadAttribute_19_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_19{
-        OnTestSendClusterColorControlCommandReadAttribute_19_FailureResponse, this
-    };
-    bool mIsFailureExpected_19 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_19()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_19_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_19 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_19_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_19 == true)
+        if (runner->mIsFailureExpected_10 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -14877,16 +14082,16 @@ private:
     }
 
     // Test Step hue down command
-    using SuccessCallback_20 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_20> mOnSuccessCallback_20{
-        OnTestSendClusterColorControlCommandStepHue_20_SuccessResponse, this
+    using SuccessCallback_11 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
+        OnTestSendClusterColorControlCommandStepHue_11_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_20{
-        OnTestSendClusterColorControlCommandStepHue_20_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{
+        OnTestSendClusterColorControlCommandStepHue_11_FailureResponse, this
     };
-    bool mIsFailureExpected_20 = 0;
+    bool mIsFailureExpected_11 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandStepHue_20()
+    CHIP_ERROR TestSendClusterColorControlCommandStepHue_11()
     {
         ChipLogProgress(chipTool, "Color Control - Step hue down command: Sending command...");
 
@@ -14900,19 +14105,19 @@ private:
         uint8_t transitionTimeArgument  = 25;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.StepHue(mOnSuccessCallback_20.Cancel(), mOnFailureCallback_20.Cancel(), stepModeArgument, stepSizeArgument,
+        err = cluster.StepHue(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel(), stepModeArgument, stepSizeArgument,
                               transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepHue_20_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepHue_11_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step hue down command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_20 == false)
+        if (runner->mIsFailureExpected_11 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -14922,131 +14127,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepHue_20_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepHue_11_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step hue down command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_20 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_21 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_21> mOnSuccessCallback_21{
-        OnTestSendClusterColorControlCommandReadAttribute_21_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_21{
-        OnTestSendClusterColorControlCommandReadAttribute_21_FailureResponse, this
-    };
-    bool mIsFailureExpected_21 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_21()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_21.Cancel(), mOnFailureCallback_21.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_21_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_21 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_21_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_21 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched before any change
-    using SuccessCallback_22 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_22> mOnSuccessCallback_22{
-        OnTestSendClusterColorControlCommandReadAttribute_22_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_22{
-        OnTestSendClusterColorControlCommandReadAttribute_22_FailureResponse, this
-    };
-    bool mIsFailureExpected_22 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_22()
-    {
-        ChipLogProgress(chipTool, "Color Control - Check Saturation attribute value matched before any change: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_22.Cancel(), mOnFailureCallback_22.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_22_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Check Saturation attribute value matched before any change: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_22 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_22_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(chipTool, "Color Control - Check Saturation attribute value matched before any change: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_22 == true)
+        if (runner->mIsFailureExpected_11 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15057,16 +14144,16 @@ private:
     }
 
     // Test Move to saturation command
-    using SuccessCallback_23 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_23> mOnSuccessCallback_23{
-        OnTestSendClusterColorControlCommandMoveToSaturation_23_SuccessResponse, this
+    using SuccessCallback_12 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
+        OnTestSendClusterColorControlCommandMoveToSaturation_12_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_23{
-        OnTestSendClusterColorControlCommandMoveToSaturation_23_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_12{
+        OnTestSendClusterColorControlCommandMoveToSaturation_12_FailureResponse, this
     };
-    bool mIsFailureExpected_23 = 0;
+    bool mIsFailureExpected_12 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveToSaturation_23()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveToSaturation_12()
     {
         ChipLogProgress(chipTool, "Color Control - Move to saturation command: Sending command...");
 
@@ -15079,19 +14166,19 @@ private:
         uint16_t transitionTimeArgument = 10U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveToSaturation(mOnSuccessCallback_23.Cancel(), mOnFailureCallback_23.Cancel(), saturationArgument,
+        err = cluster.MoveToSaturation(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel(), saturationArgument,
                                        transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToSaturation_23_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveToSaturation_12_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move to saturation command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_23 == false)
+        if (runner->mIsFailureExpected_12 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15101,75 +14188,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToSaturation_23_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveToSaturation_12_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Move to saturation command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_23 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_24 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_24> mOnSuccessCallback_24{
-        OnTestSendClusterColorControlCommandReadAttribute_24_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_24{
-        OnTestSendClusterColorControlCommandReadAttribute_24_FailureResponse, this
-    };
-    bool mIsFailureExpected_24 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_24()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_24.Cancel(), mOnFailureCallback_24.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_24_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_24 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_24_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_24 == true)
+        if (runner->mIsFailureExpected_12 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15180,16 +14205,16 @@ private:
     }
 
     // Test Move saturation up command
-    using SuccessCallback_25 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_25> mOnSuccessCallback_25{
-        OnTestSendClusterColorControlCommandMoveSaturation_25_SuccessResponse, this
+    using SuccessCallback_13 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
+        OnTestSendClusterColorControlCommandMoveSaturation_13_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_25{
-        OnTestSendClusterColorControlCommandMoveSaturation_25_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_13{
+        OnTestSendClusterColorControlCommandMoveSaturation_13_FailureResponse, this
     };
-    bool mIsFailureExpected_25 = 0;
+    bool mIsFailureExpected_13 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveSaturation_25()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveSaturation_13()
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation up command: Sending command...");
 
@@ -15202,19 +14227,19 @@ private:
         uint8_t rateArgument            = 5;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveSaturation(mOnSuccessCallback_25.Cancel(), mOnFailureCallback_25.Cancel(), moveModeArgument, rateArgument,
+        err = cluster.MoveSaturation(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel(), moveModeArgument, rateArgument,
                                      optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveSaturation_25_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveSaturation_13_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation up command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_25 == false)
+        if (runner->mIsFailureExpected_13 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15224,75 +14249,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveSaturation_25_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveSaturation_13_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation up command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_25 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_26 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_26> mOnSuccessCallback_26{
-        OnTestSendClusterColorControlCommandReadAttribute_26_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_26{
-        OnTestSendClusterColorControlCommandReadAttribute_26_FailureResponse, this
-    };
-    bool mIsFailureExpected_26 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_26()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_26.Cancel(), mOnFailureCallback_26.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_26_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_26 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_26_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_26 == true)
+        if (runner->mIsFailureExpected_13 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15303,16 +14266,16 @@ private:
     }
 
     // Test Move saturation down command
-    using SuccessCallback_27 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_27> mOnSuccessCallback_27{
-        OnTestSendClusterColorControlCommandMoveSaturation_27_SuccessResponse, this
+    using SuccessCallback_14 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_14> mOnSuccessCallback_14{
+        OnTestSendClusterColorControlCommandMoveSaturation_14_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_27{
-        OnTestSendClusterColorControlCommandMoveSaturation_27_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_14{
+        OnTestSendClusterColorControlCommandMoveSaturation_14_FailureResponse, this
     };
-    bool mIsFailureExpected_27 = 0;
+    bool mIsFailureExpected_14 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveSaturation_27()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveSaturation_14()
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation down command: Sending command...");
 
@@ -15325,19 +14288,19 @@ private:
         uint8_t rateArgument            = 5;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveSaturation(mOnSuccessCallback_27.Cancel(), mOnFailureCallback_27.Cancel(), moveModeArgument, rateArgument,
+        err = cluster.MoveSaturation(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel(), moveModeArgument, rateArgument,
                                      optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveSaturation_27_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveSaturation_14_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation down command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_27 == false)
+        if (runner->mIsFailureExpected_14 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15347,75 +14310,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveSaturation_27_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveSaturation_14_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Move saturation down command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_27 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_28 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_28> mOnSuccessCallback_28{
-        OnTestSendClusterColorControlCommandReadAttribute_28_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_28{
-        OnTestSendClusterColorControlCommandReadAttribute_28_FailureResponse, this
-    };
-    bool mIsFailureExpected_28 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_28()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_28.Cancel(), mOnFailureCallback_28.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_28_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_28 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_28_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_28 == true)
+        if (runner->mIsFailureExpected_14 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15426,16 +14327,16 @@ private:
     }
 
     // Test Step saturation up command
-    using SuccessCallback_29 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_29> mOnSuccessCallback_29{
-        OnTestSendClusterColorControlCommandStepSaturation_29_SuccessResponse, this
+    using SuccessCallback_15 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_15> mOnSuccessCallback_15{
+        OnTestSendClusterColorControlCommandStepSaturation_15_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_29{
-        OnTestSendClusterColorControlCommandStepSaturation_29_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_15{
+        OnTestSendClusterColorControlCommandStepSaturation_15_FailureResponse, this
     };
-    bool mIsFailureExpected_29 = 0;
+    bool mIsFailureExpected_15 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandStepSaturation_29()
+    CHIP_ERROR TestSendClusterColorControlCommandStepSaturation_15()
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation up command: Sending command...");
 
@@ -15449,19 +14350,19 @@ private:
         uint8_t transitionTimeArgument  = 10;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.StepSaturation(mOnSuccessCallback_29.Cancel(), mOnFailureCallback_29.Cancel(), stepModeArgument,
+        err = cluster.StepSaturation(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel(), stepModeArgument,
                                      stepSizeArgument, transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepSaturation_29_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepSaturation_15_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation up command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_29 == false)
+        if (runner->mIsFailureExpected_15 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15471,75 +14372,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepSaturation_29_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepSaturation_15_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation up command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_29 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_30 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_30> mOnSuccessCallback_30{
-        OnTestSendClusterColorControlCommandReadAttribute_30_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_30{
-        OnTestSendClusterColorControlCommandReadAttribute_30_FailureResponse, this
-    };
-    bool mIsFailureExpected_30 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_30()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_30.Cancel(), mOnFailureCallback_30.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_30_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_30 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_30_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_30 == true)
+        if (runner->mIsFailureExpected_15 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15550,16 +14389,16 @@ private:
     }
 
     // Test Step saturation down command
-    using SuccessCallback_31 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_31> mOnSuccessCallback_31{
-        OnTestSendClusterColorControlCommandStepSaturation_31_SuccessResponse, this
+    using SuccessCallback_16 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_16> mOnSuccessCallback_16{
+        OnTestSendClusterColorControlCommandStepSaturation_16_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_31{
-        OnTestSendClusterColorControlCommandStepSaturation_31_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_16{
+        OnTestSendClusterColorControlCommandStepSaturation_16_FailureResponse, this
     };
-    bool mIsFailureExpected_31 = 0;
+    bool mIsFailureExpected_16 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandStepSaturation_31()
+    CHIP_ERROR TestSendClusterColorControlCommandStepSaturation_16()
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation down command: Sending command...");
 
@@ -15573,19 +14412,19 @@ private:
         uint8_t transitionTimeArgument  = 10;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.StepSaturation(mOnSuccessCallback_31.Cancel(), mOnFailureCallback_31.Cancel(), stepModeArgument,
+        err = cluster.StepSaturation(mOnSuccessCallback_16.Cancel(), mOnFailureCallback_16.Cancel(), stepModeArgument,
                                      stepSizeArgument, transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepSaturation_31_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepSaturation_16_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation down command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_31 == false)
+        if (runner->mIsFailureExpected_16 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15595,75 +14434,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepSaturation_31_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepSaturation_16_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step saturation down command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_31 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_32 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_32> mOnSuccessCallback_32{
-        OnTestSendClusterColorControlCommandReadAttribute_32_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_32{
-        OnTestSendClusterColorControlCommandReadAttribute_32_FailureResponse, this
-    };
-    bool mIsFailureExpected_32 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_32()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_32.Cancel(), mOnFailureCallback_32.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_32_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_32 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_32_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_32 == true)
+        if (runner->mIsFailureExpected_16 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15674,16 +14451,16 @@ private:
     }
 
     // Test Move To current hue and saturation command
-    using SuccessCallback_33 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_33> mOnSuccessCallback_33{
-        OnTestSendClusterColorControlCommandMoveToHueAndSaturation_33_SuccessResponse, this
+    using SuccessCallback_17 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_17> mOnSuccessCallback_17{
+        OnTestSendClusterColorControlCommandMoveToHueAndSaturation_17_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_33{
-        OnTestSendClusterColorControlCommandMoveToHueAndSaturation_33_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_17{
+        OnTestSendClusterColorControlCommandMoveToHueAndSaturation_17_FailureResponse, this
     };
-    bool mIsFailureExpected_33 = 0;
+    bool mIsFailureExpected_17 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveToHueAndSaturation_33()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveToHueAndSaturation_17()
     {
         ChipLogProgress(chipTool, "Color Control - Move To current hue and saturation command: Sending command...");
 
@@ -15697,20 +14474,20 @@ private:
         uint16_t transitionTimeArgument = 10U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveToHueAndSaturation(mOnSuccessCallback_33.Cancel(), mOnFailureCallback_33.Cancel(), hueArgument,
+        err = cluster.MoveToHueAndSaturation(mOnSuccessCallback_17.Cancel(), mOnFailureCallback_17.Cancel(), hueArgument,
                                              saturationArgument, transitionTimeArgument, optionsMaskArgument,
                                              optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToHueAndSaturation_33_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveToHueAndSaturation_17_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move To current hue and saturation command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_33 == false)
+        if (runner->mIsFailureExpected_17 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15720,137 +14497,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveToHueAndSaturation_33_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveToHueAndSaturation_17_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Move To current hue and saturation command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_33 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current hue attribute value matched the value sent by the last command
-    using SuccessCallback_34 = void (*)(void * context, uint8_t currentHue);
-    chip::Callback::Callback<SuccessCallback_34> mOnSuccessCallback_34{
-        OnTestSendClusterColorControlCommandReadAttribute_34_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_34{
-        OnTestSendClusterColorControlCommandReadAttribute_34_FailureResponse, this
-    };
-    bool mIsFailureExpected_34 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_34()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentHue(mOnSuccessCallback_34.Cancel(), mOnFailureCallback_34.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_34_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_34 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_34_SuccessResponse(void * context, uint8_t currentHue)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current hue attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_34 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_35 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_35> mOnSuccessCallback_35{
-        OnTestSendClusterColorControlCommandReadAttribute_35_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_35{
-        OnTestSendClusterColorControlCommandReadAttribute_35_FailureResponse, this
-    };
-    bool mIsFailureExpected_35 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_35()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_35.Cancel(), mOnFailureCallback_35.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_35_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_35 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_35_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
-
-        if (runner->mIsFailureExpected_35 == true)
+        if (runner->mIsFailureExpected_17 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15861,13 +14514,13 @@ private:
     }
 
     // Test Turn off light that we turned on
-    using SuccessCallback_36 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_36> mOnSuccessCallback_36{ OnTestSendClusterOnOffCommandOff_36_SuccessResponse, this };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_36{ OnTestSendClusterOnOffCommandOff_36_FailureResponse,
+    using SuccessCallback_18 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_18> mOnSuccessCallback_18{ OnTestSendClusterOnOffCommandOff_18_SuccessResponse, this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_18{ OnTestSendClusterOnOffCommandOff_18_FailureResponse,
                                                                             this };
-    bool mIsFailureExpected_36 = 0;
+    bool mIsFailureExpected_18 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandOff_36()
+    CHIP_ERROR TestSendClusterOnOffCommandOff_18()
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Sending command...");
 
@@ -15876,18 +14529,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.Off(mOnSuccessCallback_36.Cancel(), mOnFailureCallback_36.Cancel());
+        err = cluster.Off(mOnSuccessCallback_18.Cancel(), mOnFailureCallback_18.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandOff_36_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandOff_18_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_36 == false)
+        if (runner->mIsFailureExpected_18 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15897,13 +14550,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandOff_36_SuccessResponse(void * context)
+    static void OnTestSendClusterOnOffCommandOff_18_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_36 == true)
+        if (runner->mIsFailureExpected_18 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15914,16 +14567,16 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_37 = void (*)(void * context, uint8_t onOff);
-    chip::Callback::Callback<SuccessCallback_37> mOnSuccessCallback_37{
-        OnTestSendClusterOnOffCommandReadAttribute_37_SuccessResponse, this
+    using SuccessCallback_19 = void (*)(void * context, uint8_t onOff);
+    chip::Callback::Callback<SuccessCallback_19> mOnSuccessCallback_19{
+        OnTestSendClusterOnOffCommandReadAttribute_19_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_37{
-        OnTestSendClusterOnOffCommandReadAttribute_37_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_19{
+        OnTestSendClusterOnOffCommandReadAttribute_19_FailureResponse, this
     };
-    bool mIsFailureExpected_37 = 0;
+    bool mIsFailureExpected_19 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_37()
+    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_19()
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Sending command...");
 
@@ -15932,18 +14585,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_37.Cancel(), mOnFailureCallback_37.Cancel());
+        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_19.Cancel(), mOnFailureCallback_19.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_37_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandReadAttribute_19_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Failure Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_37 == false)
+        if (runner->mIsFailureExpected_19 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -15953,13 +14606,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_37_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_19_SuccessResponse(void * context, uint8_t onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
         Test_TC_CC_3_4 * runner = reinterpret_cast<Test_TC_CC_3_4 *>(context);
 
-        if (runner->mIsFailureExpected_37 == true)
+        if (runner->mIsFailureExpected_19 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -16009,43 +14662,19 @@ public:
             err = TestSendClusterColorControlCommandMoveToColor_2();
             break;
         case 3:
-            err = TestSendClusterColorControlCommandReadAttribute_3();
+            err = TestSendClusterColorControlCommandMoveColor_3();
             break;
         case 4:
-            err = TestSendClusterColorControlCommandReadAttribute_4();
+            err = TestSendClusterColorControlCommandStopMoveStep_4();
             break;
         case 5:
-            err = TestSendClusterColorControlCommandMoveColor_5();
+            err = TestSendClusterColorControlCommandStepColor_5();
             break;
         case 6:
-            err = TestSendClusterColorControlCommandReadAttribute_6();
+            err = TestSendClusterOnOffCommandOff_6();
             break;
         case 7:
-            err = TestSendClusterColorControlCommandReadAttribute_7();
-            break;
-        case 8:
-            err = TestSendClusterColorControlCommandStopMoveStep_8();
-            break;
-        case 9:
-            err = TestSendClusterColorControlCommandReadAttribute_9();
-            break;
-        case 10:
-            err = TestSendClusterColorControlCommandReadAttribute_10();
-            break;
-        case 11:
-            err = TestSendClusterColorControlCommandStepColor_11();
-            break;
-        case 12:
-            err = TestSendClusterColorControlCommandReadAttribute_12();
-            break;
-        case 13:
-            err = TestSendClusterColorControlCommandReadAttribute_13();
-            break;
-        case 14:
-            err = TestSendClusterOnOffCommandOff_14();
-            break;
-        case 15:
-            err = TestSendClusterOnOffCommandReadAttribute_15();
+            err = TestSendClusterOnOffCommandReadAttribute_7();
             break;
         }
 
@@ -16058,7 +14687,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 16;
+    const uint16_t mTestCount = 8;
 
     //
     // Tests methods
@@ -16241,37 +14870,38 @@ private:
         runner->NextTest();
     }
 
-    // Test Check current y attribute value matched the value sent by the last command
-    using SuccessCallback_3 = void (*)(void * context, uint16_t currentX);
+    // Test Move Color command
+    using SuccessCallback_3 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse, this
+        OnTestSendClusterColorControlCommandMoveColor_3_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveColor_3_FailureResponse, this
     };
     bool mIsFailureExpected_3 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_3()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveColor_3()
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Move Color command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeCurrentX(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
+        int16_t rateXArgument           = 15;
+        int16_t rateYArgument           = 20;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.MoveColor(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel(), rateXArgument, rateYArgument,
+                                optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveColor_3_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Move Color command: Failure Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
@@ -16285,11 +14915,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse(void * context, uint16_t currentX)
+    static void OnTestSendClusterColorControlCommandMoveColor_3_SuccessResponse(void * context)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Move Color command: Success Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
@@ -16303,37 +14931,36 @@ private:
         runner->NextTest();
     }
 
-    // Test Check current x attribute value matched the value sent by the last command
-    using SuccessCallback_4 = void (*)(void * context, uint16_t currentY);
+    // Test Stop Move Step command
+    using SuccessCallback_4 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
-        OnTestSendClusterColorControlCommandReadAttribute_4_SuccessResponse, this
+        OnTestSendClusterColorControlCommandStopMoveStep_4_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
-        OnTestSendClusterColorControlCommandReadAttribute_4_FailureResponse, this
+        OnTestSendClusterColorControlCommandStopMoveStep_4_FailureResponse, this
     };
     bool mIsFailureExpected_4 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_4()
+    CHIP_ERROR TestSendClusterColorControlCommandStopMoveStep_4()
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeCurrentY(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.StopMoveStep(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel(), optionsMaskArgument,
+                                   optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_4_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStopMoveStep_4_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Failure Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
@@ -16347,11 +14974,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_4_SuccessResponse(void * context, uint16_t currentY)
+    static void OnTestSendClusterColorControlCommandStopMoveStep_4_SuccessResponse(void * context)
     {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Success Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
@@ -16365,385 +14990,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Move Color command
+    // Test Step Color command
     using SuccessCallback_5 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
-        OnTestSendClusterColorControlCommandMoveColor_5_SuccessResponse, this
+        OnTestSendClusterColorControlCommandStepColor_5_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_5{
-        OnTestSendClusterColorControlCommandMoveColor_5_FailureResponse, this
+        OnTestSendClusterColorControlCommandStepColor_5_FailureResponse, this
     };
     bool mIsFailureExpected_5 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandMoveColor_5()
-    {
-        ChipLogProgress(chipTool, "Color Control - Move Color command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        int16_t rateXArgument           = 15;
-        int16_t rateYArgument           = 20;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.MoveColor(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel(), rateXArgument, rateYArgument,
-                                optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveColor_5_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move Color command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_5 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveColor_5_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Move Color command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_5 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current x attribute value matched the value sent by the last command
-    using SuccessCallback_6 = void (*)(void * context, uint16_t currentX);
-    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
-        OnTestSendClusterColorControlCommandReadAttribute_6_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
-        OnTestSendClusterColorControlCommandReadAttribute_6_FailureResponse, this
-    };
-    bool mIsFailureExpected_6 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_6()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentX(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_6_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_6 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_6_SuccessResponse(void * context, uint16_t currentX)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_6 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current y attribute value matched the value sent by the last command
-    using SuccessCallback_7 = void (*)(void * context, uint16_t currentY);
-    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse, this
-    };
-    bool mIsFailureExpected_7 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_7()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentY(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_7 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse(void * context, uint16_t currentY)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_7 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Stop Move Step command
-    using SuccessCallback_8 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{
-        OnTestSendClusterColorControlCommandStopMoveStep_8_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{
-        OnTestSendClusterColorControlCommandStopMoveStep_8_FailureResponse, this
-    };
-    bool mIsFailureExpected_8 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandStopMoveStep_8()
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.StopMoveStep(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), optionsMaskArgument,
-                                   optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandStopMoveStep_8_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_8 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandStopMoveStep_8_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Move Step command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_8 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current x attribute value matched the value sent by the last command
-    using SuccessCallback_9 = void (*)(void * context, uint16_t currentX);
-    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse, this
-    };
-    bool mIsFailureExpected_9 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_9()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentX(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_9 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse(void * context, uint16_t currentX)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_9 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current y attribute value matched the value sent by the last command
-    using SuccessCallback_10 = void (*)(void * context, uint16_t currentY);
-    chip::Callback::Callback<SuccessCallback_10> mOnSuccessCallback_10{
-        OnTestSendClusterColorControlCommandReadAttribute_10_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_10{
-        OnTestSendClusterColorControlCommandReadAttribute_10_FailureResponse, this
-    };
-    bool mIsFailureExpected_10 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_10()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentY(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_10_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_10 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_10_SuccessResponse(void * context, uint16_t currentY)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_10 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Step Color command
-    using SuccessCallback_11 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
-        OnTestSendClusterColorControlCommandStepColor_11_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{
-        OnTestSendClusterColorControlCommandStepColor_11_FailureResponse, this
-    };
-    bool mIsFailureExpected_11 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandStepColor_11()
+    CHIP_ERROR TestSendClusterColorControlCommandStepColor_5()
     {
         ChipLogProgress(chipTool, "Color Control - Step Color command: Sending command...");
 
@@ -16757,19 +15014,19 @@ private:
         uint16_t transitionTimeArgument = 50U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.StepColor(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel(), stepXArgument, stepYArgument,
+        err = cluster.StepColor(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel(), stepXArgument, stepYArgument,
                                 transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepColor_11_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepColor_5_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step Color command: Failure Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_11 == false)
+        if (runner->mIsFailureExpected_5 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -16779,137 +15036,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepColor_11_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepColor_5_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step Color command: Success Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_11 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current x attribute value matched the value sent by the last command
-    using SuccessCallback_12 = void (*)(void * context, uint16_t currentX);
-    chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
-        OnTestSendClusterColorControlCommandReadAttribute_12_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_12{
-        OnTestSendClusterColorControlCommandReadAttribute_12_FailureResponse, this
-    };
-    bool mIsFailureExpected_12 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_12()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentX(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_12_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_12 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_12_SuccessResponse(void * context, uint16_t currentX)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current x attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_12 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check current y attribute value matched the value sent by the last command
-    using SuccessCallback_13 = void (*)(void * context, uint16_t currentY);
-    chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse, this
-    };
-    bool mIsFailureExpected_13 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_13()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentY(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_13 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse(void * context, uint16_t currentY)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check current y attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
-
-        if (runner->mIsFailureExpected_13 == true)
+        if (runner->mIsFailureExpected_5 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -16920,13 +15053,13 @@ private:
     }
 
     // Test Turn off light that we turned on
-    using SuccessCallback_14 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_14> mOnSuccessCallback_14{ OnTestSendClusterOnOffCommandOff_14_SuccessResponse, this };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_14{ OnTestSendClusterOnOffCommandOff_14_FailureResponse,
-                                                                            this };
-    bool mIsFailureExpected_14 = 0;
+    using SuccessCallback_6 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{ OnTestSendClusterOnOffCommandOff_6_SuccessResponse, this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{ OnTestSendClusterOnOffCommandOff_6_FailureResponse,
+                                                                           this };
+    bool mIsFailureExpected_6 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandOff_14()
+    CHIP_ERROR TestSendClusterOnOffCommandOff_6()
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Sending command...");
 
@@ -16935,18 +15068,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.Off(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
+        err = cluster.Off(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandOff_14_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandOff_6_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Failure Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_14 == false)
+        if (runner->mIsFailureExpected_6 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -16956,13 +15089,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandOff_14_SuccessResponse(void * context)
+    static void OnTestSendClusterOnOffCommandOff_6_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Success Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_14 == true)
+        if (runner->mIsFailureExpected_6 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -16973,16 +15106,15 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_15 = void (*)(void * context, uint8_t onOff);
-    chip::Callback::Callback<SuccessCallback_15> mOnSuccessCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse, this
+    using SuccessCallback_7 = void (*)(void * context, uint8_t onOff);
+    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{ OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse,
+                                                                      this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
+        OnTestSendClusterOnOffCommandReadAttribute_7_FailureResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse, this
-    };
-    bool mIsFailureExpected_15 = 0;
+    bool mIsFailureExpected_7 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_15()
+    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_7()
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Sending command...");
 
@@ -16991,18 +15123,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandReadAttribute_7_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Failure Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_15 == false)
+        if (runner->mIsFailureExpected_7 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17012,13 +15144,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse(void * context, uint8_t onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
         Test_TC_CC_5 * runner = reinterpret_cast<Test_TC_CC_5 *>(context);
 
-        if (runner->mIsFailureExpected_15 == true)
+        if (runner->mIsFailureExpected_7 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17068,43 +15200,25 @@ public:
             err = TestSendClusterColorControlCommandMoveToColorTemperature_2();
             break;
         case 3:
-            err = TestSendClusterColorControlCommandReadAttribute_3();
+            err = TestSendClusterColorControlCommandMoveColorTemperature_3();
             break;
         case 4:
             err = TestSendClusterColorControlCommandMoveColorTemperature_4();
             break;
         case 5:
-            err = TestSendClusterColorControlCommandReadAttribute_5();
+            err = TestSendClusterColorControlCommandMoveColorTemperature_5();
             break;
         case 6:
-            err = TestSendClusterColorControlCommandMoveColorTemperature_6();
+            err = TestSendClusterColorControlCommandStepColorTemperature_6();
             break;
         case 7:
-            err = TestSendClusterColorControlCommandReadAttribute_7();
+            err = TestSendClusterColorControlCommandStepColorTemperature_7();
             break;
         case 8:
-            err = TestSendClusterColorControlCommandMoveColorTemperature_8();
+            err = TestSendClusterOnOffCommandOff_8();
             break;
         case 9:
-            err = TestSendClusterColorControlCommandReadAttribute_9();
-            break;
-        case 10:
-            err = TestSendClusterColorControlCommandStepColorTemperature_10();
-            break;
-        case 11:
-            err = TestSendClusterColorControlCommandReadAttribute_11();
-            break;
-        case 12:
-            err = TestSendClusterColorControlCommandStepColorTemperature_12();
-            break;
-        case 13:
-            err = TestSendClusterColorControlCommandReadAttribute_13();
-            break;
-        case 14:
-            err = TestSendClusterOnOffCommandOff_14();
-            break;
-        case 15:
-            err = TestSendClusterOnOffCommandReadAttribute_15();
+            err = TestSendClusterOnOffCommandReadAttribute_9();
             break;
         }
 
@@ -17117,7 +15231,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 16;
+    const uint16_t mTestCount = 10;
 
     //
     // Tests methods
@@ -17299,73 +15413,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Read current color temprature
-    using SuccessCallback_3 = void (*)(void * context, uint16_t colorTemperature);
+    // Test Move up color temperature command
+    using SuccessCallback_3 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse, this
+        OnTestSendClusterColorControlCommandMoveColorTemperature_3_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
-        OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveColorTemperature_3_FailureResponse, this
     };
     bool mIsFailureExpected_3 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_3()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_3 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_3_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_3 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move up color temperature command
-    using SuccessCallback_4 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_4_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_4_FailureResponse, this
-    };
-    bool mIsFailureExpected_4 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_4()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_3()
     {
         ChipLogProgress(chipTool, "Color Control - Move up color temperature command: Sending command...");
 
@@ -17380,6 +15438,70 @@ private:
         uint16_t colorTemperatureMaximumArgument = 255U;
         uint8_t optionsMaskArgument              = 0;
         uint8_t optionsOverrideArgument          = 0;
+        err = cluster.MoveColorTemperature(mOnSuccessCallback_3.Cancel(), mOnFailureCallback_3.Cancel(), moveModeArgument,
+                                           rateArgument, colorTemperatureMinimumArgument, colorTemperatureMaximumArgument,
+                                           optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveColorTemperature_3_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move up color temperature command: Failure Response");
+
+        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
+
+        if (runner->mIsFailureExpected_3 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandMoveColorTemperature_3_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Move up color temperature command: Success Response");
+
+        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
+
+        if (runner->mIsFailureExpected_3 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Stop Color Temperature command
+    using SuccessCallback_4 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
+        OnTestSendClusterColorControlCommandMoveColorTemperature_4_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
+        OnTestSendClusterColorControlCommandMoveColorTemperature_4_FailureResponse, this
+    };
+    bool mIsFailureExpected_4 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_4()
+    {
+        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t moveModeArgument                 = 0;
+        uint16_t rateArgument                    = 10U;
+        uint16_t colorTemperatureMinimumArgument = 1U;
+        uint16_t colorTemperatureMaximumArgument = 255U;
+        uint8_t optionsMaskArgument              = 0;
+        uint8_t optionsOverrideArgument          = 0;
         err = cluster.MoveColorTemperature(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel(), moveModeArgument,
                                            rateArgument, colorTemperatureMinimumArgument, colorTemperatureMaximumArgument,
                                            optionsMaskArgument, optionsOverrideArgument);
@@ -17389,7 +15511,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandMoveColorTemperature_4_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Move up color temperature command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
@@ -17405,7 +15527,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandMoveColorTemperature_4_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Move up color temperature command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
@@ -17419,193 +15541,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Read current color temprature
-    using SuccessCallback_5 = void (*)(void * context, uint16_t colorTemperature);
+    // Test Move down color temperature command
+    using SuccessCallback_5 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
-        OnTestSendClusterColorControlCommandReadAttribute_5_SuccessResponse, this
+        OnTestSendClusterColorControlCommandMoveColorTemperature_5_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_5{
-        OnTestSendClusterColorControlCommandReadAttribute_5_FailureResponse, this
+        OnTestSendClusterColorControlCommandMoveColorTemperature_5_FailureResponse, this
     };
     bool mIsFailureExpected_5 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_5()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_5_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_5 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_5_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_5 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Stop Color Temperature command
-    using SuccessCallback_6 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_6_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_6_FailureResponse, this
-    };
-    bool mIsFailureExpected_6 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_6()
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument                 = 0;
-        uint16_t rateArgument                    = 10U;
-        uint16_t colorTemperatureMinimumArgument = 1U;
-        uint16_t colorTemperatureMaximumArgument = 255U;
-        uint8_t optionsMaskArgument              = 0;
-        uint8_t optionsOverrideArgument          = 0;
-        err = cluster.MoveColorTemperature(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), moveModeArgument,
-                                           rateArgument, colorTemperatureMinimumArgument, colorTemperatureMaximumArgument,
-                                           optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveColorTemperature_6_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_6 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandMoveColorTemperature_6_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Stop Color Temperature command: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_6 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Read current color temprature
-    using SuccessCallback_7 = void (*)(void * context, uint16_t colorTemperature);
-    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
-        OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse, this
-    };
-    bool mIsFailureExpected_7 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_7()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_7 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_7_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_7 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Move down color temperature command
-    using SuccessCallback_8 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_8_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{
-        OnTestSendClusterColorControlCommandMoveColorTemperature_8_FailureResponse, this
-    };
-    bool mIsFailureExpected_8 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_8()
+    CHIP_ERROR TestSendClusterColorControlCommandMoveColorTemperature_5()
     {
         ChipLogProgress(chipTool, "Color Control - Move down color temperature command: Sending command...");
 
@@ -17620,20 +15566,20 @@ private:
         uint16_t colorTemperatureMaximumArgument = 255U;
         uint8_t optionsMaskArgument              = 0;
         uint8_t optionsOverrideArgument          = 0;
-        err = cluster.MoveColorTemperature(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), moveModeArgument,
+        err = cluster.MoveColorTemperature(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel(), moveModeArgument,
                                            rateArgument, colorTemperatureMinimumArgument, colorTemperatureMaximumArgument,
                                            optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandMoveColorTemperature_8_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandMoveColorTemperature_5_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Move down color temperature command: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_8 == false)
+        if (runner->mIsFailureExpected_5 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17643,69 +15589,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandMoveColorTemperature_8_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandMoveColorTemperature_5_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Move down color temperature command: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_8 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Read current color temprature
-    using SuccessCallback_9 = void (*)(void * context, uint16_t colorTemperature);
-    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
-        OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse, this
-    };
-    bool mIsFailureExpected_9 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_9()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_9 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_9_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_9 == true)
+        if (runner->mIsFailureExpected_5 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17716,16 +15606,16 @@ private:
     }
 
     // Test Step up color temperature command
-    using SuccessCallback_10 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_10> mOnSuccessCallback_10{
-        OnTestSendClusterColorControlCommandStepColorTemperature_10_SuccessResponse, this
+    using SuccessCallback_6 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
+        OnTestSendClusterColorControlCommandStepColorTemperature_6_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_10{
-        OnTestSendClusterColorControlCommandStepColorTemperature_10_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_6{
+        OnTestSendClusterColorControlCommandStepColorTemperature_6_FailureResponse, this
     };
-    bool mIsFailureExpected_10 = 0;
+    bool mIsFailureExpected_6 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandStepColorTemperature_10()
+    CHIP_ERROR TestSendClusterColorControlCommandStepColorTemperature_6()
     {
         ChipLogProgress(chipTool, "Color Control - Step up color temperature command: Sending command...");
 
@@ -17741,20 +15631,20 @@ private:
         uint16_t colorTemperatureMaximumArgument = 100U;
         uint8_t optionsMaskArgument              = 0;
         uint8_t optionsOverrideArgument          = 0;
-        err = cluster.StepColorTemperature(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel(), stepModeArgument,
+        err = cluster.StepColorTemperature(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), stepModeArgument,
                                            stepSizeArgument, transitionTimeArgument, colorTemperatureMinimumArgument,
                                            colorTemperatureMaximumArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepColorTemperature_10_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepColorTemperature_6_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step up color temperature command: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_10 == false)
+        if (runner->mIsFailureExpected_6 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17764,69 +15654,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepColorTemperature_10_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepColorTemperature_6_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step up color temperature command: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_10 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Read current color temprature
-    using SuccessCallback_11 = void (*)(void * context, uint16_t colorTemperature);
-    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
-        OnTestSendClusterColorControlCommandReadAttribute_11_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{
-        OnTestSendClusterColorControlCommandReadAttribute_11_FailureResponse, this
-    };
-    bool mIsFailureExpected_11 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_11()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_11_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_11 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_11_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_11 == true)
+        if (runner->mIsFailureExpected_6 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17837,16 +15671,16 @@ private:
     }
 
     // Test Step down color temperature command
-    using SuccessCallback_12 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
-        OnTestSendClusterColorControlCommandStepColorTemperature_12_SuccessResponse, this
+    using SuccessCallback_7 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
+        OnTestSendClusterColorControlCommandStepColorTemperature_7_SuccessResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_12{
-        OnTestSendClusterColorControlCommandStepColorTemperature_12_FailureResponse, this
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
+        OnTestSendClusterColorControlCommandStepColorTemperature_7_FailureResponse, this
     };
-    bool mIsFailureExpected_12 = 0;
+    bool mIsFailureExpected_7 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandStepColorTemperature_12()
+    CHIP_ERROR TestSendClusterColorControlCommandStepColorTemperature_7()
     {
         ChipLogProgress(chipTool, "Color Control - Step down color temperature command: Sending command...");
 
@@ -17862,20 +15696,20 @@ private:
         uint16_t colorTemperatureMaximumArgument = 100U;
         uint8_t optionsMaskArgument              = 0;
         uint8_t optionsOverrideArgument          = 0;
-        err = cluster.StepColorTemperature(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel(), stepModeArgument,
+        err = cluster.StepColorTemperature(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel(), stepModeArgument,
                                            stepSizeArgument, transitionTimeArgument, colorTemperatureMinimumArgument,
                                            colorTemperatureMaximumArgument, optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandStepColorTemperature_12_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandStepColorTemperature_7_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Step down color temperature command: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_12 == false)
+        if (runner->mIsFailureExpected_7 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17885,69 +15719,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandStepColorTemperature_12_SuccessResponse(void * context)
+    static void OnTestSendClusterColorControlCommandStepColorTemperature_7_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "Color Control - Step down color temperature command: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_12 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Read current color temprature
-    using SuccessCallback_13 = void (*)(void * context, uint16_t colorTemperature);
-    chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse, this
-    };
-    bool mIsFailureExpected_13 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_13()
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeColorTemperature(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Failure Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_13 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse(void * context, uint16_t colorTemperature)
-    {
-        ChipLogProgress(chipTool, "Color Control - Read current color temprature: Success Response");
-
-        Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
-
-        if (runner->mIsFailureExpected_13 == true)
+        if (runner->mIsFailureExpected_7 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17958,13 +15736,13 @@ private:
     }
 
     // Test Turn off light that we turned on
-    using SuccessCallback_14 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_14> mOnSuccessCallback_14{ OnTestSendClusterOnOffCommandOff_14_SuccessResponse, this };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_14{ OnTestSendClusterOnOffCommandOff_14_FailureResponse,
-                                                                            this };
-    bool mIsFailureExpected_14 = 0;
+    using SuccessCallback_8 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{ OnTestSendClusterOnOffCommandOff_8_SuccessResponse, this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{ OnTestSendClusterOnOffCommandOff_8_FailureResponse,
+                                                                           this };
+    bool mIsFailureExpected_8 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandOff_14()
+    CHIP_ERROR TestSendClusterOnOffCommandOff_8()
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Sending command...");
 
@@ -17973,18 +15751,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.Off(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
+        err = cluster.Off(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandOff_14_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandOff_8_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_14 == false)
+        if (runner->mIsFailureExpected_8 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -17994,13 +15772,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandOff_14_SuccessResponse(void * context)
+    static void OnTestSendClusterOnOffCommandOff_8_SuccessResponse(void * context)
     {
         ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_14 == true)
+        if (runner->mIsFailureExpected_8 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -18011,16 +15789,15 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_15 = void (*)(void * context, uint8_t onOff);
-    chip::Callback::Callback<SuccessCallback_15> mOnSuccessCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse, this
+    using SuccessCallback_9 = void (*)(void * context, uint8_t onOff);
+    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{ OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse,
+                                                                      this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
+        OnTestSendClusterOnOffCommandReadAttribute_9_FailureResponse, this
     };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse, this
-    };
-    bool mIsFailureExpected_15 = 0;
+    bool mIsFailureExpected_9 = 0;
 
-    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_15()
+    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_9()
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Sending command...");
 
@@ -18029,18 +15806,18 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
+        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandReadAttribute_9_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Failure Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_15 == false)
+        if (runner->mIsFailureExpected_9 == false)
         {
             ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -18050,13 +15827,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse(void * context, uint8_t onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
         Test_TC_CC_6 * runner = reinterpret_cast<Test_TC_CC_6 *>(context);
 
-        if (runner->mIsFailureExpected_15 == true)
+        if (runner->mIsFailureExpected_9 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -18109,7 +15886,7 @@ public:
             err = TestSendClusterColorControlCommandReadAttribute_3();
             break;
         case 4:
-            err = TestSendClusterColorControlCommandReadAttribute_4();
+            err = TestSendClusterColorControlCommandEnhancedMoveHue_4();
             break;
         case 5:
             err = TestSendClusterColorControlCommandEnhancedMoveHue_5();
@@ -18121,28 +15898,19 @@ public:
             err = TestSendClusterColorControlCommandEnhancedMoveHue_7();
             break;
         case 8:
-            err = TestSendClusterColorControlCommandEnhancedMoveHue_8();
+            err = TestSendClusterColorControlCommandEnhancedStepHue_8();
             break;
         case 9:
             err = TestSendClusterColorControlCommandEnhancedStepHue_9();
             break;
         case 10:
-            err = TestSendClusterColorControlCommandEnhancedStepHue_10();
+            err = TestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10();
             break;
         case 11:
-            err = TestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11();
+            err = TestSendClusterOnOffCommandOff_11();
             break;
         case 12:
-            err = TestSendClusterColorControlCommandReadAttribute_12();
-            break;
-        case 13:
-            err = TestSendClusterColorControlCommandReadAttribute_13();
-            break;
-        case 14:
-            err = TestSendClusterOnOffCommandOff_14();
-            break;
-        case 15:
-            err = TestSendClusterOnOffCommandReadAttribute_15();
+            err = TestSendClusterOnOffCommandReadAttribute_12();
             break;
         }
 
@@ -18155,7 +15923,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 16;
+    const uint16_t mTestCount = 13;
 
     //
     // Tests methods
@@ -18407,37 +16175,38 @@ private:
         runner->NextTest();
     }
 
-    // Test Check EnhancedCurrentHue attribute value matched the value sent by the last command
-    using SuccessCallback_4 = void (*)(void * context, uint16_t enhancedCurrentHue);
+    // Test Enhanced Move Hue Down command
+    using SuccessCallback_4 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_4> mOnSuccessCallback_4{
-        OnTestSendClusterColorControlCommandReadAttribute_4_SuccessResponse, this
+        OnTestSendClusterColorControlCommandEnhancedMoveHue_4_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_4{
-        OnTestSendClusterColorControlCommandReadAttribute_4_FailureResponse, this
+        OnTestSendClusterColorControlCommandEnhancedMoveHue_4_FailureResponse, this
     };
     bool mIsFailureExpected_4 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_4()
+    CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveHue_4()
     {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel());
+        uint8_t moveModeArgument        = 3;
+        uint16_t rateArgument           = 5U;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
+        err = cluster.EnhancedMoveHue(mOnSuccessCallback_4.Cancel(), mOnFailureCallback_4.Cancel(), moveModeArgument, rateArgument,
+                                      optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_4_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterColorControlCommandEnhancedMoveHue_4_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18451,11 +16220,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_4_SuccessResponse(void * context, uint16_t enhancedCurrentHue)
+    static void OnTestSendClusterColorControlCommandEnhancedMoveHue_4_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Success Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18469,7 +16236,7 @@ private:
         runner->NextTest();
     }
 
-    // Test Enhanced Move Hue Down command
+    // Test Enhanced Move Hue Stop command
     using SuccessCallback_5 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
         OnTestSendClusterColorControlCommandEnhancedMoveHue_5_SuccessResponse, this
@@ -18481,15 +16248,15 @@ private:
 
     CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveHue_5()
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t moveModeArgument        = 3;
-        uint16_t rateArgument           = 5U;
+        uint8_t moveModeArgument        = 0;
+        uint16_t rateArgument           = 0U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
         err = cluster.EnhancedMoveHue(mOnSuccessCallback_5.Cancel(), mOnFailureCallback_5.Cancel(), moveModeArgument, rateArgument,
@@ -18500,7 +16267,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_5_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18516,7 +16283,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_5_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Down command : Success Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18530,7 +16297,7 @@ private:
         runner->NextTest();
     }
 
-    // Test Enhanced Move Hue Stop command
+    // Test Enhanced Move Hue Up command
     using SuccessCallback_6 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
         OnTestSendClusterColorControlCommandEnhancedMoveHue_6_SuccessResponse, this
@@ -18542,15 +16309,15 @@ private:
 
     CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveHue_6()
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t moveModeArgument        = 0;
-        uint16_t rateArgument           = 0U;
+        uint8_t moveModeArgument        = 1;
+        uint16_t rateArgument           = 50U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
         err = cluster.EnhancedMoveHue(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), moveModeArgument, rateArgument,
@@ -18561,7 +16328,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_6_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18577,7 +16344,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_6_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18591,7 +16358,7 @@ private:
         runner->NextTest();
     }
 
-    // Test Enhanced Move Hue Up command
+    // Test Enhanced Move Hue Stop command
     using SuccessCallback_7 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
         OnTestSendClusterColorControlCommandEnhancedMoveHue_7_SuccessResponse, this
@@ -18603,15 +16370,15 @@ private:
 
     CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveHue_7()
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Sending command...");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Sending command...");
 
         chip::Controller::ColorControlCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t moveModeArgument        = 1;
-        uint16_t rateArgument           = 50U;
+        uint8_t moveModeArgument        = 0;
+        uint16_t rateArgument           = 0U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
         err = cluster.EnhancedMoveHue(mOnSuccessCallback_7.Cancel(), mOnFailureCallback_7.Cancel(), moveModeArgument, rateArgument,
@@ -18622,7 +16389,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_7_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18638,7 +16405,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedMoveHue_7_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Up command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18652,78 +16419,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Enhanced Move Hue Stop command
+    // Test Enhanced Step Hue Up command
     using SuccessCallback_8 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{
-        OnTestSendClusterColorControlCommandEnhancedMoveHue_8_SuccessResponse, this
+        OnTestSendClusterColorControlCommandEnhancedStepHue_8_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_8{
-        OnTestSendClusterColorControlCommandEnhancedMoveHue_8_FailureResponse, this
+        OnTestSendClusterColorControlCommandEnhancedStepHue_8_FailureResponse, this
     };
     bool mIsFailureExpected_8 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveHue_8()
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t moveModeArgument        = 0;
-        uint16_t rateArgument           = 0U;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.EnhancedMoveHue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), moveModeArgument, rateArgument,
-                                      optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandEnhancedMoveHue_8_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Failure Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_8 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandEnhancedMoveHue_8_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Move Hue Stop command: Success Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_8 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Enhanced Step Hue Up command
-    using SuccessCallback_9 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
-        OnTestSendClusterColorControlCommandEnhancedStepHue_9_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
-        OnTestSendClusterColorControlCommandEnhancedStepHue_9_FailureResponse, this
-    };
-    bool mIsFailureExpected_9 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandEnhancedStepHue_9()
+    CHIP_ERROR TestSendClusterColorControlCommandEnhancedStepHue_8()
     {
         ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Up command: Sending command...");
 
@@ -18737,6 +16443,68 @@ private:
         uint16_t transitionTimeArgument = 1U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
+        err = cluster.EnhancedStepHue(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), stepModeArgument,
+                                      stepSizeArgument, transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandEnhancedStepHue_8_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Up command: Failure Response");
+
+        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
+
+        if (runner->mIsFailureExpected_8 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandEnhancedStepHue_8_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Up command: Success Response");
+
+        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
+
+        if (runner->mIsFailureExpected_8 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Enhanced Step Hue Down command
+    using SuccessCallback_9 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
+        OnTestSendClusterColorControlCommandEnhancedStepHue_9_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
+        OnTestSendClusterColorControlCommandEnhancedStepHue_9_FailureResponse, this
+    };
+    bool mIsFailureExpected_9 = 0;
+
+    CHIP_ERROR TestSendClusterColorControlCommandEnhancedStepHue_9()
+    {
+        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Sending command...");
+
+        chip::Controller::ColorControlCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint8_t stepModeArgument        = 1;
+        uint16_t stepSizeArgument       = 75U;
+        uint16_t transitionTimeArgument = 1U;
+        uint8_t optionsMaskArgument     = 0;
+        uint8_t optionsOverrideArgument = 0;
         err = cluster.EnhancedStepHue(mOnSuccessCallback_9.Cancel(), mOnFailureCallback_9.Cancel(), stepModeArgument,
                                       stepSizeArgument, transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
 
@@ -18745,7 +16513,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedStepHue_9_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Up command: Failure Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18761,7 +16529,7 @@ private:
 
     static void OnTestSendClusterColorControlCommandEnhancedStepHue_9_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Up command: Success Response");
+        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18775,79 +16543,17 @@ private:
         runner->NextTest();
     }
 
-    // Test Enhanced Step Hue Down command
+    // Test Enhanced move to hue and saturation command
     using SuccessCallback_10 = void (*)(void * context);
     chip::Callback::Callback<SuccessCallback_10> mOnSuccessCallback_10{
-        OnTestSendClusterColorControlCommandEnhancedStepHue_10_SuccessResponse, this
+        OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_10{
-        OnTestSendClusterColorControlCommandEnhancedStepHue_10_FailureResponse, this
+        OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10_FailureResponse, this
     };
     bool mIsFailureExpected_10 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandEnhancedStepHue_10()
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        uint8_t stepModeArgument        = 1;
-        uint16_t stepSizeArgument       = 75U;
-        uint16_t transitionTimeArgument = 1U;
-        uint8_t optionsMaskArgument     = 0;
-        uint8_t optionsOverrideArgument = 0;
-        err = cluster.EnhancedStepHue(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel(), stepModeArgument,
-                                      stepSizeArgument, transitionTimeArgument, optionsMaskArgument, optionsOverrideArgument);
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandEnhancedStepHue_10_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Failure Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_10 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandEnhancedStepHue_10_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "Color Control - Enhanced Step Hue Down command: Success Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_10 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Enhanced move to hue and saturation command
-    using SuccessCallback_11 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
-        OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{
-        OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11_FailureResponse, this
-    };
-    bool mIsFailureExpected_11 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11()
+    CHIP_ERROR TestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10()
     {
         ChipLogProgress(chipTool, "Color Control - Enhanced move to hue and saturation command: Sending command...");
 
@@ -18861,17 +16567,70 @@ private:
         uint16_t transitionTimeArgument = 10U;
         uint8_t optionsMaskArgument     = 0;
         uint8_t optionsOverrideArgument = 0;
-        err = cluster.EnhancedMoveToHueAndSaturation(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel(),
+        err = cluster.EnhancedMoveToHueAndSaturation(mOnSuccessCallback_10.Cancel(), mOnFailureCallback_10.Cancel(),
                                                      enhancedHueArgument, saturationArgument, transitionTimeArgument,
                                                      optionsMaskArgument, optionsOverrideArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11_FailureResponse(void * context,
+    static void OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10_FailureResponse(void * context,
                                                                                                       uint8_t status)
     {
         ChipLogProgress(chipTool, "Color Control - Enhanced move to hue and saturation command: Failure Response");
+
+        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
+
+        if (runner->mIsFailureExpected_10 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_10_SuccessResponse(void * context)
+    {
+        ChipLogProgress(chipTool, "Color Control - Enhanced move to hue and saturation command: Success Response");
+
+        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
+
+        if (runner->mIsFailureExpected_10 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test Turn off light that we turned on
+    using SuccessCallback_11 = void (*)(void * context);
+    chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{ OnTestSendClusterOnOffCommandOff_11_SuccessResponse, this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_11{ OnTestSendClusterOnOffCommandOff_11_FailureResponse,
+                                                                            this };
+    bool mIsFailureExpected_11 = 0;
+
+    CHIP_ERROR TestSendClusterOnOffCommandOff_11()
+    {
+        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Sending command...");
+
+        chip::Controller::OnOffCluster cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        err = cluster.Off(mOnSuccessCallback_11.Cancel(), mOnFailureCallback_11.Cancel());
+
+        return err;
+    }
+
+    static void OnTestSendClusterOnOffCommandOff_11_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18885,9 +16644,9 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandEnhancedMoveToHueAndSaturation_11_SuccessResponse(void * context)
+    static void OnTestSendClusterOnOffCommandOff_11_SuccessResponse(void * context)
     {
-        ChipLogProgress(chipTool, "Color Control - Enhanced move to hue and saturation command: Success Response");
+        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18901,37 +16660,33 @@ private:
         runner->NextTest();
     }
 
-    // Test Check EnhancedCurrentHue attribute value matched the value sent by the last command
-    using SuccessCallback_12 = void (*)(void * context, uint16_t enhancedCurrentHue);
+    // Test Check on/off attribute value is false after off command
+    using SuccessCallback_12 = void (*)(void * context, uint8_t onOff);
     chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
-        OnTestSendClusterColorControlCommandReadAttribute_12_SuccessResponse, this
+        OnTestSendClusterOnOffCommandReadAttribute_12_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_12{
-        OnTestSendClusterColorControlCommandReadAttribute_12_FailureResponse, this
+        OnTestSendClusterOnOffCommandReadAttribute_12_FailureResponse, this
     };
     bool mIsFailureExpected_12 = 0;
 
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_12()
+    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_12()
     {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Sending command...");
+        ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Sending command...");
 
-        chip::Controller::ColorControlCluster cluster;
+        chip::Controller::OnOffCluster cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeEnhancedCurrentHue(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
+        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_12.Cancel(), mOnFailureCallback_12.Cancel());
 
         return err;
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_12_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOnOffCommandReadAttribute_12_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Failure Response");
+        ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Failure Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
@@ -18945,186 +16700,13 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterColorControlCommandReadAttribute_12_SuccessResponse(void * context, uint16_t enhancedCurrentHue)
-    {
-        ChipLogProgress(chipTool,
-                        "Color Control - Check EnhancedCurrentHue attribute value matched the value sent by the last command: "
-                        "Success Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_12 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check Saturation attribute value matched the value sent by the last command
-    using SuccessCallback_13 = void (*)(void * context, uint8_t currentSaturation);
-    chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_13{
-        OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse, this
-    };
-    bool mIsFailureExpected_13 = 0;
-
-    CHIP_ERROR TestSendClusterColorControlCommandReadAttribute_13()
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Sending command...");
-
-        chip::Controller::ColorControlCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeCurrentSaturation(mOnSuccessCallback_13.Cancel(), mOnFailureCallback_13.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Failure Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_13 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterColorControlCommandReadAttribute_13_SuccessResponse(void * context, uint8_t currentSaturation)
-    {
-        ChipLogProgress(
-            chipTool,
-            "Color Control - Check Saturation attribute value matched the value sent by the last command: Success Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_13 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Turn off light that we turned on
-    using SuccessCallback_14 = void (*)(void * context);
-    chip::Callback::Callback<SuccessCallback_14> mOnSuccessCallback_14{ OnTestSendClusterOnOffCommandOff_14_SuccessResponse, this };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_14{ OnTestSendClusterOnOffCommandOff_14_FailureResponse,
-                                                                            this };
-    bool mIsFailureExpected_14 = 0;
-
-    CHIP_ERROR TestSendClusterOnOffCommandOff_14()
-    {
-        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Sending command...");
-
-        chip::Controller::OnOffCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.Off(mOnSuccessCallback_14.Cancel(), mOnFailureCallback_14.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterOnOffCommandOff_14_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Failure Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_14 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterOnOffCommandOff_14_SuccessResponse(void * context)
-    {
-        ChipLogProgress(chipTool, "On/Off - Turn off light that we turned on: Success Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_14 == true)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    // Test Check on/off attribute value is false after off command
-    using SuccessCallback_15 = void (*)(void * context, uint8_t onOff);
-    chip::Callback::Callback<SuccessCallback_15> mOnSuccessCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse, this
-    };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_15{
-        OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse, this
-    };
-    bool mIsFailureExpected_15 = 0;
-
-    CHIP_ERROR TestSendClusterOnOffCommandReadAttribute_15()
-    {
-        ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Sending command...");
-
-        chip::Controller::OnOffCluster cluster;
-        cluster.Associate(mDevice, 1);
-
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = cluster.ReadAttributeOnOff(mOnSuccessCallback_15.Cancel(), mOnFailureCallback_15.Cancel());
-
-        return err;
-    }
-
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_FailureResponse(void * context, uint8_t status)
-    {
-        ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Failure Response");
-
-        Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
-
-        if (runner->mIsFailureExpected_15 == false)
-        {
-            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        runner->NextTest();
-    }
-
-    static void OnTestSendClusterOnOffCommandReadAttribute_15_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_12_SuccessResponse(void * context, uint8_t onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
         Test_TC_CC_7 * runner = reinterpret_cast<Test_TC_CC_7 *>(context);
 
-        if (runner->mIsFailureExpected_15 == true)
+        if (runner->mIsFailureExpected_12 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);

--- a/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
@@ -26,39 +26,42 @@ tests:
               - name: "status"
                 value: 1
 
+    # TODO: Support chars validation
     - label: "Read attribute vendor name"
+      disabled: true
       command: "readAttribute"
       attribute: "vendor name"
+      response:
+          value: "exampleVendorName1"
 
-      # TODO: Support chars validation
-      # response:
-      #     value: "exampleVendorName1"
     - label: "Read attribute vendor id"
       command: "readAttribute"
       attribute: "vendor id"
       response:
           value: 1
 
+    # TODO: Support chars validation
     - label: "Read attribute name"
+      disabled: true
       command: "readAttribute"
       attribute: "application name"
+      response:
+          value: "exampleName1"
 
-      # TODO: Support chars validation
-      # response:
-      #     value: "exampleName1"
     - label: "Read attribute product id"
       command: "readAttribute"
       attribute: "product id"
       response:
           value: 1
 
+    # TODO: Support chars validation
     - label: "Read attribute id"
+      disabled: true
       command: "readAttribute"
       attribute: "application id"
+      response:
+          value: "appId"
 
-      # TODO: Support chars validation
-      # response:
-      #     value: "appId"
     - label: "Read attribute catalog vendor id"
       command: "readAttribute"
       attribute: "catalog vendor id"

--- a/src/app/tests/suites/certification/Test_TC_CC_3_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_4.yaml
@@ -49,10 +49,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
-    #      response:
-    #          value: 150
+      response:
+          value: 150
 
     - label: "Move to hue longest distance command"
       command: "MoveToHue"
@@ -72,10 +73,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
-    #      response:
-    #          value: 150
+      response:
+          value: 150
 
     - label: "Move to hue up command"
       command: "MoveToHue"
@@ -95,10 +97,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
-    #      response:
-    #          value: 250
+      response:
+          value: 250
 
     - label: "Move to hue down command"
       command: "MoveToHue"
@@ -118,10 +121,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
-    #      response:
-    #          value: 225
+      response:
+          value: 225
 
     - label: "Move hue up command"
       command: "MoveHue"
@@ -139,8 +143,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Move hue stop command"
       command: "MoveHue"
@@ -158,8 +165,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Move hue down command"
       command: "MoveHue"
@@ -177,8 +187,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Move hue stop command"
       command: "MoveHue"
@@ -196,8 +209,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Step hue up command"
       command: "StepHue"
@@ -217,8 +233,11 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Step hue down command"
       command: "StepHue"
@@ -238,14 +257,18 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
+      response:
+          value: -1
 
     - label: "Check Saturation attribute value matched before any change"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
-    #      response:
-    #          value: 90
+      response:
+          value: 90
 
     - label: "Move to saturation command"
       command: "MoveToSaturation"
@@ -263,10 +286,11 @@ tests:
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
-    #      response:
-    #          value: 90
+      response:
+          value: 90
 
     - label: "Move saturation up command"
       command: "MoveSaturation"
@@ -284,8 +308,11 @@ tests:
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
+      response:
+          value: -1
 
     - label: "Move saturation down command"
       command: "MoveSaturation"
@@ -303,8 +330,11 @@ tests:
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
+      response:
+          value: -1
 
     - label: "Step saturation up command"
       command: "StepSaturation"
@@ -324,8 +354,11 @@ tests:
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
+      response:
+          value: -1
 
     - label: "Step saturation down command"
       command: "StepSaturation"
@@ -345,8 +378,11 @@ tests:
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
+      response:
+          value: -1
 
     - label: "Move To current hue and saturation command"
       command: "MoveToHueAndSaturation"
@@ -365,18 +401,20 @@ tests:
     - label:
           "Check current hue attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current hue"
-    #      response:
-    #          value: 40
+      response:
+          value: 40
 
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
-    #      response:
-    #          value: 160
+      response:
+          value: 160
 
     - label: "Turn off light that we turned on"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5.yaml
@@ -48,17 +48,20 @@ tests:
     - label:
           "Check current y attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current x"
-    #      response:
-    #          value: 200
+      response:
+          value: 200
+
     - label:
           "Check current x attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current y"
-    #      response:
-    #          value: 300
+      response:
+          value: 300
 
     - label: "Move Color command"
       command: "MoveColor"
@@ -76,14 +79,20 @@ tests:
     - label:
           "Check current x attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current x"
+      response:
+          value: -1
 
     - label:
           "Check current y attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current y"
+      response:
+          value: -1
 
     - label: "Stop Move Step command"
       command: "StopMoveStep"
@@ -97,14 +106,20 @@ tests:
     - label:
           "Check current x attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current x"
+      response:
+          value: -1
 
     - label:
           "Check current y attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current y"
+      response:
+          value: -1
 
     - label: "Step Color command"
       command: "StepColor"
@@ -124,14 +139,20 @@ tests:
     - label:
           "Check current x attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current x"
+      response:
+          value: -1
 
     - label:
           "Check current y attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current y"
+      response:
+          value: -1
 
     - label: "Turn off light that we turned on"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6.yaml
@@ -44,10 +44,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
-    #      response:
-    #          value: 100
+      response:
+          value: 100
 
     - label: "Move up color temperature command"
       command: "MoveColorTemperature"
@@ -67,8 +68,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
+      response:
+          value: -1
 
     - label: "Stop Color Temperature command"
       command: "MoveColorTemperature"
@@ -88,8 +92,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
+      response:
+          value: -1
 
     - label: "Move down color temperature command"
       command: "MoveColorTemperature"
@@ -109,8 +116,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
+      response:
+          value: -1
 
     - label: "Step up color temperature command"
       command: "StepColorTemperature"
@@ -132,8 +142,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
+      response:
+          value: -1
 
     - label: "Step down color temperature command"
       command: "StepColorTemperature"
@@ -155,8 +168,11 @@ tests:
                 value: 0
 
     - label: "Read current color temprature"
+      disabled: true
       command: "readAttribute"
       attribute: "color temperature"
+      response:
+          value: -1
 
     - label: "Turn off light that we turned on"
       cluster: "On/Off"

--- a/src/app/tests/suites/certification/Test_TC_CC_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7.yaml
@@ -56,10 +56,11 @@ tests:
     - label:
           "Check EnhancedCurrentHue attribute value matched the value sent by
           the last command"
+      disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
-    #      response:
-    #          value: 1025
+      response:
+          value: 1025
 
     - label: "Enhanced Move Hue Down command "
       command: "EnhancedMoveHue"
@@ -91,6 +92,8 @@ tests:
       disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
+      response:
+          value: -1
 
     - label: "Enhanced Move Hue Up command"
       command: "EnhancedMoveHue"
@@ -122,6 +125,8 @@ tests:
       disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
+      response:
+          value: -1
 
     - label: "Enhanced Step Hue Up command"
       command: "EnhancedStepHue"
@@ -144,8 +149,8 @@ tests:
       disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
-    #      response:
-    #          value: 1075
+      response:
+          value: 1075
 
     - label: "Enhanced Step Hue Down command"
       command: "EnhancedStepHue"
@@ -168,8 +173,8 @@ tests:
       disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
-    #      response:
-    #          value: 1000
+      response:
+          value: 1000
 
     - label: "Enhanced move to hue and saturation command"
       command: "EnhancedMoveToHueAndSaturation"
@@ -189,18 +194,20 @@ tests:
     - label:
           "Check EnhancedCurrentHue attribute value matched the value sent by
           the last command"
+      disabled: true
       command: "readAttribute"
       attribute: "enhanced current hue"
-    #      response:
-    #          value: 1200
+      response:
+          value: 1200
 
     - label:
           "Check Saturation attribute value matched the value sent by the last
           command"
+      disabled: true
       command: "readAttribute"
       attribute: "current saturation"
-    #      response:
-    #          value: 90
+      response:
+          value: 90
 
     - label: "Turn off light that we turned on"
       cluster: "On/Off"

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -39,12 +39,19 @@ const kResponseName      = 'response';
 const kDisabledName      = 'disabled';
 const kResponseErrorName = 'error';
 
+function throwError(test, errorStr)
+{
+  console.error('Error in: ' + test.filename + '.yaml for test with label: "' + test.label + '"\n');
+  console.error(errorStr);
+  throw new Error();
+}
+
 function setDefault(test, name, defaultValue)
 {
   if (!(name in test)) {
     if (defaultValue == null) {
-      const errorStr = 'Test with label "' + test.label + '" does not have any "' + name + '" defined.';
-      throw new Error(errorStr);
+      const errorStr = 'Test does not have any "' + name + '" defined.';
+      throwError(test, errorStr);
     }
 
     test[name] = defaultValue;
@@ -84,8 +91,8 @@ function setDefaultArguments(test)
   }
 
   if (!('value' in test[kArgumentsName])) {
-    const errorStr = 'Test with label "' + test.label + '" does not have a "value" defined.';
-    throw new Error(errorStr);
+    const errorStr = 'Test does not have a "value" defined.';
+    throwError(test, errorStr);
   }
 
   test[kArgumentsName].values.push({ name : test.attribute, value : test[kArgumentsName].value });
@@ -103,23 +110,46 @@ function setDefaultResponse(test)
   const defaultResponseValues = [];
   setDefault(test[kResponseName], kValuesName, defaultResponseValues);
 
-  const defaultResponseConstraints = [];
+  const defaultResponseConstraints = {};
   setDefault(test[kResponseName], kConstraintsName, defaultResponseConstraints);
+
+  const hasResponseValue              = 'value' in test[kResponseName];
+  const hasResponseConstraints        = 'constraints' in test[kResponseName] && Object.keys(test[kResponseName].constraints).length;
+  const hasResponseValueOrConstraints = hasResponseValue || hasResponseConstraints;
+
+  if (test.isCommand && hasResponseValueOrConstraints) {
+    const errorStr = 'Test has a "value" or a "constraints" defined.\n' +
+        '\n' +
+        'Command should explicitly use the response argument name. Example: \n' +
+        '- label: "Send Test Specific Command"\n' +
+        '  command: "testSpecific"\n' +
+        '  response: \n' +
+        '    values: \n' +
+        '      - name: "returnValue"\n' +
+        '      - value: 7\n';
+    throwError(test, errorStr);
+  }
+
+  if (test.isWriteAttribute && hasResponseValueOrConstraints) {
+    const errorStr = 'Attribute write test has a "value" or a "constraints" defined.';
+    throwError(test, errorStr);
+  }
 
   if (!test.isReadAttribute) {
     return;
   }
 
-  if (!('value' in test[kResponseName]) && !('constraints' in test[kResponseName])) {
-    const errorStr = 'Test with label "' + test.label + '" does not have a "value" or a "constraints" defined.';
-    throw new Error(errorStr);
+  if (!hasResponseValueOrConstraints) {
+    console.log(test[kResponseName]);
+    const errorStr = 'Test does not have a "value" or a "constraints" defined.';
+    throwError(test, errorStr);
   }
 
-  if ('value' in test[kResponseName]) {
+  if (hasResponseValue) {
     test[kResponseName].values.push({ name : test.attribute, value : test[kResponseName].value });
   }
 
-  if ('constraints' in test[kResponseName]) {
+  if (hasResponseConstraints) {
     test[kResponseName].values.push({ name : test.attribute, constraints : test[kResponseName].constraints });
   }
 
@@ -155,6 +185,7 @@ function parse(filename)
 
   const defaultConfig = yaml.config || [];
   yaml.tests.forEach(test => {
+    test.filename = filename;
     test.testName = yaml.name;
     setDefaults(test, defaultConfig);
   });
@@ -262,7 +293,7 @@ function chip_tests_item_parameters(options)
 
 function chip_tests_item_response_parameters(options)
 {
-  const responseValues = this.response.values;
+  const responseValues = this.response.values.slice();
 
   const promise = assertCommandOrAttribute(this).then(item => {
     const responseArgs = item.response.arguments;
@@ -270,8 +301,9 @@ function chip_tests_item_response_parameters(options)
     const responses = responseArgs.map(responseArg => {
       responseArg = JSON.parse(JSON.stringify(responseArg));
 
-      const expected = responseValues.find(value => value.name.toLowerCase() == responseArg.name.toLowerCase());
-      if (expected) {
+      const expectedIndex = responseValues.findIndex(value => value.name.toLowerCase() == responseArg.name.toLowerCase());
+      if (expectedIndex != -1) {
+        const expected = responseValues.splice(expectedIndex, 1)[0];
         if ('value' in expected) {
           responseArg.hasExpectedValue = true;
           responseArg.expectedValue    = expected.value;
@@ -282,6 +314,13 @@ function chip_tests_item_response_parameters(options)
           responseArg.expectedConstraints    = expected.constraints;
         }
       }
+
+      const unusedResponseValues = responseValues.filter(response => 'value' in response);
+      unusedResponseValues.forEach(unusedResponseValue => {
+        printErrorAndExit(this,
+            'Missing "' + unusedResponseValue.name + '" in response arguments list:\n\t* '
+                + responseArgs.map(response => response.name).join('\n\t* '));
+      });
 
       return responseArg;
     });

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -3217,25 +3217,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000003_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000004_MoveToHue
+- (void)testSendClusterTest_TC_CC_3_4_000003_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue longest distance command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3262,25 +3244,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000005_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000006_MoveToHue
+- (void)testSendClusterTest_TC_CC_3_4_000004_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3307,25 +3271,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000007_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000008_MoveToHue
+- (void)testSendClusterTest_TC_CC_3_4_000005_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3352,25 +3298,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000009_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000010_MoveHue
+- (void)testSendClusterTest_TC_CC_3_4_000006_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3395,25 +3323,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000011_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000012_MoveHue
+- (void)testSendClusterTest_TC_CC_3_4_000007_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue stop command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3438,25 +3348,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000013_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000014_MoveHue
+- (void)testSendClusterTest_TC_CC_3_4_000008_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3481,25 +3373,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000015_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000016_MoveHue
+- (void)testSendClusterTest_TC_CC_3_4_000009_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue stop command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3524,25 +3398,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000017_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000018_StepHue
+- (void)testSendClusterTest_TC_CC_3_4_000010_StepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step hue up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3569,25 +3425,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000019_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000020_StepHue
+- (void)testSendClusterTest_TC_CC_3_4_000011_StepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step hue down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3614,43 +3452,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000021_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000022_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched before any change"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched before any change Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000023_MoveToSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000012_MoveToSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to saturation command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3675,25 +3477,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000024_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000025_MoveSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000013_MoveSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move saturation up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3718,25 +3502,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000026_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000027_MoveSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000014_MoveSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move saturation down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3761,25 +3527,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000028_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000029_StepSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000015_StepSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step saturation up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3806,25 +3554,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000030_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000031_StepSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000016_StepSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step saturation down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3851,25 +3581,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000032_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000033_MoveToHueAndSaturation
+- (void)testSendClusterTest_TC_CC_3_4_000017_MoveToHueAndSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move To current hue and saturation command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3896,43 +3608,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000034_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current hue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current hue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000035_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_3_4_000036_Off
+- (void)testSendClusterTest_TC_CC_3_4_000018_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -3949,7 +3625,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_3_4_000037_ReadAttribute
+- (void)testSendClusterTest_TC_CC_3_4_000019_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4030,43 +3706,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_5_000003_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current y attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentXWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current y attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000004_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current x attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentYWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current x attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000005_MoveColor
+- (void)testSendClusterTest_TC_CC_5_000003_MoveColor
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move Color command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4091,43 +3731,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_5_000006_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current x attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentXWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current x attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000007_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current y attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentYWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current y attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000008_StopMoveStep
+- (void)testSendClusterTest_TC_CC_5_000004_StopMoveStep
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Stop Move Step command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4148,43 +3752,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_5_000009_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current x attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentXWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current x attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000010_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current y attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentYWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current y attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000011_StepColor
+- (void)testSendClusterTest_TC_CC_5_000005_StepColor
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step Color command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4211,43 +3779,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_5_000012_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current x attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentXWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current x attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000013_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check current y attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentYWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check current y attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_5_000014_Off
+- (void)testSendClusterTest_TC_CC_5_000006_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4264,7 +3796,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_5_000015_ReadAttribute
+- (void)testSendClusterTest_TC_CC_5_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4343,24 +3875,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000003_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000004_MoveColorTemperature
+- (void)testSendClusterTest_TC_CC_6_000003_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move up color temperature command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4389,24 +3904,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000005_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000006_MoveColorTemperature
+- (void)testSendClusterTest_TC_CC_6_000004_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Stop Color Temperature command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4435,24 +3933,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000007_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000008_MoveColorTemperature
+- (void)testSendClusterTest_TC_CC_6_000005_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move down color temperature command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4481,24 +3962,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000009_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000010_StepColorTemperature
+- (void)testSendClusterTest_TC_CC_6_000006_StepColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step up color temperature command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4529,24 +3993,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000011_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000012_StepColorTemperature
+- (void)testSendClusterTest_TC_CC_6_000007_StepColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step down color temperature command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4577,24 +4024,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000013_ReadAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Read current color temprature"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeColorTemperatureWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Read current color temprature Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_6_000014_Off
+- (void)testSendClusterTest_TC_CC_6_000008_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4611,7 +4041,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_6_000015_ReadAttribute
+- (void)testSendClusterTest_TC_CC_6_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4711,25 +4141,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000004_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check EnhancedCurrentHue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeEnhancedCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check EnhancedCurrentHue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_7_000005_EnhancedMoveHue
+- (void)testSendClusterTest_TC_CC_7_000004_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Down command "];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4754,7 +4166,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000006_EnhancedMoveHue
+- (void)testSendClusterTest_TC_CC_7_000005_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Stop command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4779,7 +4191,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000007_EnhancedMoveHue
+- (void)testSendClusterTest_TC_CC_7_000006_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4804,7 +4216,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000008_EnhancedMoveHue
+- (void)testSendClusterTest_TC_CC_7_000007_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Stop command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4829,7 +4241,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000009_EnhancedStepHue
+- (void)testSendClusterTest_TC_CC_7_000008_EnhancedStepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Step Hue Up command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4856,7 +4268,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000010_EnhancedStepHue
+- (void)testSendClusterTest_TC_CC_7_000009_EnhancedStepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Step Hue Down command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4883,7 +4295,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000011_EnhancedMoveToHueAndSaturation
+- (void)testSendClusterTest_TC_CC_7_000010_EnhancedMoveToHueAndSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced move to hue and saturation command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4910,43 +4322,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000012_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check EnhancedCurrentHue attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeEnhancedCurrentHueWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check EnhancedCurrentHue attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_7_000013_ReadAttribute
-{
-    XCTestExpectation * expectation =
-        [self expectationWithDescription:@"Check Saturation attribute value matched the value sent by the last command"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPColorControl * cluster = [[CHIPColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster readAttributeCurrentSaturationWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check Saturation attribute value matched the value sent by the last command Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTest_TC_CC_7_000014_Off
+- (void)testSendClusterTest_TC_CC_7_000011_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -4963,7 +4339,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_CC_7_000015_ReadAttribute
+- (void)testSendClusterTest_TC_CC_7_000012_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);


### PR DESCRIPTION
#### Problems

While writing yaml tests and especially when configuring the expected response, the parser is not strict enough, so it is possible to mistype the name, or to write yaml that is not understood by the parser, or again to not use an expected value for reading attribute instead of using the `disabled` tag that should be used for those cases.

#### Change overview
 * Update `ClusterTestsGeneration.js` so it is stricter about how the yaml is written
 * Update various `yaml` tests to match the expectations
 
#### Testing
This is not affecting the core binaries, only the test suites itself.