### PR TITLE
Move some macros to CHIPConfig.h

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -49,12 +49,12 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
 
     mReportingEngine.Init();
 
-    for (uint32_t index = 0; index < IM_SERVER_MAX_NUM_PATH_GROUPS - 1; index++)
+    for (uint32_t index = 0; index < CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS - 1; index++)
     {
         mClusterInfoPool[index].mpNext = &mClusterInfoPool[index + 1];
     }
-    mClusterInfoPool[IM_SERVER_MAX_NUM_PATH_GROUPS - 1].mpNext = nullptr;
-    mpNextAvailableClusterInfo                                 = mClusterInfoPool;
+    mClusterInfoPool[CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS - 1].mpNext = nullptr;
+    mpNextAvailableClusterInfo                                      = mClusterInfoPool;
 
     return CHIP_NO_ERROR;
 }
@@ -109,7 +109,7 @@ void InteractionModelEngine::Shutdown()
         }
     }
 
-    for (uint32_t index = 0; index < IM_SERVER_MAX_NUM_PATH_GROUPS; index++)
+    for (uint32_t index = 0; index < CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS; index++)
     {
         mClusterInfoPool[index].mpNext = nullptr;
         mClusterInfoPool[index].ClearDirty();

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -49,16 +49,6 @@
 #include <app/reporting/Engine.h>
 #include <app/util/basic-types.h>
 
-// TODO: Make number of command/read/write client/handler configurable
-#define CHIP_MAX_NUM_COMMAND_HANDLER 4
-#define CHIP_MAX_NUM_COMMAND_SENDER 4
-#define CHIP_MAX_NUM_READ_CLIENT 4
-#define CHIP_MAX_NUM_READ_HANDLER 4
-#define CHIP_MAX_REPORTS_IN_FLIGHT 4
-#define IM_SERVER_MAX_NUM_PATH_GROUPS 8
-#define CHIP_MAX_NUM_WRITE_CLIENT 4
-#define CHIP_MAX_NUM_WRITE_HANDLER 4
-
 namespace chip {
 namespace app {
 
@@ -191,14 +181,17 @@ private:
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
-    CommandHandler mCommandHandlerObjs[CHIP_MAX_NUM_COMMAND_HANDLER];
-    CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER];
-    ReadClient mReadClients[CHIP_MAX_NUM_READ_CLIENT];
-    ReadHandler mReadHandlers[CHIP_MAX_NUM_READ_HANDLER];
-    WriteClient mWriteClients[CHIP_MAX_NUM_WRITE_CLIENT];
-    WriteHandler mWriteHandlers[CHIP_MAX_NUM_WRITE_HANDLER];
+
+    // TODO(#8006): investgate if we can disable some IM functions on some compact accessories.
+    // TODO(#8006): investgate if we can provide more flexible object management on devices with more resources.
+    CommandHandler mCommandHandlerObjs[CHIP_IM_MAX_NUM_COMMAND_HANDLER];
+    CommandSender mCommandSenderObjs[CHIP_IM_MAX_NUM_COMMAND_SENDER];
+    ReadClient mReadClients[CHIP_IM_MAX_NUM_READ_CLIENT];
+    ReadHandler mReadHandlers[CHIP_IM_MAX_NUM_READ_HANDLER];
+    WriteClient mWriteClients[CHIP_IM_MAX_NUM_WRITE_CLIENT];
+    WriteHandler mWriteHandlers[CHIP_IM_MAX_NUM_WRITE_HANDLER];
     reporting::Engine mReportingEngine;
-    ClusterInfo mClusterInfoPool[IM_SERVER_MAX_NUM_PATH_GROUPS];
+    ClusterInfo mClusterInfoPool[CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS];
     ClusterInfo * mpNextAvailableClusterInfo = nullptr;
 };
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -324,7 +324,7 @@ void Engine::Run()
     InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
     ReadHandler * readHandler         = imEngine->mReadHandlers + mCurReadHandlerIdx;
 
-    while ((mNumReportsInFlight < CHIP_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_MAX_NUM_READ_HANDLER))
+    while ((mNumReportsInFlight < CHIP_IM_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_IM_MAX_NUM_READ_HANDLER))
     {
         if (readHandler->IsReportable())
         {
@@ -333,7 +333,7 @@ void Engine::Run()
             return;
         }
         numReadHandled++;
-        mCurReadHandlerIdx = (mCurReadHandlerIdx + 1) % CHIP_MAX_NUM_READ_HANDLER;
+        mCurReadHandlerIdx = (mCurReadHandlerIdx + 1) % CHIP_IM_MAX_NUM_READ_HANDLER;
         readHandler        = imEngine->mReadHandlers + mCurReadHandlerIdx;
     }
 }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2394,3 +2394,97 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #define CHIP_COMMISSIONING_HINT_INDEX_PRESS_RESET_SECONDS_WITH_POWER 10
 #define CHIP_COMMISSIONING_HINT_INDEX_PRESS_RESET_UNTIL_BLINK_WITH_POWER 11
 #endif
+
+/**
+ *  @name Interaction Model object pool configuration.
+ *
+ *  @brief
+ *    The following definitions sets the maximum number of corresponding interaction model object pool size.
+ *
+ *      * #CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *      * #CHIP_IM_MAX_NUM_COMMAND_SENDER
+ *      * #CHIP_IM_MAX_NUM_READ_HANDLER
+ *      * #CHIP_IM_MAX_NUM_READ_CLIENT
+ *      * #CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *      * #CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *      * #CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *      * #CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ *  @{
+ */
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER
+ *
+ * @brief Defines the maximum number of CommandHandler, limits the number of active commands transactions on server.
+ */
+#ifndef CHIP_IM_MAX_NUM_COMMAND_HANDLER
+#define CHIP_IM_MAX_NUM_COMMAND_HANDLER 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_COMMAND_SENDER
+ *
+ * @brief Defines the maximum number of CommandSender, limits the number of active command transactions on client.
+ */
+#ifndef CHIP_IM_MAX_NUM_COMMAND_SENDER
+#define CHIP_IM_MAX_NUM_COMMAND_SENDER 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_HANDLER
+ *
+ * @brief Defines the maximum number of ReadHandler, limits the number of active read transactions on server.
+ */
+#ifndef CHIP_IM_MAX_NUM_READ_HANDLER
+#define CHIP_IM_MAX_NUM_READ_HANDLER 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_READ_CLIENT
+ *
+ * @brief Defines the maximum number of ReadClient, limits the number of active read transactions on client.
+ */
+#ifndef CHIP_IM_MAX_NUM_READ_CLIENT
+#define CHIP_IM_MAX_NUM_READ_CLIENT 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_REPORTS_IN_FLIGHT
+ *
+ * @brief Defines the maximum number of Reports, limits the traffic of read and subscription transactions.
+ */
+#ifndef CHIP_IM_MAX_REPORTS_IN_FLIGHT
+#define CHIP_IM_MAX_REPORTS_IN_FLIGHT 4
+#endif
+
+/**
+ * @def CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+ *
+ * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
+ */
+#ifndef CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 8
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_HANDLER
+ *
+ * @brief Defines the maximum number of WriteHandler, limits the number of active write transactions on server.
+ */
+#ifndef CHIP_IM_MAX_NUM_WRITE_HANDLER
+#define CHIP_IM_MAX_NUM_WRITE_HANDLER 4
+#endif
+
+/**
+ * @def CHIP_IM_MAX_NUM_WRITE_CLIENT
+ *
+ * @brief Defines the maximum number of WriteClient, limits the number of active write transactions on client.
+ */
+#ifndef CHIP_IM_MAX_NUM_WRITE_CLIENT
+#define CHIP_IM_MAX_NUM_WRITE_CLIENT 4
+#endif
+
+/**
+ * @}
+ */


### PR DESCRIPTION
#### Problem

* Related #8006

#### Change overview

- This is PR contains trivial change to PR to move some macros from `src/app/InteractionModelEngine.h` to `src/lib/core/CHIPConfig.h` to make it configurable by `CHIPProjectConfig.h` with some renaming.
- Extracts discussions in #8006 as TODOs in this PR. They will be addressed after later updates to IM.

#### Testing
How was this tested? (at least one bullet point required)
* Build passed, no logic is changed in this PR.
