### PR TITLE
Optimize SystemObject unit test 

### DIFF
--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -57,6 +57,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <type_traits>
 
 // Test context
 using namespace chip::System;
@@ -83,6 +84,7 @@ private:
         kPoolSize = 112 // a multiple of kNumThreads, less than CHIP_SYS_STATS_COUNT_MAX
     };
     static ObjectPool<TestObject, kPoolSize> sPool;
+    static_assert(kPoolSize < CHIP_SYS_STATS_COUNT_MAX, "kPoolSize is not less than CHIP_SYS_STATS_COUNT_MAX");
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     unsigned int mDelay;
@@ -90,6 +92,7 @@ private:
     static constexpr int kNumThreads         = 16;
     static constexpr int kLoopIterations     = 1000;
     static constexpr int kMaxDelayIterations = 3;
+    static_assert(kPoolSize % kNumThreads == 0, "kPoolSize is not a multiple of kNumThreads");
 
     void Delay(volatile unsigned int & aAccumulator);
     static void * CheckConcurrencyThread(void * aContext);

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -80,7 +80,7 @@ public:
 private:
     enum
     {
-        kPoolSize = 122 // a multiple of kNumThreads, less than CHIP_SYS_STATS_COUNT_MAX
+        kPoolSize = 112 // a multiple of kNumThreads, less than CHIP_SYS_STATS_COUNT_MAX
     };
     static ObjectPool<TestObject, kPoolSize> sPool;
 
@@ -88,7 +88,7 @@ private:
     unsigned int mDelay;
 
     static constexpr int kNumThreads         = 16;
-    static constexpr int kLoopIterations     = 100000;
+    static constexpr int kLoopIterations     = 1000;
     static constexpr int kMaxDelayIterations = 3;
 
     void Delay(volatile unsigned int & aAccumulator);
@@ -143,8 +143,6 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
         TestObject * lCreated = sPool.TryCreate(lLayer);
 
         NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
-        if (lCreated == nullptr)
-            continue;
         NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained(lLayer));
         NL_TEST_ASSERT(lContext.mTestSuite, &(lCreated->SystemLayer()) == &lLayer);
 
@@ -359,7 +357,7 @@ void TestObject::CheckConcurrency(nlTestSuite * inSuite, void * aContext)
 void TestObject::CheckHighWatermarkConcurrency(nlTestSuite * inSuite, void * aContext)
 {
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
-    for (unsigned int i = 0; i < 1000; i++)
+    for (unsigned int i = 0; i < 100; i++)
     {
         MultithreadedTest(inSuite, aContext, CheckHighWatermarkThread);
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* SystemObject Unit Test take more than 10s to complete on my local Linux machine, and it does not test ObjectPool boundary condition since kPoolSize(122) is not set as a multiple of kNumThreads(16).

#### Change overview
* Reduce alloc/free iteration from 100000 to 1000 to make SystemObject unit test complete within 2 seconds.
* Set kPoolSize to 112 to be multiple of kNumThreads(16).

#### Testing
How was this tested? (at least one bullet point required)
* $ ./TestSystemObject 
```
'#0:','chip-system-object'
'#2:','Setup                   ','PASSED'
'#3:','Retention               ','PASSED'
'#3:','Concurrency             ','PASSED'
'#3:','HighWatermark           ','PASSED'
'#3:','HighWatermarkConcurrency','PASSED'
'#4:','Teardown                ','PASSED'
'#6:','0','4'
'#7:','0','83429'
```