### PR TITLE
[cloudbuild] Add compress flag to compress built artifacts

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,29 +6,19 @@ steps:
       args:
           [
               "./scripts/build/build_examples.py --platform all build
-              --copy-artifacts-to /workspace/artifacts/",
+              --create-archives /workspace/artifacts/",
           ]
       timeout: 7200s
-
-    # Final steps: upload artifacts. Use this because the artifacts/objects command does not seem to
-    # support recursive copies.
-    #
-    # This has the unfortunate sideffect that 'artifacts' will not be visible as part of the
-    # build run information.
-    - name: "gcr.io/cloud-builders/gsutil"
-      args:
-          [
-              "-m",
-              "cp",
-              "-r",
-              "artifacts/*",
-              "gs://matter-build-automation-artifacts/$PROJECT_ID/$COMMIT_SHA/",
-          ]
 
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
 timeout: 7200s
+
+artifacts:
+    objects:
+        location: "gs://matter-build-automation-artifacts/$PROJECT_ID/$COMMIT_SHA/"
+        paths: ["/workspace/artifacts/*.tar.gz"]
 
 # Using higher CPU machines generally speeds up builds by > 4x (faster as we spend more time
 # building instead of docker download/checkout/bootstrap)

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -139,6 +139,15 @@ class Context:
     # any generated output was cleaned
     self.completed_steps.discard(BuildSteps.GENERATED)
 
+  def CreateArtifactArchives(self, directory: str):
+    logging.info('Copying build artifacts to %s', directory)
+    if not os.path.exists(directory):
+      os.makedirs(directory)
+    for builder in self.builders:
+      # FIXME: builder subdir...
+        builder.CompressArtifacts(os.path.join(
+            directory, f'{builder.identifier}.tar.gz'))
+
   def CopyArtifactsTo(self, path: str):
     logging.info('Copying build artifacts to %s', path)
     if not os.path.exists(path):

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -151,12 +151,20 @@ def cmd_generate(context):
     default=None,
     type=click.Path(file_okay=False, resolve_path=True),
     help='Prefix for the generated file output.')
+@click.option(
+    '--create-archives',
+    default=None,
+    type=click.Path(file_okay=False, resolve_path=True),
+    help='Prefix of compressed archives of the generated files.')
 @click.pass_context
-def cmd_build(context, copy_artifacts_to):
+def cmd_build(context, copy_artifacts_to, create_archives):
   context.obj.Build()
 
   if copy_artifacts_to:
     context.obj.CopyArtifactsTo(copy_artifacts_to)
+
+  if create_archives:
+    context.obj.CreateArtifactArchives(create_archives)
 
 
 if __name__ == '__main__':

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import shutil
+import tarfile
 from abc import ABC, abstractmethod
 
 
@@ -56,6 +57,12 @@ class Builder(ABC):
 
   def _Execute(self, cmdarray, cwd=None, title=None):
     self._runner.Run(cmdarray, cwd=cwd, title=title)
+
+  def CompressArtifacts(self, target_file: str):
+    with tarfile.open(target_file, "w:gz") as tar:
+      for target_name, source_name in self.outputs().items():
+        logging.info(f'Adding {source_name} into {target_file}/{target_name}')
+        tar.add(source_name, target_name)
 
   def CopyArtifacts(self, target_dir: str):
     for target_name, source_name in self.outputs().items():


### PR DESCRIPTION
#### Problem
* Fixes #8766
* build-examples.yaml should support tarballs for artifact creation 

#### Change overview

* Adds `--compress` flag to `./scripts/build/build_examples.py` to pack the artifacts into several tar.gz archives.

#### Testing

* Manaully tested on cloudbuild.
