### PR TITLE
Fix the commissiong mode of "commissioning for on-network" usecases

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -69,6 +69,9 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
             // connectivity. MDNS still wants to refresh its listening interfaces to include the
             // newly selected address.
             chip::app::Mdns::StartServer();
+#ifdef RENDEZVOUS_WAIT_FOR_COMMISSIONING_COMPLETE
+            chip::app::Mdns::AdvertiseCommissionableNode();
+#endif
         }
         break;
     }

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -920,6 +920,7 @@ bool GenericConfigurationManagerImpl<ImplClass>::_IsFullyProvisioned()
 #if CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
         (!UseManufacturerCredentialsAsOperational() && _OperationalDeviceCredentialsProvisioned()) &&
 #endif
+        (mFlags.Has(Flags::kIsServiceProvisioned) && mFlags.Has(Flags::kOperationalDeviceCredentialsProvisioned)) &&
         // TODO: Add checks regarding fabric membership (IsMemberOfFabric()) and account pairing (IsPairedToAccount()),
         // when functionalities will be implemented.
         true;


### PR DESCRIPTION
* Enabled Commissionable Mode of the device for On-Network Commissioning 

#### Change overview
* Advertise Commissionable Node after connecting to AP 
* Check kIsServiceProvisioned, kOperationalDeviceCredentialsProvisioned flags, to check if device is fully provisioned

#### Testing
How was this tested? (at least one bullet point required)
* Tested output of chip-device-ctrl with all-clusters-app example
