### PR TITLE
Fix integer overflow in ExtractIdFromServiceName.

### DIFF
--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -17,7 +17,9 @@
 
 #include "ServiceNaming.h"
 
-#include <support/CodeUtils.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/CodeUtils.h>
 
 #include <cstdio>
 #include <inttypes.h>
@@ -25,27 +27,6 @@
 
 namespace chip {
 namespace Mdns {
-namespace {
-
-uint8_t HexToInt(char c)
-{
-    if ('0' <= c && c <= '9')
-    {
-        return static_cast<uint8_t>(c - '0');
-    }
-    else if ('a' <= c && c <= 'f')
-    {
-        return static_cast<uint8_t>(0x0a + c - 'a');
-    }
-    else if ('A' <= c && c <= 'F')
-    {
-        return static_cast<uint8_t>(0x0a + c - 'A');
-    }
-
-    return UINT8_MAX;
-}
-
-} // namespace
 
 CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peerId)
 {
@@ -65,43 +46,36 @@ CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerId * peerId)
     ReturnErrorCodeIf(name == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(peerId == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    peerId->SetNodeId(0);
-    peerId->SetFabricId(0);
+    // Make sure the string is long enough.
+    static constexpr size_t fabricIdByteLength   = 8;
+    static constexpr size_t fabricIdStringLength = fabricIdByteLength * 2;
+    static constexpr size_t nodeIdByteLength     = 8;
+    static constexpr size_t nodeIdStringLength   = nodeIdByteLength * 2;
+    static constexpr size_t totalLength          = fabricIdStringLength + nodeIdStringLength + 1; // +1 for '-'
 
-    bool deliminatorFound = false;
-    bool hasFabricPart    = false;
-    bool hasNodePart      = false;
+    // Ensure we have at least totalLength chars.
+    size_t len = strnlen(name, totalLength);
+    ReturnErrorCodeIf(len < totalLength, CHIP_ERROR_INVALID_ARGUMENT);
 
-    for (; *name != '\0'; name++)
-    {
-        if (*name == '.')
-        {
-            break;
-        }
-        else if (*name == '-')
-        {
-            deliminatorFound = true;
-            continue;
-        }
+    // Check that we have a proper terminator.
+    ReturnErrorCodeIf(name[totalLength] != '\0' && name[totalLength] != '.', CHIP_ERROR_WRONG_NODE_ID);
 
-        uint8_t val = HexToInt(*name);
-        ReturnErrorCodeIf(val == UINT8_MAX, CHIP_ERROR_WRONG_NODE_ID);
+    // Check what we have a separator where we expect.
+    ReturnErrorCodeIf(name[fabricIdStringLength] != '-', CHIP_ERROR_WRONG_NODE_ID);
 
-        if (deliminatorFound)
-        {
-            hasNodePart = true;
-            peerId->SetNodeId(peerId->GetNodeId() * 16 + val);
-        }
-        else
-        {
-            hasFabricPart = true;
-            peerId->SetFabricId(peerId->GetFabricId() * 16 + val);
-        }
-    }
+    static constexpr size_t bufferSize = max(fabricIdByteLength, nodeIdByteLength);
+    uint8_t buf[bufferSize];
 
-    ReturnErrorCodeIf(!deliminatorFound, CHIP_ERROR_WRONG_NODE_ID);
-    ReturnErrorCodeIf(!hasNodePart, CHIP_ERROR_WRONG_NODE_ID);
-    ReturnErrorCodeIf(!hasFabricPart, CHIP_ERROR_WRONG_NODE_ID);
+    ReturnErrorCodeIf(Encoding::HexToBytes(name, fabricIdStringLength, buf, bufferSize) == 0, CHIP_ERROR_WRONG_NODE_ID);
+    // Buf now stores the fabric id, as big-endian bytes.
+    static_assert(fabricIdByteLength == sizeof(uint64_t), "Wrong number of bytes");
+    peerId->SetFabricId(Encoding::BigEndian::Get64(buf));
+
+    ReturnErrorCodeIf(Encoding::HexToBytes(name + fabricIdStringLength + 1, nodeIdStringLength, buf, bufferSize) == 0,
+                      CHIP_ERROR_WRONG_NODE_ID);
+    // Buf now stores the node id id, as big-endian bytes.
+    static_assert(nodeIdByteLength == sizeof(uint64_t), "Wrong number of bytes");
+    peerId->SetNodeId(Encoding::BigEndian::Get64(buf));
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/mdns/ServiceNaming.h
+++ b/src/lib/mdns/ServiceNaming.h
@@ -52,7 +52,10 @@ constexpr size_t kMaxOperationalServiceNameSize =
 /// builds the MDNS advertising name for a given fabric + nodeid pair
 CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peerId);
 
-/// Inverse of MakeInstanceName
+/// Inverse of MakeInstanceName.  Will return errors on non-spec-compliant ids,
+/// _except_ for allowing lowercase hex, not just the spec-defined uppercase
+/// hex.  The part of "name" up to the first '.' (or end of string, whichever
+/// comes first) is parsed as a FABRICID-NODEID.
 CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerId * peerId);
 
 /// Generates the host name that a CHIP device is to use for a given unique


### PR DESCRIPTION
In particular, we enforce that the ids we are trying to extract are
the right length (exactly 16 hex chars each).

#### Problem
ExtractIdFromServiceName can end up with integer overflow if the hex strings involved are longer than 16 digits.

#### Change overview
Check that hex strings are the right length, use existing hex-to-bytes utility instead of having our own private hex-parsing code.

Fixes https://github.com/project-chip/connectedhomeip/issues/8768

#### Testing
Unit tests.