### PR TITLE
Fix BasicAttributeFilter and PrepareListFromTLV generation

### DIFF
--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -12,6 +12,7 @@
 #include <app/util/attribute-list-byte-span.h>
 #include <app/util/basic-types.h>
 #include <app/util/CHIPDeviceCallbacksMgr.h>
+#include <controller/BasicAttributeFilter.h>
 #include <core/CHIPEncoding.h>
 #include <support/BytesToHex.h>
 #include <support/SafeInt.h>
@@ -757,6 +758,7 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
     return true;
 }
 
+{{#if (chip_any_server_has_list_attributes)}}
 static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t *& message, uint16_t & messageLen)
 {
     CHIP_ERROR tlvError = CHIP_NO_ERROR;
@@ -781,6 +783,7 @@ static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t 
     reader.ExitContainer(type);
     return EMBER_ZCL_STATUS_SUCCESS;
 }
+{{/if}}
 
 {{#chip_client_clusters}}
 {{#if (chip_server_has_list_attributes)}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -1,6 +1,5 @@
 {{> header}}
 
-{{#if (chip_has_client_clusters)}}
 #pragma once
 
 #include <app/Command.h>
@@ -11,68 +10,12 @@
 #include <lib/support/FunctionTraits.h>
 #include <lib/support/Span.h>
 
-// Note: The IMDefaultResponseCallback is a bridge to the old CallbackMgr before IM is landed, so it still accepts EmberAfStatus
-// instead of IM status code.
-// #6308 should handle IM error code on the application side, either modify this function or remove this.
-bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
-bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
-                                            chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
-
-// Global Response Callbacks
-typedef void (*DefaultSuccessCallback)(void * context);
-typedef void (*DefaultFailureCallback)(void * context, uint8_t status);
-typedef void (*BooleanAttributeCallback)(void * context, bool value);
-typedef void (*Int8uAttributeCallback)(void * context, uint8_t value);
-typedef void (*Int8sAttributeCallback)(void * context, int8_t value);
-typedef void (*Int16uAttributeCallback)(void * context, uint16_t value);
-typedef void (*Int16sAttributeCallback)(void * context, int16_t value);
-typedef void (*Int32uAttributeCallback)(void * context, uint32_t value);
-typedef void (*Int32sAttributeCallback)(void * context, int32_t value);
-typedef void (*Int64uAttributeCallback)(void * context, uint64_t value);
-typedef void (*Int64sAttributeCallback)(void * context, int64_t value);
-typedef void (*StringAttributeCallback)(void * context, const chip::ByteSpan value);
-typedef void (*AttributeResponseFilter)(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess, chip::Callback::Cancelable * onFailure);
-
-/**
- * BasicAttributeFilter accepts the actual type of onSuccess callback as template parameter.
- * It will check whether the type of the TLV data is expected by onSuccess callback.
- * If a non expected value received, onFailure callback will be called with EMBER_ZCL_STATUS_INVALID_VALUE.
- */
-template <typename CallbackType>
-void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
-                          chip::Callback::Cancelable * onFailure)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    typename chip::FunctionTraits<CallbackType>::template ArgType<1> value;
-
-    if ((err = data->Get(value)) == CHIP_NO_ERROR)
-    {
-        chip::Callback::Callback<CallbackType> * cb = chip::Callback::Callback<CallbackType>::FromCancelable(onSuccess);
-        cb->mCall(cb->mContext, value);
-    }
-    else
-    {
-        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
-        chip::Callback::Callback<DefaultFailureCallback> * cb =
-            chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
-        cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);
-    }
-}
-
-template <>
-void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
-                                                   chip::Callback::Cancelable * onFailure);
-
-typedef void (*ReadReportingConfigurationReportedCallback)(void* context, uint16_t minInterval, uint16_t maxInterval);
-typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16_t timeout);
-
 // Cluster Specific Response Callbacks
 {{#chip_client_clusters}}
 {{#chip_server_cluster_responses}}
 typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_server_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_server_cluster_response_arguments}});
 {{/chip_server_cluster_responses}}
 {{/chip_client_clusters}}
-{{/if}}
 
 // List specific responses
 {{#chip_client_clusters}}

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "chip-zcl-zpro-codec-api.h"
+#include <controller/BasicAttributeFilter.h>
 #include <lib/support/Span.h>
 #include <gen/CHIPClientCallbacks.h>
 

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -230,6 +230,10 @@ function chip_server_cluster_response_arguments(options)
   return asBlocks.call(this, promise, options);
 }
 
+function chip_any_server_has_list_attributes(options)
+{
+}
+
 /**
  * Returns if a given server cluster has any attributes of type List[T]
  *

--- a/src/controller/BasicAttributeFilter.h
+++ b/src/controller/BasicAttributeFilter.h
@@ -1,0 +1,82 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/Command.h>
+#include <app/InteractionModelEngine.h>
+#include <app/common/gen/af-structs.h>
+#include <app/util/af-enums.h>
+#include <inttypes.h>
+#include <lib/support/FunctionTraits.h>
+#include <lib/support/Span.h>
+
+// Note: The IMDefaultResponseCallback is a bridge to the old CallbackMgr before IM is landed, so it still accepts EmberAfStatus
+// instead of IM status code.
+// #6308 should handle IM error code on the application side, either modify this function or remove this.
+bool IMDefaultResponseCallback(const chip::app::Command * commandObj, EmberAfStatus status);
+bool IMReadReportAttributesResponseCallback(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
+                                            chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status);
+
+// Global Response Callbacks
+typedef void (*DefaultSuccessCallback)(void * context);
+typedef void (*DefaultFailureCallback)(void * context, uint8_t status);
+typedef void (*BooleanAttributeCallback)(void * context, bool value);
+typedef void (*Int8uAttributeCallback)(void * context, uint8_t value);
+typedef void (*Int8sAttributeCallback)(void * context, int8_t value);
+typedef void (*Int16uAttributeCallback)(void * context, uint16_t value);
+typedef void (*Int16sAttributeCallback)(void * context, int16_t value);
+typedef void (*Int32uAttributeCallback)(void * context, uint32_t value);
+typedef void (*Int32sAttributeCallback)(void * context, int32_t value);
+typedef void (*Int64uAttributeCallback)(void * context, uint64_t value);
+typedef void (*Int64sAttributeCallback)(void * context, int64_t value);
+typedef void (*StringAttributeCallback)(void * context, const chip::ByteSpan value);
+typedef void (*AttributeResponseFilter)(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
+                                        chip::Callback::Cancelable * onFailure);
+
+/**
+ * BasicAttributeFilter accepts the actual type of onSuccess callback as template parameter.
+ * It will check whether the type of the TLV data is expected by onSuccess callback.
+ * If a non expected value received, onFailure callback will be called with EMBER_ZCL_STATUS_INVALID_VALUE.
+ */
+template <typename CallbackType>
+void BasicAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
+                          chip::Callback::Cancelable * onFailure)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    typename chip::FunctionTraits<CallbackType>::template ArgType<1> value;
+
+    if ((err = data->Get(value)) == CHIP_NO_ERROR)
+    {
+        chip::Callback::Callback<CallbackType> * cb = chip::Callback::Callback<CallbackType>::FromCancelable(onSuccess);
+        cb->mCall(cb->mContext, value);
+    }
+    else
+    {
+        ChipLogError(Zcl, "Failed to get value from TLV data for attribute reading response: %s", chip::ErrorStr(err));
+        chip::Callback::Callback<DefaultFailureCallback> * cb =
+            chip::Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailure);
+        cb->mCall(cb->mContext, EMBER_ZCL_STATUS_INVALID_VALUE);
+    }
+}
+
+template <>
+void BasicAttributeFilter<StringAttributeCallback>(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccess,
+                                                   chip::Callback::Cancelable * onFailure);
+
+typedef void (*ReadReportingConfigurationReportedCallback)(void * context, uint16_t minInterval, uint16_t maxInterval);
+typedef void (*ReadReportingConfigurationReceivedCallback)(void * context, uint16_t timeout);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -30,6 +30,7 @@
 
 #include <app/InteractionModelDelegate.h>
 #include <controller/AbstractMdnsDiscoveryController.h>
+#include <controller/BasicAttributeFilter.h>
 #include <controller/CHIPDevice.h>
 #include <controller/OperationalCredentialsDelegate.h>
 #include <controller/data_model/gen/CHIPClientCallbacks.h>


### PR DESCRIPTION
#### Problem
`BasicAttributeFilter` function definition is generated for any build that contains client clusters. This causes build errors for applications that both contain client clusters and depend on `src/controller`.

Also: there is a case where `PrepareListFromTLV` can be generated but never called, which leads to "defined but not used" compiler errors.

#### Change overview
* move `BasicAttributeFilter` definition to its own file
* change zapt files to include `BasicAttributeFilter` standalone file and not generate `BasicAttributeFilter`
* only generate `PrepareListFromTLV` if a cluster exists with list attributes to avoid "defined but not used" compiler errors

#### Testing
Confirmed build succeeds with local "ota-requestor" application (not yet checked in)
