### PR TITLE
[K32W] Sync button push with cluster state

### DIFF
--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -100,6 +100,7 @@ CHIP_ERROR AppTask::Init()
 
     sLightLED.Init(LIGHT_STATE_LED);
     sLightLED.Set(LightingMgr().IsTurnedOff());
+    UpdateClusterState();
 
     /* intialize the Keyboard and button press calback */
     KBD_Init(KBD_Callback);
@@ -565,6 +566,11 @@ void AppTask::ActionInitiated(LightingManager::Action_t aAction, int32_t aActor)
         K32W_LOG("Turn off Action has been initiated")
     }
 
+    if (aActor == AppEvent::kEventType_Button)
+    {
+        sAppTask.mSyncClusterToButtonAction = true;
+    }
+
     sAppTask.mFunction = kFunctionTurnOnTurnOff;
 }
 
@@ -581,6 +587,12 @@ void AppTask::ActionCompleted(LightingManager::Action_t aAction)
     {
         K32W_LOG("Turn off action has been completed")
         sLightLED.Set(false);
+    }
+
+    if (sAppTask.mSyncClusterToButtonAction)
+    {
+        sAppTask.UpdateClusterState();
+        sAppTask.mSyncClusterToButtonAction = false;
     }
 
     sAppTask.mFunction = kFunction_NoneSelected;

--- a/examples/lighting-app/k32w/main/include/AppTask.h
+++ b/examples/lighting-app/k32w/main/include/AppTask.h
@@ -89,6 +89,7 @@ private:
 
     Function_t mFunction;
     bool mResetTimerActive;
+    bool mSyncClusterToButtonAction;
 
     static AppTask sAppTask;
 };

--- a/examples/lighting-app/k32w/main/include/AppTask.h
+++ b/examples/lighting-app/k32w/main/include/AppTask.h
@@ -87,9 +87,9 @@ private:
         kFunction_Invalid
     } Function;
 
-    Function_t mFunction;
-    bool mResetTimerActive;
-    bool mSyncClusterToButtonAction;
+    Function_t mFunction = kFunction_NoneSelected;
+    bool mResetTimerActive = false;
+    bool mSyncClusterToButtonAction = false;
 
     static AppTask sAppTask;
 };

--- a/examples/lighting-app/k32w/main/include/AppTask.h
+++ b/examples/lighting-app/k32w/main/include/AppTask.h
@@ -87,8 +87,8 @@ private:
         kFunction_Invalid
     } Function;
 
-    Function_t mFunction = kFunction_NoneSelected;
-    bool mResetTimerActive = false;
+    Function_t mFunction            = kFunction_NoneSelected;
+    bool mResetTimerActive          = false;
     bool mSyncClusterToButtonAction = false;
 
     static AppTask sAppTask;

--- a/examples/lock-app/k32w/main/AppTask.cpp
+++ b/examples/lock-app/k32w/main/AppTask.cpp
@@ -97,6 +97,7 @@ CHIP_ERROR AppTask::Init()
 
     sLockLED.Init(LOCK_STATE_LED);
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
+    UpdateClusterState();
 
     /* intialize the Keyboard and button press calback */
     KBD_Init(KBD_Callback);
@@ -570,6 +571,11 @@ void AppTask::ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor)
         K32W_LOG("Unlock Action has been initiated")
     }
 
+    if (aActor == AppEvent::kEventType_Button)
+    {
+        sAppTask.mSyncClusterToButtonAction = true;
+    }
+
     sAppTask.mFunction = kFunctionLockUnlock;
     sLockLED.Blink(50, 50);
 }
@@ -588,6 +594,12 @@ void AppTask::ActionCompleted(BoltLockManager::Action_t aAction)
     {
         K32W_LOG("Unlock Action has been completed")
         sLockLED.Set(false);
+    }
+
+    if (sAppTask.mSyncClusterToButtonAction)
+    {
+        sAppTask.UpdateClusterState();
+        sAppTask.mSyncClusterToButtonAction = false;
     }
 
     sAppTask.mFunction = kFunction_NoneSelected;

--- a/examples/lock-app/k32w/main/include/AppTask.h
+++ b/examples/lock-app/k32w/main/include/AppTask.h
@@ -79,9 +79,9 @@ private:
         kFunction_Invalid
     } Function;
 
-    Function_t mFunction;
-    bool mResetTimerActive;
-    bool mSyncClusterToButtonAction;
+    Function_t mFunction = kFunction_NoneSelected;
+    bool mResetTimerActive = false;
+    bool mSyncClusterToButtonAction = false;
 
     static AppTask sAppTask;
 };

--- a/examples/lock-app/k32w/main/include/AppTask.h
+++ b/examples/lock-app/k32w/main/include/AppTask.h
@@ -81,6 +81,7 @@ private:
 
     Function_t mFunction;
     bool mResetTimerActive;
+    bool mSyncClusterToButtonAction;
 
     static AppTask sAppTask;
 };

--- a/examples/lock-app/k32w/main/include/AppTask.h
+++ b/examples/lock-app/k32w/main/include/AppTask.h
@@ -79,8 +79,8 @@ private:
         kFunction_Invalid
     } Function;
 
-    Function_t mFunction = kFunction_NoneSelected;
-    bool mResetTimerActive = false;
+    Function_t mFunction            = kFunction_NoneSelected;
+    bool mResetTimerActive          = false;
     bool mSyncClusterToButtonAction = false;
 
     static AppTask sAppTask;


### PR DESCRIPTION
#### Problem
If buttons are used for locking/unlocking the elock or for
turn off/down of the lighting then this change needs to be
propagated to the cluster state.

#### Change overview
Sync the cluster state:

- for the elock: each time the lock/unlock button is pushed;
- for the lighting app: each time the turn on/turn off button is pushed.

#### Testing
Manually tested.
