### PR TITLE
readme update to correct the func of pressing SW2, for lighting and lock app on K32W061

### DIFF
--- a/examples/lighting-app/k32w/README.md
+++ b/examples/lighting-app/k32w/README.md
@@ -124,12 +124,12 @@ states are depicted:
 **LED D3** shows the state of the simulated light bulb. When the LED is lit the
 light bulb is on; when not lit, the light bulb is off.
 
-**Button SW2** can be used to reset the device to a default state. Pressing and
-holding Button SW2 for 6 seconds initiates a factory reset. After an initial
-period of 3 seconds, LED2 D2 and D3 will flash in unison to signal the pending
-reset. Holding the button past 6 seconds will cause the device to reset its
-persistent configuration and initiate a reboot. The reset action can be
-cancelled by releasing the button at any point before the 6 second limit.
+**Button SW2** can be used to reset the device to a default state. A short Press
+Button SW2 initiates a factory reset. After an initial period of 3 seconds, LED2
+D2 and D3 will flash in unison to signal the pending reset. After 6 seconds will
+cause the device to reset its persistent configuration and initiate a reboot.
+The reset action can be cancelled by press SW2 button at any point before the 6
+second limit.
 
 **Button SW3** can be used to change the state of the simulated light bulb. This
 can be used to mimic a user manually operating a switch. The button behaves as a
@@ -139,7 +139,7 @@ toggle, swapping the state every time it is pressed.
 a Border Router. Default parameters for a Thread network are hard-coded and are
 being used if this button is pressed.
 
-The remaining two LEDs (D1/D2) and button (SW1) are unused.
+The remaining two LEDs (D1/D4) and button (SW1) are unused.
 
 Directly on the development board, **Button USERINTERFACE** can be used for
 enabling Bluetooth LE advertising for a predefined period of time. Also, pushing

--- a/examples/lock-app/k32w/README.md
+++ b/examples/lock-app/k32w/README.md
@@ -127,12 +127,12 @@ bolt is extended (i.e. door locked); when not lit, the bolt is retracted (door
 unlocked). The LED will flash whenever the simulated bolt is in motion from one
 position to another.
 
-**Button SW2** can be used to reset the device to a default state. Pressing and
-holding Button SW2 for 6 seconds initiates a factory reset. After an initial
-period of 3 seconds, LED2 D2 and D3 will flash in unison to signal the pending
-reset. Holding the button past 6 seconds will cause the device to reset its
-persistent configuration and initiate a reboot. The reset action can be
-cancelled by releasing the button at any point before the 6 second limit.
+**Button SW2** can be used to reset the device to a default state. A short Press
+Button SW2 initiates a factory reset. After an initial period of 3 seconds, LED2
+D2 and D3 will flash in unison to signal the pending reset. After 6 seconds will
+cause the device to reset its persistent configuration and initiate a reboot.
+The reset action can be cancelled by press SW2 button at any point before the 6
+second limit.
 
 **Button SW3** can be used to change the state of the simulated bolt. This can
 be used to mimic a user manually operating the lock. The button behaves as a
@@ -142,7 +142,7 @@ toggle, swapping the state every time it is pressed.
 a Border Router. Default parameters for a Thread network are hard-coded and are
 being used if this button is pressed.
 
-The remaining two LEDs (D1/D2) and button (SW1) are unused.
+The remaining two LEDs (D1/D4) and button (SW1) are unused.
 
 Directly on the development board, **Button USERINTERFACE** can be used for
 enabling Bluetooth LE advertising for a predefined period of time. Also, pushing


### PR DESCRIPTION
Signed-off-by: Kenney Qu <kenney.qu@nxp.com>

#### Problem
* The description for the function of SW2 on OM15082 is incorrect

#### Change overview
Update the description for SW2 function on K32W061, that is about how to perform a factory reset

#### Testing
It's a doc update, checked the format
