### PR TITLE
Rename the default Matter output message "No Error" by "Success"

### DIFF
--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -74,7 +74,7 @@ DLL_EXPORT const char * ErrorStr(CHIP_ERROR err)
     }
     if (err == CHIP_NO_ERROR)
     {
-        (void) snprintf(formattedError, formattedSpace, "No Error");
+        (void) snprintf(formattedError, formattedSpace, CHIP_NO_ERROR_STRING);
         return sErrorStr;
     }
 
@@ -82,7 +82,7 @@ DLL_EXPORT const char * ErrorStr(CHIP_ERROR err)
 
     if (err == CHIP_NO_ERROR)
     {
-        return "No Error";
+        return CHIP_NO_ERROR_STRING;
     }
 
 #endif // CHIP_CONFIG_ERROR_SOURCE && !CHIP_CONFIG_SHORT_ERROR_STR

--- a/src/lib/support/ErrorStr.h
+++ b/src/lib/support/ErrorStr.h
@@ -32,6 +32,15 @@
 
 namespace chip {
 
+/**
+ *  @def CHIP_NO_ERROR_STRING
+ *
+ *  @brief
+ *    This defines the CHIP error string for success or no error.
+ *
+ */
+#define CHIP_NO_ERROR_STRING "Success"
+
 struct ErrorFormatter
 {
     typedef bool (*FormatFunct)(char * buf, uint16_t bufSize, CHIP_ERROR err);

--- a/src/lib/support/tests/TestErrorStr.cpp
+++ b/src/lib/support/tests/TestErrorStr.cpp
@@ -119,7 +119,7 @@ static void CheckRegisterDeregisterErrorFormatter(nlTestSuite * inSuite, void * 
 
 static void CheckNoError(nlTestSuite * inSuite, void * inContext)
 {
-    NL_TEST_ASSERT(inSuite, strcmp(CHECK_AND_SKIP_SOURCE(inSuite, ErrorStr(CHIP_NO_ERROR)), "No Error") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(CHECK_AND_SKIP_SOURCE(inSuite, ErrorStr(CHIP_NO_ERROR)), CHIP_NO_ERROR_STRING) == 0);
 }
 
 static void CheckFormatErr(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
Little PR to simplify the logs readers 
We replace the "No Error" by "Success"

#### Problem
This does not solve any problem, just simplify the life
Also helps to "grep" logs and find Error as real errors !

#### Change overview
What's in this PR
- Small change of the "No Error" text message 
- Use a macro DEFINE to hold the text

#### Testing

Tested on a controller + a device target

Here Chip-device-ctrl python
[1628181313.682096][36514:36522] CHIP:IN: Sending msg 0x7fd3111e51b0 to 0x0000000000000030 at utc time: 8387569 msec
[1628181313.682098][36514:36522] CHIP:IN: Sending secure msg on generic transport
AttributeReadResult(path=AttributePath(nodeId=48, endpointId=1, clusterId=258, attributeId=19), status=0, value=11)
[1628181313.682170][36514:36522] CHIP:IN: Secure msg send status ../../src/inet/IPEndPointBasis.cpp:915: Success


Here EFR32 log:
00> <detail> [DL] Thread packet SENT: UDP, len 127
00> <detail> [DL]     src  FD11:22::A1D3:9EA2:C9B7:E56D, port 5540
00> <detail> [DL]     dest FD11:42F8:CAAE:D92E:1B34:2ED3:4B44:A634, port 5541
00> <info  > [IN] Secure msg send status Success
00> <detail> [DMG] IM RH moving to [Uninitialized]
