### PR TITLE
[ZAP] Add a script to update .zap files automatically

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3433,7 +3433,7 @@
               "reportableChange": 0
             },
             {
-              "name": "supported fabrics",
+              "name": "SupportedFabrics",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -3448,7 +3448,7 @@
               "reportableChange": 0
             },
             {
-              "name": "commissioned fabrics",
+              "name": "CommissionedFabrics",
               "code": 3,
               "mfgCode": null,
               "side": "server",
@@ -6677,7 +6677,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -6728,7 +6728,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -10075,7 +10075,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -10146,7 +10146,7 @@
               "reportableChange": 0
             },
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -14438,7 +14438,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -14489,7 +14489,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -17089,6 +17089,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -2113,7 +2113,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -2139,7 +2139,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -2796,7 +2796,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -2847,7 +2847,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3350,6 +3350,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -2931,7 +2931,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -2957,7 +2957,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -3646,7 +3646,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3721,7 +3721,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4935,6 +4935,5 @@
       "endpointVersion": "",
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -661,7 +661,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -712,7 +712,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3750,7 +3750,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3801,7 +3801,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4362,6 +4362,5 @@
       "endpointVersion": 0,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-app/pump-common/pump-app.zap
+++ b/examples/pump-app/pump-common/pump-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -2744,7 +2744,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -2770,7 +2770,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -3965,7 +3965,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4016,7 +4016,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4999,6 +4999,5 @@
       "endpointVersion": 1,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -2744,7 +2744,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -2770,7 +2770,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -3965,7 +3965,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4016,7 +4016,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -4999,6 +4999,5 @@
       "endpointVersion": 1,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
@@ -2497,6 +2497,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3222,7 +3222,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -3248,7 +3248,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -3289,7 +3289,7 @@
               "outgoing": 0
             },
             {
-              "name": "AddOpCert",
+              "name": "AddNOC",
               "code": 6,
               "mfgCode": null,
               "source": "client",
@@ -3380,7 +3380,7 @@
               "outgoing": 1
             },
             {
-              "name": "OpCertResponse",
+              "name": "NOCResponse",
               "code": 8,
               "mfgCode": null,
               "source": "server",
@@ -6522,7 +6522,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -6573,7 +6573,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -13650,7 +13650,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -13701,7 +13701,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -16226,6 +16226,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -563,7 +563,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3102,7 +3102,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -3128,7 +3128,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -5927,7 +5927,7 @@
       "deviceTypeProfileId": 2457,
       "clusters": [
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -5978,7 +5978,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -6787,7 +6787,7 @@
       "deviceTypeProfileId": 2457,
       "clusters": [
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -6838,7 +6838,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -8323,6 +8323,5 @@
       "endpointVersion": 1,
       "deviceIdentifier": 36
     }
-  ],
-  "log": []
+  ]
 }

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 39,
+  "featureLevel": 45,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -2483,7 +2483,7 @@
           ],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -2509,7 +2509,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -5147,6 +5147,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }

--- a/scripts/tools/zap/convert.py
+++ b/scripts/tools/zap/convert.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import urllib.request
+
+CHIP_ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../..'))
+
+def checkPythonVersion():
+    if sys.version_info[0] < 3:
+        print('Must use Python 3. Current version is ' + str(sys.version_info[0]))
+        exit(1)
+
+def checkFileExists(path):
+    if not os.path.isfile(path):
+        print('Error: ' + path + ' does not exists or is not a file.')
+        exit(1)
+
+def checkDirExists(path):
+    if not os.path.isdir(path):
+        print('Error: ' + path + ' does not exists or is not a directory.')
+        exit(1)
+
+def getFilePath(name):
+    fullpath = os.path.join(CHIP_ROOT_DIR, name)
+    checkFileExists(fullpath)
+    return fullpath
+
+def getDirPath(name):
+    fullpath = os.path.join(CHIP_ROOT_DIR, name)
+    checkDirExists(fullpath)
+    return fullpath
+
+def runArgumentsParser():
+    parser = argparse.ArgumentParser(description='Convert .zap files to the current zap version')
+    parser.add_argument('zap', help='Path to the application .zap file')
+    args = parser.parse_args()
+
+    zap_file = getFilePath(args.zap)
+
+    return zap_file
+
+def runConversion(zap_file):
+    templates_file = getFilePath('src/app/zap-templates/app-templates.json')
+    zcl_file = getFilePath('src/app/zap-templates/zcl/zcl.json')
+
+    generator_dir = getDirPath('third_party/zap/repo')
+    os.chdir(generator_dir)
+    subprocess.check_call(['node', './src-script/zap-convert.js', '-z', zcl_file, '-g', templates_file, '-o', zap_file, zap_file])
+
+def main():
+    checkPythonVersion()
+    os.chdir(CHIP_ROOT_DIR)
+
+    zap_file = runArgumentsParser()
+    runConversion(zap_file)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tools/zap_convert_all.py
+++ b/scripts/tools/zap_convert_all.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+from pathlib import Path
+import sys
+import subprocess
+
+CHIP_ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '../..'))
+
+def checkPythonVersion():
+    if sys.version_info[0] < 3:
+        print('Must use Python 3. Current version is ' + str(sys.version_info[0]))
+        exit(1)
+
+def getTargets():
+    targets = []
+    targets.extend([[str(filepath)] for filepath in Path('./examples').rglob('*.zap')])
+    targets.extend([[str(filepath)] for filepath in Path('./src/darwin').rglob('*.zap')])
+    targets.extend([[str(filepath)] for filepath in Path('./src/controller/data_model').rglob('*.zap')])
+    return targets
+
+def main():
+    checkPythonVersion()
+    os.chdir(CHIP_ROOT_DIR)
+
+    targets = getTargets()
+    for target in targets:
+        subprocess.check_call(['./scripts/tools/zap/convert.py'] + target)
+
+if __name__ == '__main__':
+    main()

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -587,7 +587,7 @@
           ]
         },
         {
-          "name": "On/off",
+          "name": "On/Off",
           "code": 6,
           "mfgCode": null,
           "define": "ON_OFF_CLUSTER",
@@ -3835,7 +3835,7 @@
               "reportableChange": 0
             },
             {
-              "name": "supported fabrics",
+              "name": "SupportedFabrics",
               "code": 2,
               "mfgCode": null,
               "side": "server",
@@ -3850,7 +3850,7 @@
               "reportableChange": 0
             },
             {
-              "name": "commissioned fabrics",
+              "name": "CommissionedFabrics",
               "code": 3,
               "mfgCode": null,
               "side": "server",
@@ -5771,7 +5771,7 @@
           "commands": [],
           "attributes": [
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "client",
@@ -5842,7 +5842,7 @@
               "reportableChange": 0
             },
             {
-              "name": "cluster revision",
+              "name": "ClusterRevision",
               "code": 65533,
               "mfgCode": null,
               "side": "server",
@@ -9695,6 +9695,5 @@
       "endpointVersion": null,
       "deviceIdentifier": null
     }
-  ],
-  "log": []
+  ]
 }


### PR DESCRIPTION
#### Problem

When `third_party/zap/repo` is updated, or when some of the definitions from `src/app/zap-templates/data-model/` are updated, the `.zap` files needs to be changed accordingly. There is a zap-script for it, but it has not been used much.

In order to make it easier to use, this PR add a script `./scripts/tools/zap_convert_all.py` that converts all files using `scripts/tools/zap/convert.py`

#### Change overview
 * Add `scripts/tools/zap_convert_all.py`
 * Add `scripts/tools/zap/convert.py`
 * Run `scripts/tools/zap_convert_all.py` and commit the changes

#### Testing
* The generated code has not changed (after running `zap_regen_all.py`, as such the output binary are not changes.