### PR TITLE
Fix name prefix for host builds

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -33,7 +33,7 @@ class HostApp(Enum):
 
   def BinaryName(self):
     if self == HostApp.ALL_CLUSTERS:
-      return 'all-clusters-app'
+      return 'chip-all-clusters-app'
     elif self == HostApp.CHIP_TOOL:
       return 'chip-tool'
     else:


### PR DESCRIPTION
#### Problem
build-examples.py fails to copy host output binaries because the name of the app is `chip-all-clusters-app` (code is missing the `chip-` prefix)

#### Change overview
Add the prefix

#### Testing

Manual test with `--copy-artifacts-to` argument passed in