### PR TITLE
Increase timeout to 20 minutes for regular builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
 
                   scripts/build/gn_gen.sh --args="$GN_ARGS"
             - name: Run Build
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: scripts/build/gn_build.sh
             - name: Run Tests
               timeout-minutes: 2
@@ -114,14 +114,14 @@ jobs:
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
             - name: Run Build Without Detail Logging
               if: ${{ matrix.type == 'gcc_debug' }}
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: scripts/build/gn_build.sh
             - name: Setup Build Without Progress Logging
               if: ${{ matrix.type == 'gcc_debug' }}
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
             - name: Run Build Without Progress Logging
               if: ${{ matrix.type == 'gcc_debug' }}
-              timeout-minutes: 10
+              timeout-minutes: 20
               run: scripts/build/gn_build.sh
     build_darwin:
         name: Build on Darwin


### PR DESCRIPTION
#### Problem
Restarted several master builds today that fail on "Build on linux (gcc_debug)" with timing out in 10 minutes

#### Change overview
Increase timeout to 20 minutes for build

#### Testing
Github action, modifying time constant. Not tested.
