### PR TITLE
Cleanup prefix chip:: from all cluster implementations

### DIFF
--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -27,28 +27,29 @@
 #include <app/util/af.h>
 #include <string>
 
-bool accountLoginClusterIsUserLoggedIn(std::string requestTempAccountIdentifier, std::string requestSetupPin);
-std::string accountLoginClusterGetSetupPin(std::string requestTempAccountIdentifier, chip::EndpointId endpoint);
+using namespace chip;
 
-void sendResponse(chip::app::CommandHandler * command, const char * responseSetupPin)
+bool accountLoginClusterIsUserLoggedIn(std::string requestTempAccountIdentifier, std::string requestSetupPin);
+std::string accountLoginClusterGetSetupPin(std::string requestTempAccountIdentifier, EndpointId endpoint);
+
+void sendResponse(app::CommandHandler * command, const char * responseSetupPin)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_ACCOUNT_LOGIN_CLUSTER_ID,
-                                               ZCL_GET_SETUP_PIN_RESPONSE_COMMAND_ID,
-                                               (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_ACCOUNT_LOGIN_CLUSTER_ID,
+                                         ZCL_GET_SETUP_PIN_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->PutString(chip::TLV::ContextTag(0), responseSetupPin));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(0), responseSetupPin));
     SuccessOrExit(err = command->FinishCommand());
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to encode GetSetupPIN command. Error:%s", chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to encode GetSetupPIN command. Error:%s", ErrorStr(err));
     }
 }
 
-bool emberAfAccountLoginClusterGetSetupPINCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
+bool emberAfAccountLoginClusterGetSetupPINCallback(EndpointId endpoint, app::CommandHandler * command,
                                                    uint8_t * tempAccountIdentifier)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
@@ -58,8 +59,8 @@ bool emberAfAccountLoginClusterGetSetupPINCallback(chip::EndpointId endpoint, ch
     return true;
 }
 
-bool emberAfAccountLoginClusterLoginCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                             uint8_t * tempAccountIdentifier, uint8_t * tempSetupPin)
+bool emberAfAccountLoginClusterLoginCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * tempAccountIdentifier,
+                                             uint8_t * tempSetupPin)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string tempAccountIdentifierString(reinterpret_cast<char *>(tempAccountIdentifier));

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -32,8 +32,7 @@ using namespace chip;
 // Specifications section 5.4.2.3. Announcement Duration
 constexpr uint32_t kMaxCommissionioningTimeoutSeconds = 15 * 60;
 
-bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(chip::EndpointId endpoint,
-                                                                             app::CommandHandler * commandObj,
+bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                                              uint16_t commissioningTimeout, ByteSpan pakeVerifier,
                                                                              uint16_t discriminator, uint32_t iterations,
                                                                              ByteSpan salt, uint16_t passcodeID)
@@ -70,7 +69,7 @@ exit:
     return true;
 }
 
-bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallback(chip::EndpointId endpoint,
+bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallback(EndpointId endpoint,
                                                                                   app::CommandHandler * commandObj,
                                                                                   uint16_t commissioningTimeout)
 {
@@ -91,8 +90,7 @@ exit:
     return true;
 }
 
-bool emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(chip::EndpointId endpoint,
-                                                                         app::CommandHandler * commandObj)
+bool emberAfAdministratorCommissioningClusterRevokeCommissioningCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     ChipLogProgress(Zcl, "Received command to close commissioning window");
     ClosePairingWindow();

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -27,9 +27,11 @@
 #include <app/util/af.h>
 #include <string>
 
-bool applicationBasicClusterChangeApplicationStatus(EmberAfApplicationBasicStatus status, chip::EndpointId endpoint);
+using namespace chip;
 
-bool emberAfApplicationBasicClusterChangeStatusCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool applicationBasicClusterChangeApplicationStatus(EmberAfApplicationBasicStatus status, EndpointId endpoint);
+
+bool emberAfApplicationBasicClusterChangeStatusCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                         uint8_t newApplicationStatus)
 {
     bool success = applicationBasicClusterChangeApplicationStatus(static_cast<EmberAfApplicationBasicStatus>(newApplicationStatus),

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -30,32 +30,32 @@
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 ApplicationLauncherResponse applicationLauncherClusterLaunchApp(EmberAfApplicationLauncherApp application, std::string data);
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t *, uint8_t *)
+bool emberAfApplicationLauncherClusterLaunchAppCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t *, uint8_t *)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 
-void sendResponse(chip::app::CommandHandler * command, ApplicationLauncherResponse response)
+void sendResponse(app::CommandHandler * command, ApplicationLauncherResponse response)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_APPLICATION_LAUNCHER_CLUSTER_ID,
-                                               ZCL_LAUNCH_APP_RESPONSE_COMMAND_ID,
-                                               (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_APPLICATION_LAUNCHER_CLUSTER_ID,
+                                         ZCL_LAUNCH_APP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(0), response.status));
-    SuccessOrExit(err = writer->PutString(chip::TLV::ContextTag(1), reinterpret_cast<const char *>(response.data)));
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(0), response.status));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(1), reinterpret_cast<const char *>(response.data)));
     SuccessOrExit(err = command->FinishCommand());
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to send LaunchAppResponse. Error:%s", chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to send LaunchAppResponse. Error:%s", ErrorStr(err));
     }
 }
 
@@ -67,9 +67,8 @@ EmberAfApplicationLauncherApp getApplicationFromCommand(uint16_t catalogVendorId
     return application;
 }
 
-bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                        uint8_t * requestData, uint16_t requestApplicationCatalogVendorId,
-                                                        uint8_t * requestApplicationId)
+bool emberAfApplicationLauncherClusterLaunchAppCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * requestData,
+                                                        uint16_t requestApplicationCatalogVendorId, uint8_t * requestApplicationId)
 {
     EmberAfApplicationLauncherApp application = getApplicationFromCommand(requestApplicationCatalogVendorId, requestApplicationId);
     // TODO: Char is not null terminated, verify this code once #7963 gets merged.

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -25,10 +25,12 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 bool audioOutputClusterSelectOutput(uint8_t index);
 bool audioOutputClusterRenameOutput(uint8_t index, uint8_t * name);
 
-bool emberAfAudioOutputClusterRenameOutputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t index,
+bool emberAfAudioOutputClusterRenameOutputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t index,
                                                    uint8_t * name)
 {
     bool success         = audioOutputClusterRenameOutput(index, name);
@@ -37,7 +39,7 @@ bool emberAfAudioOutputClusterRenameOutputCallback(chip::EndpointId endpoint, ch
     return true;
 }
 
-bool emberAfAudioOutputClusterSelectOutputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t index)
+bool emberAfAudioOutputClusterSelectOutputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t index)
 {
     bool success         = audioOutputClusterSelectOutput(index);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/barrier-control-server/barrier-control-server.cpp
+++ b/src/app/clusters/barrier-control-server/barrier-control-server.cpp
@@ -296,8 +296,8 @@ static void sendDefaultResponse(EmberAfStatus status)
     }
 }
 
-bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::EndpointId aEndpoint,
-                                                                   chip::app::CommandHandler * commandObj, uint8_t percentOpen)
+bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(EndpointId aEndpoint, app::CommandHandler * commandObj,
+                                                                   uint8_t percentOpen)
 {
     EndpointId endpoint  = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
@@ -339,7 +339,7 @@ bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::Endpoin
     return true;
 }
 
-bool emberAfBarrierControlClusterBarrierControlStopCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj)
+bool emberAfBarrierControlClusterBarrierControlStopCallback(EndpointId aEndpoint, app::CommandHandler * commandObj)
 {
     EndpointId endpoint = emberAfCurrentCommand()->apsFrame->destinationEndpoint;
     emberAfDeactivateServerTick(endpoint, BarrierControl::Id);

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -44,7 +44,7 @@ uint8_t * MakeZclCharString(uint8_t (&zclString)[BufferLength], char (&cString)[
 }
 } // namespace
 
-void emberAfBasicClusterServerInitCallback(chip::EndpointId endpoint)
+void emberAfBasicClusterServerInitCallback(EndpointId endpoint)
 {
     uint16_t vendorId;
     uint16_t productId;

--- a/src/app/clusters/binary-input-server/binary-input-server.cpp
+++ b/src/app/clusters/binary-input-server/binary-input-server.cpp
@@ -24,32 +24,33 @@
 #include <app/common/gen/cluster-id.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
-
 #include <support/logging/CHIPLogging.h>
+
+using namespace chip;
 
 #ifndef emberAfBinaryInputBasicClusterPrintln
 #define emberAfBinaryInputBasicClusterPrintln(...) ChipLogProgress(Zcl, __VA_ARGS__);
 #endif
 
-EmberAfStatus emberAfBinaryInputBasicClusterGetPresentValue(chip::EndpointId endpoint, bool * presentValue)
+EmberAfStatus emberAfBinaryInputBasicClusterGetPresentValue(EndpointId endpoint, bool * presentValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_PRESENT_VALUE_ATTRIBUTE_ID,
                                       (uint8_t *) presentValue, sizeof(uint8_t));
 }
 
-EmberAfStatus emberAfBinaryInputBasicClusterGetOutOfService(chip::EndpointId endpoint, bool * isOutOfService)
+EmberAfStatus emberAfBinaryInputBasicClusterGetOutOfService(EndpointId endpoint, bool * isOutOfService)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_OUT_OF_SERVICE_ATTRIBUTE_ID,
                                       (uint8_t *) isOutOfService, sizeof(uint8_t));
 }
 
-EmberAfStatus emberAfBinaryInputBasicClusterSetPresentValueCallback(chip::EndpointId endpoint, bool presentValue)
+EmberAfStatus emberAfBinaryInputBasicClusterSetPresentValueCallback(EndpointId endpoint, bool presentValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_PRESENT_VALUE_ATTRIBUTE_ID,
                                        (uint8_t *) &presentValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
 
-EmberAfStatus emberAfBinaryInputBasicClusterSetOutOfServiceCallback(chip::EndpointId endpoint, bool isOutOfService)
+EmberAfStatus emberAfBinaryInputBasicClusterSetOutOfServiceCallback(EndpointId endpoint, bool isOutOfService)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_BINARY_INPUT_BASIC_CLUSTER_ID, ZCL_OUT_OF_SERVICE_ATTRIBUTE_ID,
                                        (uint8_t *) &isOutOfService, ZCL_BOOLEAN_ATTRIBUTE_TYPE);

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -88,8 +88,8 @@ EmberStatus getUnusedBindingIndex(uint8_t * bindingIndex)
     return EMBER_NOT_FOUND;
 }
 
-bool emberAfBindingClusterBindCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, NodeId nodeId,
-                                       GroupId groupId, EndpointId endpointId, ClusterId clusterId)
+bool emberAfBindingClusterBindCallback(EndpointId endpoint, app::CommandHandler * commandObj, NodeId nodeId, GroupId groupId,
+                                       EndpointId endpointId, ClusterId clusterId)
 {
     ChipLogDetail(Zcl, "RX: BindCallback");
 
@@ -118,8 +118,8 @@ bool emberAfBindingClusterBindCallback(chip::EndpointId endpoint, chip::app::Com
     return true;
 }
 
-bool emberAfBindingClusterUnbindCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, NodeId nodeId,
-                                         GroupId groupId, EndpointId endpointId, ClusterId clusterId)
+bool emberAfBindingClusterUnbindCallback(EndpointId endpoint, app::CommandHandler * commandObj, NodeId nodeId, GroupId groupId,
+                                         EndpointId endpointId, ClusterId clusterId)
 {
     ChipLogDetail(Zcl, "RX: UnbindCallback");
 

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -419,9 +419,9 @@ static bool moveToHueAndSaturation(uint16_t hue, uint8_t saturation, uint16_t tr
  * @param saturation   Ver.: always
  * @param transitionTime   Ver.: always
  */
-bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                              uint8_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                              uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveToHueAndSaturationCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t hue,
+                                                              uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
+                                                              uint8_t optionsOverride)
 {
     return moveToHueAndSaturation(static_cast<uint16_t>(hue), saturation, transitionTime, optionsMask, optionsOverride, false);
 }
@@ -518,14 +518,14 @@ static bool moveHue(uint8_t moveMode, uint16_t rate, uint8_t optionsMask, uint8_
     return true;
 }
 
-bool emberAfColorControlClusterMoveHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t moveMode,
+bool emberAfColorControlClusterMoveHueCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t moveMode,
                                                uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveHue(moveMode, static_cast<uint16_t>(rate), optionsMask, optionsOverride, false);
 }
 
-bool emberAfColorControlClusterMoveSaturationCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveSaturationCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, uint8_t moveMode,
+                                                      uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
 
@@ -689,16 +689,15 @@ static bool moveToHue(uint16_t hue, uint8_t hueMoveMode, uint16_t transitionTime
     return true;
 }
 
-bool emberAfColorControlClusterMoveToHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t hue,
+bool emberAfColorControlClusterMoveToHueCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t hue,
                                                  uint8_t hueMoveMode, uint16_t transitionTime, uint8_t optionsMask,
                                                  uint8_t optionsOverride)
 {
     return moveToHue(static_cast<uint16_t>(hue), hueMoveMode, transitionTime, optionsMask, optionsOverride, false);
 }
 
-bool emberAfColorControlClusterMoveToSaturationCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
-                                                        uint8_t optionsOverride)
+bool emberAfColorControlClusterMoveToSaturationCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, uint8_t saturation,
+                                                        uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
 
@@ -830,7 +829,7 @@ static bool stepHue(uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime
     return true;
 }
 
-bool emberAfColorControlClusterStepHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t stepMode,
+bool emberAfColorControlClusterStepHueCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t stepMode,
                                                uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
                                                uint8_t optionsOverride)
 {
@@ -838,9 +837,9 @@ bool emberAfColorControlClusterStepHueCallback(chip::EndpointId endpoint, chip::
                    false);
 }
 
-bool emberAfColorControlClusterStepSaturationCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime,
-                                                      uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterStepSaturationCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, uint8_t stepMode,
+                                                      uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
+                                                      uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
 
@@ -972,8 +971,8 @@ static uint16_t readEnhancedHue(EndpointId endpoint)
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_XY
 
-bool emberAfColorControlClusterMoveToColorCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
-                                                   uint16_t colorX, uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
+bool emberAfColorControlClusterMoveToColorCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, uint16_t colorX,
+                                                   uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
                                                    uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1023,7 +1022,7 @@ bool emberAfColorControlClusterMoveToColorCallback(chip::EndpointId aEndpoint, c
     return true;
 }
 
-bool emberAfColorControlClusterMoveColorCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj, int16_t rateX,
+bool emberAfColorControlClusterMoveColorCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, int16_t rateX,
                                                  int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1104,7 +1103,7 @@ bool emberAfColorControlClusterMoveColorCallback(chip::EndpointId aEndpoint, chi
     return true;
 }
 
-bool emberAfColorControlClusterStepColorCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj, int16_t stepX,
+bool emberAfColorControlClusterStepColorCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, int16_t stepX,
                                                  int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
                                                  uint8_t optionsOverride)
 {
@@ -1243,7 +1242,7 @@ static void moveToColorTemp(EndpointId endpoint, uint16_t colorTemperature, uint
     emberEventControlSetDelayMS(&COLOR_TEMP_CONTROL, UPDATE_TIME_MS);
 }
 
-bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
+bool emberAfColorControlClusterMoveToColorTemperatureCallback(EndpointId aEndpoint, app::CommandHandler * commandObj,
                                                               uint16_t colorTemperature, uint16_t transitionTime,
                                                               uint8_t optionsMask, uint8_t optionsOverride)
 {
@@ -1261,7 +1260,7 @@ bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::EndpointId a
     return true;
 }
 
-bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
+bool emberAfColorControlClusterMoveColorTemperatureCallback(EndpointId aEndpoint, app::CommandHandler * commandObj,
                                                             uint8_t moveMode, uint16_t rate, uint16_t colorTemperatureMinimum,
                                                             uint16_t colorTemperatureMaximum, uint8_t optionsMask,
                                                             uint8_t optionsOverride)
@@ -1346,7 +1345,7 @@ bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::EndpointId aEn
     return true;
 }
 
-bool emberAfColorControlClusterStepColorTemperatureCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
+bool emberAfColorControlClusterStepColorTemperatureCallback(EndpointId aEndpoint, app::CommandHandler * commandObj,
                                                             uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
                                                             uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
                                                             uint8_t optionsMask, uint8_t optionsOverride)
@@ -1484,8 +1483,8 @@ void emberAfPluginLevelControlCoupledColorTempChangeCallback(EndpointId endpoint
 
 #endif //#ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_TEMP
 
-bool emberAfColorControlClusterStopMoveStepCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
-                                                    uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterStopMoveStepCallback(EndpointId aEndpoint, app::CommandHandler * commandObj, uint8_t optionsMask,
+                                                    uint8_t optionsOverride)
 {
     // Received a stop command.  This is all we need to do.
     EndpointId endpoint = emberAfCurrentEndpoint();
@@ -1499,40 +1498,39 @@ bool emberAfColorControlClusterStopMoveStepCallback(chip::EndpointId aEndpoint, 
     return true;
 }
 
-bool emberAfColorControlClusterColorLoopSetCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                    uint8_t updateFlags, uint8_t action, uint8_t direction, uint16_t time,
-                                                    uint16_t startHue, uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterColorLoopSetCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t updateFlags,
+                                                    uint8_t action, uint8_t direction, uint16_t time, uint16_t startHue,
+                                                    uint8_t optionsMask, uint8_t optionsOverride)
 {
     // TODO IMPLEMENT LOGIC
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_UNSUP_COMMAND);
     return true;
 }
 
-bool emberAfColorControlClusterEnhancedMoveHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                       uint8_t moveMode, uint16_t rate, uint8_t optionsMask,
-                                                       uint8_t optionsOverride)
+bool emberAfColorControlClusterEnhancedMoveHueCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t moveMode,
+                                                       uint16_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveHue(moveMode, rate, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedMoveToHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfColorControlClusterEnhancedMoveToHueCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                          uint16_t enhancedHue, uint8_t direction, uint16_t transitionTime,
                                                          uint8_t optionsMask, uint8_t optionsOverride)
 {
     return moveToHue(enhancedHue, direction, transitionTime, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(chip::EndpointId endpoint,
-                                                                      chip::app::CommandHandler * commandObj, uint16_t enhancedHue,
-                                                                      uint8_t saturation, uint16_t transitionTime,
-                                                                      uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                      uint16_t enhancedHue, uint8_t saturation,
+                                                                      uint16_t transitionTime, uint8_t optionsMask,
+                                                                      uint8_t optionsOverride)
 {
     return moveToHueAndSaturation(enhancedHue, saturation, transitionTime, optionsMask, optionsOverride, true);
 }
 
-bool emberAfColorControlClusterEnhancedStepHueCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                       uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
-                                                       uint8_t optionsMask, uint8_t optionsOverride)
+bool emberAfColorControlClusterEnhancedStepHueCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t stepMode,
+                                                       uint16_t stepSize, uint16_t transitionTime, uint8_t optionsMask,
+                                                       uint8_t optionsOverride)
 {
     return stepHue(stepMode, stepSize, transitionTime, optionsMask, optionsOverride, true);
 }

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -41,14 +41,16 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-bool emberAfContentLauncherClusterLaunchContentCallback(chip::app::CommandHandler * commandObj)
+using namespace chip;
+
+bool emberAfContentLauncherClusterLaunchContentCallback(app::CommandHandler * commandObj)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 
-bool emberAfContentLauncherClusterLaunchURLCallback(chip::app::CommandHandler * commandObj)
+bool emberAfContentLauncherClusterLaunchURLCallback(app::CommandHandler * commandObj)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -18,9 +18,10 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
-bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                             uint8_t intent, uint8_t requestedProtocol,
-                                                             chip::ByteSpan transferFileDesignator)
+using namespace chip;
+
+bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t intent,
+                                                             uint8_t requestedProtocol, ByteSpan transferFileDesignator)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/door-lock-client/door-lock-client.cpp
+++ b/src/app/clusters/door-lock-client/door-lock-client.cpp
@@ -27,14 +27,14 @@
 
 using namespace chip;
 
-bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status)
+bool emberAfDoorLockClusterLockDoorResponseCallback(app::CommandHandler * commandObj, uint8_t status)
 {
     emberAfDoorLockClusterPrintln("RX: LockDoorResponse 0x%x", status);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status)
+bool emberAfDoorLockClusterUnlockDoorResponseCallback(app::CommandHandler * commandObj, uint8_t status)
 {
     emberAfDoorLockClusterPrintln("RX: UnlockDoorResponse 0x%x", status);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-logging.cpp
@@ -117,7 +117,7 @@ bool emberAfPluginDoorLockServerGetLogEntry(uint16_t * entryId, EmberAfPluginDoo
     return true;
 }
 
-bool emberAfDoorLockClusterGetLogRecordCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t entryId)
+bool emberAfDoorLockClusterGetLogRecordCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t entryId)
 {
     EmberStatus status;
     EmberAfPluginDoorLockServerLogEntry entry;
@@ -135,7 +135,7 @@ bool emberAfDoorLockClusterGetLogRecordCallback(chip::EndpointId endpoint, chip:
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                                  ZCL_GET_LOG_RECORD_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-schedule.cpp
@@ -120,9 +120,9 @@ void emAfPluginDoorLockServerInitSchedule(void)
 #endif
 }
 
-bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t scheduleId, uint16_t userId, uint8_t daysMask, uint8_t startHour,
-                                                      uint8_t startMinute, uint8_t stopHour, uint8_t stopMinute)
+bool emberAfDoorLockClusterSetWeekdayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                      uint16_t userId, uint8_t daysMask, uint8_t startHour, uint8_t startMinute,
+                                                      uint8_t stopHour, uint8_t stopMinute)
 {
     uint8_t status                  = 0x00;
     uint8_t userPin                 = 0x00;
@@ -151,7 +151,7 @@ bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -178,8 +178,8 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterGetWeekdayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                      uint16_t userId)
 {
     EmberAfStatus zclStatus =
         ((scheduleId > EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE) ? EMBER_ZCL_STATUS_INVALID_FIELD
@@ -196,7 +196,7 @@ bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -218,8 +218,8 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterClearWeekdayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                        uint16_t userId)
 {
     EmberAfStatus zclStatus =
         ((scheduleId > EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_WEEKDAY_SCHEDULE_TABLE_SIZE) ? EMBER_ZCL_STATUS_INVALID_FIELD
@@ -234,7 +234,7 @@ bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::EndpointId endpoin
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_WEEKDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -249,9 +249,8 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t scheduleId, uint16_t userId, uint32_t localStartTime,
-                                                      uint32_t localEndTime)
+bool emberAfDoorLockClusterSetYeardayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                      uint16_t userId, uint32_t localStartTime, uint32_t localEndTime)
 {
     uint8_t status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -271,7 +270,7 @@ bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -286,8 +285,8 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterGetYeardayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                      uint16_t userId)
 {
     EmberAfPluginDoorLockServerYeardayScheduleEntry * entry = &yeardayScheduleTable[0];
     EmberAfStatus zclStatus;
@@ -313,7 +312,7 @@ bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -332,8 +331,8 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t scheduleId, uint16_t userId)
+bool emberAfDoorLockClusterClearYeardayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t scheduleId,
+                                                        uint16_t userId)
 {
     uint8_t status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -351,7 +350,7 @@ bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::EndpointId endpoin
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_YEARDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -366,7 +365,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfDoorLockClusterSetHolidayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                       uint8_t holidayScheduleId, uint32_t localStartTime, uint32_t localEndTime,
                                                       uint8_t operatingModeDuringHoliday)
 {
@@ -390,7 +389,7 @@ bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_SET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -405,7 +404,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfDoorLockClusterGetHolidayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                       uint8_t holidayScheduleId)
 {
     EmberAfPluginDoorLockServerHolidayScheduleEntry * entry = &holidayScheduleTable[0];
@@ -431,7 +430,7 @@ bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::EndpointId endpoint,
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_GET_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -450,7 +449,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfDoorLockClusterClearHolidayScheduleCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                         uint8_t holidayScheduleId)
 {
     uint8_t status;
@@ -468,7 +467,7 @@ bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::EndpointId endpoin
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_CLEAR_HOLIDAY_SCHEDULE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -220,7 +220,7 @@ static uint8_t clearUserPinOrRfid(uint16_t userId, EmberAfPluginDoorLockServerUs
     return (success ? 0x00 : 0x01); // See 7.3.2.17.8 and 7.3.2.17.25).
 }
 
-bool emberAfDoorLockClusterGetUserTypeCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetUserTypeCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (emAfPluginDoorLockServerCheckForSufficientSpace(userId, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE))
@@ -229,8 +229,7 @@ bool emberAfDoorLockClusterGetUserTypeCallback(chip::EndpointId endpoint, chip::
 
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                                 ZCL_GET_USER_TYPE_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 ZCL_GET_USER_TYPE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -247,7 +246,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterSetUserTypeCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId,
+bool emberAfDoorLockClusterSetUserTypeCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId,
                                                uint8_t userType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -258,8 +257,7 @@ bool emberAfDoorLockClusterSetUserTypeCallback(chip::EndpointId endpoint, chip::
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_USER_TYPE_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_SET_USER_TYPE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -290,7 +288,7 @@ bool emAfPluginDoorLockServerSetPinUserType(uint16_t userId, EmberAfDoorLockUser
 // ------------------------------------------------------------------------------
 // PIN handling
 
-bool emberAfDoorLockClusterSetPinCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId,
+bool emberAfDoorLockClusterSetPinCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId,
                                           uint8_t userStatus, uint8_t userType, uint8_t * pin)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -300,7 +298,7 @@ bool emberAfDoorLockClusterSetPinCallback(chip::EndpointId endpoint, chip::app::
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_SET_PIN_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -342,7 +340,7 @@ static bool getSendPinOverTheAir(void)
     return sendPinOverTheAir;
 }
 
-bool emberAfDoorLockClusterGetPinCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetPinCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId)
 {
     EmberAfPluginDoorLockServerUser user;
     EmberStatus status = EMBER_SUCCESS;
@@ -351,7 +349,7 @@ bool emberAfDoorLockClusterGetPinCallback(chip::EndpointId endpoint, chip::app::
     {
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                                 ZCL_GET_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 ZCL_GET_PIN_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -386,7 +384,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearPinCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterClearPinCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status = clearUserPinOrRfid(userId, pinUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_PIN_USER_TABLE_SIZE);
@@ -396,7 +394,7 @@ bool emberAfDoorLockClusterClearPinCallback(chip::EndpointId endpoint, chip::app
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_PIN_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_CLEAR_PIN_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -428,7 +426,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllPinsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfDoorLockClusterClearAllPinsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     uint8_t i;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -440,8 +438,7 @@ bool emberAfDoorLockClusterClearAllPinsCallback(chip::EndpointId endpoint, chip:
     // 7.3.2.17.9 says that "0x00" indicates success.
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -459,7 +456,7 @@ exit:
 // ------------------------------------------------------------------------------
 // RFID handling
 
-bool emberAfDoorLockClusterSetRfidCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId,
+bool emberAfDoorLockClusterSetRfidCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId,
                                            uint8_t userStatus, uint8_t userType, uint8_t * rfid)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -468,7 +465,7 @@ bool emberAfDoorLockClusterSetRfidCallback(chip::EndpointId endpoint, chip::app:
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_SET_RFID_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_SET_RFID_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -483,7 +480,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterGetRfidCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterGetRfidCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId)
 {
     EmberAfPluginDoorLockServerUser user;
     EmberStatus status = EMBER_SUCCESS;
@@ -492,8 +489,7 @@ bool emberAfDoorLockClusterGetRfidCallback(chip::EndpointId endpoint, chip::app:
     {
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                                 ZCL_GET_RFID_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 ZCL_GET_RFID_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -521,14 +517,14 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearRfidCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t userId)
+bool emberAfDoorLockClusterClearRfidCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t userId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t status = clearUserPinOrRfid(userId, rfidUserTable, EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE);
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_RFID_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_CLEAR_RFID_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -543,7 +539,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterClearAllRfidsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfDoorLockClusterClearAllRfidsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     for (uint8_t i = 0; i < EMBER_AF_PLUGIN_DOOR_LOCK_SERVER_RFID_USER_TABLE_SIZE; i++)
@@ -554,8 +550,7 @@ bool emberAfDoorLockClusterClearAllRfidsCallback(chip::EndpointId endpoint, chip
     // 7.3.2.17.26 says that "0x00" indicates success.
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_CLEAR_ALL_RFIDS_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_CLEAR_ALL_RFIDS_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -625,7 +620,7 @@ static bool verifyPin(uint8_t * pin, uint8_t * userId)
     return false;
 }
 
-bool emberAfDoorLockClusterLockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t * PIN)
+bool emberAfDoorLockClusterLockDoorCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t * PIN)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(PIN, &userId);
@@ -651,7 +646,7 @@ bool emberAfDoorLockClusterLockDoorCallback(chip::EndpointId endpoint, chip::app
     // send response
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_LOCK_DOOR_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_LOCK_DOOR_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -689,7 +684,7 @@ exit:
     return true;
 }
 
-bool emberAfDoorLockClusterUnlockDoorCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t * pin)
+bool emberAfDoorLockClusterUnlockDoorCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t * pin)
 {
     uint8_t userId                = 0;
     bool pinVerified              = verifyPin(pin, &userId);
@@ -713,7 +708,7 @@ bool emberAfDoorLockClusterUnlockDoorCallback(chip::EndpointId endpoint, chip::a
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
-                                             ZCL_UNLOCK_DOOR_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_UNLOCK_DOOR_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -878,8 +873,8 @@ void emberAfDoorLockClusterServerAttributeChangedCallback(EndpointId endpoint, A
     }
 }
 
-bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                     uint16_t timeoutS, uint8_t * pin)
+bool emberAfDoorLockClusterUnlockWithTimeoutCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t timeoutS,
+                                                     uint8_t * pin)
 {
     uint8_t userId;
     uint8_t status;
@@ -906,7 +901,7 @@ bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::EndpointId endpoint, 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_DOOR_LOCK_CLUSTER_ID,
                                              ZCL_UNLOCK_WITH_TIMEOUT_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/electrical-measurement-server/electrical-measurement-server.cpp
+++ b/src/app/clusters/electrical-measurement-server/electrical-measurement-server.cpp
@@ -25,113 +25,115 @@
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 
-EmberAfStatus emberAfElectricalMeasurementClusterGetMeasurementType(chip::EndpointId endpoint, uint32_t * value)
+using namespace chip;
+
+EmberAfStatus emberAfElectricalMeasurementClusterGetMeasurementType(EndpointId endpoint, uint32_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_MEASUREMENT_TYPE_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetTotalActivePower(chip::EndpointId endpoint, int32_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetTotalActivePower(EndpointId endpoint, int32_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_TOTAL_ACTIVE_POWER_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltage(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltage(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltageMin(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltageMin(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_MIN_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltageMax(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsVoltageMax(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_MAX_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrent(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrent(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrentMin(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrentMin(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_MIN_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrentMax(chip::EndpointId endpoint, uint16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetRmsCurrentMax(EndpointId endpoint, uint16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_MAX_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetActivePower(chip::EndpointId endpoint, int16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetActivePower(EndpointId endpoint, int16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetActivePowerMin(chip::EndpointId endpoint, int16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetActivePowerMin(EndpointId endpoint, int16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_MIN_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
-EmberAfStatus emberAfElectricalMeasurementClusterGetActivePowerMax(chip::EndpointId endpoint, int16_t * value)
+EmberAfStatus emberAfElectricalMeasurementClusterGetActivePowerMax(EndpointId endpoint, int16_t * value)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_MAX_ATTRIBUTE_ID,
                                       (uint8_t *) value, sizeof(*value));
 }
 
-EmberAfStatus emberAfElectricalMeasurementClusterSetMeasurementType(chip::EndpointId endpoint, uint32_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetMeasurementType(EndpointId endpoint, uint32_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_MEASUREMENT_TYPE_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_BITMAP32_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetTotalActivePower(chip::EndpointId endpoint, int32_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetTotalActivePower(EndpointId endpoint, int32_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_TOTAL_ACTIVE_POWER_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT32S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltage(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltage(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltageMin(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltageMin(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_MIN_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltageMax(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsVoltageMax(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_VOLTAGE_MAX_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrent(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrent(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrentMin(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrentMin(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_MIN_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrentMax(chip::EndpointId endpoint, uint16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetRmsCurrentMax(EndpointId endpoint, uint16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_RMS_CURRENT_MAX_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetActivePower(chip::EndpointId endpoint, int16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetActivePower(EndpointId endpoint, int16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetActivePowerMin(chip::EndpointId endpoint, int16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetActivePowerMin(EndpointId endpoint, int16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_MIN_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
-EmberAfStatus emberAfElectricalMeasurementClusterSetActivePowerMax(chip::EndpointId endpoint, int16_t value)
+EmberAfStatus emberAfElectricalMeasurementClusterSetActivePowerMax(EndpointId endpoint, int16_t value)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_ELECTRICAL_MEASUREMENT_CLUSTER_ID, ZCL_ACTIVE_POWER_MAX_ATTRIBUTE_ID,
                                        (uint8_t *) &value, ZCL_INT16S_ATTRIBUTE_TYPE);

--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -19,9 +19,10 @@
 #include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
 
+using namespace chip;
 using namespace chip::app::Clusters;
 
-bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = EthernetNetworkDiagnostics::Attributes::SetPacketRxCount(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -29,7 +29,7 @@
 
 using namespace chip;
 
-bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfGeneralCommissioningClusterArmFailSafeCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                            uint16_t expiryLengthSeconds, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().ArmFailSafe(expiryLengthSeconds);
@@ -38,8 +38,7 @@ bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::EndpointId endp
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::EndpointId endpoint,
-                                                                     chip::app::CommandHandler * commandObj)
+bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().CommissioningComplete();
     emberAfSendImmediateDefaultResponse(err == CHIP_NO_ERROR ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE);
@@ -47,9 +46,9 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::Endpo
     return true;
 }
 
-bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::EndpointId endpoint,
-                                                                   chip::app::CommandHandler * commandObj, uint8_t location,
-                                                                   uint8_t * countryCode, uint64_t breadcrumb, uint32_t timeoutMs)
+bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                   uint8_t location, uint8_t * countryCode, uint64_t breadcrumb,
+                                                                   uint32_t timeoutMs)
 {
     CHIP_ERROR err = DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().SetRegulatoryConfig(
         location, reinterpret_cast<const char *>(countryCode), breadcrumb);

--- a/src/app/clusters/groups-client/groups-client.cpp
+++ b/src/app/clusters/groups-client/groups-client.cpp
@@ -50,14 +50,14 @@
 
 using namespace chip;
 
-bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
+bool emberAfGroupsClusterAddGroupResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: AddGroupResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+bool emberAfGroupsClusterViewGroupResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                    uint8_t * groupName)
 {
     emberAfGroupsClusterPrint("RX: ViewGroupResponse 0x%x, 0x%2x, \"", status, groupId);
@@ -67,8 +67,8 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::CommandHandler * c
     return true;
 }
 
-bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::CommandHandler * commandObj, uint8_t capacity,
-                                                            uint8_t groupCount, uint8_t * groupList)
+bool emberAfGroupsClusterGetGroupMembershipResponseCallback(app::CommandHandler * commandObj, uint8_t capacity, uint8_t groupCount,
+                                                            uint8_t * groupList)
 {
     uint8_t i;
     emberAfGroupsClusterPrint("RX: GetGroupMembershipResponse 0x%x, 0x%x,", capacity, groupCount);
@@ -81,7 +81,7 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::CommandHa
     return true;
 }
 
-bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
+bool emberAfGroupsClusterRemoveGroupResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfGroupsClusterPrintln("RX: RemoveGroupResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -151,7 +151,7 @@ static EmberAfStatus removeEntryFromGroupTable(EndpointId endpoint, GroupId grou
     return EMBER_ZCL_STATUS_NOT_FOUND;
 }
 
-bool emberAfGroupsClusterAddGroupCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
+bool emberAfGroupsClusterAddGroupCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId,
                                           uint8_t * groupName)
 {
     EmberAfStatus status;
@@ -172,7 +172,7 @@ bool emberAfGroupsClusterAddGroupCallback(chip::EndpointId endpoint, chip::app::
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_ADD_GROUP_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_ADD_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -188,7 +188,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterViewGroupCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId)
+bool emberAfGroupsClusterViewGroupCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status                                          = EMBER_ZCL_STATUS_NOT_FOUND;
     CHIP_ERROR err                                                = CHIP_NO_ERROR;
@@ -213,7 +213,7 @@ bool emberAfGroupsClusterViewGroupCallback(chip::EndpointId endpoint, chip::app:
 
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_VIEW_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -230,8 +230,8 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterGetGroupMembershipCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                    uint8_t groupCount, uint8_t * groupList)
+bool emberAfGroupsClusterGetGroupMembershipCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t groupCount,
+                                                    uint8_t * groupList)
 {
     EmberStatus status = EMBER_ZCL_STATUS_FAILURE;
     uint8_t i, j;
@@ -301,7 +301,7 @@ bool emberAfGroupsClusterGetGroupMembershipCallback(chip::EndpointId endpoint, c
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
                                                  ZCL_GET_GROUP_MEMBERSHIP_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -328,7 +328,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterRemoveGroupCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId)
+bool emberAfGroupsClusterRemoveGroupCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -350,8 +350,7 @@ bool emberAfGroupsClusterRemoveGroupCallback(chip::EndpointId endpoint, chip::ap
     emberAfScenesClusterRemoveScenesInGroupCallback(emberAfCurrentEndpoint(), groupId);
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_GROUPS_CLUSTER_ID,
-                                             ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_REMOVE_GROUP_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -367,7 +366,7 @@ exit:
     return true;
 }
 
-bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj)
+bool emberAfGroupsClusterRemoveAllGroupsCallback(EndpointId aEndpoint, app::CommandHandler * commandObj)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;
     uint8_t i;
@@ -415,8 +414,8 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::EndpointId aEndpoint, chi
     return true;
 }
 
-bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                       GroupId groupId, uint8_t * groupName)
+bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId,
+                                                       uint8_t * groupName)
 {
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;

--- a/src/app/clusters/ias-zone-client/ias-zone-client.cpp
+++ b/src/app/clusters/ias-zone-client/ias-zone-client.cpp
@@ -82,6 +82,8 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 //-----------------------------------------------------------------------------
 // Globals
 
@@ -307,7 +309,7 @@ static uint8_t findIasZoneServerByNodeId(EmberNodeId nodeId)
     return i;
 }
 
-bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::CommandHandler * commandObj, uint16_t zoneStatus,
+bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(app::CommandHandler * commandObj, uint16_t zoneStatus,
                                                                uint8_t extendedStatus, uint8_t zoneId, uint16_t delay)
 {
     uint8_t serverIndex = findIasZoneServerByNodeId(emberAfCurrentCommand()->source);
@@ -328,8 +330,7 @@ bool emberAfIasZoneClusterZoneStatusChangeNotificationCallback(chip::app::Comman
     return true;
 }
 
-bool emberAfIasZoneClusterZoneEnrollRequestCallback(chip::app::CommandHandler * commandObj, uint16_t zoneType,
-                                                    uint16_t manufacturerCode)
+bool emberAfIasZoneClusterZoneEnrollRequestCallback(app::CommandHandler * commandObj, uint16_t zoneType, uint16_t manufacturerCode)
 {
     EmberAfIasEnrollResponseCode responseCode = EMBER_ZCL_IAS_ENROLL_RESPONSE_CODE_NO_ENROLL_PERMIT;
     uint8_t zoneId                            = UNKNOWN_ZONE_ID;

--- a/src/app/clusters/ias-zone-server/ias-zone-server.cpp
+++ b/src/app/clusters/ias-zone-server/ias-zone-server.cpp
@@ -348,7 +348,7 @@ static void updateEnrollState(EndpointId endpoint, bool enrolled)
     emberAfIasZoneClusterPrintln("IAS Zone Server State: %pEnrolled", (enrolled ? "" : "NOT "));
 }
 
-bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::EndpointId aEndpoint, chip::app::CommandHandler * commandObj,
+bool emberAfIasZoneClusterZoneEnrollResponseCallback(EndpointId aEndpoint, app::CommandHandler * commandObj,
                                                      uint8_t enrollResponseCode, uint8_t zoneId)
 {
     EndpointId endpoint;

--- a/src/app/clusters/identify-client/identify-client.cpp
+++ b/src/app/clusters/identify-client/identify-client.cpp
@@ -27,7 +27,7 @@
 
 using namespace chip;
 
-bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::CommandHandler * commandObj, uint16_t timeout)
+bool emberAfIdentifyClusterIdentifyQueryResponseCallback(app::CommandHandler * commandObj, uint16_t timeout)
 {
     emberAfIdentifyClusterPrintln("RX: IdentifyQueryResponse 0x%4x", timeout);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -103,7 +103,7 @@ void emberAfIdentifyClusterServerAttributeChangedCallback(EndpointId endpoint, A
     }
 }
 
-bool emberAfIdentifyClusterIdentifyCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint16_t time)
+bool emberAfIdentifyClusterIdentifyCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t time)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;
     // This Identify callback writes the new attribute, which will trigger the
@@ -120,7 +120,7 @@ bool emberAfIdentifyClusterIdentifyCallback(chip::EndpointId endpoint, chip::app
     return true;
 }
 
-bool emberAfIdentifyClusterIdentifyQueryCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfIdentifyClusterIdentifyQueryCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status;
     EmberStatus sendStatus = EMBER_SUCCESS;
@@ -157,8 +157,7 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(chip::EndpointId endpoint, chip
     emberAfIdentifyClusterPrintln("Identifying for %d more seconds", identifyTime);
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_IDENTIFY_CLUSTER_ID,
-                                             ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
 
         VerifyOrExit(commandObj != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -27,29 +27,31 @@
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 EmberAfKeypadInputStatus keypadInputClusterSendKey(EmberAfKeypadInputCecKeyCode keyCode);
 
-static void sendResponse(chip::app::CommandHandler * command, EmberAfKeypadInputStatus keypadInputStatus)
+static void sendResponse(app::CommandHandler * command, EmberAfKeypadInputStatus keypadInputStatus)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_KEYPAD_INPUT_CLUSTER_ID,
-                                               ZCL_SEND_KEY_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_KEYPAD_INPUT_CLUSTER_ID,
+                                         ZCL_SEND_KEY_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrExit(command != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(0), keypadInputStatus));
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(0), keypadInputStatus));
     SuccessOrExit(err = command->FinishCommand());
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to encode KeypadInputResponse command. Error:%s", chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to encode KeypadInputResponse command. Error:%s", ErrorStr(err));
     }
 }
 
-bool emberAfKeypadInputClusterSendKeyCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t keyCode)
+bool emberAfKeypadInputClusterSendKeyCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t keyCode)
 {
     EmberAfKeypadInputStatus status = keypadInputClusterSendKey(static_cast<EmberAfKeypadInputCecKeyCode>(keyCode));
     sendResponse(command, status);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -406,7 +406,7 @@ static bool shouldExecuteIfOff(EndpointId endpoint, CommandId commandId, uint8_t
 #endif
 }
 
-bool emberAfLevelControlClusterMoveToLevelCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t level,
+bool emberAfLevelControlClusterMoveToLevelCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t level,
                                                    uint16_t transitionTime, uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL %x %2x %x %x", "RX level-control:", level, transitionTime, optionMask,
@@ -416,8 +416,8 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::EndpointId endpoint, ch
     return true;
 }
 
-bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                            uint8_t level, uint16_t transitionTime)
+bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t level,
+                                                            uint16_t transitionTime)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_TO_LEVEL_WITH_ON_OFF %x %2x", "RX level-control:", level, transitionTime);
     moveToLevelHandler(ZCL_MOVE_TO_LEVEL_WITH_ON_OFF_COMMAND_ID, level, transitionTime, 0xFF, 0xFF,
@@ -425,23 +425,23 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::EndpointId end
     return true;
 }
 
-bool emberAfLevelControlClusterMoveCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t moveMode,
-                                            uint8_t rate, uint8_t optionMask, uint8_t optionOverride)
+bool emberAfLevelControlClusterMoveCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t moveMode, uint8_t rate,
+                                            uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pMOVE %x %x", "RX level-control:", moveMode, rate);
     moveHandler(ZCL_MOVE_COMMAND_ID, moveMode, rate, optionMask, optionOverride);
     return true;
 }
 
-bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                     uint8_t moveMode, uint8_t rate)
+bool emberAfLevelControlClusterMoveWithOnOffCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t moveMode,
+                                                     uint8_t rate)
 {
     emberAfLevelControlClusterPrintln("%pMOVE_WITH_ON_OFF %x %x", "RX level-control:", moveMode, rate);
     moveHandler(ZCL_MOVE_WITH_ON_OFF_COMMAND_ID, moveMode, rate, 0xFF, 0xFF);
     return true;
 }
 
-bool emberAfLevelControlClusterStepCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t stepMode,
+bool emberAfLevelControlClusterStepCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t stepMode,
                                             uint8_t stepSize, uint16_t transitionTime, uint8_t optionMask, uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pSTEP %x %x %2x", "RX level-control:", stepMode, stepSize, transitionTime);
@@ -449,15 +449,15 @@ bool emberAfLevelControlClusterStepCallback(chip::EndpointId endpoint, chip::app
     return true;
 }
 
-bool emberAfLevelControlClusterStepWithOnOffCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                     uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime)
+bool emberAfLevelControlClusterStepWithOnOffCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t stepMode,
+                                                     uint8_t stepSize, uint16_t transitionTime)
 {
     emberAfLevelControlClusterPrintln("%pSTEP_WITH_ON_OFF %x %x %2x", "RX level-control:", stepMode, stepSize, transitionTime);
     stepHandler(ZCL_STEP_WITH_ON_OFF_COMMAND_ID, stepMode, stepSize, transitionTime, 0xFF, 0xFF);
     return true;
 }
 
-bool emberAfLevelControlClusterStopCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, uint8_t optionMask,
+bool emberAfLevelControlClusterStopCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint8_t optionMask,
                                             uint8_t optionOverride)
 {
     emberAfLevelControlClusterPrintln("%pSTOP", "RX level-control:");
@@ -465,7 +465,7 @@ bool emberAfLevelControlClusterStopCallback(chip::EndpointId endpoint, chip::app
     return true;
 }
 
-bool emberAfLevelControlClusterStopWithOnOffCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfLevelControlClusterStopWithOnOffCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     emberAfLevelControlClusterPrintln("%pSTOP_WITH_ON_OFF", "RX level-control:");
     stopHandler(ZCL_STOP_WITH_ON_OFF_COMMAND_ID, 0xFF, 0xFF);

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -25,9 +25,11 @@
 #include <app/CommandHandler.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 bool lowPowerClusterSleep();
 
-bool emberAfLowPowerClusterSleepCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfLowPowerClusterSleepCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     bool success         = lowPowerClusterSleep();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -29,12 +29,14 @@
 #include <app/util/af.h>
 #include <string>
 
+using namespace chip;
+
 bool mediaInputClusterSelectInput(uint8_t input);
 bool mediaInputClusterShowInputStatus();
 bool mediaInputClusterHideInputStatus();
 bool mediaInputClusterRenameInput(uint8_t input, std::string name);
 
-static void storeCurrentInput(chip::EndpointId endpoint, uint8_t currentInput)
+static void storeCurrentInput(EndpointId endpoint, uint8_t currentInput)
 {
     EmberAfStatus status = emberAfWriteServerAttribute(
         endpoint, ZCL_MEDIA_INPUT_CLUSTER_ID, ZCL_MEDIA_INPUT_CURRENT_INPUT_ATTRIBUTE_ID, &currentInput, ZCL_INT8U_ATTRIBUTE_TYPE);
@@ -44,7 +46,7 @@ static void storeCurrentInput(chip::EndpointId endpoint, uint8_t currentInput)
     }
 }
 
-bool emberAfMediaInputClusterSelectInputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t input)
+bool emberAfMediaInputClusterSelectInputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t input)
 {
     bool success         = mediaInputClusterSelectInput(input);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -56,7 +58,7 @@ bool emberAfMediaInputClusterSelectInputCallback(chip::EndpointId endpoint, chip
     return true;
 }
 
-bool emberAfMediaInputClusterShowInputStatusCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaInputClusterShowInputStatusCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     bool success         = mediaInputClusterShowInputStatus();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -64,7 +66,7 @@ bool emberAfMediaInputClusterShowInputStatusCallback(chip::EndpointId endpoint, 
     return true;
 }
 
-bool emberAfMediaInputClusterHideInputStatusCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaInputClusterHideInputStatusCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     bool success         = mediaInputClusterHideInputStatus();
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -72,8 +74,7 @@ bool emberAfMediaInputClusterHideInputStatusCallback(chip::EndpointId endpoint, 
     return true;
 }
 
-bool emberAfMediaInputClusterRenameInputCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t input,
-                                                 uint8_t * name)
+bool emberAfMediaInputClusterRenameInputCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t input, uint8_t * name)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string nameString(reinterpret_cast<char *>(name));

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -31,10 +31,12 @@
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 EmberAfMediaPlaybackStatus mediaPlaybackClusterSendMediaPlaybackRequest(MediaPlaybackRequest mediaPlaybackRequest,
                                                                         uint64_t deltaPositionMilliseconds);
 
-static void writePlaybackState(chip::EndpointId endpoint, uint8_t playbackState)
+static void writePlaybackState(EndpointId endpoint, uint8_t playbackState)
 {
     EmberAfStatus status = emberAfWriteServerAttribute(
         endpoint, ZCL_MEDIA_PLAYBACK_CLUSTER_ID, ZCL_MEDIA_PLAYBACK_STATE_ATTRIBUTE_ID, &playbackState, ZCL_INT8U_ATTRIBUTE_TYPE);
@@ -44,7 +46,7 @@ static void writePlaybackState(chip::EndpointId endpoint, uint8_t playbackState)
     }
 }
 
-static uint8_t readPlaybackStatus(chip::EndpointId endpoint)
+static uint8_t readPlaybackStatus(EndpointId endpoint)
 {
     uint8_t playbackState;
     EmberAfStatus status = emberAfReadServerAttribute(endpoint, ZCL_MEDIA_PLAYBACK_CLUSTER_ID,
@@ -57,7 +59,7 @@ static uint8_t readPlaybackStatus(chip::EndpointId endpoint)
     return playbackState;
 }
 
-void storeNewPlaybackState(chip::EndpointId endpoint, uint8_t newPlaybackState)
+void storeNewPlaybackState(EndpointId endpoint, uint8_t newPlaybackState)
 {
     uint8_t mediaPlaybackClusterPlaybackState = readPlaybackStatus(endpoint);
 
@@ -71,28 +73,28 @@ void storeNewPlaybackState(chip::EndpointId endpoint, uint8_t newPlaybackState)
     }
 }
 
-static void sendResponse(chip::app::CommandHandler * command, const char * responseName, chip::CommandId commandId,
+static void sendResponse(app::CommandHandler * command, const char * responseName, CommandId commandId,
                          EmberAfMediaPlaybackStatus mediaPlaybackStatus)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_MEDIA_PLAYBACK_CLUSTER_ID, commandId,
-                                               (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_MEDIA_PLAYBACK_CLUSTER_ID, commandId,
+                                         (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrExit(command != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(0), mediaPlaybackStatus));
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(0), mediaPlaybackStatus));
     SuccessOrExit(err = command->FinishCommand());
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to send %s. Error:%s", responseName, chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to send %s. Error:%s", responseName, ErrorStr(err));
     }
 }
 
-bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaPlayCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PLAY, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PLAYING);
@@ -100,7 +102,7 @@ bool emberAfMediaPlaybackClusterMediaPlayCallback(chip::EndpointId endpoint, chi
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaPauseCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PAUSE, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_PAUSED);
@@ -108,7 +110,7 @@ bool emberAfMediaPlaybackClusterMediaPauseCallback(chip::EndpointId endpoint, ch
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaStopCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaStopCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_STOP, 0);
     storeNewPlaybackState(emberAfCurrentEndpoint(), EMBER_ZCL_MEDIA_PLAYBACK_STATE_NOT_PLAYING);
@@ -116,28 +118,28 @@ bool emberAfMediaPlaybackClusterMediaStopCallback(chip::EndpointId endpoint, chi
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaFastForwardCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaFastForwardCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_FAST_FORWARD, 0);
     sendResponse(command, "MediaFastForward", ZCL_MEDIA_FAST_FORWARD_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaPreviousCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaPreviousCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_PREVIOUS, 0);
     sendResponse(command, "MediaPrevious", ZCL_MEDIA_PREVIOUS_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaRewindCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_REWIND, 0);
     sendResponse(command, "MediaRewind", ZCL_MEDIA_REWIND_RESPONSE_COMMAND_ID, status);
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
+bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(EndpointId endpoint, app::CommandHandler * command,
                                                           uint64_t deltaPositionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
@@ -146,7 +148,7 @@ bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::EndpointId endpo
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
+bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(EndpointId endpoint, app::CommandHandler * command,
                                                          uint64_t deltaPositionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
@@ -155,8 +157,7 @@ bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::EndpointId endpoi
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                  uint64_t positionMilliseconds)
+bool emberAfMediaPlaybackClusterMediaSeekCallback(EndpointId endpoint, app::CommandHandler * command, uint64_t positionMilliseconds)
 {
     EmberAfMediaPlaybackStatus status =
         mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_SEEK, positionMilliseconds);
@@ -164,13 +165,13 @@ bool emberAfMediaPlaybackClusterMediaSeekCallback(chip::EndpointId endpoint, chi
     return true;
 }
 
-bool emberAfMediaPlaybackClusterMediaNextCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaNextCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_NEXT, 0);
     sendResponse(command, "MediaNext", ZCL_MEDIA_NEXT_RESPONSE_COMMAND_ID, status);
     return true;
 }
-bool emberAfMediaPlaybackClusterMediaStartOverCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command)
+bool emberAfMediaPlaybackClusterMediaStartOverCallback(EndpointId endpoint, app::CommandHandler * command)
 {
     EmberAfMediaPlaybackStatus status = mediaPlaybackClusterSendMediaPlaybackRequest(MEDIA_PLAYBACK_REQUEST_START_OVER, 0);
     sendResponse(command, "MediaStartOver", ZCL_MEDIA_START_OVER_RESPONSE_COMMAND_ID, status);

--- a/src/app/clusters/messaging-client/messaging-client.cpp
+++ b/src/app/clusters/messaging-client/messaging-client.cpp
@@ -47,6 +47,8 @@
 #include "app/framework/plugin/esi-management/esi-management.h"
 #include <app/CommandHandler.h>
 
+using namespace chip;
+
 static EmberAfPluginMessagingClientMessage messageTable[EMBER_AF_MESSAGING_CLUSTER_CLIENT_ENDPOINT_COUNT];
 
 #define MESSAGE_CONTROL_INTER_PAN_TRANSMISSION_ONLY (0x2)
@@ -121,9 +123,9 @@ void emberAfMessagingClusterClientTickCallback(EndpointId endpoint)
     }
 }
 
-bool emberAfMessagingClusterDisplayMessageCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
-                                                   uint8_t messageControl, uint32_t startTime, uint16_t durationInMinutes,
-                                                   uint8_t * msg, uint8_t optionalExtendedMessageControl)
+bool emberAfMessagingClusterDisplayMessageCallback(app::CommandHandler * commandObj, uint32_t messageId, uint8_t messageControl,
+                                                   uint32_t startTime, uint16_t durationInMinutes, uint8_t * msg,
+                                                   uint8_t optionalExtendedMessageControl)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);
@@ -242,8 +244,7 @@ kickout:
     return true;
 }
 
-bool emberAfMessagingClusterCancelMessageCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
-                                                  uint8_t messageControl)
+bool emberAfMessagingClusterCancelMessageCallback(app::CommandHandler * commandObj, uint32_t messageId, uint8_t messageControl)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     uint8_t ep          = emberAfFindClusterClientEndpointIndex(endpoint, ZCL_MESSAGING_CLUSTER_ID);

--- a/src/app/clusters/messaging-server/messaging-server.cpp
+++ b/src/app/clusters/messaging-server/messaging-server.cpp
@@ -86,7 +86,7 @@ void emberAfMessagingClusterServerInitCallback(EndpointId endpoint)
     msgTable[ep].messageStatusControl &= ~VALID;
 }
 
-bool emberAfMessagingClusterGetLastMessageCallback(chip::app::CommandHandler * commandObj)
+bool emberAfMessagingClusterGetLastMessageCallback(app::CommandHandler * commandObj)
 {
     EndpointId endpoint = emberAfCurrentEndpoint();
     EmberAfPluginMessagingServerMessage message;
@@ -109,10 +109,10 @@ bool emberAfMessagingClusterGetLastMessageCallback(chip::app::CommandHandler * c
 #if defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_0) || defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1B) ||                                   \
     defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_0) || defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1) ||                                    \
     defined(EMBER_AF_HAS_SPEC_VERSIONS_SE_1_1A)
-bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterMessageConfirmationCallback(app::CommandHandler * commandObj, uint32_t messageId,
                                                         uint32_t confirmationTime)
 #else
-bool emberAfMessagingClusterMessageConfirmationCallback(chip::app::CommandHandler * commandObj, uint32_t messageId,
+bool emberAfMessagingClusterMessageConfirmationCallback(app::CommandHandler * commandObj, uint32_t messageId,
                                                         uint32_t confirmationTime, uint8_t messageConfirmationControl,
                                                         uint8_t * messageResponse)
 #endif

--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -32,32 +32,31 @@
 
 using namespace chip;
 
-bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                                 ByteSpan operationalDataset, uint64_t breadcrumb,
                                                                 uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
+    EmberAfNetworkCommissioningError err = app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
         nullptr, emberAfCurrentEndpoint(), operationalDataset, breadcrumb, timeoutMs);
     emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
                                                                                              : EMBER_ZCL_STATUS_FAILURE);
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                              ByteSpan ssid, ByteSpan credentials, uint64_t breadcrumb,
-                                                              uint32_t timeoutMs)
+bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj, ByteSpan ssid,
+                                                              ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
+    EmberAfNetworkCommissioningError err = app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
         nullptr, emberAfCurrentEndpoint(), ssid, credentials, breadcrumb, timeoutMs);
     emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
                                                                                              : EMBER_ZCL_STATUS_FAILURE);
     return true;
 }
 
-bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterEnableNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                              ByteSpan networkID, uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
+    EmberAfNetworkCommissioningError err = app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
         nullptr, emberAfCurrentEndpoint(), networkID, breadcrumb, timeoutMs);
     emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
                                                                                              : EMBER_ZCL_STATUS_FAILURE);
@@ -67,39 +66,38 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::EndpointId en
 // TODO: The following commands needed to be implemented.
 // These commands are not implemented thus not handled yet, return false so ember will return a error.
 
-bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterDisableNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                               ByteSpan networkID, uint64_t breadcrumb, uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::EndpointId endpoint,
-                                                                                 chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(EndpointId endpoint,
+                                                                                 app::CommandHandler * commandObj,
                                                                                  uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                              ByteSpan NetworkID, uint64_t Breadcrumb, uint32_t TimeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                            ByteSpan ssid, uint64_t breadcrumb, uint32_t timeoutMs)
+bool emberAfNetworkCommissioningClusterScanNetworksCallback(EndpointId endpoint, app::CommandHandler * commandObj, ByteSpan ssid,
+                                                            uint64_t breadcrumb, uint32_t timeoutMs)
 {
     return false;
 }
-bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::EndpointId endpoint,
-                                                                   chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                                    ByteSpan operationalDataset, uint64_t breadcrumb,
                                                                    uint32_t timeoutMs)
 {
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                                  ByteSpan ssid, ByteSpan credentials, uint64_t breadcrumb,
                                                                  uint32_t timeoutMs)
 {

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -171,7 +171,7 @@ EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Co
             memcpy(sNetworks[i].mData.mWiFi.mSSID, ssid.data(), ssid.size());
 
             using WiFiSSIDLenType = decltype(sNetworks[i].mData.mWiFi.mSSIDLen);
-            VerifyOrExit(chip::CanCastTo<WiFiSSIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
+            VerifyOrExit(CanCastTo<WiFiSSIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
             sNetworks[i].mData.mWiFi.mSSIDLen = static_cast<WiFiSSIDLenType>(ssid.size());
 
             VerifyOrExit(credentials.size() <= sizeof(sNetworks[i].mData.mWiFi.mCredentials),
@@ -179,15 +179,14 @@ EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Co
             memcpy(sNetworks[i].mData.mWiFi.mCredentials, credentials.data(), credentials.size());
 
             using WiFiCredentialsLenType = decltype(sNetworks[i].mData.mWiFi.mCredentialsLen);
-            VerifyOrExit(chip::CanCastTo<WiFiCredentialsLenType>(ssid.size()),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
+            VerifyOrExit(CanCastTo<WiFiCredentialsLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
             sNetworks[i].mData.mWiFi.mCredentialsLen = static_cast<WiFiCredentialsLenType>(credentials.size());
 
             VerifyOrExit(ssid.size() <= sizeof(sNetworks[i].mNetworkID), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
             memcpy(sNetworks[i].mNetworkID, sNetworks[i].mData.mWiFi.mSSID, ssid.size());
 
             using NetworkIDLenType = decltype(sNetworks[i].mNetworkIDLen);
-            VerifyOrExit(chip::CanCastTo<NetworkIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
+            VerifyOrExit(CanCastTo<NetworkIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
             sNetworks[i].mNetworkIDLen = static_cast<NetworkIDLenType>(ssid.size());
 
             sNetworks[i].mNetworkType = NetworkType::kWiFi;

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -62,7 +62,7 @@ using namespace chip;
 //******************************************************************************
 // Plugin init function
 //******************************************************************************
-void emberAfOccupancySensingClusterServerInitCallback(chip::EndpointId endpoint)
+void emberAfOccupancySensingClusterServerInitCallback(EndpointId endpoint)
 {
     HalOccupancySensorType deviceType;
 
@@ -119,7 +119,7 @@ void halOccupancyStateChangedCallback(EndpointId endpoint, HalOccupancyState occ
 
 void emberAfPluginOccupancyClusterServerPostInitCallback(EndpointId endpoint) {}
 
-HalOccupancySensorType __attribute__((weak)) halOccupancyGetSensorType(chip::EndpointId endpoint)
+HalOccupancySensorType __attribute__((weak)) halOccupancyGetSensorType(EndpointId endpoint)
 {
     return HAL_OCCUPANCY_SENSOR_TYPE_PIR;
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -165,7 +165,7 @@ EmberAfStatus emberAfOnOffClusterSetValueCallback(EndpointId endpoint, uint8_t c
     return EMBER_ZCL_STATUS_SUCCESS;
 }
 
-bool emberAfOnOffClusterOffCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfOnOffClusterOffCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_OFF_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
@@ -178,7 +178,7 @@ bool emberAfOnOffClusterOffCallback(chip::EndpointId endpoint, chip::app::Comman
     return true;
 }
 
-bool emberAfOnOffClusterOnCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfOnOffClusterOnCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_ON_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER
@@ -191,7 +191,7 @@ bool emberAfOnOffClusterOnCallback(chip::EndpointId endpoint, chip::app::Command
     return true;
 }
 
-bool emberAfOnOffClusterToggleCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfOnOffClusterToggleCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = emberAfOnOffClusterSetValueCallback(emberAfCurrentEndpoint(), ZCL_TOGGLE_COMMAND_ID, false);
 #ifdef EMBER_AF_PLUGIN_ZLL_ON_OFF_SERVER

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -227,8 +227,8 @@ void emberAfPluginOperationalCredentialsServerInitCallback(void)
 }
 
 // TODO: Use FabricIndex as a parameter instead of fabricId/nodeId/vendorId once AddOptCert + FabricIndex are implemented
-bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                              chip::FabricId fabricId, chip::NodeId nodeId, uint16_t vendorId)
+bool emberAfOperationalCredentialsClusterRemoveFabricCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                              FabricId fabricId, NodeId nodeId, uint16_t vendorId)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: RemoveFabric"); // TODO: Generate emberAfFabricClusterPrintln
 
@@ -253,8 +253,7 @@ exit:
 }
 
 // TODO: remove SetFabric once AddOptCert + FabricIndex are implemented
-bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                           uint16_t VendorId)
+bool emberAfOperationalCredentialsClusterSetFabricCallback(EndpointId endpoint, app::CommandHandler * commandObj, uint16_t VendorId)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: SetFabric with vendorId %" PRIX16, VendorId);
 
@@ -276,7 +275,7 @@ bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::EndpointId endp
     // fabricId until addOptCert + fabricIndex are implemented. Once they are, this method and its response will go away.
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
-                                             ZCL_SET_FABRIC_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_SET_FABRIC_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
 
         VerifyOrExit(commandObj != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -305,8 +304,8 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::EndpointId endpoint,
-                                                                   chip::app::CommandHandler * commandObj, uint8_t * Label)
+bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                   uint8_t * Label)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: UpdateFabricLabel");
 
@@ -337,11 +336,10 @@ void DoRemoveAllFabrics(intptr_t)
     OpenDefaultPairingWindow(ResetFabrics::kYes);
 }
 
-CHIP_ERROR SendNOCResponse(chip::app::Command * commandObj, EmberAfNodeOperationalCertStatus status, uint8_t index,
-                           ByteSpan debug_text)
+CHIP_ERROR SendNOCResponse(app::Command * commandObj, EmberAfNodeOperationalCertStatus status, uint8_t index, ByteSpan debug_text)
 {
     app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
-                                         ZCL_NOC_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                         ZCL_NOC_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -391,7 +389,7 @@ EmberAfNodeOperationalCertStatus ConvertToNOCResponseStatus(CHIP_ERROR err)
 } // namespace
 
 // Up for discussion in Multi-Admin TT: chip-spec:#2891
-bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: Remove all Fabrics");
     PlatformMgr().ScheduleWork(DoRemoveAllFabrics, 0);
@@ -399,9 +397,8 @@ bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::Endpoint
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterAddNOCCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        chip::ByteSpan NOCArray, chip::ByteSpan IPKValue,
-                                                        chip::NodeId CaseAdminNode, uint16_t AdminVendorId)
+bool emberAfOperationalCredentialsClusterAddNOCCallback(EndpointId endpoint, app::CommandHandler * commandObj, ByteSpan NOCArray,
+                                                        ByteSpan IPKValue, NodeId CaseAdminNode, uint16_t AdminVendorId)
 {
     EmberAfNodeOperationalCertStatus nocResponse = EMBER_ZCL_NODE_OPERATIONAL_CERT_STATUS_SUCCESS;
 
@@ -423,7 +420,7 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(chip::EndpointId endpoin
     // can't just wait until we get network configuration commands, because we
     // might be on the operational network already, in which case we are
     // expected to be live with our new identity at this point.
-    chip::app::Mdns::AdvertiseOperational();
+    app::Mdns::AdvertiseOperational();
 
     fabricIndex = GetGlobalFabricTable().GetFabricIndex(fabric);
 
@@ -439,14 +436,14 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                              chip::ByteSpan CSRNonce)
+bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                              ByteSpan CSRNonce)
 {
     EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
     EmberStatus sendStatus = EMBER_SUCCESS;
     CHIP_ERROR err         = CHIP_NO_ERROR;
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> csr;
+    Platform::ScopedMemoryBuffer<uint8_t> csr;
     size_t csrLength = Crypto::kMAX_CSR_Length;
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> csrElements;
@@ -454,7 +451,7 @@ bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::EndpointId e
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: commissioner has requested an OpCSR");
 
     app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_OPERATIONAL_CREDENTIALS_CLUSTER_ID,
-                                         ZCL_OP_CSR_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                         ZCL_OP_CSR_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
 
     TLV::TLVWriter * writer = nullptr;
     TLV::TLVWriter csrElementWriter;
@@ -520,17 +517,16 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterUpdateOpCertCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                              chip::ByteSpan NOC, chip::ByteSpan ICACertificate)
+bool emberAfOperationalCredentialsClusterUpdateOpCertCallback(EndpointId endpoint, app::CommandHandler * commandObj, ByteSpan NOC,
+                                                              ByteSpan ICACertificate)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(chip::EndpointId endpoint,
-                                                                           chip::app::CommandHandler * commandObj,
-                                                                           chip::ByteSpan RootCertificate)
+bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                           ByteSpan RootCertificate)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -553,9 +549,8 @@ exit:
     return true;
 }
 
-bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(chip::EndpointId endpoint,
-                                                                              chip::app::CommandHandler * commandObj,
-                                                                              chip::ByteSpan TrustedRootIdentifier)
+bool emberAfOperationalCredentialsClusterRemoveTrustedRootCertificateCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                              ByteSpan TrustedRootIdentifier)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -31,6 +31,7 @@
 #include "ota-provider-delegate.h"
 #include "ota-provider.h"
 
+using namespace chip;
 using chip::app::clusters::OTAProviderDelegate;
 
 namespace {
@@ -40,13 +41,13 @@ constexpr size_t kUpdateTokenParamLength = 32;  // The expected length of the Up
 
 OTAProviderDelegate * gDelegateTable[EMBER_AF_OTA_PROVIDER_CLUSTER_SERVER_ENDPOINT_COUNT] = { nullptr };
 
-OTAProviderDelegate * GetDelegate(chip::EndpointId endpoint)
+OTAProviderDelegate * GetDelegate(EndpointId endpoint)
 {
     uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_OTA_PROVIDER_CLUSTER_ID);
     return (ep == 0xFFFF ? NULL : gDelegateTable[ep]);
 }
 
-bool SendStatusIfDelegateNull(chip::EndpointId endpoint)
+bool SendStatusIfDelegateNull(EndpointId endpoint)
 {
     if (GetDelegate(endpoint) == nullptr)
     {
@@ -67,9 +68,8 @@ bool SendStatusIfDelegateNull(chip::EndpointId endpoint)
  * @param newVersion The SoftwareVersion value of the new Software Image that the client is ready to apply.
  */
 
-bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::EndpointId endpoint,
-                                                                       chip::app::CommandHandler * commandObj,
-                                                                       chip::ByteSpan updateToken, uint32_t newVersion)
+bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                       ByteSpan updateToken, uint32_t newVersion)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
@@ -105,9 +105,8 @@ bool emberAfOtaSoftwareUpdateProviderClusterApplyUpdateRequestCallback(chip::End
  *                       OTA Requestor's Basic Information Cluster.
  */
 
-bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::EndpointId endpoint,
-                                                                        chip::app::CommandHandler * commandObj,
-                                                                        chip::ByteSpan updateToken, uint32_t currentVersion)
+bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(EndpointId endpoint, app::CommandHandler * commandObj,
+                                                                        ByteSpan updateToken, uint32_t currentVersion)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
@@ -151,12 +150,12 @@ bool emberAfOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedCallback(chip::En
  * @param metadataForProvider Optional, max 512 octets. A TLV-encoded Vendor-specific payload.
  */
 
-bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
+bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoint, app::CommandHandler * commandObj,
                                                                uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                                                uint16_t hardwareVersion, uint32_t currentVersion,
                                                                /* TODO(#8605): change this to list */ uint8_t protocolsSupported,
                                                                uint8_t * location, uint8_t clientCanConsent,
-                                                               chip::ByteSpan metadataForProvider)
+                                                               ByteSpan metadataForProvider)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;
     OTAProviderDelegate * delegate = GetDelegate(endpoint);
@@ -181,7 +180,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::EndpointId 
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
 
-    chip::ByteSpan locationSpan(location, locationLen);
+    ByteSpan locationSpan(location, locationLen);
 
     status = delegate->HandleQueryImage(vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported,
                                         locationSpan, clientCanConsent, metadataForProvider);
@@ -197,7 +196,7 @@ namespace chip {
 namespace app {
 namespace clusters {
 
-void OTAProvider::SetDelegate(chip::EndpointId endpoint, OTAProviderDelegate * delegate)
+void OTAProvider::SetDelegate(EndpointId endpoint, OTAProviderDelegate * delegate)
 {
     uint16_t ep = emberAfFindClusterServerEndpointIndex(endpoint, ZCL_OTA_PROVIDER_CLUSTER_ID);
     if (ep != 0xFFFF)

--- a/src/app/clusters/relative-humidity-measurement-server/relative-humidity-measurement-server.cpp
+++ b/src/app/clusters/relative-humidity-measurement-server/relative-humidity-measurement-server.cpp
@@ -17,58 +17,56 @@
 
 #include "relative-humidity-measurement-server.h"
 
-#include <app/util/af.h>
-
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/util/af-event.h>
+#include <app/util/af.h>
 #include <app/util/attribute-storage.h>
-
 #include <support/logging/CHIPLogging.h>
+
+using namespace chip;
 
 #ifndef emberAfRelativeHumidityMeasurementClusterPrintln
 #define emberAfRelativeHumidityMeasurementClusterPrintln(...) ChipLogProgress(Zcl, __VA_ARGS__);
 #endif
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMeasuredValue(chip::EndpointId endpoint, uint16_t * measuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMeasuredValue(EndpointId endpoint, uint16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                       ZCL_RELATIVE_HUMIDITY_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) measuredValue,
                                       sizeof(*measuredValue));
 }
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMinMeasuredValue(chip::EndpointId endpoint, uint16_t * minMeasuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMinMeasuredValue(EndpointId endpoint, uint16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                       ZCL_RELATIVE_HUMIDITY_MIN_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) minMeasuredValue,
                                       sizeof(*minMeasuredValue));
 }
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMaxMeasuredValue(chip::EndpointId endpoint, uint16_t * maxMeasuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterGetMaxMeasuredValue(EndpointId endpoint, uint16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                       ZCL_RELATIVE_HUMIDITY_MAX_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) maxMeasuredValue,
                                       sizeof(*maxMeasuredValue));
 }
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMeasuredValueCallback(chip::EndpointId endpoint, uint16_t measuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMeasuredValueCallback(EndpointId endpoint, uint16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                        ZCL_RELATIVE_HUMIDITY_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) &measuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMinMeasuredValueCallback(chip::EndpointId endpoint,
-                                                                                   uint16_t minMeasuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMinMeasuredValueCallback(EndpointId endpoint, uint16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                        ZCL_RELATIVE_HUMIDITY_MIN_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) &minMeasuredValue,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
 
-EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMaxMeasuredValueCallback(chip::EndpointId endpoint,
-                                                                                   uint16_t maxMeasuredValue)
+EmberAfStatus emberAfRelativeHumidityMeasurementClusterSetMaxMeasuredValueCallback(EndpointId endpoint, uint16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER_ID,
                                        ZCL_RELATIVE_HUMIDITY_MAX_MEASURED_VALUE_ATTRIBUTE_ID, (uint8_t *) &maxMeasuredValue,

--- a/src/app/clusters/scenes-client/scenes-client.cpp
+++ b/src/app/clusters/scenes-client/scenes-client.cpp
@@ -46,13 +46,13 @@
 
 using namespace chip;
 
-bool emberAfScenesClusterAddSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterAddSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                   uint8_t sceneId)
 {
     return emberAfPluginScenesClientParseAddSceneResponse(emberAfCurrentCommand(), status, groupId, sceneId);
 }
 
-bool emberAfScenesClusterViewSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterViewSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                    uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                    uint8_t * extensionFieldSets)
 {
@@ -60,7 +60,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::CommandHandler * c
                                                            sceneName, extensionFieldSets);
 }
 
-bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterRemoveSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                      uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: RemoveSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
@@ -68,14 +68,14 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::CommandHandler *
     return true;
 }
 
-bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
+bool emberAfScenesClusterRemoveAllScenesResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId)
 {
     emberAfScenesClusterPrintln("RX: RemoveAllScenesResponse 0x%x, 0x%2x", status, groupId);
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
 
-bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
+bool emberAfScenesClusterStoreSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, GroupId groupId,
                                                     uint8_t sceneId)
 {
     emberAfScenesClusterPrintln("RX: StoreSceneResponse 0x%x, 0x%2x, 0x%x", status, groupId, sceneId);
@@ -83,9 +83,8 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::CommandHandler * 
     return true;
 }
 
-bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status,
-                                                            uint8_t capacity, GroupId groupId, uint8_t sceneCount,
-                                                            uint8_t * sceneList)
+bool emberAfScenesClusterGetSceneMembershipResponseCallback(app::CommandHandler * commandObj, uint8_t status, uint8_t capacity,
+                                                            GroupId groupId, uint8_t sceneCount, uint8_t * sceneList)
 {
     emberAfScenesClusterPrint("RX: GetSceneMembershipResponse 0x%x, 0x%x, 0x%2x", status, capacity, groupId);
 

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -216,21 +216,19 @@ void emAfPluginScenesServerPrintInfo(void)
     }
 }
 
-bool emberAfScenesClusterAddSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
-                                          uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                                          uint8_t * extensionFieldSets)
+bool emberAfScenesClusterAddSceneCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId,
+                                          uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets)
 {
     return emberAfPluginScenesServerParseAddScene(commandObj, emberAfCurrentCommand(), groupId, sceneId, transitionTime, sceneName,
                                                   extensionFieldSets);
 }
 
-bool emberAfScenesClusterViewSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
-                                           uint8_t sceneId)
+bool emberAfScenesClusterViewSceneCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId)
 {
     return emberAfPluginScenesServerParseViewScene(commandObj, emberAfCurrentCommand(), groupId, sceneId);
 }
 
-bool emberAfScenesClusterRemoveSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
+bool emberAfScenesClusterRemoveSceneCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId,
                                              uint8_t sceneId)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
@@ -267,8 +265,7 @@ bool emberAfScenesClusterRemoveSceneCallback(chip::EndpointId endpoint, chip::ap
     {
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
-                                                 ZCL_REMOVE_SCENE_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 ZCL_REMOVE_SCENE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -286,7 +283,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterRemoveAllScenesCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId)
+bool emberAfScenesClusterRemoveAllScenesCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_FIELD;
     CHIP_ERROR err       = CHIP_NO_ERROR;
@@ -318,7 +315,7 @@ bool emberAfScenesClusterRemoveAllScenesCallback(chip::EndpointId endpoint, chip
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                                  ZCL_REMOVE_ALL_SCENES_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -335,8 +332,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterStoreSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
-                                            uint8_t sceneId)
+bool emberAfScenesClusterStoreSceneCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId, uint8_t sceneId)
 {
     EmberAfStatus status;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -349,8 +345,7 @@ bool emberAfScenesClusterStoreSceneCallback(chip::EndpointId endpoint, chip::app
     {
         {
             app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
-                                                 ZCL_STORE_SCENE_RESPONSE_COMMAND_ID,
-                                                 (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                                 ZCL_STORE_SCENE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
             TLV::TLVWriter * writer          = nullptr;
             SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
             VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -368,7 +363,7 @@ exit:
     return true;
 }
 
-bool emberAfScenesClusterRecallSceneCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj, GroupId groupId,
+bool emberAfScenesClusterRecallSceneCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId,
                                              uint8_t sceneId, uint16_t transitionTime)
 {
     // NOTE: TransitionTime field in the RecallScene command is currently
@@ -402,8 +397,7 @@ bool emberAfScenesClusterRecallSceneCallback(chip::EndpointId endpoint, chip::ap
     return true;
 }
 
-bool emberAfScenesClusterGetSceneMembershipCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                    GroupId groupId)
+bool emberAfScenesClusterGetSceneMembershipCallback(EndpointId endpoint, app::CommandHandler * commandObj, GroupId groupId)
 {
     CHIP_ERROR err       = CHIP_NO_ERROR;
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
@@ -440,7 +434,7 @@ bool emberAfScenesClusterGetSceneMembershipCallback(chip::EndpointId endpoint, c
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
                                              ZCL_GET_SCENE_MEMBERSHIP_RESPONSE_COMMAND_ID,
-                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             (app::CommandPathFlags::kEndpointIdValid) };
         TLV::TLVWriter * writer          = nullptr;
         SuccessOrExit(err = commandObj->PrepareCommand(cmdParams));
         VerifyOrExit((writer = commandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -450,7 +444,7 @@ bool emberAfScenesClusterGetSceneMembershipCallback(chip::EndpointId endpoint, c
                                                              emberAfPluginScenesServerNumSceneEntriesInUse())));
         SuccessOrExit(err = writer->Put(TLV::ContextTag(2), groupId));
         SuccessOrExit(err = writer->Put(TLV::ContextTag(3), sceneCount));
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(4), chip::ByteSpan(sceneList, sceneCount)));
+        SuccessOrExit(err = writer->Put(TLV::ContextTag(4), ByteSpan(sceneList, sceneCount)));
         SuccessOrExit(err = commandObj->FinishCommand());
     }
 
@@ -723,8 +717,8 @@ EmberAfStatus emberAfScenesClusterRecallSavedSceneCallback(EndpointId endpoint, 
     return EMBER_ZCL_STATUS_NOT_FOUND;
 }
 
-bool emberAfPluginScenesServerParseAddScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
-                                            GroupId groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
+bool emberAfPluginScenesServerParseAddScene(app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd, GroupId groupId,
+                                            uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                             uint8_t * extensionFieldSets)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1060,7 +1054,7 @@ kickout:
     }
     {
         app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
-                                             ZCL_ADD_SCENE_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                             ZCL_ADD_SCENE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
         if (enhanced)
         {
             cmdParams.mCommandId = ZCL_ENHANCED_ADD_SCENE_RESPONSE_COMMAND_ID;
@@ -1082,8 +1076,8 @@ exit:
     return true;
 }
 
-bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd,
-                                             GroupId groupId, uint8_t sceneId)
+bool emberAfPluginScenesServerParseViewScene(app::CommandHandler * commandObj, const EmberAfClusterCommand * cmd, GroupId groupId,
+                                             uint8_t sceneId)
 {
     CHIP_ERROR err               = CHIP_NO_ERROR;
     EmberAfSceneTableEntry entry = {};
@@ -1116,7 +1110,7 @@ bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * command
     // the transition time, name, and extension fields are only included if the
     // scene was found.
     app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_SCENES_CLUSTER_ID,
-                                         ZCL_VIEW_SCENE_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                         ZCL_VIEW_SCENE_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
     if (enhanced)
     {
         cmdParams.mCommandId = ZCL_ENHANCED_VIEW_SCENE_RESPONSE_COMMAND_ID;
@@ -1136,7 +1130,7 @@ bool emberAfPluginScenesServerParseViewScene(chip::app::CommandHandler * command
     SuccessOrExit(err = writer->PutString(TLV::ContextTag(4), ""));
 #endif
     // #6620: Need the build the array for response.
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(5), chip::ByteSpan(nullptr, 0)));
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(5), ByteSpan(nullptr, 0)));
     SuccessOrExit(err = commandObj->FinishCommand());
 
     /*

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -19,9 +19,10 @@
 #include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
 
+using namespace chip;
 using namespace chip::app::Clusters;
 
-bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     uint64_t currentHeapUsed;
 

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -30,29 +30,30 @@
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 TargetNavigatorResponse targetNavigatorClusterNavigateTarget(uint8_t target, std::string data);
 
-void sendResponse(chip::app::CommandHandler * command, TargetNavigatorResponse response)
+void sendResponse(app::CommandHandler * command, TargetNavigatorResponse response)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TARGET_NAVIGATOR_CLUSTER_ID,
-                                               ZCL_NAVIGATE_TARGET_RESPONSE_COMMAND_ID,
-                                               (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TARGET_NAVIGATOR_CLUSTER_ID,
+                                         ZCL_NAVIGATE_TARGET_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(0), response.status));
-    SuccessOrExit(err = writer->PutString(chip::TLV::ContextTag(1), reinterpret_cast<const char *>(response.data)));
+    SuccessOrExit(err = writer->Put(TLV::ContextTag(0), response.status));
+    SuccessOrExit(err = writer->PutString(TLV::ContextTag(1), reinterpret_cast<const char *>(response.data)));
     SuccessOrExit(err = command->FinishCommand());
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to send NavigateTargetResponse. Error:%s", chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to send NavigateTargetResponse. Error:%s", ErrorStr(err));
     }
 }
 
-bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                         uint8_t target, uint8_t * data)
+bool emberAfTargetNavigatorClusterNavigateTargetCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t target,
+                                                         uint8_t * data)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string dataString(reinterpret_cast<char *>(data));

--- a/src/app/clusters/temperature-measurement-server/temperature-measurement-server.cpp
+++ b/src/app/clusters/temperature-measurement-server/temperature-measurement-server.cpp
@@ -17,14 +17,12 @@
 
 #include "temperature-measurement-server.h"
 
-#include <app/util/af.h>
-
 #include <app/common/gen/attribute-id.h>
 #include <app/common/gen/attribute-type.h>
 #include <app/common/gen/cluster-id.h>
 #include <app/util/af-event.h>
+#include <app/util/af.h>
 #include <app/util/attribute-storage.h>
-
 #include <support/logging/CHIPLogging.h>
 
 using namespace chip;
@@ -33,37 +31,37 @@ using namespace chip;
 #define emberAfTemperatureMeasurementClusterPrintln(...) ChipLogProgress(Zcl, __VA_ARGS__);
 #endif
 
-EmberAfStatus emberAfTemperatureMeasurementClusterGetMeasuredValue(chip::EndpointId endpoint, int16_t * measuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterGetMeasuredValue(EndpointId endpoint, int16_t * measuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MEASURED_VALUE_ATTRIBUTE_ID,
                                       (uint8_t *) measuredValue, sizeof(*measuredValue));
 }
 
-EmberAfStatus emberAfTemperatureMeasurementClusterGetMinMeasuredValue(chip::EndpointId endpoint, int16_t * minMeasuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterGetMinMeasuredValue(EndpointId endpoint, int16_t * minMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MIN_MEASURED_VALUE_ATTRIBUTE_ID,
                                       (uint8_t *) minMeasuredValue, sizeof(*minMeasuredValue));
 }
 
-EmberAfStatus emberAfTemperatureMeasurementClusterGetMaxMeasuredValue(chip::EndpointId endpoint, int16_t * maxMeasuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterGetMaxMeasuredValue(EndpointId endpoint, int16_t * maxMeasuredValue)
 {
     return emberAfReadServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MAX_MEASURED_VALUE_ATTRIBUTE_ID,
                                       (uint8_t *) maxMeasuredValue, sizeof(*maxMeasuredValue));
 }
 
-EmberAfStatus emberAfTemperatureMeasurementClusterSetMeasuredValueCallback(chip::EndpointId endpoint, int16_t measuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterSetMeasuredValueCallback(EndpointId endpoint, int16_t measuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MEASURED_VALUE_ATTRIBUTE_ID,
                                        (uint8_t *) &measuredValue, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
-EmberAfStatus emberAfTemperatureMeasurementClusterSetMinMeasuredValueCallback(chip::EndpointId endpoint, int16_t minMeasuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterSetMinMeasuredValueCallback(EndpointId endpoint, int16_t minMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MIN_MEASURED_VALUE_ATTRIBUTE_ID,
                                        (uint8_t *) &minMeasuredValue, ZCL_INT16S_ATTRIBUTE_TYPE);
 }
 
-EmberAfStatus emberAfTemperatureMeasurementClusterSetMaxMeasuredValueCallback(chip::EndpointId endpoint, int16_t maxMeasuredValue)
+EmberAfStatus emberAfTemperatureMeasurementClusterSetMaxMeasuredValueCallback(EndpointId endpoint, int16_t maxMeasuredValue)
 {
     return emberAfWriteServerAttribute(endpoint, ZCL_TEMP_MEASUREMENT_CLUSTER_ID, ZCL_TEMP_MAX_MEASURED_VALUE_ATTRIBUTE_ID,
                                        (uint8_t *) &maxMeasuredValue, ZCL_INT16S_ATTRIBUTE_TYPE);

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -83,7 +83,7 @@ EmberAfStatus writeTestListOctetAttribute(EndpointId endpoint)
 
     uint16_t attributeCount = 4;
     char data[6]            = { 'T', 'e', 's', 't', 'N', '\0' };
-    chip::ByteSpan span     = chip::ByteSpan(Uint8::from_char(data), strlen(data));
+    ByteSpan span           = ByteSpan(Uint8::from_char(data), strlen(data));
 
     for (uint8_t index = 0; index < attributeCount; index++)
     {
@@ -105,7 +105,7 @@ EmberAfStatus writeTestListStructOctetAttribute(EndpointId endpoint)
 
     uint16_t attributeCount = 4;
     char data[6]            = { 'T', 'e', 's', 't', 'N', '\0' };
-    chip::ByteSpan span     = chip::ByteSpan(Uint8::from_char(data), strlen(data));
+    ByteSpan span           = ByteSpan(Uint8::from_char(data), strlen(data));
 
     for (uint8_t index = 0; index < attributeCount; index++)
     {
@@ -148,7 +148,7 @@ void emberAfPluginTestClusterServerInitCallback(void)
     }
 }
 
-bool emberAfTestClusterClusterTestCallback(chip::EndpointId endpoint, chip::app::CommandHandler *)
+bool emberAfTestClusterClusterTestCallback(EndpointId endpoint, app::CommandHandler *)
 {
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
     return true;
@@ -159,7 +159,7 @@ bool sendNumericResponse(EndpointId endpoint, app::CommandHandler * apCommandObj
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     app::CommandPathParams cmdParams = { endpoint, /* group id */ 0, ZCL_TEST_CLUSTER_ID, responseCommand,
-                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+                                         (app::CommandPathFlags::kEndpointIdValid) };
     TLV::TLVWriter * writer          = nullptr;
 
     VerifyOrExit(apCommandObj != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/thermostat-server/thermostat.cpp
+++ b/src/app/clusters/thermostat-server/thermostat.cpp
@@ -45,33 +45,31 @@ void emberAfThermostatClusterServerInitCallback(void)
     // or should this just be the responsibility of the thermostat application?
 }
 
-bool emberAfThermostatClusterClearWeeklyScheduleCallback(chip::app::CommandHandler * commandObj)
+bool emberAfThermostatClusterClearWeeklyScheduleCallback(app::CommandHandler * commandObj)
 {
     // TODO
     return false;
 }
-bool emberAfThermostatClusterGetRelayStatusLogCallback(chip::app::CommandHandler * commandObj)
-{
-    // TODO
-    return false;
-}
-
-bool emberAfThermostatClusterGetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj, uint8_t daysToReturn,
-                                                       uint8_t modeToReturn)
+bool emberAfThermostatClusterGetRelayStatusLogCallback(app::CommandHandler * commandObj)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterSetWeeklyScheduleCallback(chip::app::CommandHandler * commandObj,
-                                                       uint8_t numberOfTransitionsForSequence, uint8_t daysOfWeekForSequence,
-                                                       uint8_t modeForSequence, uint8_t * payload)
+bool emberAfThermostatClusterGetWeeklyScheduleCallback(app::CommandHandler * commandObj, uint8_t daysToReturn, uint8_t modeToReturn)
 {
     // TODO
     return false;
 }
 
-bool emberAfThermostatClusterSetpointRaiseLowerCallback(chip::app::CommandHandler * commandObj, uint8_t mode, int8_t amount)
+bool emberAfThermostatClusterSetWeeklyScheduleCallback(app::CommandHandler * commandObj, uint8_t numberOfTransitionsForSequence,
+                                                       uint8_t daysOfWeekForSequence, uint8_t modeForSequence, uint8_t * payload)
+{
+    // TODO
+    return false;
+}
+
+bool emberAfThermostatClusterSetpointRaiseLowerCallback(app::CommandHandler * commandObj, uint8_t mode, int8_t amount)
 {
     bool result             = false;
     EndpointId endpoint     = 1;                            // Hard code to 1 for now/

--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -19,9 +19,10 @@
 #include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
 
+using namespace chip;
 using namespace chip::app::Clusters;
 
-bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = ThreadNetworkDiagnostics::Attributes::SetOverrunCount(endpoint, 0);
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/src/app/clusters/tv-channel-server/tv-channel-server.cpp
+++ b/src/app/clusters/tv-channel-server/tv-channel-server.cpp
@@ -44,32 +44,33 @@
 #include <app/common/gen/command-id.h>
 #include <app/util/af.h>
 
+using namespace chip;
+
 EmberAfTvChannelInfo tvChannelClusterChangeChannel(std::string match);
 bool tvChannelClusterChangeChannelByNumber(uint16_t majorNumer, uint16_t minorNumber);
 bool tvChannelClusterSkipChannel(uint16_t count);
 
-void sendResponse(chip::app::CommandHandler * command, EmberAfTvChannelInfo channelInfo)
+void sendResponse(app::CommandHandler * command, EmberAfTvChannelInfo channelInfo)
 {
-    CHIP_ERROR err                         = CHIP_NO_ERROR;
-    chip::app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TV_CHANNEL_CLUSTER_ID,
-                                               ZCL_CHANGE_CHANNEL_RESPONSE_COMMAND_ID,
-                                               (chip::app::CommandPathFlags::kEndpointIdValid) };
-    chip::TLV::TLVWriter * writer          = nullptr;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    app::CommandPathParams cmdParams = { emberAfCurrentEndpoint(), /* group id */ 0, ZCL_TV_CHANNEL_CLUSTER_ID,
+                                         ZCL_CHANGE_CHANNEL_RESPONSE_COMMAND_ID, (app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
     SuccessOrExit(err = command->PrepareCommand(cmdParams));
     VerifyOrExit((writer = command->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     // TODO: Enable this once struct as param is supported
-    // SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(0), channelInfo));
+    // SuccessOrExit(err = writer->Put(TLV::ContextTag(0), channelInfo));
     // EmberAfTvChannelErrorType. errorType
-    // SuccessOrExit(err = writer->Put(chip::TLV::ContextTag(1), errorType));
+    // SuccessOrExit(err = writer->Put(TLV::ContextTag(1), errorType));
     SuccessOrExit(err = command->FinishCommand());
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Failed to send ChangeChannel. Error:%s", chip::ErrorStr(err));
+        ChipLogError(Zcl, "Failed to send ChangeChannel. Error:%s", ErrorStr(err));
     }
 }
 
-bool emberAfTvChannelClusterChangeChannelCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint8_t * match)
+bool emberAfTvChannelClusterChangeChannelCallback(EndpointId endpoint, app::CommandHandler * command, uint8_t * match)
 {
     // TODO: char is not null terminated, verify this code once #7963 gets merged.
     std::string matchString(reinterpret_cast<char *>(match));
@@ -80,8 +81,8 @@ bool emberAfTvChannelClusterChangeChannelCallback(chip::EndpointId endpoint, chi
     return true;
 }
 
-bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                          uint16_t majorNumber, uint16_t minorNumber)
+bool emberAfTvChannelClusterChangeChannelByNumberCallback(EndpointId endpoint, app::CommandHandler * command, uint16_t majorNumber,
+                                                          uint16_t minorNumber)
 {
     bool success         = tvChannelClusterChangeChannelByNumber(majorNumber, minorNumber);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
@@ -89,7 +90,7 @@ bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::EndpointId endpo
     return true;
 }
 
-bool emberAfTvChannelClusterSkipChannelCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command, uint16_t count)
+bool emberAfTvChannelClusterSkipChannelCallback(EndpointId endpoint, app::CommandHandler * command, uint16_t count)
 {
     bool success         = tvChannelClusterSkipChannel(count);
     EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;

--- a/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
+++ b/src/app/clusters/wifi_network_diagnostics_server/wifi_network_diagnostics_server.cpp
@@ -19,9 +19,10 @@
 #include <app/common/gen/attributes/Accessors.h>
 #include <app/util/af.h>
 
+using namespace chip;
 using namespace chip::app::Clusters;
 
-bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj)
+bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoint, app::CommandHandler * commandObj)
 {
     EmberAfStatus status = WiFiNetworkDiagnostics::Attributes::SetBeaconLostCount(endpoint, 0);
     VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconLostCount attribute"));

--- a/src/app/clusters/zll-identify-server/zll-identify-server.c
+++ b/src/app/clusters/zll-identify-server/zll-identify-server.c
@@ -62,6 +62,8 @@
 #include "hal/hal.h"
 #endif
 
+using namespace chip;
+
 typedef struct
 {
     bool active;
@@ -149,7 +151,7 @@ void emberAfPluginZllIdentifyServerTriggerEffectEndpointEventHandler(uint8_t end
     }
 }
 
-bool emberAfIdentifyClusterTriggerEffectCallback(chip::app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
+bool emberAfIdentifyClusterTriggerEffectCallback(app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
 {
     uint8_t endpoint             = emberAfCurrentEndpoint();
     EmAfZllIdentifyState * state = getZllIdentifyState(endpoint);

--- a/src/app/clusters/zll-on-off-server/zll-on-off-server.c
+++ b/src/app/clusters/zll-on-off-server/zll-on-off-server.c
@@ -56,6 +56,8 @@
 #include "../../include/af.h"
 #include <app/CommandHandler.h>
 
+using namespace chip;
+
 #define ZLL_ON_OFF_CLUSTER_ON_OFF_CONTROL_ACCEPT_ONLY_WHEN_ON_MASK EMBER_BIT(0)
 
 #define readOnOff(endpoint, onOff) readBoolean((endpoint), ZCL_ON_OFF_ATTRIBUTE_ID, "on/off", (onOff))
@@ -167,7 +169,7 @@ void emberAfOnOffClusterServerTickCallback(uint8_t endpoint)
     emberAfScheduleServerTick(endpoint, ZCL_ON_OFF_CLUSTER_ID, MILLISECOND_TICKS_PER_SECOND / 10);
 }
 
-bool emberAfOnOffClusterOffWithEffectCallback(chip::app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
+bool emberAfOnOffClusterOffWithEffectCallback(app::CommandHandler * commandObj, uint8_t effectId, uint8_t effectVariant)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_INVALID_VALUE;
     bool globalSceneControl;
@@ -228,7 +230,7 @@ kickout:
     return true;
 }
 
-bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(chip::app::CommandHandler * commandObj)
+bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback(app::CommandHandler * commandObj)
 {
     EmberAfStatus status;
     bool globalSceneControl;
@@ -279,7 +281,7 @@ kickout:
     return true;
 }
 
-bool emberAfOnOffClusterOnWithTimedOffCallback(chip::app::CommandHandler * commandObj, uint8_t onOffControl, uint16_t onTime,
+bool emberAfOnOffClusterOnWithTimedOffCallback(app::CommandHandler * commandObj, uint8_t onOffControl, uint16_t onTime,
                                                uint16_t offWaitTime)
 {
     EmberAfStatus status;

--- a/src/app/clusters/zll-scenes-client/zll-scenes-client.c
+++ b/src/app/clusters/zll-scenes-client/zll-scenes-client.c
@@ -56,13 +56,15 @@
 #include "../scenes-client/scenes-client.h"
 #include <app/CommandHandler.h>
 
-bool emberAfScenesClusterEnhancedAddSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
+using namespace chip;
+
+bool emberAfScenesClusterEnhancedAddSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
                                                           uint8_t sceneId)
 {
     return emberAfPluginScenesClientParseAddSceneResponse(emberAfCurrentCommand(), status, groupId, sceneId);
 }
 
-bool emberAfScenesClusterEnhancedViewSceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
+bool emberAfScenesClusterEnhancedViewSceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, uint16_t groupId,
                                                            uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
                                                            uint8_t * extensionFieldSets)
 {
@@ -70,7 +72,7 @@ bool emberAfScenesClusterEnhancedViewSceneResponseCallback(chip::app::CommandHan
                                                            sceneName, extensionFieldSets);
 }
 
-bool emberAfScenesClusterCopySceneResponseCallback(chip::app::CommandHandler * commandObj, uint8_t status, uint16_t groupIdFrom,
+bool emberAfScenesClusterCopySceneResponseCallback(app::CommandHandler * commandObj, uint8_t status, uint16_t groupIdFrom,
                                                    uint8_t sceneIdFrom)
 {
     emberAfScenesClusterPrintln("RX: CopySceneResponse 0x%x, 0x%2x, 0x%x", status, groupIdFrom, sceneIdFrom);

--- a/src/app/clusters/zll-scenes-server/zll-scenes-server.c
+++ b/src/app/clusters/zll-scenes-server/zll-scenes-server.c
@@ -56,21 +56,23 @@
 #include "../scenes/scenes.h"
 #include <app/CommandHandler.h>
 
+using namespace chip;
+
 #define ZCL_SCENES_CLUSTER_MODE_COPY_ALL_SCENES_MASK EMBER_BIT(0)
 
-bool emberAfScenesClusterEnhancedAddSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
+bool emberAfScenesClusterEnhancedAddSceneCallback(app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId,
                                                   uint16_t transitionTime, uint8_t * sceneName, uint8_t * extensionFieldSets)
 {
     return emberAfPluginScenesServerParseAddScene(emberAfCurrentCommand(), groupId, sceneId, transitionTime, sceneName,
                                                   extensionFieldSets);
 }
 
-bool emberAfScenesClusterEnhancedViewSceneCallback(chip::app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId)
+bool emberAfScenesClusterEnhancedViewSceneCallback(app::CommandHandler * commandObj, uint16_t groupId, uint8_t sceneId)
 {
     return emberAfPluginScenesServerParseViewScene(emberAfCurrentCommand(), groupId, sceneId);
 }
 
-bool emberAfScenesClusterCopySceneCallback(chip::app::CommandHandler * commandObj, uint8_t mode, uint16_t groupIdFrom,
+bool emberAfScenesClusterCopySceneCallback(app::CommandHandler * commandObj, uint8_t mode, uint16_t groupIdFrom,
                                            uint8_t sceneIdFrom, uint16_t groupIdTo, uint8_t sceneIdTo)
 {
     EmberStatus sendStatus = EMBER_SUCCESS;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* This is the follow-up of review comment in https://github.com/project-chip/connectedhomeip/pull/8644, Some cluster impls have extraneous chip:: all over the place when they should not, and it hurts readability.

* Fixes #8658

#### Change overview
Cleanup prefix chip:: from all cluster implementations

#### Testing
How was this tested? (at least one bullet point required)
* No logic change, the regression test is covered by CI.

