### PR TITLE
Remove server/client prefixes before commands/responses iterators ins…

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -106,8 +106,8 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
 }
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_responses}}
-static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
+{{#chip_cluster_responses}}
+static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
 {
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
 
@@ -115,7 +115,7 @@ static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-{{/chip_server_cluster_responses}}
+{{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
@@ -167,7 +167,7 @@ constexpr chip::ClusterId k{{asCamelCased name false}}ClusterId = {{asHex code 4
 {{#chip_client_clusters}}
 {{> cluster_header}}
 
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
 /*
  * Command {{asCamelCased name false}}
  */
@@ -176,13 +176,13 @@ class {{asCamelCased clusterName false}}{{asCamelCased name false}}: public Mode
 public:
     {{asCamelCased clusterName false}}{{asCamelCased name false}}(): ModelCommand("{{asDelimitedCommand name}}")
     {
-        {{#chip_server_cluster_command_arguments}}
+        {{#chip_cluster_command_arguments}}
         {{#if (isString type)}}
         AddArgument("{{asCamelCased label false}}", &m{{asCamelCased label false}});
         {{else}}
         AddArgument("{{asCamelCased label false}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asCamelCased label false}});
         {{/if}}
-        {{/chip_server_cluster_command_arguments}}
+        {{/chip_cluster_command_arguments}}
         ModelCommand::AddArguments();
     }
     ~{{asCamelCased clusterName false}}{{asCamelCased name false}}()
@@ -197,7 +197,7 @@ public:
 
         chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asCamelCased label false}}), strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asCamelCased label false}}), strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_cluster_command_arguments}});
     }
 
 private:
@@ -207,16 +207,16 @@ private:
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     {{/if}}
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    {{#chip_server_cluster_command_arguments}}
+    {{#chip_cluster_command_arguments}}
     {{#if (isCharString type)}}
     char * m{{asCamelCased label false}};
     {{else}}
     {{chipType}} m{{asCamelCased label false}};
     {{/if}}
-    {{/chip_server_cluster_command_arguments}}
+    {{/chip_cluster_command_arguments}}
 };
 
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 
 /*
  * Discover Attributes
@@ -389,9 +389,9 @@ void registerCluster{{asCamelCased name false}}(Commands & commands)
     const char * clusterName = "{{asCamelCased name false}}";
 
     commands_list clusterCommands = {
-        {{#chip_server_cluster_commands}}
+        {{#chip_cluster_commands}}
         make_unique<{{asCamelCased clusterName false}}{{asCamelCased name false}}>(), //
-        {{/chip_server_cluster_commands}}
+        {{/chip_cluster_commands}}
         make_unique<Discover{{asCamelCased name false}}Attributes>(), //
         {{#chip_server_cluster_attributes}}
         make_unique<Read{{asCamelCased parent.name false}}{{asCamelCased name false}}>(), //

--- a/examples/chip-tool/templates/reporting-commands.zapt
+++ b/examples/chip-tool/templates/reporting-commands.zapt
@@ -16,25 +16,25 @@ public:
 
     ~Listen()
     {
-{{#chip_clusters}}
+{{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
     delete onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback;
 {{/if}}
 {{/chip_server_cluster_attributes}}
-{{/chip_clusters}}
+{{/chip_client_clusters}}
     }
     
     void AddReportCallbacks(uint8_t endpointId) override
     {
         chip::app::CHIPDeviceCallbacksMgr & callbacksMgr = chip::app::CHIPDeviceCallbacksMgr::GetInstance();
-{{#chip_clusters}}
+{{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
         callbacksMgr.AddReportCallback(GetExecContext()->storage->GetRemoteNodeId(), endpointId, {{asHex parent.code 4}}, {{asHex code 4}}, onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback->Cancel());
 {{/if}}
 {{/chip_server_cluster_attributes}}
-{{/chip_clusters}}
+{{/chip_client_clusters}}
     }
 
     static void OnDefaultSuccessResponse(void * context)
@@ -73,13 +73,13 @@ public:
     }
 
 private:
-{{#chip_clusters}}
+{{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
     chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
 {{/if}}
 {{/chip_server_cluster_attributes}}
-{{/chip_clusters}}
+{{/chip_client_clusters}}
 };
 
 void registerCommandsReporting(Commands & commands)

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -569,7 +569,8 @@ Clusters.getAttributesByClusterName = function(name)
 //
 // Helpers: Get by Cluster Side
 //
-const kSideFilter = (side, item) => side == (item.clusterSide || item.side);
+const kSideFilter = (side, item) => item.source ? ((item.source == side && item.outgoing) || (item.source != side && item.incoming))
+                                                : item.side == side;
 
 Clusters.getCommandsByClusterSide = function(side)
 {

--- a/src/app/zap-templates/partials/cluster_header.zapt
+++ b/src/app/zap-templates/partials/cluster_header.zapt
@@ -2,9 +2,9 @@
 {{pad (concat "| Cluster " (asCamelCased name false)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
 {{pad "|" 79 '-'}}|
 {{pad "| Commands: " 70 ' '}}{{pad "| " 9 ' '}}|
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
 {{pad (concat "| * " (asCamelCased name false)) 70 ' '}}{{pad (concat "|   " (asHex code 2)) 9 ' '}}|
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 {{pad "|" 79 '-'}}|
 {{pad "| Attributes: " 70 ' '}}{{pad "| " 9 ' '}}|
 {{#chip_server_cluster_attributes}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -838,11 +838,11 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_responses}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj{{#chip_server_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_server_cluster_response_arguments}})
+{{#chip_cluster_responses}}
+bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
-    {{#chip_server_cluster_response_arguments}}
+    {{#chip_cluster_response_arguments}}
     {{#if (isStrEqual label "status")}}
     LogStatus(status);
     {{else if (isOctetString type)}}
@@ -853,11 +853,11 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
     {{else}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: {{asPrintFormat type}}", {{asSymbol label}});
     {{/if}}
-    {{/chip_server_cluster_response_arguments}}
+    {{/chip_cluster_response_arguments}}
 
     GET_CLUSTER_RESPONSE_CALLBACKS("{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback");
 
-    {{#chip_server_cluster_response_arguments}}
+    {{#chip_cluster_response_arguments}}
     {{#if (isStrEqual label "status")}}
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -866,14 +866,14 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
         return true;
     }
     {{/if}}
-    {{/chip_server_cluster_response_arguments}}
+    {{/chip_cluster_response_arguments}}
 
     Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback> * cb = Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}});
+    cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}});
     return true;
 }
 
-{{/chip_server_cluster_responses}}
+{{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -68,9 +68,9 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16
 
 // Cluster Specific Response Callbacks
 {{#chip_client_clusters}}
-{{#chip_server_cluster_responses}}
-typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}});
-{{/chip_server_cluster_responses}}
+{{#chip_cluster_responses}}
+typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}});
+{{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 {{/if}}
 

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -68,8 +68,8 @@ namespace Controller {
 {{#chip_client_clusters}}
 
 // {{asUpperCamelCase name}} Cluster Commands
-{{#chip_server_cluster_commands}}
-CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_server_cluster_command_arguments}})
+{{#chip_cluster_commands}}
+CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}})
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandSender * sender = nullptr;
@@ -89,7 +89,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
 
     SuccessOrExit(err = sender->PrepareCommand(cmdParams));
 
-{{#chip_server_cluster_command_arguments}}
+{{#chip_cluster_command_arguments}}
 {{#first}}
     VerifyOrExit((writer = sender->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 {{/first}}
@@ -97,7 +97,7 @@ CHIP_ERROR {{asUpperCamelCase clusterName}}Cluster::{{asUpperCamelCase name}}(Ca
     SuccessOrExit(err = writer->Put(TLV::ContextTag(argSeqNumber++), {{asLowerCamelCase label}}));
 {{else}}
     // Command takes no arguments.
-{{/chip_server_cluster_command_arguments}}
+{{/chip_cluster_command_arguments}}
 
     SuccessOrExit(err = sender->FinishCommand());
 
@@ -115,9 +115,9 @@ exit:
     return err;
 }
 
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 // {{asUpperCamelCase name}} Cluster Attributes
-CHIP_ERROR {{asUpperCamelCase name}}Cluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
+CHIP_ERROR {{asCamelCased name false}}Cluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     COMMAND_HEADER("Discover{{asUpperCamelCase name}}Attributes", {{asUpperCamelCase name}}::Id);
     buf.Put8(kFrameControlGlobalCommand)

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -20,13 +20,13 @@ class DLL_EXPORT {{asUpperCamelCase name}}Cluster : public ClusterBase
 public:
     {{asUpperCamelCase name}}Cluster() : ClusterBase(app::Clusters::{{asUpperCamelCase name}}::Id) {}
     ~{{asUpperCamelCase name}}Cluster() {}
-    {{#chip_server_cluster_commands}}
+    {{#chip_cluster_commands}}
     {{#first}}
 
     // Cluster Commands
     {{/first}}
-    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_server_cluster_command_arguments}});
-    {{/chip_server_cluster_commands}}
+    CHIP_ERROR {{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback{{#chip_cluster_command_arguments}}, {{chipType}} {{asLowerCamelCase label}}{{/chip_cluster_command_arguments}});
+    {{/chip_cluster_commands}}
 
     // Cluster Attributes
     CHIP_ERROR DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
@@ -44,12 +44,12 @@ public:
     CHIP_ERROR ReportAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onReportCallback);
     {{/if}}
     {{/chip_server_cluster_attributes}}
-    {{#chip_server_cluster_commands}}
+    {{#chip_cluster_commands}}
     {{#first}}
 
 private:
     {{/first}}
-    {{/chip_server_cluster_commands}}
+    {{/chip_cluster_commands}}
 };
 
 {{/chip_client_clusters}}

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -5532,7 +5532,7 @@
               "mfgCode": null,
               "source": "client",
               "incoming": 0,
-              "outgoing": 0
+              "outgoing": 1
             }
           ],
           "attributes": [

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -289,7 +289,7 @@ class CHIP{{chipCallback.name}}AttributeCallback : public Callback::Callback<{{c
 {{/chip_server_global_responses}}
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_responses}}
+{{#chip_cluster_responses}}
 class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback : public Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>
 {
     public:
@@ -316,7 +316,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             env->DeleteGlobalRef(javaCallbackRef);
         };
 
-        static void CallbackFn(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
+        static void CallbackFn(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
         {
             StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -324,7 +324,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             jobject javaCallbackRef;
             jmethodID javaMethod;
             CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback * cppCallback = nullptr;
-            {{#chip_server_cluster_response_arguments}}
+            {{#chip_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
@@ -333,7 +333,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             UtfString {{asSymbol label}}Str(env, "");
             {{/if}}
             {{/unless}}
-            {{/chip_server_cluster_response_arguments}}
+            {{/chip_cluster_response_arguments}}
 
             VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -343,10 +343,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type}}{{/if}}{{/unless}}{{/chip_server_cluster_response_arguments}})V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type}}{{/if}}{{/unless}}{{/chip_cluster_response_arguments}})V", &javaMethod);
             SuccessOrExit(err);
 
-            {{#chip_server_cluster_response_arguments}}
+            {{#chip_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             {{asSymbol label}}Arr = env->NewByteArray({{asSymbol label}}.size());
@@ -356,10 +356,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
             {{/if}}
             {{/unless}}
-            {{/chip_server_cluster_response_arguments}}
+            {{/chip_cluster_response_arguments}}
 
             env->CallVoidMethod(javaCallbackRef, javaMethod
-                {{#chip_server_cluster_response_arguments}}
+                {{#chip_cluster_response_arguments}}
                 {{#unless (isStrEqual label "status")}}
                 {{#if isArray}}
                 // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -372,16 +372,16 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
                 , static_cast<{{asJniBasicTypeForZclType type}}>({{asSymbol label}})
                 {{/if}}
                 {{/unless}}
-                {{/chip_server_cluster_response_arguments}}
+                {{/chip_cluster_response_arguments}}
             );
 
-            {{#chip_server_cluster_response_arguments}}
+            {{#chip_cluster_response_arguments}}
             {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             env->DeleteLocalRef({{asSymbol label}}Arr);
             {{/if}}
             {{/unless}}
-            {{/chip_server_cluster_response_arguments}}
+            {{/chip_cluster_response_arguments}}
 
         exit:
             if (err != CHIP_NO_ERROR) {
@@ -397,7 +397,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
         jobject javaCallbackRef;
 };
 
-{{/chip_server_cluster_responses}}
+{{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
@@ -528,9 +528,9 @@ JNI_METHOD(jlong, {{asCamelCased name false}}Cluster, initWithDevice)(JNIEnv * e
     return reinterpret_cast<jlong>(cppCluster);
 }
 
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_server_cluster_command_arguments}}{{asJniBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}})
+JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_cluster_command_arguments}}{{asJniBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}})
 {{else}}
 JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {{/if}}
@@ -539,13 +539,13 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(J
     CHIP_ERROR err = CHIP_NO_ERROR;
     {{asCamelCased ../name false}}Cluster * cppCluster;
     
-    {{#chip_server_cluster_command_arguments}}
+    {{#chip_cluster_command_arguments}}
     {{#if (isOctetString type)}}
     JniByteArray {{asCamelCased label}}Arr(env, {{asCamelCased label}});
     {{else if (isCharString type)}}
     JniUtfString {{asCamelCased label}}Str(env, {{asCamelCased label}});
     {{/if}}
-    {{/chip_server_cluster_command_arguments}}
+    {{/chip_cluster_command_arguments}}
     {{#if hasSpecificResponse}}
     CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback * onSuccess;
     {{else}}
@@ -565,7 +565,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(J
     onFailure = new CHIPDefaultFailureCallback(callback);
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asCamelCased label}}Arr.data(), {{asCamelCased label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}, strlen({{asCamelCased label}}Str.c_str())){{else}}{{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}});
+    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asCamelCased label}}Arr.data(), {{asCamelCased label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}, strlen({{asCamelCased label}}Str.c_str())){{else}}{{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}});
     SuccessOrExit(err);
 
 exit: 
@@ -590,7 +590,7 @@ exit:
         env->CallVoidMethod(callback, method, exception);
     }
 }
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}
 
 JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, read{{asCamelCased name false}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -69,33 +69,33 @@ public class ChipClusters {
 
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
-  {{#chip_server_cluster_commands}}
+  {{#chip_cluster_commands}}
 
   {{#if (zcl_command_arguments_count this.id)}}
-    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}}) {
+    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}}) {
   {{else}}
     public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback) {
   {{/if}}
   {{#if (zcl_command_arguments_count this.id)}}
-      {{asCamelCased name}}(chipClusterPtr, callback, {{#chip_server_cluster_command_arguments}}{{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}});
+      {{asCamelCased name}}(chipClusterPtr, callback, {{#chip_cluster_command_arguments}}{{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
   {{else}}
       {{asCamelCased name}}(chipClusterPtr, callback);
   {{/if}}    
     }
 
-  {{/chip_server_cluster_commands}}
-  {{#chip_server_cluster_commands}}
+  {{/chip_cluster_commands}}
+  {{#chip_cluster_commands}}
   {{#if (zcl_command_arguments_count this.id)}}
-    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_server_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_server_cluster_command_arguments}});
+    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
   {{else}}
     private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback);
   {{/if}}
 
-  {{/chip_server_cluster_commands}}
-  {{#chip_server_cluster_responses}}
+  {{/chip_cluster_commands}}
+  {{#chip_cluster_responses}}
     public interface {{asCamelCased name false}}Callback {
       void onSuccess(
-{{#chip_server_cluster_response_arguments}}
+{{#chip_cluster_response_arguments}}
 {{#unless (isStrEqual label "status")}}
 {{#if isArray}}
       // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -108,13 +108,13 @@ public class ChipClusters {
       {{omitCommaForFirstNonStatusCommand parent.id index}}{{asJavaBasicTypeForZclType type false}} {{asSymbol label}}
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_response_arguments}}
+{{/chip_cluster_response_arguments}}
       );
       
       void onError(Exception error);
     }
 
-  {{/chip_server_cluster_responses}}
+  {{/chip_cluster_responses}}
 
   {{#chip_server_cluster_attributes}}
   {{#if isList}}

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -113,16 +113,15 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 {{#chip_client_clusters}}
 // Cluster {{asCamelCased name false}}
 
-{{#chip_server_cluster_commands}}
-chip::ChipError::StorageType chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_server_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asCamelCased label}}, uint32_t {{asCamelCased label}}_Len{{else}}{{chipType}} {{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}})
+{{#chip_cluster_commands}}
+chip::ChipError::StorageType chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asCamelCased label}}, uint32_t {{asCamelCased label}}_Len{{else}}{{chipType}} {{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}})
 {
     VerifyOrReturnError(device != nullptr, chip::ChipError::AsInteger(CHIP_ERROR_INVALID_ARGUMENT));
     chip::Controller::{{asCamelCased clusterName false}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return chip::ChipError::AsInteger(cluster.{{asCamelCased name false}}(nullptr, nullptr{{#chip_server_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asCamelCased label}}, {{asCamelCased label}}_Len){{else}}{{asCamelCased label}}{{/if}}
-    {{/chip_server_cluster_command_arguments}}));
+    return chip::ChipError::AsInteger(cluster.{{asCamelCased name false}}(nullptr, nullptr{{#chip_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asCamelCased label}}, {{asCamelCased label}}_Len){{else}}{{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}}));
 }
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
 chip::ChipError::StorageType chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -23,13 +23,13 @@ class ChipClusters:
         return {
 {{#chip_client_clusters}}
             "{{asCamelCased name false}}": {
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
                 "{{asCamelCased name false}}": {
-{{#chip_server_cluster_command_arguments}}
+{{#chip_cluster_command_arguments}}
                     "{{asCamelCased label}}": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
-{{/chip_server_cluster_command_arguments}}
+{{/chip_cluster_command_arguments}}
                 },
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
             },
 {{/chip_client_clusters}}
         }
@@ -89,17 +89,17 @@ class ChipClusters:
     # Cluster commands
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_commands}}
-    def Cluster{{asCamelCased clusterName false}}_Command{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}: {{asPythonType chipType}}{{/chip_server_cluster_command_arguments}}):
-{{#chip_server_cluster_command_arguments}}
+{{#chip_cluster_commands}}
+    def Cluster{{asCamelCased clusterName false}}_Command{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments}}, {{asCamelCased label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments}}):
+{{#chip_cluster_command_arguments}}
 {{#if (isCharString type)}}
         {{asCamelCased label}} = {{asCamelCased label}}.encode("utf-8") + b'\x00'
 {{/if}}
-{{/chip_server_cluster_command_arguments}}
+{{/chip_cluster_command_arguments}}
         return self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(
-                device, ZCLendpoint, ZCLgroupid{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}{{#if (isString type)}}, len({{asCamelCased label}}){{/if}}{{/chip_server_cluster_command_arguments}}
+                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments}}, {{asCamelCased label}}{{#if (isString type)}}, len({{asCamelCased label}}){{/if}}{{/chip_cluster_command_arguments}}
         )
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 {{/chip_client_clusters}}
 
     # Cluster attributes
@@ -133,11 +133,11 @@ class ChipClusters:
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
 {{#chip_client_clusters}}
         # Cluster {{asCamelCased name false}}
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
         # Cluster {{asCamelCased clusterName false}} Command {{asCamelCased name false}}
-        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_server_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_server_cluster_command_arguments}}]
+        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments}}]
         self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}
         # Cluster {{asCamelCased parent.name false}} ReadAttribute {{asCamelCased name false}}
         self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -417,7 +417,7 @@ private:
 };
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_responses}}
+{{#chip_cluster_responses}}
 class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge : public Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>
 {
 public:
@@ -425,14 +425,14 @@ public:
 
     ~CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge() {};
 
-    static void CallbackFn(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}})
+    static void CallbackFn(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
     {
         CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge * callback = reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge *>(context);
         if (callback && callback->mQueue)
         {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @{
-                  {{#chip_server_cluster_response_arguments}}
+                  {{#chip_cluster_response_arguments}}
                   {{#unless (isStrEqual label "status")}}
                   {{#if isArray}}
                   // {{asSymbol label}}: {{asUnderlyingZclType type}}
@@ -445,7 +445,7 @@ public:
                   @"{{asSymbol label}}": [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
                   {{/if}}
                   {{/unless}}
-                  {{/chip_server_cluster_response_arguments}}
+                  {{/chip_cluster_response_arguments}}
                 });
                 callback->Cancel();
                 delete callback;
@@ -458,7 +458,7 @@ private:
     dispatch_queue_t mQueue;
 };
 
-{{/chip_server_cluster_responses}}
+{{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
@@ -582,9 +582,9 @@ private:
     return &_cppCluster;
 }
 
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
+- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler
 {{/if}}
@@ -608,7 +608,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asLowerCamelCase label}}.bytes, {{asLowerCamelCase label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asLowerCamelCase label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asLowerCamelCase label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        err = self.cppCluster.{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*){{asLowerCamelCase label}}.bytes, {{asLowerCamelCase label}}.length){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*)[{{asLowerCamelCase label}} dataUsingEncoding:NSUTF8StringEncoding].bytes, [{{asLowerCamelCase label}} lengthOfBytesUsingEncoding:NSUTF8StringEncoding]){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -617,7 +617,7 @@ private:
         responseHandler([CHIPError errorForCHIPErrorCode:err], nil);
     }
 }
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
 - (void)readAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -33,13 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIP{{asUpperCamelCase name}} : CHIPCluster
 
-{{#chip_server_cluster_commands}}
+{{#chip_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-- (void){{asLowerCamelCase name}}:{{#chip_server_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_server_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
+- (void){{asLowerCamelCase name}}:{{#chip_cluster_command_arguments}}{{#not_first}}{{asLowerCamelCase label}}:{{/not_first}}({{asObjectiveCBasicType type}}){{asLowerCamelCase label}} {{/chip_cluster_command_arguments}}responseHandler:(ResponseHandler)responseHandler;
 {{else}}
 - (void){{asLowerCamelCase name}}:(ResponseHandler)responseHandler;
 {{/if}}
-{{/chip_server_cluster_commands}}
+{{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
 - (void)readAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler;


### PR DESCRIPTION
…ide chip_server_clusters/chip_client_clusters blocks

#### Problem

The current usage of `chip_server_cluster_responses`, `chip_server_cluster_commands`,  `chip_server_cluster_response_arguments` and `chip_server_cluster_command_arguments` is misleading since there are mostly intended to be used `chip_client_clusters` block.

#### Change overview
 * Remove the `client`/`server` prefix from those helpers and get them to retrieve the cluster side from the current context.
 * fix a missing `GetRelayStatusLog` into `src/controller/data_model/controller-clusters.zap` file that what showing as a difference from the changes.
  
#### Testing
 * I have tested by generating the code with the new code. There is no source file change, so the final binary will not changed.
