### PR TITLE
Add esp32 flash script generation on more apps, update example_build

### DIFF
--- a/examples/bridge-app/esp32/.gitignore
+++ b/examples/bridge-app/esp32/.gitignore
@@ -1,0 +1,2 @@
+/sdkconfig
+/sdkconfig.old

--- a/examples/bridge-app/esp32/.gitignore
+++ b/examples/bridge-app/esp32/.gitignore
@@ -1,2 +1,3 @@
+/build/
 /sdkconfig
 /sdkconfig.old

--- a/examples/bridge-app/esp32/CMakeLists.txt
+++ b/examples/bridge-app/esp32/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -25,3 +26,5 @@ set(EXTRA_COMPONENT_DIRS
 project(chip-bridge-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H;-DDYNAMIC_ENDPOINT_COUNT=16" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+flashing_script()

--- a/examples/bridge-app/esp32/CMakeLists.txt
+++ b/examples/bridge-app/esp32/CMakeLists.txt
@@ -28,3 +28,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
 flashing_script()
+

--- a/examples/lock-app/esp32/CMakeLists.txt
+++ b/examples/lock-app/esp32/CMakeLists.txt
@@ -48,3 +48,4 @@ set_target_properties(pw_build.cpp17 PROPERTIES INTERFACE_COMPILE_OPTIONS "${_ta
 endif(CONFIG_ENABLE_PW_RPC)
 
 flashing_script()
+

--- a/examples/lock-app/esp32/CMakeLists.txt
+++ b/examples/lock-app/esp32/CMakeLists.txt
@@ -18,6 +18,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
@@ -45,3 +46,5 @@ list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
 list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
 set_target_properties(pw_build.cpp17 PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)
+
+flashing_script()

--- a/examples/shell/esp32/CMakeLists.txt
+++ b/examples/shell/esp32/CMakeLists.txt
@@ -18,6 +18,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../common/cmake/idf_flashing.cmake)
 
 set(EXTRA_COMPONENT_DIRS
     ${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components
@@ -26,3 +27,5 @@ set(EXTRA_COMPONENT_DIRS
 project(chip-shell)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
+
+flashing_script()

--- a/examples/shell/esp32/CMakeLists.txt
+++ b/examples/shell/esp32/CMakeLists.txt
@@ -29,3 +29,4 @@ idf_build_set_property(CXX_COMPILE_OPTIONS "-std=gnu++14;-Os;-DLWIP_IPV6_SCOPES=
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)
 
 flashing_script()
+

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -94,8 +94,11 @@ _MATCHERS[Platform.HOST].AcceptApplication(Application.CHIP_TOOL, app=HostApp.CH
 
 _MATCHERS[Platform.ESP32].AcceptBoard(Board.DEVKITC, board=Esp32Board.DevKitC)
 _MATCHERS[Platform.ESP32].AcceptBoard(Board.M5STACK, board=Esp32Board.M5Stack)
+_MATCHERS[Platform.ESP32].AcceptBoard(Board.C3DEVKIT, board=Esp32Board.C3DevKit)
 _MATCHERS[Platform.ESP32].AcceptApplication(
     Application.ALL_CLUSTERS, app=Esp32App.ALL_CLUSTERS)
+_MATCHERS[Platform.ESP32].AcceptApplicationForBoard(
+    Application.SHELL, Board.DEVKITC, app=Esp32App.SHELL)
 _MATCHERS[Platform.ESP32].AcceptApplicationForBoard(
     Application.LOCK, Board.DEVKITC, app=Esp32App.LOCK)
 

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -101,6 +101,8 @@ _MATCHERS[Platform.ESP32].AcceptApplicationForBoard(
     Application.SHELL, Board.DEVKITC, app=Esp32App.SHELL)
 _MATCHERS[Platform.ESP32].AcceptApplicationForBoard(
     Application.LOCK, Board.DEVKITC, app=Esp32App.LOCK)
+_MATCHERS[Platform.ESP32].AcceptApplicationForBoard(
+    Application.BRIDGE, Board.DEVKITC, app=Esp32App.BRIDGE)
 
 _MATCHERS[Platform.QPG].AcceptApplication(Application.LOCK)
 _MATCHERS[Platform.QPG].AcceptBoard(Board.QPG6100)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -79,6 +79,7 @@ class Application(IntEnum):
   WINDOW_COVERING = auto()
   SHELL = auto()
   CHIP_TOOL = auto()
+  BRIDGE = auto()
 
   @property
   def ArgName(self):

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -50,6 +50,7 @@ class Board(IntEnum):
   # ESP32 platform
   M5STACK = auto()
   DEVKITC = auto()
+  C3DEVKIT = auto()
 
   # EFR32 platform
   BRD4161A = auto()

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -24,11 +24,13 @@ from .builder import Builder
 class Esp32Board(Enum):
   DevKitC = auto()
   M5Stack = auto()
+  C3DevKit = auto()
 
 
 class Esp32App(Enum):
   ALL_CLUSTERS = auto()
   LOCK = auto()
+  SHELL = auto()
 
   @property
   def ExampleName(self):
@@ -36,6 +38,8 @@ class Esp32App(Enum):
       return 'all-clusters-app'
     elif self == Esp32App.LOCK:
       return 'lock-app'
+    elif self == Esp32App.SHELL:
+      return 'shell'
     else:
       raise Exception('Unknown app type: %r' % self)
 
@@ -45,6 +49,8 @@ class Esp32App(Enum):
       return 'chip-all-clusters-app'
     elif self == Esp32App.LOCK:
       return 'chip-lock-app'
+    elif self == Esp32App.SHELL:
+      return 'chip-shell-app'
     else:
       raise Exception('Unknown app type: %r' % self)
 
@@ -58,6 +64,8 @@ def DefaultsFileName(board: Esp32Board, app: Esp32App):
     return 'sdkconfig.defaults'
   elif board == Esp32Board.M5Stack:
     return 'sdkconfig_m5stack.defaults'
+  elif board == Esp32Board.C3DevKit:
+    return 'sdkconfig_c3devkit.defaults'
   else:
     raise Exception('Unknown board type')
 

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -31,6 +31,7 @@ class Esp32App(Enum):
   ALL_CLUSTERS = auto()
   LOCK = auto()
   SHELL = auto()
+  BRIDGE = auto()
 
   @property
   def ExampleName(self):
@@ -40,6 +41,8 @@ class Esp32App(Enum):
       return 'lock-app'
     elif self == Esp32App.SHELL:
       return 'shell'
+    elif self == Esp32App.BRIDGE:
+      return 'bridge-app'
     else:
       raise Exception('Unknown app type: %r' % self)
 
@@ -50,7 +53,9 @@ class Esp32App(Enum):
     elif self == Esp32App.LOCK:
       return 'chip-lock-app'
     elif self == Esp32App.SHELL:
-      return 'chip-shell-app'
+      return 'chip-shell'
+    elif self == Esp32App.BRIDGE:
+      return 'chip-bridge-app'
     else:
       raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
#### Problem
Only all_clusters_app generate flashing script data in esp32 builds. 
build_examples.py only supports a subset of esp32 app builds

#### Change overview
Update build_examples.py support:
  - add C3DevKit support for 'all-clusters-app'
  - add shell and bridge compilation
  - add flashing_script CMake instruction for more esp32 CMakeFiles.txt 
  
#### Testing
Compile testing using build_examples.py
