### PR TITLE
[dns-sd] Expose operational node TXT entries

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -48,6 +48,16 @@ public:
         nodeData.mAddress.ToString(addrBuffer);
         ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Address: %s, Port: %" PRIu16, nodeData.mPeerId.GetNodeId(),
                         addrBuffer, nodeData.mPort);
+
+        if (nodeData.mMrpRetryIntervalIdle != 0)
+            ChipLogProgress(chipTool, "   MRP retry interval (idle): %" PRIu32 "ms", nodeData.mMrpRetryIntervalIdle);
+
+        if (nodeData.mMrpRetryIntervalActive != 0)
+            ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", nodeData.mMrpRetryIntervalActive);
+
+        if (nodeData.mSupportsTcp)
+            ChipLogProgress(chipTool, "   Supports TCP: yes");
+
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -48,6 +48,7 @@ public:
         nodeData.mAddress.ToString(addrBuffer);
         ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Address: %s, Port: %" PRIu16, nodeData.mPeerId.GetNodeId(),
                         addrBuffer, nodeData.mPort);
+        ChipLogProgress(chipTool, "    Hostname: %s", nodeData.mHostName);
 
         auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
 
@@ -59,7 +60,7 @@ public:
         if (retryInterval.HasValue())
             ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", retryInterval.Value());
 
-        ChipLogProgress(chipTool, "   Supports TCP: %s\n", nodeData.mSupportsTcp ? "yes" : "no");
+        ChipLogProgress(chipTool, "   Supports TCP: %s", nodeData.mSupportsTcp ? "yes" : "no");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -49,15 +49,17 @@ public:
         ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Address: %s, Port: %" PRIu16, nodeData.mPeerId.GetNodeId(),
                         addrBuffer, nodeData.mPort);
 
-        if (nodeData.mMrpRetryIntervalIdle != 0)
-            ChipLogProgress(chipTool, "   MRP retry interval (idle): %" PRIu32 "ms", nodeData.mMrpRetryIntervalIdle);
+        auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
 
-        if (nodeData.mMrpRetryIntervalActive != 0)
-            ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", nodeData.mMrpRetryIntervalActive);
+        if (retryInterval.HasValue())
+            ChipLogProgress(chipTool, "   MRP retry interval (idle): %" PRIu32 "ms", retryInterval.Value());
 
-        if (nodeData.mSupportsTcp)
-            ChipLogProgress(chipTool, "   Supports TCP: yes");
+        retryInterval = nodeData.GetMrpRetryIntervalActive();
 
+        if (retryInterval.HasValue())
+            ChipLogProgress(chipTool, "   MRP retry interval (active): %" PRIu32 "ms", retryInterval.Value());
+
+        ChipLogProgress(chipTool, "   Supports TCP: %s\n", nodeData.mSupportsTcp ? "yes" : "no");
         SetCommandExitStatus(CHIP_NO_ERROR);
     }
 

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -38,6 +38,7 @@ static constexpr size_t kMaxMacSize = 8;
 // Operational node TXT entries
 static constexpr size_t kTxtRetryIntervalIdleMaxLength   = 7; // [CRI] 0-3600000
 static constexpr size_t kTxtRetryIntervalActiveMaxLength = 7; // [CRA] 0-3600000
+static constexpr size_t kMaxRetryInterval                = 3600000;
 
 // Commissionable/commissioner node TXT entries
 static constexpr size_t kKeyDiscriminatorMaxLength      = 5;

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -481,7 +481,7 @@ void DiscoveryImplPlatform::HandleNodeResolve(void * context, MdnsService * resu
     {
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, &data);
+        FillNodeDataFromTxt(key, val, data);
     }
     mgr->mResolverDelegate->OnNodeDiscoveryComplete(data);
 }
@@ -542,6 +542,13 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
     nodeData.mInterfaceId = result->mInterface;
     nodeData.mAddress     = result->mAddress.ValueOr({});
     nodeData.mPort        = result->mPort;
+
+    for (size_t i = 0; i < result->mTextEntrySize; ++i)
+    {
+        ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
+        ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
+        FillNodeDataFromTxt(key, val, nodeData);
+    }
 
     nodeData.LogNodeIdResolved();
     mgr->mResolverDelegate->OnNodeIdResolved(nodeData);

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -539,6 +539,7 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
         return;
     }
 
+    Platform::CopyString(nodeData.mHostName, result->mHostName);
     nodeData.mInterfaceId = result->mInterface;
     nodeData.mAddress     = result->mAddress.ValueOr({});
     nodeData.mPort        = result->mPort;

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -44,9 +44,12 @@ struct ResolvedNodeData
     }
 
     PeerId mPeerId;
-    Inet::InterfaceId mInterfaceId;
-    Inet::IPAddress mAddress;
-    uint16_t mPort;
+    Inet::IPAddress mAddress         = Inet::IPAddress::Any;
+    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;
+    uint16_t mPort                   = 0;
+    bool mSupportsTcp                = false;
+    uint32_t mMrpRetryIntervalIdle   = 0;
+    uint32_t mMrpRetryIntervalActive = 0;
 };
 
 constexpr size_t kMaxDeviceNameLen         = 32;

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -31,6 +31,8 @@
 namespace chip {
 namespace Mdns {
 
+// Largest host name is 64-bits in hex.
+static constexpr int kMaxHostNameSize      = 16;
 constexpr uint32_t kUndefinedRetryInterval = std::numeric_limits<uint32_t>::max();
 
 struct ResolvedNodeData
@@ -60,20 +62,19 @@ struct ResolvedNodeData
     }
 
     PeerId mPeerId;
-    Inet::IPAddress mAddress         = Inet::IPAddress::Any;
-    Inet::InterfaceId mInterfaceId   = INET_NULL_INTERFACEID;
-    uint16_t mPort                   = 0;
-    bool mSupportsTcp                = false;
-    uint32_t mMrpRetryIntervalIdle   = kUndefinedRetryInterval;
-    uint32_t mMrpRetryIntervalActive = kUndefinedRetryInterval;
+    Inet::IPAddress mAddress             = Inet::IPAddress::Any;
+    Inet::InterfaceId mInterfaceId       = INET_NULL_INTERFACEID;
+    uint16_t mPort                       = 0;
+    char mHostName[kMaxHostNameSize + 1] = {};
+    bool mSupportsTcp                    = false;
+    uint32_t mMrpRetryIntervalIdle       = kUndefinedRetryInterval;
+    uint32_t mMrpRetryIntervalActive     = kUndefinedRetryInterval;
 };
 
 constexpr size_t kMaxDeviceNameLen         = 32;
 constexpr size_t kMaxRotatingIdLen         = 50;
 constexpr size_t kMaxPairingInstructionLen = 128;
 
-// Largest host name is 64-bits in hex.
-static constexpr int kMaxHostNameSize     = 16;
 static constexpr int kMaxInstanceNameSize = 16;
 struct DiscoveredNodeData
 {

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -27,7 +27,7 @@
 #include <mdns/minimal/QueryBuilder.h>
 #include <mdns/minimal/RecordData.h>
 #include <mdns/minimal/core/FlatAllocatedQName.h>
-
+#include <support/CHIPMemString.h>
 #include <support/logging/CHIPLogging.h>
 
 // MDNS servers will receive all broadcast packets over the network.
@@ -122,6 +122,12 @@ void PacketDataReporter::OnHeader(ConstHeaderRef & header)
 
 void PacketDataReporter::OnOperationalSrvRecord(SerializedQNameIterator name, const SrvRecord & srv)
 {
+    mdns::Minimal::SerializedQNameIterator it = srv.GetName();
+    if (it.Next())
+    {
+        Platform::CopyString(mNodeData.mHostName, it.Value());
+    }
+
     if (!name.Next())
     {
 #ifdef MINMDNS_RESOLVER_OVERLY_VERBOSE
@@ -148,7 +154,7 @@ void PacketDataReporter::OnCommissionableNodeSrvRecord(SerializedQNameIterator n
     mdns::Minimal::SerializedQNameIterator it = srv.GetName();
     if (it.Next())
     {
-        strncpy(mDiscoveredNodeData.hostName, it.Value(), sizeof(DiscoveredNodeData::hostName));
+        Platform::CopyString(mDiscoveredNodeData.hostName, it.Value());
     }
     if (name.Next())
     {

--- a/src/lib/mdns/TxtFields.h
+++ b/src/lib/mdns/TxtFields.h
@@ -42,6 +42,9 @@ enum class TxtFieldKey : uint8_t
     kRotatingDeviceId,
     kPairingInstruction,
     kPairingHint,
+    kMrpRetryIntervalIdle,
+    kMrpRetryIntervalActive,
+    kTcpSupport,
 };
 
 TxtFieldKey GetTxtFieldKey(const ByteSpan & key);
@@ -61,7 +64,8 @@ void GetPairingInstruction(const ByteSpan & value, char * pairingInstruction);
 } // namespace Internal
 #endif
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DiscoveredNodeData * nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DiscoveredNodeData & nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedNodeData & nodeData);
 
 } // namespace Mdns
 } // namespace chip

--- a/src/lib/mdns/TxtFields.h
+++ b/src/lib/mdns/TxtFields.h
@@ -51,7 +51,7 @@ TxtFieldKey GetTxtFieldKey(const ByteSpan & key);
 
 uint16_t GetProduct(const ByteSpan & value);
 uint16_t GetVendor(const ByteSpan & value);
-uint16_t GetLongDisriminator(const ByteSpan & value);
+uint16_t GetLongDiscriminator(const ByteSpan & value);
 uint8_t GetAdditionalPairing(const ByteSpan & value);
 uint8_t GetCommissioningMode(const ByteSpan & value);
 // TODO: possibly 32-bit? see spec issue #3226

--- a/src/lib/mdns/tests/TestTxtFields.cpp
+++ b/src/lib/mdns/tests/TestTxtFields.cpp
@@ -42,7 +42,7 @@ ByteSpan GetSpan(char * key)
 
 void TestGetTxtFieldKey(nlTestSuite * inSuite, void * inContext)
 {
-    char key[3];
+    char key[4];
     sprintf(key, "D");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kLongDiscriminator);
 
@@ -69,6 +69,15 @@ void TestGetTxtFieldKey(nlTestSuite * inSuite, void * inContext)
 
     sprintf(key, "PH");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kPairingHint);
+
+    sprintf(key, "CRI");
+    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kMrpRetryIntervalIdle);
+
+    sprintf(key, "CRA");
+    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kMrpRetryIntervalActive);
+
+    sprintf(key, "T");
+    NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kTcpSupport);
 
     sprintf(key, "XX");
     NL_TEST_ASSERT(inSuite, GetTxtFieldKey(GetSpan(key)) == TxtFieldKey::kUnknown);
@@ -302,7 +311,7 @@ bool NodeDataIsEmpty(const DiscoveredNodeData & node)
 }
 
 // The individual fill tests test the error cases for each key type, this test is used to ensure the proper record is filled.
-void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
+void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
 {
     char key[3];
     char val[16];
@@ -311,7 +320,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Long discriminator
     sprintf(key, "D");
     sprintf(val, "840");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.longDiscriminator == 840);
     filled.longDiscriminator = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -319,7 +328,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // vendor and product
     sprintf(key, "VP");
     sprintf(val, "123+456");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.vendorId == 123);
     NL_TEST_ASSERT(inSuite, filled.productId == 456);
     filled.vendorId  = 0;
@@ -329,7 +338,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Additional Pairing
     sprintf(key, "AP");
     sprintf(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.additionalPairing == 1);
     filled.additionalPairing = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -337,7 +346,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Commissioning mode
     sprintf(key, "CM");
     sprintf(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.commissioningMode == 1);
     filled.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -345,7 +354,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Device type
     sprintf(key, "DT");
     sprintf(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.deviceType == 1);
     filled.deviceType = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -353,7 +362,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Device name
     sprintf(key, "DN");
     sprintf(val, "abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, strcmp(filled.deviceName, "abc") == 0);
     memset(filled.deviceName, 0, sizeof(filled.deviceName));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -361,7 +370,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Rotating device id
     sprintf(key, "RI");
     sprintf(val, "1A2B");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.rotatingId[0] == 0x1A);
     NL_TEST_ASSERT(inSuite, filled.rotatingId[1] == 0x2B);
     NL_TEST_ASSERT(inSuite, filled.rotatingIdLen == 2);
@@ -372,7 +381,7 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Pairing instruction
     sprintf(key, "PI");
     sprintf(val, "hint");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, strcmp(filled.pairingInstruction, "hint") == 0);
     memset(filled.pairingInstruction, 0, sizeof(filled.pairingInstruction));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -380,27 +389,138 @@ void TestFillNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Pairing hint
     sprintf(key, "PH");
     sprintf(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), &filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
     NL_TEST_ASSERT(inSuite, filled.pairingHint == 1);
     filled.pairingHint = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 }
 
+bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
+{
+    return nodeData.mPeerId == PeerId{} && nodeData.mAddress == Inet::IPAddress::Any && nodeData.mPort == 0 &&
+        nodeData.mMrpRetryIntervalIdle == 0 && nodeData.mMrpRetryIntervalActive == 0 && !nodeData.mSupportsTcp;
+}
+
+// Test CRI
+void TxtFieldMrpRetryIntervalIdle(nlTestSuite * inSuite, void * inContext)
+{
+    char key[4];
+    char val[8];
+    ResolvedNodeData nodeData;
+
+    // Minimum
+    sprintf(key, "CRI");
+    sprintf(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalIdle == 1);
+
+    // Maximum
+    sprintf(key, "CRI");
+    sprintf(val, "3600000");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalIdle == 3600000);
+
+    // Test no other fields were populated
+    nodeData.mMrpRetryIntervalIdle = 0;
+    NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
+
+    // Invalid CRI => fallback to 0
+    sprintf(key, "CRI");
+    sprintf(val, "-1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalIdle == 0);
+
+    // Invalid CRI => fallback to 0
+    sprintf(key, "CRI");
+    sprintf(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalIdle == 0);
+}
+
+// Test CRA
+void TxtFieldMrpRetryIntervalActive(nlTestSuite * inSuite, void * inContext)
+{
+    char key[4];
+    char val[8];
+    ResolvedNodeData nodeData;
+
+    // Minimum
+    sprintf(key, "CRA");
+    sprintf(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalActive == 1);
+
+    // Maximum
+    sprintf(key, "CRA");
+    sprintf(val, "3600000");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalActive == 3600000);
+
+    // Test no other fields were populated
+    nodeData.mMrpRetryIntervalActive = 0;
+    NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
+
+    // Invalid CRI => fallback to 0
+    sprintf(key, "CRA");
+    sprintf(val, "-1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalActive == 0);
+
+    // Invalid CRI => fallback to 0
+    sprintf(key, "CRA");
+    sprintf(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mMrpRetryIntervalActive == 0);
+}
+
+// Test T (TCP support)
+void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
+{
+    char key[4];
+    char val[8];
+    ResolvedNodeData nodeData;
+
+    // True
+    sprintf(key, "T");
+    sprintf(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, nodeData.mSupportsTcp);
+
+    // Test no other fields were populated
+    nodeData.mSupportsTcp = false;
+    NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(nodeData));
+
+    // False
+    sprintf(key, "T");
+    sprintf(val, "0");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, !nodeData.mSupportsTcp);
+
+    // Invalid value, stil false
+    sprintf(key, "T");
+    sprintf(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    NL_TEST_ASSERT(inSuite, !nodeData.mSupportsTcp);
+}
+
 const nlTest sTests[] = {
-    NL_TEST_DEF("TxtFieldKey", TestGetTxtFieldKey),                               //
-    NL_TEST_DEF("TxtFieldKeyCaseInsensitive", TestGetTxtFieldKeyCaseInsensitive), //
-    NL_TEST_DEF("TxtFieldProduct", TestGetProduct),                               //
-    NL_TEST_DEF("TxtFieldVendor", TestGetVendor),                                 //
-    NL_TEST_DEF("TxtFieldLongDiscriminator", TestGetLongDiscriminator),           //
-    NL_TEST_DEF("TxtFieldAdditionalPairing", TestGetAdditionalPairing),           //
-    NL_TEST_DEF("TxtFieldCommissioningMode", TestGetCommissioningMode),           //
-    NL_TEST_DEF("TxtFieldDeviceType", TestGetDeviceType),                         //
-    NL_TEST_DEF("TxtFieldDeviceName", TestGetDeviceName),                         //
-    NL_TEST_DEF("TxtFieldRotatingDeviceId", TestGetRotatingDeviceId),             //
-    NL_TEST_DEF("TxtFieldPairingHint", TestGetPairingHint),                       //
-    NL_TEST_DEF("TxtFieldPairingInstruction", TestGetPairingInstruction),         //
-    NL_TEST_DEF("TxtFieldFillNodeDataFromTxt", TestFillNodeDataFromTxt),          //
-    NL_TEST_SENTINEL()                                                            //
+    NL_TEST_DEF("TxtFieldKey", TestGetTxtFieldKey),                                          //
+    NL_TEST_DEF("TxtFieldKeyCaseInsensitive", TestGetTxtFieldKeyCaseInsensitive),            //
+    NL_TEST_DEF("TxtFieldProduct", TestGetProduct),                                          //
+    NL_TEST_DEF("TxtFieldVendor", TestGetVendor),                                            //
+    NL_TEST_DEF("TxtFieldLongDiscriminator", TestGetLongDiscriminator),                      //
+    NL_TEST_DEF("TxtFieldAdditionalPairing", TestGetAdditionalPairing),                      //
+    NL_TEST_DEF("TxtFieldCommissioningMode", TestGetCommissioningMode),                      //
+    NL_TEST_DEF("TxtFieldDeviceType", TestGetDeviceType),                                    //
+    NL_TEST_DEF("TxtFieldDeviceName", TestGetDeviceName),                                    //
+    NL_TEST_DEF("TxtFieldRotatingDeviceId", TestGetRotatingDeviceId),                        //
+    NL_TEST_DEF("TxtFieldPairingHint", TestGetPairingHint),                                  //
+    NL_TEST_DEF("TxtFieldPairingInstruction", TestGetPairingInstruction),                    //
+    NL_TEST_DEF("TxtFieldFillDiscoveredNodeDataFromTxt", TestFillDiscoveredNodeDataFromTxt), //
+    NL_TEST_DEF("TxtFieldMrpRetryIntervalIdle", TxtFieldMrpRetryIntervalIdle),               //
+    NL_TEST_DEF("TxtFieldMrpRetryIntervalActive", TxtFieldMrpRetryIntervalActive),           //
+    NL_TEST_DEF("TxtFieldTcpSupport", TxtFieldTcpSupport),                                   //
+    NL_TEST_SENTINEL()                                                                       //
 };
 
 } // namespace

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -40,6 +40,7 @@ public:
     {
         streamer_printf(streamer_get(), "DNS resolve for " ChipLogFormatX64 "-" ChipLogFormatX64 " succeeded:\n",
                         ChipLogValueX64(nodeData.mPeerId.GetFabricId()), ChipLogValueX64(nodeData.mPeerId.GetNodeId()));
+        streamer_printf(streamer_get(), "   Hostname: %s\n", nodeData.mHostName);
         streamer_printf(streamer_get(), "   IP address: %s\n", nodeData.mAddress.ToString(ipAddressBuf));
         streamer_printf(streamer_get(), "   Port: %" PRIu16 "\n", nodeData.mPort);
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -43,14 +43,17 @@ public:
         streamer_printf(streamer_get(), "   IP address: %s\n", nodeData.mAddress.ToString(ipAddressBuf));
         streamer_printf(streamer_get(), "   Port: %" PRIu16 "\n", nodeData.mPort);
 
-        if (nodeData.mMrpRetryIntervalIdle != 0)
-            streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\n", nodeData.mMrpRetryIntervalIdle);
+        auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
 
-        if (nodeData.mMrpRetryIntervalActive != 0)
-            streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\n", nodeData.mMrpRetryIntervalActive);
+        if (retryInterval.HasValue())
+            streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\n", retryInterval.Value());
 
-        if (nodeData.mSupportsTcp)
-            streamer_printf(streamer_get(), "   Supports TCP: yes\n");
+        retryInterval = nodeData.GetMrpRetryIntervalActive();
+
+        if (retryInterval.HasValue())
+            streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\n", retryInterval.Value());
+
+        streamer_printf(streamer_get(), "   Supports TCP: %s\n", nodeData.mSupportsTcp ? "yes" : "no");
     }
 
     void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override {}
@@ -70,6 +73,18 @@ public:
         streamer_printf(streamer_get(), "   Device type: %d\n", nodeData.deviceType);
         streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.deviceName);
         streamer_printf(streamer_get(), "   Commissioning mode: %d\n", nodeData.commissioningMode);
+
+        auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
+
+        if (retryInterval.HasValue())
+            streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\n", retryInterval.Value());
+
+        retryInterval = nodeData.GetMrpRetryIntervalActive();
+
+        if (retryInterval.HasValue())
+            streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\n", retryInterval.Value());
+
+        streamer_printf(streamer_get(), "   Supports TCP: %s\n", nodeData.supportsTcp ? "yes" : "no");
         streamer_printf(streamer_get(), "   IP addresses:\n");
         for (uint8_t i = 0; i < nodeData.kMaxIPAddresses; i++)
         {

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -41,7 +41,16 @@ public:
         streamer_printf(streamer_get(), "DNS resolve for " ChipLogFormatX64 "-" ChipLogFormatX64 " succeeded:\n",
                         ChipLogValueX64(nodeData.mPeerId.GetFabricId()), ChipLogValueX64(nodeData.mPeerId.GetNodeId()));
         streamer_printf(streamer_get(), "   IP address: %s\n", nodeData.mAddress.ToString(ipAddressBuf));
-        streamer_printf(streamer_get(), "   Port: %d\n", nodeData.mPort);
+        streamer_printf(streamer_get(), "   Port: %" PRIu16 "\n", nodeData.mPort);
+
+        if (nodeData.mMrpRetryIntervalIdle != 0)
+            streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\n", nodeData.mMrpRetryIntervalIdle);
+
+        if (nodeData.mMrpRetryIntervalActive != 0)
+            streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\n", nodeData.mMrpRetryIntervalActive);
+
+        if (nodeData.mSupportsTcp)
+            streamer_printf(streamer_get(), "   Supports TCP: yes\n");
     }
 
     void OnNodeIdResolutionFailed(const PeerId & peerId, CHIP_ERROR error) override {}


### PR DESCRIPTION
#### Problem
Currently, the resolver interface for operational node discovery only returns IP address and port, and TXT entries
are ignored. 

#### Change overview
Extend the interface to expose values published via TXT entries such as CRI, CRA and T.
Print those values in chip-tool and "dns resolve" shell command output.

#### Testing
* Unit tests for TXT entry parsing and populating `ResolveNodeData` structure added.
* Also, tested manually using `chip-tool` built with both minimal mDNS and Avahi implementations, and using nRF Connect Lock example build with `west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_LIB_SHELL=y` which enables "matter dns resolve" shell command.
