### PR TITLE
Emit bool instead of uint8_t for Boolean types

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -5746,7 +5746,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             uint32_t currentVersion;
             uint8_t protocolsSupported;
             const uint8_t * location;
-            uint8_t requestorCanConsent;
+            bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
 

--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -580,7 +580,7 @@ static void OnOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponse(void * 
 
 static void OnOtaSoftwareUpdateProviderClusterQueryImageResponse(void * context, uint32_t delayedActionTime, uint8_t * imageURI,
                                                                  uint32_t softwareVersion, chip::ByteSpan updateToken,
-                                                                 uint8_t userConsentNeeded, chip::ByteSpan metadataForRequestor)
+                                                                 bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(chipTool, "OtaSoftwareUpdateProviderClusterQueryImageResponse");
 
@@ -832,9 +832,9 @@ static void OnGeneralDiagnosticsNetworkInterfacesListAttributeResponse(void * co
     {
         ChipLogProgress(chipTool, "NetworkInterfaceType[%" PRIu16 "]:", i);
         ChipLogProgress(Zcl, "  Name: %zu", entries[i].Name.size());
-        ChipLogProgress(chipTool, "  FabricConnected: %" PRIu8 "", entries[i].FabricConnected);
-        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv4: %" PRIu8 "", entries[i].OffPremiseServicesReachableIPv4);
-        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv6: %" PRIu8 "", entries[i].OffPremiseServicesReachableIPv6);
+        ChipLogProgress(chipTool, "  FabricConnected: %d", entries[i].FabricConnected);
+        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv4: %d", entries[i].OffPremiseServicesReachableIPv4);
+        ChipLogProgress(chipTool, "  OffPremiseServicesReachableIPv6: %d", entries[i].OffPremiseServicesReachableIPv6);
         ChipLogProgress(Zcl, "  HardwareAddress: %zu", entries[i].HardwareAddress.size());
         ChipLogProgress(chipTool, "  Type: %" PRIu8 "", entries[i].Type);
     }
@@ -1004,10 +1004,10 @@ static void OnThreadNetworkDiagnosticsNeighborTableListListAttributeResponse(voi
         ChipLogProgress(chipTool, "  LastRssi: %" PRId8 "", entries[i].LastRssi);
         ChipLogProgress(chipTool, "  FrameErrorRate: %" PRIu8 "", entries[i].FrameErrorRate);
         ChipLogProgress(chipTool, "  MessageErrorRate: %" PRIu8 "", entries[i].MessageErrorRate);
-        ChipLogProgress(chipTool, "  RxOnWhenIdle: %" PRIu8 "", entries[i].RxOnWhenIdle);
-        ChipLogProgress(chipTool, "  FullThreadDevice: %" PRIu8 "", entries[i].FullThreadDevice);
-        ChipLogProgress(chipTool, "  FullNetworkData: %" PRIu8 "", entries[i].FullNetworkData);
-        ChipLogProgress(chipTool, "  IsChild: %" PRIu8 "", entries[i].IsChild);
+        ChipLogProgress(chipTool, "  RxOnWhenIdle: %d", entries[i].RxOnWhenIdle);
+        ChipLogProgress(chipTool, "  FullThreadDevice: %d", entries[i].FullThreadDevice);
+        ChipLogProgress(chipTool, "  FullNetworkData: %d", entries[i].FullNetworkData);
+        ChipLogProgress(chipTool, "  IsChild: %d", entries[i].IsChild);
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
@@ -1029,8 +1029,8 @@ static void OnThreadNetworkDiagnosticsRouteTableListListAttributeResponse(void *
         ChipLogProgress(chipTool, "  LQIIn: %" PRIu8 "", entries[i].LQIIn);
         ChipLogProgress(chipTool, "  LQIOut: %" PRIu8 "", entries[i].LQIOut);
         ChipLogProgress(chipTool, "  Age: %" PRIu8 "", entries[i].Age);
-        ChipLogProgress(chipTool, "  Allocated: %" PRIu8 "", entries[i].Allocated);
-        ChipLogProgress(chipTool, "  LinkEstablished: %" PRIu8 "", entries[i].LinkEstablished);
+        ChipLogProgress(chipTool, "  Allocated: %d", entries[i].Allocated);
+        ChipLogProgress(chipTool, "  LinkEstablished: %d", entries[i].LinkEstablished);
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
@@ -1061,18 +1061,18 @@ static void OnThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeR
     for (uint16_t i = 0; i < count; i++)
     {
         ChipLogProgress(chipTool, "OperationalDatasetComponents[%" PRIu16 "]:", i);
-        ChipLogProgress(chipTool, "  ActiveTimestampPresent: %" PRIu8 "", entries[i].ActiveTimestampPresent);
-        ChipLogProgress(chipTool, "  PendingTimestampPresent: %" PRIu8 "", entries[i].PendingTimestampPresent);
-        ChipLogProgress(chipTool, "  MasterKeyPresent: %" PRIu8 "", entries[i].MasterKeyPresent);
-        ChipLogProgress(chipTool, "  NetworkNamePresent: %" PRIu8 "", entries[i].NetworkNamePresent);
-        ChipLogProgress(chipTool, "  ExtendedPanIdPresent: %" PRIu8 "", entries[i].ExtendedPanIdPresent);
-        ChipLogProgress(chipTool, "  MeshLocalPrefixPresent: %" PRIu8 "", entries[i].MeshLocalPrefixPresent);
-        ChipLogProgress(chipTool, "  DelayPresent: %" PRIu8 "", entries[i].DelayPresent);
-        ChipLogProgress(chipTool, "  PanIdPresent: %" PRIu8 "", entries[i].PanIdPresent);
-        ChipLogProgress(chipTool, "  ChannelPresent: %" PRIu8 "", entries[i].ChannelPresent);
-        ChipLogProgress(chipTool, "  PskcPresent: %" PRIu8 "", entries[i].PskcPresent);
-        ChipLogProgress(chipTool, "  SecurityPolicyPresent: %" PRIu8 "", entries[i].SecurityPolicyPresent);
-        ChipLogProgress(chipTool, "  ChannelMaskPresent: %" PRIu8 "", entries[i].ChannelMaskPresent);
+        ChipLogProgress(chipTool, "  ActiveTimestampPresent: %d", entries[i].ActiveTimestampPresent);
+        ChipLogProgress(chipTool, "  PendingTimestampPresent: %d", entries[i].PendingTimestampPresent);
+        ChipLogProgress(chipTool, "  MasterKeyPresent: %d", entries[i].MasterKeyPresent);
+        ChipLogProgress(chipTool, "  NetworkNamePresent: %d", entries[i].NetworkNamePresent);
+        ChipLogProgress(chipTool, "  ExtendedPanIdPresent: %d", entries[i].ExtendedPanIdPresent);
+        ChipLogProgress(chipTool, "  MeshLocalPrefixPresent: %d", entries[i].MeshLocalPrefixPresent);
+        ChipLogProgress(chipTool, "  DelayPresent: %d", entries[i].DelayPresent);
+        ChipLogProgress(chipTool, "  PanIdPresent: %d", entries[i].PanIdPresent);
+        ChipLogProgress(chipTool, "  ChannelPresent: %d", entries[i].ChannelPresent);
+        ChipLogProgress(chipTool, "  PskcPresent: %d", entries[i].PskcPresent);
+        ChipLogProgress(chipTool, "  SecurityPolicyPresent: %d", entries[i].SecurityPolicyPresent);
+        ChipLogProgress(chipTool, "  ChannelMaskPresent: %d", entries[i].ChannelMaskPresent);
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
@@ -3341,7 +3341,7 @@ public:
     WriteBasicLocalConfigDisabled() : ModelCommand("write")
     {
         AddArgument("attr-name", "local-config-disabled");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-value", 0, 1, &mValue);
         ModelCommand::AddArguments();
     }
 
@@ -3365,7 +3365,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mValue;
+    bool mValue;
 };
 
 /*
@@ -3518,7 +3518,7 @@ public:
     WriteBinaryInputBasicOutOfService() : ModelCommand("write")
     {
         AddArgument("attr-name", "out-of-service");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-value", 0, 1, &mValue);
         ModelCommand::AddArguments();
     }
 
@@ -3542,7 +3542,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mValue;
+    bool mValue;
 };
 
 /*
@@ -3585,7 +3585,7 @@ public:
     WriteBinaryInputBasicPresentValue() : ModelCommand("write")
     {
         AddArgument("attr-name", "present-value");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-value", 0, 1, &mValue);
         ModelCommand::AddArguments();
     }
 
@@ -3609,7 +3609,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mValue;
+    bool mValue;
 };
 
 class ReportBinaryInputBasicPresentValue : public ModelCommand
@@ -7866,7 +7866,7 @@ class ContentLauncherLaunchContent : public ModelCommand
 public:
     ContentLauncherLaunchContent() : ModelCommand("launch-content")
     {
-        AddArgument("AutoPlay", 0, UINT8_MAX, &mAutoPlay);
+        AddArgument("AutoPlay", 0, 1, &mAutoPlay);
         AddArgument("Data", &mData);
         ModelCommand::AddArguments();
     }
@@ -7892,7 +7892,7 @@ private:
             OnContentLauncherClusterLaunchContentResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mAutoPlay;
+    bool mAutoPlay;
     char * mData;
 };
 
@@ -13491,7 +13491,7 @@ public:
         AddArgument("CurrentVersion", 0, UINT32_MAX, &mCurrentVersion);
         AddArgument("ProtocolsSupported", 0, UINT8_MAX, &mProtocolsSupported);
         AddArgument("Location", &mLocation);
-        AddArgument("RequestorCanConsent", 0, UINT8_MAX, &mRequestorCanConsent);
+        AddArgument("RequestorCanConsent", 0, 1, &mRequestorCanConsent);
         AddArgument("MetadataForProvider", &mMetadataForProvider);
         ModelCommand::AddArguments();
     }
@@ -13526,7 +13526,7 @@ private:
     uint32_t mCurrentVersion;
     uint8_t mProtocolsSupported;
     char * mLocation;
-    uint8_t mRequestorCanConsent;
+    bool mRequestorCanConsent;
     chip::ByteSpan mMetadataForProvider;
 };
 
@@ -17535,7 +17535,7 @@ public:
     WriteTestClusterBoolean() : ModelCommand("write")
     {
         AddArgument("attr-name", "boolean");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-value", 0, 1, &mValue);
         ModelCommand::AddArguments();
     }
 
@@ -17559,7 +17559,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mValue;
+    bool mValue;
 };
 
 /*
@@ -18914,7 +18914,7 @@ public:
     WriteTestClusterUnsupported() : ModelCommand("write")
     {
         AddArgument("attr-name", "unsupported");
-        AddArgument("attr-value", 0, UINT8_MAX, &mValue);
+        AddArgument("attr-value", 0, 1, &mValue);
         ModelCommand::AddArguments();
     }
 
@@ -18938,7 +18938,7 @@ private:
         new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    uint8_t mValue;
+    bool mValue;
 };
 
 /*

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -157,6 +157,7 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         break;
     }
 
+    case ArgumentType::Boolean:
     case ArgumentType::Number_uint8: {
         uint8_t * value = reinterpret_cast<uint8_t *>(arg.value);
 

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -59,6 +59,7 @@ enum ArgumentType
     Number_int32,
     Number_int64,
     CharString,
+    Boolean,
     OctetString,
     Attribute,
     Address
@@ -131,6 +132,10 @@ public:
      */
     size_t AddArgument(const char * name, chip::ByteSpan * value);
     size_t AddArgument(const char * name, AddressWithInterface * out);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out)
+    {
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Boolean);
+    }
     size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out)
     {
         return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8);

--- a/examples/chip-tool/commands/tests/Commands.h
+++ b/examples/chip-tool/commands/tests/Commands.h
@@ -3463,7 +3463,7 @@ private:
     }
 
     // Test Read attribute BOOLEAN Default Value
-    using SuccessCallback_5 = void (*)(void * context, uint8_t boolean);
+    using SuccessCallback_5 = void (*)(void * context, bool boolean);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{
         OnTestSendClusterTestClusterCommandReadAttribute_5_SuccessResponse, this
     };
@@ -3502,7 +3502,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandReadAttribute_5_SuccessResponse(void * context, uint8_t boolean)
+    static void OnTestSendClusterTestClusterCommandReadAttribute_5_SuccessResponse(void * context, bool boolean)
     {
         ChipLogProgress(chipTool, "Test Cluster - Read attribute BOOLEAN Default Value: Success Response");
 
@@ -3526,7 +3526,7 @@ private:
     }
 
     // Test Write attribute BOOLEAN True
-    using SuccessCallback_6 = void (*)(void * context, uint8_t boolean);
+    using SuccessCallback_6 = void (*)(void * context, bool boolean);
     chip::Callback::Callback<SuccessCallback_6> mOnSuccessCallback_6{
         OnTestSendClusterTestClusterCommandWriteAttribute_6_SuccessResponse, this
     };
@@ -3544,7 +3544,7 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t booleanArgument = 1;
+        bool booleanArgument = 1;
         err = cluster.WriteAttributeBoolean(mOnSuccessCallback_6.Cancel(), mOnFailureCallback_6.Cancel(), booleanArgument);
 
         return err;
@@ -3566,7 +3566,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandWriteAttribute_6_SuccessResponse(void * context, uint8_t boolean)
+    static void OnTestSendClusterTestClusterCommandWriteAttribute_6_SuccessResponse(void * context, bool boolean)
     {
         ChipLogProgress(chipTool, "Test Cluster - Write attribute BOOLEAN True: Success Response");
 
@@ -3583,7 +3583,7 @@ private:
     }
 
     // Test Read attribute BOOLEAN True
-    using SuccessCallback_7 = void (*)(void * context, uint8_t boolean);
+    using SuccessCallback_7 = void (*)(void * context, bool boolean);
     chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{
         OnTestSendClusterTestClusterCommandReadAttribute_7_SuccessResponse, this
     };
@@ -3622,7 +3622,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandReadAttribute_7_SuccessResponse(void * context, uint8_t boolean)
+    static void OnTestSendClusterTestClusterCommandReadAttribute_7_SuccessResponse(void * context, bool boolean)
     {
         ChipLogProgress(chipTool, "Test Cluster - Read attribute BOOLEAN True: Success Response");
 
@@ -3646,7 +3646,7 @@ private:
     }
 
     // Test Write attribute BOOLEAN False
-    using SuccessCallback_8 = void (*)(void * context, uint8_t boolean);
+    using SuccessCallback_8 = void (*)(void * context, bool boolean);
     chip::Callback::Callback<SuccessCallback_8> mOnSuccessCallback_8{
         OnTestSendClusterTestClusterCommandWriteAttribute_8_SuccessResponse, this
     };
@@ -3664,7 +3664,7 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t booleanArgument = 0;
+        bool booleanArgument = 0;
         err = cluster.WriteAttributeBoolean(mOnSuccessCallback_8.Cancel(), mOnFailureCallback_8.Cancel(), booleanArgument);
 
         return err;
@@ -3686,7 +3686,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandWriteAttribute_8_SuccessResponse(void * context, uint8_t boolean)
+    static void OnTestSendClusterTestClusterCommandWriteAttribute_8_SuccessResponse(void * context, bool boolean)
     {
         ChipLogProgress(chipTool, "Test Cluster - Write attribute BOOLEAN False: Success Response");
 
@@ -3703,7 +3703,7 @@ private:
     }
 
     // Test Read attribute BOOLEAN False
-    using SuccessCallback_9 = void (*)(void * context, uint8_t boolean);
+    using SuccessCallback_9 = void (*)(void * context, bool boolean);
     chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{
         OnTestSendClusterTestClusterCommandReadAttribute_9_SuccessResponse, this
     };
@@ -3742,7 +3742,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandReadAttribute_9_SuccessResponse(void * context, uint8_t boolean)
+    static void OnTestSendClusterTestClusterCommandReadAttribute_9_SuccessResponse(void * context, bool boolean)
     {
         ChipLogProgress(chipTool, "Test Cluster - Read attribute BOOLEAN False: Success Response");
 
@@ -9808,7 +9808,7 @@ private:
     }
 
     // Test Read attribute UNSUPPORTED
-    using SuccessCallback_109 = void (*)(void * context, uint8_t unsupported);
+    using SuccessCallback_109 = void (*)(void * context, bool unsupported);
     chip::Callback::Callback<SuccessCallback_109> mOnSuccessCallback_109{
         OnTestSendClusterTestClusterCommandReadAttribute_109_SuccessResponse, this
     };
@@ -9853,7 +9853,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandReadAttribute_109_SuccessResponse(void * context, uint8_t unsupported)
+    static void OnTestSendClusterTestClusterCommandReadAttribute_109_SuccessResponse(void * context, bool unsupported)
     {
         ChipLogProgress(chipTool, "Test Cluster - Read attribute UNSUPPORTED: Success Response");
 
@@ -9877,7 +9877,7 @@ private:
     }
 
     // Test Writeattribute UNSUPPORTED
-    using SuccessCallback_110 = void (*)(void * context, uint8_t unsupported);
+    using SuccessCallback_110 = void (*)(void * context, bool unsupported);
     chip::Callback::Callback<SuccessCallback_110> mOnSuccessCallback_110{
         OnTestSendClusterTestClusterCommandWriteAttribute_110_SuccessResponse, this
     };
@@ -9895,7 +9895,7 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint8_t unsupportedArgument = 0;
+        bool unsupportedArgument = 0;
         err = cluster.WriteAttributeUnsupported(mOnSuccessCallback_110.Cancel(), mOnFailureCallback_110.Cancel(),
                                                 unsupportedArgument);
 
@@ -9924,7 +9924,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTestClusterCommandWriteAttribute_110_SuccessResponse(void * context, uint8_t unsupported)
+    static void OnTestSendClusterTestClusterCommandWriteAttribute_110_SuccessResponse(void * context, bool unsupported)
     {
         ChipLogProgress(chipTool, "Test Cluster - Writeattribute UNSUPPORTED: Success Response");
 
@@ -10373,7 +10373,7 @@ private:
     //
 
     // Test read the mandatory attribute: OnOff
-    using SuccessCallback_0 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_0 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{ OnTestSendClusterOnOffCommandReadAttribute_0_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
@@ -10411,7 +10411,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_0_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_0_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - read the mandatory attribute: OnOff: Success Response");
 
@@ -10435,7 +10435,7 @@ private:
     }
 
     // Test reads back mandatory attribute: OnOff
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -10473,7 +10473,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - reads back mandatory attribute: OnOff: Success Response");
 
@@ -10497,7 +10497,7 @@ private:
     }
 
     // Test read LT attribute: GlobalSceneControl
-    using SuccessCallback_2 = void (*)(void * context, uint8_t globalSceneControl);
+    using SuccessCallback_2 = void (*)(void * context, bool globalSceneControl);
     chip::Callback::Callback<SuccessCallback_2> mOnSuccessCallback_2{ OnTestSendClusterOnOffCommandReadAttribute_2_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_2{
@@ -10535,7 +10535,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_2_SuccessResponse(void * context, uint8_t globalSceneControl)
+    static void OnTestSendClusterOnOffCommandReadAttribute_2_SuccessResponse(void * context, bool globalSceneControl)
     {
         ChipLogProgress(chipTool, "On/Off - read LT attribute: GlobalSceneControl: Success Response");
 
@@ -11237,7 +11237,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -11275,7 +11275,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -11352,7 +11352,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_3 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_3 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_3> mOnSuccessCallback_3{ OnTestSendClusterOnOffCommandReadAttribute_3_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_3{
@@ -11390,7 +11390,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_3_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_3_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -11467,7 +11467,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_5 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_5 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_5> mOnSuccessCallback_5{ OnTestSendClusterOnOffCommandReadAttribute_5_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_5{
@@ -11505,7 +11505,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_5_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_5_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -11582,7 +11582,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after toggle command
-    using SuccessCallback_7 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_7 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{ OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
@@ -11620,7 +11620,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after toggle command: Success Response");
 
@@ -11697,7 +11697,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after toggle command
-    using SuccessCallback_9 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_9 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{ OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
@@ -11735,7 +11735,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after toggle command: Success Response");
 
@@ -11812,7 +11812,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_11 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_11 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_11> mOnSuccessCallback_11{
         OnTestSendClusterOnOffCommandReadAttribute_11_SuccessResponse, this
     };
@@ -11851,7 +11851,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_11_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_11_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -11928,7 +11928,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_13 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_13 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_13> mOnSuccessCallback_13{
         OnTestSendClusterOnOffCommandReadAttribute_13_SuccessResponse, this
     };
@@ -11967,7 +11967,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_13_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_13_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -13149,7 +13149,7 @@ private:
     }
 
     // Test Query LocalConfigDisabled
-    using SuccessCallback_16 = void (*)(void * context, uint8_t localConfigDisabled);
+    using SuccessCallback_16 = void (*)(void * context, bool localConfigDisabled);
     chip::Callback::Callback<SuccessCallback_16> mOnSuccessCallback_16{
         OnTestSendClusterBasicCommandReadAttribute_16_SuccessResponse, this
     };
@@ -13194,7 +13194,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterBasicCommandReadAttribute_16_SuccessResponse(void * context, uint8_t localConfigDisabled)
+    static void OnTestSendClusterBasicCommandReadAttribute_16_SuccessResponse(void * context, bool localConfigDisabled)
     {
         ChipLogProgress(chipTool, "Basic - Query LocalConfigDisabled: Success Response");
 
@@ -13213,7 +13213,7 @@ private:
     }
 
     // Test Query Reachable
-    using SuccessCallback_17 = void (*)(void * context, uint8_t reachable);
+    using SuccessCallback_17 = void (*)(void * context, bool reachable);
     chip::Callback::Callback<SuccessCallback_17> mOnSuccessCallback_17{
         OnTestSendClusterBasicCommandReadAttribute_17_SuccessResponse, this
     };
@@ -13258,7 +13258,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterBasicCommandReadAttribute_17_SuccessResponse(void * context, uint8_t reachable)
+    static void OnTestSendClusterBasicCommandReadAttribute_17_SuccessResponse(void * context, bool reachable)
     {
         ChipLogProgress(chipTool, "Basic - Query Reachable: Success Response");
 
@@ -13470,7 +13470,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -13508,7 +13508,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -14567,7 +14567,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_19 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_19 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_19> mOnSuccessCallback_19{
         OnTestSendClusterOnOffCommandReadAttribute_19_SuccessResponse, this
     };
@@ -14606,7 +14606,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_19_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_19_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -14747,7 +14747,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -14785,7 +14785,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -15106,7 +15106,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_7 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_7 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_7> mOnSuccessCallback_7{ OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_7{
@@ -15144,7 +15144,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_7_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -15291,7 +15291,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -15329,7 +15329,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -15789,7 +15789,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_9 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_9 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_9> mOnSuccessCallback_9{ OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_9{
@@ -15827,7 +15827,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_9_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 
@@ -15983,7 +15983,7 @@ private:
     }
 
     // Test Check on/off attribute value is true after on command
-    using SuccessCallback_1 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_1 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{ OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse,
                                                                       this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
@@ -16021,7 +16021,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_1_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is true after on command: Success Response");
 
@@ -16661,7 +16661,7 @@ private:
     }
 
     // Test Check on/off attribute value is false after off command
-    using SuccessCallback_12 = void (*)(void * context, uint8_t onOff);
+    using SuccessCallback_12 = void (*)(void * context, bool onOff);
     chip::Callback::Callback<SuccessCallback_12> mOnSuccessCallback_12{
         OnTestSendClusterOnOffCommandReadAttribute_12_SuccessResponse, this
     };
@@ -16700,7 +16700,7 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOnOffCommandReadAttribute_12_SuccessResponse(void * context, uint8_t onOff)
+    static void OnTestSendClusterOnOffCommandReadAttribute_12_SuccessResponse(void * context, bool onOff)
     {
         ChipLogProgress(chipTool, "On/Off - Check on/off attribute value is false after off command: Success Response");
 

--- a/examples/chip-tool/templates/helper.js
+++ b/examples/chip-tool/templates/helper.js
@@ -36,6 +36,8 @@ function asTypeMinValue(type)
     return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
+      case 'bool':
+        return '0';
       case 'int8_t':
       case 'int16_t':
       case 'int32_t':
@@ -65,6 +67,8 @@ function asTypeMaxValue(type)
     return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
+      case 'bool':
+        return '1';
       case 'int8_t':
       case 'int16_t':
       case 'int32_t':

--- a/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/thermostat/thermostat-common/gen/IMClusterCommandHandler.cpp
@@ -5315,7 +5315,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             uint32_t currentVersion;
             uint8_t protocolsSupported;
             const uint8_t * location;
-            uint8_t requestorCanConsent;
+            bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
 

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -104,7 +104,7 @@ static void sendResponse(const char * responseName, ContentLaunchResponse launch
 }
 
 bool emberAfContentLauncherClusterLaunchContentCallback(chip::EndpointId endpoint, chip::app::CommandHandler * command,
-                                                        unsigned char autoplay, unsigned char * data)
+                                                        bool autoplay, unsigned char * data)
 {
 
     string dataString(reinterpret_cast<char *>(data));

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -1026,7 +1026,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
         {
         case Clusters::ContentLauncher::Commands::Ids::LaunchContent: {
             expectArgumentCount = 2;
-            uint8_t autoPlay;
+            bool autoPlay;
             const uint8_t * data;
             bool argExists[2];
 
@@ -3451,7 +3451,7 @@ void DispatchServerCommand(app::CommandHandler * apCommandObj, CommandId aComman
             uint32_t currentVersion;
             uint8_t protocolsSupported;
             const uint8_t * location;
-            uint8_t requestorCanConsent;
+            bool requestorCanConsent;
             chip::ByteSpan metadataForProvider;
             bool argExists[9];
 

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -154,7 +154,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
                                                                uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                                                uint16_t hardwareVersion, uint32_t currentVersion,
                                                                /* TODO(#8605): change this to list */ uint8_t protocolsSupported,
-                                                               uint8_t * location, uint8_t clientCanConsent,
+                                                               uint8_t * location, bool clientCanConsent,
                                                                ByteSpan metadataForProvider)
 {
     EmberAfStatus status           = EMBER_ZCL_STATUS_SUCCESS;

--- a/src/app/common/gen/af-structs.h
+++ b/src/app/common/gen/af-structs.h
@@ -207,19 +207,19 @@ typedef struct _NeighborTable
     int8_t LastRssi;
     uint8_t FrameErrorRate;
     uint8_t MessageErrorRate;
-    uint8_t RxOnWhenIdle;
-    uint8_t FullThreadDevice;
-    uint8_t FullNetworkData;
-    uint8_t IsChild;
+    bool RxOnWhenIdle;
+    bool FullThreadDevice;
+    bool FullNetworkData;
+    bool IsChild;
 } EmberAfNeighborTable;
 
 // Struct for NetworkInterfaceType
 typedef struct _NetworkInterfaceType
 {
     chip::ByteSpan Name;
-    uint8_t FabricConnected;
-    uint8_t OffPremiseServicesReachableIPv4;
-    uint8_t OffPremiseServicesReachableIPv6;
+    bool FabricConnected;
+    bool OffPremiseServicesReachableIPv4;
+    bool OffPremiseServicesReachableIPv6;
     chip::ByteSpan HardwareAddress;
     uint8_t Type;
 } EmberAfNetworkInterfaceType;
@@ -234,18 +234,18 @@ typedef struct _Notification
 // Struct for OperationalDatasetComponents
 typedef struct _OperationalDatasetComponents
 {
-    uint8_t ActiveTimestampPresent;
-    uint8_t PendingTimestampPresent;
-    uint8_t MasterKeyPresent;
-    uint8_t NetworkNamePresent;
-    uint8_t ExtendedPanIdPresent;
-    uint8_t MeshLocalPrefixPresent;
-    uint8_t DelayPresent;
-    uint8_t PanIdPresent;
-    uint8_t ChannelPresent;
-    uint8_t PskcPresent;
-    uint8_t SecurityPolicyPresent;
-    uint8_t ChannelMaskPresent;
+    bool ActiveTimestampPresent;
+    bool PendingTimestampPresent;
+    bool MasterKeyPresent;
+    bool NetworkNamePresent;
+    bool ExtendedPanIdPresent;
+    bool MeshLocalPrefixPresent;
+    bool DelayPresent;
+    bool PanIdPresent;
+    bool ChannelPresent;
+    bool PskcPresent;
+    bool SecurityPolicyPresent;
+    bool ChannelMaskPresent;
 } EmberAfOperationalDatasetComponents;
 
 // Struct for PowerProfileRecord
@@ -253,7 +253,7 @@ typedef struct _PowerProfileRecord
 {
     uint8_t powerProfileId;
     uint8_t energyPhaseId;
-    uint8_t powerProfileRemoteControl;
+    bool powerProfileRemoteControl;
     uint8_t powerProfileState;
 } EmberAfPowerProfileRecord;
 
@@ -313,8 +313,8 @@ typedef struct _RouteTable
     uint8_t LQIIn;
     uint8_t LQIOut;
     uint8_t Age;
-    uint8_t Allocated;
-    uint8_t LinkEstablished;
+    bool Allocated;
+    bool LinkEstablished;
 } EmberAfRouteTable;
 
 // Struct for SceneExtensionAttributeInfo

--- a/src/app/common/gen/attributes/Accessors.cpp
+++ b/src/app/common/gen/attributes/Accessors.cpp
@@ -719,11 +719,11 @@ EmberAfStatus SetCurrentGroup(chip::EndpointId endpoint, uint16_t currentGroup)
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::CurrentGroup, (uint8_t *) &currentGroup,
                                        ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSceneValid(chip::EndpointId endpoint, uint8_t * sceneValid)
+EmberAfStatus GetSceneValid(chip::EndpointId endpoint, bool * sceneValid)
 {
     return emberAfReadServerAttribute(endpoint, Scenes::Id, Ids::SceneValid, (uint8_t *) sceneValid, sizeof(*sceneValid));
 }
-EmberAfStatus SetSceneValid(chip::EndpointId endpoint, uint8_t sceneValid)
+EmberAfStatus SetSceneValid(chip::EndpointId endpoint, bool sceneValid)
 {
     return emberAfWriteServerAttribute(endpoint, Scenes::Id, Ids::SceneValid, (uint8_t *) &sceneValid, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
@@ -741,11 +741,11 @@ EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport)
 
 namespace OnOff {
 namespace Attributes {
-EmberAfStatus GetOnOff(chip::EndpointId endpoint, uint8_t * onOff)
+EmberAfStatus GetOnOff(chip::EndpointId endpoint, bool * onOff)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::OnOff, (uint8_t *) onOff, sizeof(*onOff));
 }
-EmberAfStatus SetOnOff(chip::EndpointId endpoint, uint8_t onOff)
+EmberAfStatus SetOnOff(chip::EndpointId endpoint, bool onOff)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::OnOff, (uint8_t *) &onOff, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
@@ -795,12 +795,12 @@ EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoin
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::SampleMfgSpecificAttribute0x00010x1040,
                                        (uint8_t *) &sampleMfgSpecificAttribute0x00010x1040, ZCL_INT16U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, uint8_t * globalSceneControl)
+EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, bool * globalSceneControl)
 {
     return emberAfReadServerAttribute(endpoint, OnOff::Id, Ids::GlobalSceneControl, (uint8_t *) globalSceneControl,
                                       sizeof(*globalSceneControl));
 }
-EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, uint8_t globalSceneControl)
+EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, bool globalSceneControl)
 {
     return emberAfWriteServerAttribute(endpoint, OnOff::Id, Ids::GlobalSceneControl, (uint8_t *) &globalSceneControl,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -1049,12 +1049,12 @@ EmberAfStatus SetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc 
 
 namespace BinaryInputBasic {
 namespace Attributes {
-EmberAfStatus GetOutOfService(chip::EndpointId endpoint, uint8_t * outOfService)
+EmberAfStatus GetOutOfService(chip::EndpointId endpoint, bool * outOfService)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::OutOfService, (uint8_t *) outOfService,
                                       sizeof(*outOfService));
 }
-EmberAfStatus SetOutOfService(chip::EndpointId endpoint, uint8_t outOfService)
+EmberAfStatus SetOutOfService(chip::EndpointId endpoint, bool outOfService)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::OutOfService, (uint8_t *) &outOfService,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -1068,12 +1068,12 @@ EmberAfStatus SetPolarity(chip::EndpointId endpoint, uint8_t polarity)
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::Polarity, (uint8_t *) &polarity,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetPresentValue(chip::EndpointId endpoint, uint8_t * presentValue)
+EmberAfStatus GetPresentValue(chip::EndpointId endpoint, bool * presentValue)
 {
     return emberAfReadServerAttribute(endpoint, BinaryInputBasic::Id, Ids::PresentValue, (uint8_t *) presentValue,
                                       sizeof(*presentValue));
 }
-EmberAfStatus SetPresentValue(chip::EndpointId endpoint, uint8_t presentValue)
+EmberAfStatus SetPresentValue(chip::EndpointId endpoint, bool presentValue)
 {
     return emberAfWriteServerAttribute(endpoint, BinaryInputBasic::Id, Ids::PresentValue, (uint8_t *) &presentValue,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -1123,12 +1123,12 @@ EmberAfStatus SetTotalProfileNum(chip::EndpointId endpoint, uint8_t totalProfile
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::TotalProfileNum, (uint8_t *) &totalProfileNum,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, uint8_t * multipleScheduling)
+EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, bool * multipleScheduling)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::MultipleScheduling, (uint8_t *) multipleScheduling,
                                       sizeof(*multipleScheduling));
 }
-EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, uint8_t multipleScheduling)
+EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, bool multipleScheduling)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::MultipleScheduling, (uint8_t *) &multipleScheduling,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -1143,12 +1143,12 @@ EmberAfStatus SetEnergyFormatting(chip::EndpointId endpoint, uint8_t energyForma
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyFormatting, (uint8_t *) &energyFormatting,
                                        ZCL_BITMAP8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, uint8_t * energyRemote)
+EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, bool * energyRemote)
 {
     return emberAfReadServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyRemote, (uint8_t *) energyRemote,
                                       sizeof(*energyRemote));
 }
-EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, uint8_t energyRemote)
+EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, bool energyRemote)
 {
     return emberAfWriteServerAttribute(endpoint, PowerProfile::Id, Ids::EnergyRemote, (uint8_t *) &energyRemote,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -1327,21 +1327,21 @@ EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVer
     return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::SoftwareVersion, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, uint8_t * localConfigDisabled)
+EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, bool * localConfigDisabled)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::LocalConfigDisabled, (uint8_t *) localConfigDisabled,
                                       sizeof(*localConfigDisabled));
 }
-EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, uint8_t localConfigDisabled)
+EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, bool localConfigDisabled)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::LocalConfigDisabled, (uint8_t *) &localConfigDisabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReachable(chip::EndpointId endpoint, uint8_t * reachable)
+EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
 {
     return emberAfReadServerAttribute(endpoint, Basic::Id, Ids::Reachable, (uint8_t *) reachable, sizeof(*reachable));
 }
-EmberAfStatus SetReachable(chip::EndpointId endpoint, uint8_t reachable)
+EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
 {
     return emberAfWriteServerAttribute(endpoint, Basic::Id, Ids::Reachable, (uint8_t *) &reachable, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
@@ -2140,12 +2140,12 @@ EmberAfStatus SetPHYRate(chip::EndpointId endpoint, uint8_t pHYRate)
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::PHYRate, (uint8_t *) &pHYRate,
                                        ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, uint8_t * fullDuplex)
+EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, bool * fullDuplex)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::FullDuplex, (uint8_t *) fullDuplex,
                                       sizeof(*fullDuplex));
 }
-EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, uint8_t fullDuplex)
+EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, bool fullDuplex)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::FullDuplex, (uint8_t *) &fullDuplex,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2200,12 +2200,12 @@ EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount)
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::OverrunCount, (uint8_t *) &overrunCount,
                                        ZCL_INT64U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, uint8_t * carrierDetect)
+EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, bool * carrierDetect)
 {
     return emberAfReadServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CarrierDetect, (uint8_t *) carrierDetect,
                                       sizeof(*carrierDetect));
 }
-EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, uint8_t carrierDetect)
+EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, bool carrierDetect)
 {
     return emberAfWriteServerAttribute(endpoint, EthernetNetworkDiagnostics::Id, Ids::CarrierDetect, (uint8_t *) &carrierDetect,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2254,11 +2254,11 @@ EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVer
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::SoftwareVersion, (uint8_t *) &softwareVersion,
                                        ZCL_INT32U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetReachable(chip::EndpointId endpoint, uint8_t * reachable)
+EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable)
 {
     return emberAfReadServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::Reachable, (uint8_t *) reachable, sizeof(*reachable));
 }
-EmberAfStatus SetReachable(chip::EndpointId endpoint, uint8_t reachable)
+EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable)
 {
     return emberAfWriteServerAttribute(endpoint, BridgedDeviceBasic::Id, Ids::Reachable, (uint8_t *) &reachable,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2400,12 +2400,12 @@ EmberAfStatus SetLockType(chip::EndpointId endpoint, uint8_t lockType)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::LockType, (uint8_t *) &lockType, ZCL_ENUM8_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, uint8_t * actuatorEnabled)
+EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, bool * actuatorEnabled)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::ActuatorEnabled, (uint8_t *) actuatorEnabled,
                                       sizeof(*actuatorEnabled));
 }
-EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, uint8_t actuatorEnabled)
+EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, bool actuatorEnabled)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::ActuatorEnabled, (uint8_t *) &actuatorEnabled,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2557,12 +2557,12 @@ EmberAfStatus SetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t minRfidCod
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::MinRfidCodeLength, (uint8_t *) &minRfidCodeLength,
                                        ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, uint8_t * enableLogging)
+EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, bool * enableLogging)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableLogging, (uint8_t *) enableLogging,
                                       sizeof(*enableLogging));
 }
-EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, uint8_t enableLogging)
+EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, bool enableLogging)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableLogging, (uint8_t *) &enableLogging,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2625,42 +2625,42 @@ EmberAfStatus SetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::DefaultConfigurationRegister,
                                        (uint8_t *) &defaultConfigurationRegister, ZCL_BITMAP16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, uint8_t * enableLocalProgramming)
+EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, bool * enableLocalProgramming)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableLocalProgramming, (uint8_t *) enableLocalProgramming,
                                       sizeof(*enableLocalProgramming));
 }
-EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, uint8_t enableLocalProgramming)
+EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, bool enableLocalProgramming)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableLocalProgramming, (uint8_t *) &enableLocalProgramming,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, uint8_t * enableOneTouchLocking)
+EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, bool * enableOneTouchLocking)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableOneTouchLocking, (uint8_t *) enableOneTouchLocking,
                                       sizeof(*enableOneTouchLocking));
 }
-EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, uint8_t enableOneTouchLocking)
+EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, bool enableOneTouchLocking)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableOneTouchLocking, (uint8_t *) &enableOneTouchLocking,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, uint8_t * enableInsideStatusLed)
+EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, bool * enableInsideStatusLed)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnableInsideStatusLed, (uint8_t *) enableInsideStatusLed,
                                       sizeof(*enableInsideStatusLed));
 }
-EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, uint8_t enableInsideStatusLed)
+EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, bool enableInsideStatusLed)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnableInsideStatusLed, (uint8_t *) &enableInsideStatusLed,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, uint8_t * enablePrivacyModeButton)
+EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, bool * enablePrivacyModeButton)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::EnablePrivacyModeButton, (uint8_t *) enablePrivacyModeButton,
                                       sizeof(*enablePrivacyModeButton));
 }
-EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, uint8_t enablePrivacyModeButton)
+EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, bool enablePrivacyModeButton)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::EnablePrivacyModeButton, (uint8_t *) &enablePrivacyModeButton,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -2685,22 +2685,22 @@ EmberAfStatus SetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::UserCodeTemporaryDisableTime,
                                        (uint8_t *) &userCodeTemporaryDisableTime, ZCL_INT8U_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, uint8_t * sendPinOverTheAir)
+EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, bool * sendPinOverTheAir)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::SendPinOverTheAir, (uint8_t *) sendPinOverTheAir,
                                       sizeof(*sendPinOverTheAir));
 }
-EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, uint8_t sendPinOverTheAir)
+EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, bool sendPinOverTheAir)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::SendPinOverTheAir, (uint8_t *) &sendPinOverTheAir,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, uint8_t * requirePinForRfOperation)
+EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, bool * requirePinForRfOperation)
 {
     return emberAfReadServerAttribute(endpoint, DoorLock::Id, Ids::RequirePinForRfOperation, (uint8_t *) requirePinForRfOperation,
                                       sizeof(*requirePinForRfOperation));
 }
-EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, uint8_t requirePinForRfOperation)
+EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, bool requirePinForRfOperation)
 {
     return emberAfWriteServerAttribute(endpoint, DoorLock::Id, Ids::RequirePinForRfOperation, (uint8_t *) &requirePinForRfOperation,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);
@@ -6650,11 +6650,11 @@ EmberAfStatus SetApplicationStatus(chip::EndpointId endpoint, uint8_t applicatio
 
 namespace TestCluster {
 namespace Attributes {
-EmberAfStatus GetBoolean(chip::EndpointId endpoint, uint8_t * boolean)
+EmberAfStatus GetBoolean(chip::EndpointId endpoint, bool * boolean)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Boolean, (uint8_t *) boolean, sizeof(*boolean));
 }
-EmberAfStatus SetBoolean(chip::EndpointId endpoint, uint8_t boolean)
+EmberAfStatus SetBoolean(chip::EndpointId endpoint, bool boolean)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Boolean, (uint8_t *) &boolean, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
 }
@@ -6773,11 +6773,11 @@ EmberAfStatus SetEnum16(chip::EndpointId endpoint, uint16_t enum16)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Enum16, (uint8_t *) &enum16, ZCL_ENUM16_ATTRIBUTE_TYPE);
 }
-EmberAfStatus GetUnsupported(chip::EndpointId endpoint, uint8_t * unsupported)
+EmberAfStatus GetUnsupported(chip::EndpointId endpoint, bool * unsupported)
 {
     return emberAfReadServerAttribute(endpoint, TestCluster::Id, Ids::Unsupported, (uint8_t *) unsupported, sizeof(*unsupported));
 }
-EmberAfStatus SetUnsupported(chip::EndpointId endpoint, uint8_t unsupported)
+EmberAfStatus SetUnsupported(chip::EndpointId endpoint, bool unsupported)
 {
     return emberAfWriteServerAttribute(endpoint, TestCluster::Id, Ids::Unsupported, (uint8_t *) &unsupported,
                                        ZCL_BOOLEAN_ATTRIBUTE_TYPE);

--- a/src/app/common/gen/attributes/Accessors.h
+++ b/src/app/common/gen/attributes/Accessors.h
@@ -187,8 +187,8 @@ EmberAfStatus GetCurrentScene(chip::EndpointId endpoint, uint8_t * currentScene)
 EmberAfStatus SetCurrentScene(chip::EndpointId endpoint, uint8_t currentScene);
 EmberAfStatus GetCurrentGroup(chip::EndpointId endpoint, uint16_t * currentGroup); // int16u
 EmberAfStatus SetCurrentGroup(chip::EndpointId endpoint, uint16_t currentGroup);
-EmberAfStatus GetSceneValid(chip::EndpointId endpoint, uint8_t * sceneValid); // boolean
-EmberAfStatus SetSceneValid(chip::EndpointId endpoint, uint8_t sceneValid);
+EmberAfStatus GetSceneValid(chip::EndpointId endpoint, bool * sceneValid); // boolean
+EmberAfStatus SetSceneValid(chip::EndpointId endpoint, bool sceneValid);
 EmberAfStatus GetNameSupport(chip::EndpointId endpoint, uint8_t * nameSupport); // bitmap8
 EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport);
 } // namespace Attributes
@@ -196,8 +196,8 @@ EmberAfStatus SetNameSupport(chip::EndpointId endpoint, uint8_t nameSupport);
 
 namespace OnOff {
 namespace Attributes {
-EmberAfStatus GetOnOff(chip::EndpointId endpoint, uint8_t * onOff); // boolean
-EmberAfStatus SetOnOff(chip::EndpointId endpoint, uint8_t onOff);
+EmberAfStatus GetOnOff(chip::EndpointId endpoint, bool * onOff); // boolean
+EmberAfStatus SetOnOff(chip::EndpointId endpoint, bool onOff);
 EmberAfStatus GetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint,
                                                         uint16_t * sampleMfgSpecificAttribute0x00000x1002); // int16u
 EmberAfStatus SetSampleMfgSpecificAttribute0x00000x1002(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00000x1002);
@@ -210,8 +210,8 @@ EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1002(chip::EndpointId endpoin
 EmberAfStatus GetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint,
                                                         uint16_t * sampleMfgSpecificAttribute0x00010x1040); // int16u
 EmberAfStatus SetSampleMfgSpecificAttribute0x00010x1040(chip::EndpointId endpoint, uint16_t sampleMfgSpecificAttribute0x00010x1040);
-EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, uint8_t * globalSceneControl); // boolean
-EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, uint8_t globalSceneControl);
+EmberAfStatus GetGlobalSceneControl(chip::EndpointId endpoint, bool * globalSceneControl); // boolean
+EmberAfStatus SetGlobalSceneControl(chip::EndpointId endpoint, bool globalSceneControl);
 EmberAfStatus GetOnTime(chip::EndpointId endpoint, uint16_t * onTime); // int16u
 EmberAfStatus SetOnTime(chip::EndpointId endpoint, uint16_t onTime);
 EmberAfStatus GetOffWaitTime(chip::EndpointId endpoint, uint16_t * offWaitTime); // int16u
@@ -287,12 +287,12 @@ EmberAfStatus SetValidUntilTime(chip::EndpointId endpoint, /* TYPE WARNING: utc 
 
 namespace BinaryInputBasic {
 namespace Attributes {
-EmberAfStatus GetOutOfService(chip::EndpointId endpoint, uint8_t * outOfService); // boolean
-EmberAfStatus SetOutOfService(chip::EndpointId endpoint, uint8_t outOfService);
+EmberAfStatus GetOutOfService(chip::EndpointId endpoint, bool * outOfService); // boolean
+EmberAfStatus SetOutOfService(chip::EndpointId endpoint, bool outOfService);
 EmberAfStatus GetPolarity(chip::EndpointId endpoint, uint8_t * polarity); // enum8
 EmberAfStatus SetPolarity(chip::EndpointId endpoint, uint8_t polarity);
-EmberAfStatus GetPresentValue(chip::EndpointId endpoint, uint8_t * presentValue); // boolean
-EmberAfStatus SetPresentValue(chip::EndpointId endpoint, uint8_t presentValue);
+EmberAfStatus GetPresentValue(chip::EndpointId endpoint, bool * presentValue); // boolean
+EmberAfStatus SetPresentValue(chip::EndpointId endpoint, bool presentValue);
 EmberAfStatus GetReliability(chip::EndpointId endpoint, uint8_t * reliability); // enum8
 EmberAfStatus SetReliability(chip::EndpointId endpoint, uint8_t reliability);
 EmberAfStatus GetStatusFlags(chip::EndpointId endpoint, uint8_t * statusFlags); // bitmap8
@@ -306,12 +306,12 @@ namespace PowerProfile {
 namespace Attributes {
 EmberAfStatus GetTotalProfileNum(chip::EndpointId endpoint, uint8_t * totalProfileNum); // int8u
 EmberAfStatus SetTotalProfileNum(chip::EndpointId endpoint, uint8_t totalProfileNum);
-EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, uint8_t * multipleScheduling); // boolean
-EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, uint8_t multipleScheduling);
+EmberAfStatus GetMultipleScheduling(chip::EndpointId endpoint, bool * multipleScheduling); // boolean
+EmberAfStatus SetMultipleScheduling(chip::EndpointId endpoint, bool multipleScheduling);
 EmberAfStatus GetEnergyFormatting(chip::EndpointId endpoint, uint8_t * energyFormatting); // bitmap8
 EmberAfStatus SetEnergyFormatting(chip::EndpointId endpoint, uint8_t energyFormatting);
-EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, uint8_t * energyRemote); // boolean
-EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, uint8_t energyRemote);
+EmberAfStatus GetEnergyRemote(chip::EndpointId endpoint, bool * energyRemote); // boolean
+EmberAfStatus SetEnergyRemote(chip::EndpointId endpoint, bool energyRemote);
 EmberAfStatus GetScheduleMode(chip::EndpointId endpoint, uint8_t * scheduleMode); // bitmap8
 EmberAfStatus SetScheduleMode(chip::EndpointId endpoint, uint8_t scheduleMode);
 } // namespace Attributes
@@ -364,10 +364,10 @@ EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareV
 EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion);
 EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
 EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion);
-EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, uint8_t * localConfigDisabled); // boolean
-EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, uint8_t localConfigDisabled);
-EmberAfStatus GetReachable(chip::EndpointId endpoint, uint8_t * reachable); // boolean
-EmberAfStatus SetReachable(chip::EndpointId endpoint, uint8_t reachable);
+EmberAfStatus GetLocalConfigDisabled(chip::EndpointId endpoint, bool * localConfigDisabled); // boolean
+EmberAfStatus SetLocalConfigDisabled(chip::EndpointId endpoint, bool localConfigDisabled);
+EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable); // boolean
+EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable);
 } // namespace Attributes
 } // namespace Basic
 
@@ -553,8 +553,8 @@ namespace EthernetNetworkDiagnostics {
 namespace Attributes {
 EmberAfStatus GetPHYRate(chip::EndpointId endpoint, uint8_t * pHYRate); // enum8
 EmberAfStatus SetPHYRate(chip::EndpointId endpoint, uint8_t pHYRate);
-EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, uint8_t * fullDuplex); // boolean
-EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, uint8_t fullDuplex);
+EmberAfStatus GetFullDuplex(chip::EndpointId endpoint, bool * fullDuplex); // boolean
+EmberAfStatus SetFullDuplex(chip::EndpointId endpoint, bool fullDuplex);
 EmberAfStatus GetPacketRxCount(chip::EndpointId endpoint, uint64_t * packetRxCount); // int64u
 EmberAfStatus SetPacketRxCount(chip::EndpointId endpoint, uint64_t packetRxCount);
 EmberAfStatus GetPacketTxCount(chip::EndpointId endpoint, uint64_t * packetTxCount); // int64u
@@ -565,8 +565,8 @@ EmberAfStatus GetCollisionCount(chip::EndpointId endpoint, uint64_t * collisionC
 EmberAfStatus SetCollisionCount(chip::EndpointId endpoint, uint64_t collisionCount);
 EmberAfStatus GetOverrunCount(chip::EndpointId endpoint, uint64_t * overrunCount); // int64u
 EmberAfStatus SetOverrunCount(chip::EndpointId endpoint, uint64_t overrunCount);
-EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, uint8_t * carrierDetect); // boolean
-EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, uint8_t carrierDetect);
+EmberAfStatus GetCarrierDetect(chip::EndpointId endpoint, bool * carrierDetect); // boolean
+EmberAfStatus SetCarrierDetect(chip::EndpointId endpoint, bool carrierDetect);
 EmberAfStatus GetTimeSinceReset(chip::EndpointId endpoint, uint64_t * timeSinceReset); // int64u
 EmberAfStatus SetTimeSinceReset(chip::EndpointId endpoint, uint64_t timeSinceReset);
 } // namespace Attributes
@@ -580,8 +580,8 @@ EmberAfStatus GetHardwareVersion(chip::EndpointId endpoint, uint16_t * hardwareV
 EmberAfStatus SetHardwareVersion(chip::EndpointId endpoint, uint16_t hardwareVersion);
 EmberAfStatus GetSoftwareVersion(chip::EndpointId endpoint, uint32_t * softwareVersion); // int32u
 EmberAfStatus SetSoftwareVersion(chip::EndpointId endpoint, uint32_t softwareVersion);
-EmberAfStatus GetReachable(chip::EndpointId endpoint, uint8_t * reachable); // boolean
-EmberAfStatus SetReachable(chip::EndpointId endpoint, uint8_t reachable);
+EmberAfStatus GetReachable(chip::EndpointId endpoint, bool * reachable); // boolean
+EmberAfStatus SetReachable(chip::EndpointId endpoint, bool reachable);
 } // namespace Attributes
 } // namespace BridgedDeviceBasic
 
@@ -631,8 +631,8 @@ EmberAfStatus GetLockState(chip::EndpointId endpoint, uint8_t * lockState); // e
 EmberAfStatus SetLockState(chip::EndpointId endpoint, uint8_t lockState);
 EmberAfStatus GetLockType(chip::EndpointId endpoint, uint8_t * lockType); // enum8
 EmberAfStatus SetLockType(chip::EndpointId endpoint, uint8_t lockType);
-EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, uint8_t * actuatorEnabled); // boolean
-EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, uint8_t actuatorEnabled);
+EmberAfStatus GetActuatorEnabled(chip::EndpointId endpoint, bool * actuatorEnabled); // boolean
+EmberAfStatus SetActuatorEnabled(chip::EndpointId endpoint, bool actuatorEnabled);
 EmberAfStatus GetDoorState(chip::EndpointId endpoint, uint8_t * doorState); // enum8
 EmberAfStatus SetDoorState(chip::EndpointId endpoint, uint8_t doorState);
 EmberAfStatus GetDoorOpenEvents(chip::EndpointId endpoint, uint32_t * doorOpenEvents); // int32u
@@ -666,8 +666,8 @@ EmberAfStatus GetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t * maxRfidC
 EmberAfStatus SetMaxRfidCodeLength(chip::EndpointId endpoint, uint8_t maxRfidCodeLength);
 EmberAfStatus GetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t * minRfidCodeLength); // int8u
 EmberAfStatus SetMinRfidCodeLength(chip::EndpointId endpoint, uint8_t minRfidCodeLength);
-EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, uint8_t * enableLogging); // boolean
-EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, uint8_t enableLogging);
+EmberAfStatus GetEnableLogging(chip::EndpointId endpoint, bool * enableLogging); // boolean
+EmberAfStatus SetEnableLogging(chip::EndpointId endpoint, bool enableLogging);
 EmberAfStatus GetLedSettings(chip::EndpointId endpoint, uint8_t * ledSettings); // int8u
 EmberAfStatus SetLedSettings(chip::EndpointId endpoint, uint8_t ledSettings);
 EmberAfStatus GetAutoRelockTime(chip::EndpointId endpoint, uint32_t * autoRelockTime); // int32u
@@ -680,22 +680,22 @@ EmberAfStatus GetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t * s
 EmberAfStatus SetSupportedOperatingModes(chip::EndpointId endpoint, uint16_t supportedOperatingModes);
 EmberAfStatus GetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t * defaultConfigurationRegister); // bitmap16
 EmberAfStatus SetDefaultConfigurationRegister(chip::EndpointId endpoint, uint16_t defaultConfigurationRegister);
-EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, uint8_t * enableLocalProgramming); // boolean
-EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, uint8_t enableLocalProgramming);
-EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, uint8_t * enableOneTouchLocking); // boolean
-EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, uint8_t enableOneTouchLocking);
-EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, uint8_t * enableInsideStatusLed); // boolean
-EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, uint8_t enableInsideStatusLed);
-EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, uint8_t * enablePrivacyModeButton); // boolean
-EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, uint8_t enablePrivacyModeButton);
+EmberAfStatus GetEnableLocalProgramming(chip::EndpointId endpoint, bool * enableLocalProgramming); // boolean
+EmberAfStatus SetEnableLocalProgramming(chip::EndpointId endpoint, bool enableLocalProgramming);
+EmberAfStatus GetEnableOneTouchLocking(chip::EndpointId endpoint, bool * enableOneTouchLocking); // boolean
+EmberAfStatus SetEnableOneTouchLocking(chip::EndpointId endpoint, bool enableOneTouchLocking);
+EmberAfStatus GetEnableInsideStatusLed(chip::EndpointId endpoint, bool * enableInsideStatusLed); // boolean
+EmberAfStatus SetEnableInsideStatusLed(chip::EndpointId endpoint, bool enableInsideStatusLed);
+EmberAfStatus GetEnablePrivacyModeButton(chip::EndpointId endpoint, bool * enablePrivacyModeButton); // boolean
+EmberAfStatus SetEnablePrivacyModeButton(chip::EndpointId endpoint, bool enablePrivacyModeButton);
 EmberAfStatus GetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t * wrongCodeEntryLimit); // int8u
 EmberAfStatus SetWrongCodeEntryLimit(chip::EndpointId endpoint, uint8_t wrongCodeEntryLimit);
 EmberAfStatus GetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t * userCodeTemporaryDisableTime); // int8u
 EmberAfStatus SetUserCodeTemporaryDisableTime(chip::EndpointId endpoint, uint8_t userCodeTemporaryDisableTime);
-EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, uint8_t * sendPinOverTheAir); // boolean
-EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, uint8_t sendPinOverTheAir);
-EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, uint8_t * requirePinForRfOperation); // boolean
-EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, uint8_t requirePinForRfOperation);
+EmberAfStatus GetSendPinOverTheAir(chip::EndpointId endpoint, bool * sendPinOverTheAir); // boolean
+EmberAfStatus SetSendPinOverTheAir(chip::EndpointId endpoint, bool sendPinOverTheAir);
+EmberAfStatus GetRequirePinForRfOperation(chip::EndpointId endpoint, bool * requirePinForRfOperation); // boolean
+EmberAfStatus SetRequirePinForRfOperation(chip::EndpointId endpoint, bool requirePinForRfOperation);
 EmberAfStatus GetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t * zigbeeSecurityLevel); // enum8
 EmberAfStatus SetZigbeeSecurityLevel(chip::EndpointId endpoint, uint8_t zigbeeSecurityLevel);
 EmberAfStatus GetAlarmMask(chip::EndpointId endpoint, uint16_t * alarmMask); // bitmap16
@@ -1830,8 +1830,8 @@ EmberAfStatus SetApplicationStatus(chip::EndpointId endpoint, uint8_t applicatio
 
 namespace TestCluster {
 namespace Attributes {
-EmberAfStatus GetBoolean(chip::EndpointId endpoint, uint8_t * boolean); // boolean
-EmberAfStatus SetBoolean(chip::EndpointId endpoint, uint8_t boolean);
+EmberAfStatus GetBoolean(chip::EndpointId endpoint, bool * boolean); // boolean
+EmberAfStatus SetBoolean(chip::EndpointId endpoint, bool boolean);
 EmberAfStatus GetBitmap8(chip::EndpointId endpoint, uint8_t * bitmap8); // bitmap8
 EmberAfStatus SetBitmap8(chip::EndpointId endpoint, uint8_t bitmap8);
 EmberAfStatus GetBitmap16(chip::EndpointId endpoint, uint16_t * bitmap16); // bitmap16
@@ -1860,8 +1860,8 @@ EmberAfStatus GetEnum8(chip::EndpointId endpoint, uint8_t * enum8); // enum8
 EmberAfStatus SetEnum8(chip::EndpointId endpoint, uint8_t enum8);
 EmberAfStatus GetEnum16(chip::EndpointId endpoint, uint16_t * enum16); // enum16
 EmberAfStatus SetEnum16(chip::EndpointId endpoint, uint16_t enum16);
-EmberAfStatus GetUnsupported(chip::EndpointId endpoint, uint8_t * unsupported); // boolean
-EmberAfStatus SetUnsupported(chip::EndpointId endpoint, uint8_t unsupported);
+EmberAfStatus GetUnsupported(chip::EndpointId endpoint, bool * unsupported); // boolean
+EmberAfStatus SetUnsupported(chip::EndpointId endpoint, bool unsupported);
 } // namespace Attributes
 } // namespace TestCluster
 

--- a/src/app/common/gen/callback.h
+++ b/src/app/common/gen/callback.h
@@ -15693,7 +15693,7 @@ bool emberAfPollControlClusterCheckInCallback(chip::EndpointId endpoint, chip::a
  * @brief  Cluster CheckInResponse Command callback (from client)
  */
 bool emberAfPollControlClusterCheckInResponseCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                      uint8_t startFastPolling, uint16_t fastPollTimeout);
+                                                      bool startFastPolling, uint16_t fastPollTimeout);
 /**
  * @brief  Cluster FastPollStop Command callback (from client)
  */
@@ -15731,7 +15731,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(chip::EndpointId 
                                                                uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                                                uint16_t hardwareVersion, uint32_t currentVersion,
                                                                uint8_t protocolsSupported, uint8_t * location,
-                                                               uint8_t requestorCanConsent, chip::ByteSpan metadataForProvider);
+                                                               bool requestorCanConsent, chip::ByteSpan metadataForProvider);
 /**
  * @brief  Cluster ApplyUpdateRequest Command callback (from client)
  */
@@ -15751,8 +15751,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::End
                                                                        chip::app::CommandSender * commandObj, uint8_t status,
                                                                        uint32_t delayedActionTime, uint8_t * imageURI,
                                                                        uint32_t softwareVersion, chip::ByteSpan updateToken,
-                                                                       uint8_t userConsentNeeded,
-                                                                       chip::ByteSpan metadataForRequestor);
+                                                                       bool userConsentNeeded, chip::ByteSpan metadataForRequestor);
 /**
  * @brief  Cluster ApplyUpdateRequestResponse Command callback (from server)
  */
@@ -16607,13 +16606,13 @@ bool emberAfIasAceClusterGetBypassedZoneListCallback(chip::EndpointId endpoint, 
  * @brief  Cluster GetZoneStatusResponse Command callback (from server)
  */
 bool emberAfIasAceClusterGetZoneStatusResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj,
-                                                       uint8_t zoneStatusComplete, uint8_t numberOfZones,
+                                                       bool zoneStatusComplete, uint8_t numberOfZones,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * zoneStatusResult);
 /**
  * @brief  Cluster GetZoneStatus Command callback (from client)
  */
 bool emberAfIasAceClusterGetZoneStatusCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                               uint8_t startingZoneId, uint8_t maxNumberOfZoneIds, uint8_t zoneStatusMaskFlag,
+                                               uint8_t startingZoneId, uint8_t maxNumberOfZoneIds, bool zoneStatusMaskFlag,
                                                uint16_t zoneStatusMask);
 /**
  * @brief  Cluster StartWarning Command callback (from client)
@@ -16790,7 +16789,7 @@ bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::EndpointId endpoint,
  * @brief  Cluster LaunchContent Command callback (from client)
  */
 bool emberAfContentLauncherClusterLaunchContentCallback(chip::EndpointId endpoint, chip::app::CommandHandler * commandObj,
-                                                        uint8_t autoPlay, uint8_t * data);
+                                                        bool autoPlay, uint8_t * data);
 /**
  * @brief  Cluster LaunchContentResponse Command callback (from server)
  */

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -145,6 +145,8 @@ function asPutLength(zclType)
 {
   const type = ChipTypesHelper.asBasicType(zclType);
   switch (type) {
+  case 'bool':
+    return '8';
   case 'int8_t':
   case 'int16_t':
   case 'int32_t':
@@ -163,6 +165,8 @@ function asPutCastType(zclType)
 {
   const type = ChipTypesHelper.asBasicType(zclType);
   switch (type) {
+  case 'bool':
+    return 'uint8_t';
   case 'int8_t':
   case 'int16_t':
   case 'int32_t':

--- a/src/app/zap-templates/common/override.js
+++ b/src/app/zap-templates/common/override.js
@@ -18,6 +18,8 @@
 function atomicType(arg)
 {
   switch (arg.name) {
+  case 'boolean':
+    return 'bool';
   case 'action_id':
   case 'cluster_id':
   case 'command_id':

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -89,6 +89,8 @@ function asReadType(type)
     return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
+      case 'bool':
+        return 'Int8u';
       case 'int8_t':
         return 'Int8s';
       case 'uint8_t':
@@ -252,6 +254,8 @@ function asPrintFormat(type)
     return zclHelper.asUnderlyingZclType.call(this, type, options).then(zclType => {
       const basicType = ChipTypesHelper.asBasicType(zclType);
       switch (basicType) {
+      case 'bool':
+        return '%d';
       case 'int8_t':
         return '%" PRId8 "';
       case 'uint8_t':

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -2763,8 +2763,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::End
                                                                        chip::app::CommandSender * commandObj, uint8_t status,
                                                                        uint32_t delayedActionTime, uint8_t * imageURI,
                                                                        uint32_t softwareVersion, chip::ByteSpan updateToken,
-                                                                       uint8_t userConsentNeeded,
-                                                                       chip::ByteSpan metadataForRequestor)
+                                                                       bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(Zcl, "QueryImageResponse:");
     LogStatus(status);
@@ -2773,7 +2772,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::End
     // ChipLogProgress(Zcl, "  imageURI: %.*s", imageURI.size(), imageURI.data());
     ChipLogProgress(Zcl, "  softwareVersion: %" PRIu32 "", softwareVersion);
     ChipLogProgress(Zcl, "  updateToken: %zu", updateToken.size());
-    ChipLogProgress(Zcl, "  userConsentNeeded: %" PRIu8 "", userConsentNeeded);
+    ChipLogProgress(Zcl, "  userConsentNeeded: %d", userConsentNeeded);
     ChipLogProgress(Zcl, "  metadataForRequestor: %zu", metadataForRequestor.size());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("OtaSoftwareUpdateProviderClusterQueryImageResponseCallback");

--- a/src/controller/data_model/gen/CHIPClientCallbacks.h
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.h
@@ -158,7 +158,7 @@ typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallbac
                                                                                    uint32_t delayedActionTime);
 typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(void * context, uint32_t delayedActionTime,
                                                                            uint8_t * imageURI, uint32_t softwareVersion,
-                                                                           chip::ByteSpan updateToken, uint8_t userConsentNeeded,
+                                                                           chip::ByteSpan updateToken, bool userConsentNeeded,
                                                                            chip::ByteSpan metadataForRequestor);
 typedef void (*OperationalCredentialsClusterNOCResponseCallback)(void * context, uint8_t StatusCode, uint8_t FabricIndex,
                                                                  chip::ByteSpan DebugText);

--- a/src/controller/data_model/gen/CHIPClusters.cpp
+++ b/src/controller/data_model/gen/CHIPClusters.cpp
@@ -1165,7 +1165,7 @@ CHIP_ERROR BasicCluster::ReadAttributeLocalConfigDisabled(Callback::Cancelable *
 }
 
 CHIP_ERROR BasicCluster::WriteAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint8_t localConfigDisabled)
+                                                           Callback::Cancelable * onFailureCallback, bool localConfigDisabled)
 {
     COMMAND_HEADER("WriteBasicLocalConfigDisabled", Basic::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -1223,7 +1223,7 @@ CHIP_ERROR BinaryInputBasicCluster::ReadAttributeOutOfService(Callback::Cancelab
 }
 
 CHIP_ERROR BinaryInputBasicCluster::WriteAttributeOutOfService(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint8_t outOfService)
+                                                               Callback::Cancelable * onFailureCallback, bool outOfService)
 {
     COMMAND_HEADER("WriteBinaryInputBasicOutOfService", BinaryInputBasic::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -1248,7 +1248,7 @@ CHIP_ERROR BinaryInputBasicCluster::ReadAttributePresentValue(Callback::Cancelab
 }
 
 CHIP_ERROR BinaryInputBasicCluster::WriteAttributePresentValue(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint8_t presentValue)
+                                                               Callback::Cancelable * onFailureCallback, bool presentValue)
 {
     COMMAND_HEADER("WriteBinaryInputBasicPresentValue", BinaryInputBasic::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -3504,7 +3504,7 @@ CHIP_ERROR ColorControlCluster::ReadAttributeClusterRevision(Callback::Cancelabl
 
 // ContentLauncher Cluster Commands
 CHIP_ERROR ContentLauncherCluster::LaunchContent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 uint8_t autoPlay, chip::ByteSpan data)
+                                                 bool autoPlay, chip::ByteSpan data)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     app::CommandSender * sender = nullptr;
@@ -7615,7 +7615,7 @@ CHIP_ERROR OtaSoftwareUpdateProviderCluster::QueryImage(Callback::Cancelable * o
                                                         Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                                                         uint16_t productId, uint16_t imageType, uint16_t hardwareVersion,
                                                         uint32_t currentVersion, uint8_t protocolsSupported,
-                                                        chip::ByteSpan location, uint8_t requestorCanConsent,
+                                                        chip::ByteSpan location, bool requestorCanConsent,
                                                         chip::ByteSpan metadataForProvider)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
@@ -9962,7 +9962,7 @@ CHIP_ERROR TestClusterCluster::ReadAttributeBoolean(Callback::Cancelable * onSuc
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeBoolean(Callback::Cancelable * onSuccessCallback,
-                                                     Callback::Cancelable * onFailureCallback, uint8_t boolean)
+                                                     Callback::Cancelable * onFailureCallback, bool boolean)
 {
     COMMAND_HEADER("WriteTestClusterBoolean", TestCluster::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -10506,7 +10506,7 @@ CHIP_ERROR TestClusterCluster::ReadAttributeUnsupported(Callback::Cancelable * o
 }
 
 CHIP_ERROR TestClusterCluster::WriteAttributeUnsupported(Callback::Cancelable * onSuccessCallback,
-                                                         Callback::Cancelable * onFailureCallback, uint8_t unsupported)
+                                                         Callback::Cancelable * onFailureCallback, bool unsupported)
 {
     COMMAND_HEADER("WriteTestClusterUnsupported", TestCluster::Id);
     buf.Put8(kFrameControlGlobalCommand)

--- a/src/controller/data_model/gen/CHIPClusters.h
+++ b/src/controller/data_model/gen/CHIPClusters.h
@@ -194,7 +194,7 @@ public:
     CHIP_ERROR WriteAttributeLocation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                       chip::ByteSpan value);
     CHIP_ERROR WriteAttributeLocalConfigDisabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 uint8_t value);
+                                                 bool value);
 
 private:
 };
@@ -212,9 +212,9 @@ public:
     CHIP_ERROR ReadAttributeStatusFlags(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR WriteAttributeOutOfService(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint8_t value);
+                                          bool value);
     CHIP_ERROR WriteAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint8_t value);
+                                          bool value);
     CHIP_ERROR ConfigureAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                               uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributePresentValue(Callback::Cancelable * onReportCallback);
@@ -438,7 +438,7 @@ public:
     ~ContentLauncherCluster() {}
 
     // Cluster Commands
-    CHIP_ERROR LaunchContent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint8_t autoPlay,
+    CHIP_ERROR LaunchContent(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, bool autoPlay,
                              chip::ByteSpan data);
     CHIP_ERROR LaunchURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                          chip::ByteSpan contentURL, chip::ByteSpan displayString);
@@ -869,7 +869,7 @@ public:
                                    chip::ByteSpan updateToken, uint32_t currentVersion);
     CHIP_ERROR QueryImage(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t vendorId,
                           uint16_t productId, uint16_t imageType, uint16_t hardwareVersion, uint32_t currentVersion,
-                          uint8_t protocolsSupported, chip::ByteSpan location, uint8_t requestorCanConsent,
+                          uint8_t protocolsSupported, chip::ByteSpan location, bool requestorCanConsent,
                           chip::ByteSpan metadataForProvider);
 
     // Cluster Attributes
@@ -1195,7 +1195,7 @@ public:
     CHIP_ERROR ReadAttributeUnsupported(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR WriteAttributeBoolean(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                     uint8_t value);
+                                     bool value);
     CHIP_ERROR WriteAttributeBitmap8(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                      uint8_t value);
     CHIP_ERROR WriteAttributeBitmap16(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1233,7 +1233,7 @@ public:
     CHIP_ERROR WriteAttributeLongCharString(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                             chip::ByteSpan value);
     CHIP_ERROR WriteAttributeUnsupported(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                         uint8_t value);
+                                         bool value);
 
 private:
 };

--- a/src/controller/data_model/gen/IMClusterCommandHandler.cpp
+++ b/src/controller/data_model/gen/IMClusterCommandHandler.cpp
@@ -4050,7 +4050,7 @@ void DispatchClientCommand(app::CommandSender * apCommandObj, CommandId aCommand
             const uint8_t * imageURI;
             uint32_t softwareVersion;
             chip::ByteSpan updateToken;
-            uint8_t userConsentNeeded;
+            bool userConsentNeeded;
             chip::ByteSpan metadataForRequestor;
             bool argExists[7];
 

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -4792,7 +4792,7 @@ public:
     };
 
     static void CallbackFn(void * context, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-                           chip::ByteSpan updateToken, uint8_t userConsentNeeded, chip::ByteSpan metadataForRequestor)
+                           chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -4814,7 +4814,7 @@ public:
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
         err =
-            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BI[B)V", &javaMethod);
+            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BZ[B)V", &javaMethod);
         SuccessOrExit(err);
 
         updateTokenArr = env->NewByteArray(updateToken.size());
@@ -4830,7 +4830,7 @@ public:
         VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jlong>(delayedActionTime), imageURIStr.jniValue(),
-                            static_cast<jlong>(softwareVersion), updateTokenArr, static_cast<jint>(userConsentNeeded),
+                            static_cast<jlong>(softwareVersion), updateTokenArr, static_cast<jboolean>(userConsentNeeded),
                             metadataForRequestorArr);
 
         env->DeleteLocalRef(updateTokenArr);
@@ -6513,17 +6513,17 @@ public:
                 Zcl,
                 "Could not find class chip/devicecontroller/ChipClusters$GeneralDiagnosticsCluster$NetworkInterfacesAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "([BIII[BI)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "([BZZZ[BI)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find NetworkInterfacesAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
             jbyteArray name = env->NewByteArray(entries[i].Name.size());
             env->SetByteArrayRegion(name, 0, entries[i].Name.size(), reinterpret_cast<const jbyte *>(entries[i].Name.data()));
-            jint fabricConnected                 = entries[i].FabricConnected;
-            jint offPremiseServicesReachableIPv4 = entries[i].OffPremiseServicesReachableIPv4;
-            jint offPremiseServicesReachableIPv6 = entries[i].OffPremiseServicesReachableIPv6;
-            jbyteArray hardwareAddress           = env->NewByteArray(entries[i].HardwareAddress.size());
+            jboolean fabricConnected                 = entries[i].FabricConnected;
+            jboolean offPremiseServicesReachableIPv4 = entries[i].OffPremiseServicesReachableIPv4;
+            jboolean offPremiseServicesReachableIPv6 = entries[i].OffPremiseServicesReachableIPv6;
+            jbyteArray hardwareAddress               = env->NewByteArray(entries[i].HardwareAddress.size());
             env->SetByteArrayRegion(hardwareAddress, 0, entries[i].HardwareAddress.size(),
                                     reinterpret_cast<const jbyte *>(entries[i].HardwareAddress.data()));
             jint type = entries[i].Type;
@@ -7344,25 +7344,25 @@ public:
                          "Could not find class "
                          "chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$NeighborTableListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JJIJJIIIIIIIII)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JJIJJIIIIIZZZZ)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find NeighborTableListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jlong extAddress       = entries[i].ExtAddress;
-            jlong age              = entries[i].Age;
-            jint rloc16            = entries[i].Rloc16;
-            jlong linkFrameCounter = entries[i].LinkFrameCounter;
-            jlong mleFrameCounter  = entries[i].MleFrameCounter;
-            jint lqi               = entries[i].LQI;
-            jint averageRssi       = entries[i].AverageRssi;
-            jint lastRssi          = entries[i].LastRssi;
-            jint frameErrorRate    = entries[i].FrameErrorRate;
-            jint messageErrorRate  = entries[i].MessageErrorRate;
-            jint rxOnWhenIdle      = entries[i].RxOnWhenIdle;
-            jint fullThreadDevice  = entries[i].FullThreadDevice;
-            jint fullNetworkData   = entries[i].FullNetworkData;
-            jint isChild           = entries[i].IsChild;
+            jlong extAddress          = entries[i].ExtAddress;
+            jlong age                 = entries[i].Age;
+            jint rloc16               = entries[i].Rloc16;
+            jlong linkFrameCounter    = entries[i].LinkFrameCounter;
+            jlong mleFrameCounter     = entries[i].MleFrameCounter;
+            jint lqi                  = entries[i].LQI;
+            jint averageRssi          = entries[i].AverageRssi;
+            jint lastRssi             = entries[i].LastRssi;
+            jint frameErrorRate       = entries[i].FrameErrorRate;
+            jint messageErrorRate     = entries[i].MessageErrorRate;
+            jboolean rxOnWhenIdle     = entries[i].RxOnWhenIdle;
+            jboolean fullThreadDevice = entries[i].FullThreadDevice;
+            jboolean fullNetworkData  = entries[i].FullNetworkData;
+            jboolean isChild          = entries[i].IsChild;
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, extAddress, age, rloc16, linkFrameCounter,
                                                   mleFrameCounter, lqi, averageRssi, lastRssi, frameErrorRate, messageErrorRate,
@@ -7442,21 +7442,21 @@ public:
                 Zcl,
                 "Could not find class chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$RouteTableListAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JIIIIIIIII)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(JIIIIIIIZZ)V");
         VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find RouteTableListAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jlong extAddress     = entries[i].ExtAddress;
-            jint rloc16          = entries[i].Rloc16;
-            jint routerId        = entries[i].RouterId;
-            jint nextHop         = entries[i].NextHop;
-            jint pathCost        = entries[i].PathCost;
-            jint lQIIn           = entries[i].LQIIn;
-            jint lQIOut          = entries[i].LQIOut;
-            jint age             = entries[i].Age;
-            jint allocated       = entries[i].Allocated;
-            jint linkEstablished = entries[i].LinkEstablished;
+            jlong extAddress         = entries[i].ExtAddress;
+            jint rloc16              = entries[i].Rloc16;
+            jint routerId            = entries[i].RouterId;
+            jint nextHop             = entries[i].NextHop;
+            jint pathCost            = entries[i].PathCost;
+            jint lQIIn               = entries[i].LQIIn;
+            jint lQIOut              = entries[i].LQIOut;
+            jint age                 = entries[i].Age;
+            jboolean allocated       = entries[i].Allocated;
+            jboolean linkEstablished = entries[i].LinkEstablished;
 
             jobject attributeObj = env->NewObject(attributeClass, attributeCtor, extAddress, rloc16, routerId, nextHop, pathCost,
                                                   lQIIn, lQIOut, age, allocated, linkEstablished);
@@ -7621,24 +7621,24 @@ public:
                 "Could not find class "
                 "chip/devicecontroller/ChipClusters$ThreadNetworkDiagnosticsCluster$OperationalDatasetComponentsAttribute"));
         JniClass attributeJniClass(attributeClass);
-        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(IIIIIIIIIIII)V");
+        jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>", "(ZZZZZZZZZZZZ)V");
         VerifyOrReturn(attributeCtor != nullptr,
                        ChipLogError(Zcl, "Could not find OperationalDatasetComponentsAttribute constructor"));
 
         for (uint16_t i = 0; i < count; i++)
         {
-            jint activeTimestampPresent  = entries[i].ActiveTimestampPresent;
-            jint pendingTimestampPresent = entries[i].PendingTimestampPresent;
-            jint masterKeyPresent        = entries[i].MasterKeyPresent;
-            jint networkNamePresent      = entries[i].NetworkNamePresent;
-            jint extendedPanIdPresent    = entries[i].ExtendedPanIdPresent;
-            jint meshLocalPrefixPresent  = entries[i].MeshLocalPrefixPresent;
-            jint delayPresent            = entries[i].DelayPresent;
-            jint panIdPresent            = entries[i].PanIdPresent;
-            jint channelPresent          = entries[i].ChannelPresent;
-            jint pskcPresent             = entries[i].PskcPresent;
-            jint securityPolicyPresent   = entries[i].SecurityPolicyPresent;
-            jint channelMaskPresent      = entries[i].ChannelMaskPresent;
+            jboolean activeTimestampPresent  = entries[i].ActiveTimestampPresent;
+            jboolean pendingTimestampPresent = entries[i].PendingTimestampPresent;
+            jboolean masterKeyPresent        = entries[i].MasterKeyPresent;
+            jboolean networkNamePresent      = entries[i].NetworkNamePresent;
+            jboolean extendedPanIdPresent    = entries[i].ExtendedPanIdPresent;
+            jboolean meshLocalPrefixPresent  = entries[i].MeshLocalPrefixPresent;
+            jboolean delayPresent            = entries[i].DelayPresent;
+            jboolean panIdPresent            = entries[i].PanIdPresent;
+            jboolean channelPresent          = entries[i].ChannelPresent;
+            jboolean pskcPresent             = entries[i].PskcPresent;
+            jboolean securityPolicyPresent   = entries[i].SecurityPolicyPresent;
+            jboolean channelMaskPresent      = entries[i].ChannelMaskPresent;
 
             jobject attributeObj =
                 env->NewObject(attributeClass, attributeCtor, activeTimestampPresent, pendingTimestampPresent, masterKeyPresent,
@@ -9910,7 +9910,7 @@ JNI_METHOD(void, BasicCluster, readLocalConfigDisabledAttribute)(JNIEnv * env, j
 }
 
 JNI_METHOD(void, BasicCluster, writeLocalConfigDisabledAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);
@@ -10067,7 +10067,7 @@ JNI_METHOD(void, BinaryInputBasicCluster, readOutOfServiceAttribute)(JNIEnv * en
 }
 
 JNI_METHOD(void, BinaryInputBasicCluster, writeOutOfServiceAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);
@@ -10142,7 +10142,7 @@ JNI_METHOD(void, BinaryInputBasicCluster, readPresentValueAttribute)(JNIEnv * en
 }
 
 JNI_METHOD(void, BinaryInputBasicCluster, writePresentValueAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);
@@ -14327,7 +14327,7 @@ JNI_METHOD(jlong, ContentLauncherCluster, initWithDevice)(JNIEnv * env, jobject 
 }
 
 JNI_METHOD(void, ContentLauncherCluster, launchContent)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint autoPlay, jstring data)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean autoPlay, jstring data)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -20193,7 +20193,7 @@ exit:
 }
 JNI_METHOD(void, OtaSoftwareUpdateProviderCluster, queryImage)
 (JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint vendorId, jint productId, jint imageType,
- jint hardwareVersion, jlong currentVersion, jint protocolsSupported, jstring location, jint requestorCanConsent,
+ jint hardwareVersion, jlong currentVersion, jint protocolsSupported, jstring location, jboolean requestorCanConsent,
  jbyteArray metadataForProvider)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
@@ -23974,7 +23974,7 @@ JNI_METHOD(void, TestClusterCluster, readBooleanAttribute)(JNIEnv * env, jobject
 }
 
 JNI_METHOD(void, TestClusterCluster, writeBooleanAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);
@@ -25520,7 +25520,7 @@ JNI_METHOD(void, TestClusterCluster, readUnsupportedAttribute)(JNIEnv * env, job
 }
 
 JNI_METHOD(void, TestClusterCluster, writeUnsupportedAttribute)
-(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint value)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jboolean value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);

--- a/src/controller/java/gen/ChipClusters.java
+++ b/src/controller/java/gen/ChipClusters.java
@@ -528,7 +528,7 @@ public class ChipClusters {
       readLocalConfigDisabledAttribute(chipClusterPtr, callback);
     }
 
-    public void writeLocalConfigDisabledAttribute(DefaultClusterCallback callback, int value) {
+    public void writeLocalConfigDisabledAttribute(DefaultClusterCallback callback, boolean value) {
       writeLocalConfigDisabledAttribute(chipClusterPtr, callback, value);
     }
 
@@ -598,7 +598,7 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeLocalConfigDisabledAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, int value);
+        long chipClusterPtr, DefaultClusterCallback callback, boolean value);
 
     private native void readReachableAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback);
@@ -619,7 +619,7 @@ public class ChipClusters {
       readOutOfServiceAttribute(chipClusterPtr, callback);
     }
 
-    public void writeOutOfServiceAttribute(DefaultClusterCallback callback, int value) {
+    public void writeOutOfServiceAttribute(DefaultClusterCallback callback, boolean value) {
       writeOutOfServiceAttribute(chipClusterPtr, callback, value);
     }
 
@@ -627,7 +627,7 @@ public class ChipClusters {
       readPresentValueAttribute(chipClusterPtr, callback);
     }
 
-    public void writePresentValueAttribute(DefaultClusterCallback callback, int value) {
+    public void writePresentValueAttribute(DefaultClusterCallback callback, boolean value) {
       writePresentValueAttribute(chipClusterPtr, callback, value);
     }
 
@@ -643,13 +643,13 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeOutOfServiceAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, int value);
+        long chipClusterPtr, DefaultClusterCallback callback, boolean value);
 
     private native void readPresentValueAttribute(
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writePresentValueAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, int value);
+        long chipClusterPtr, DefaultClusterCallback callback, boolean value);
 
     private native void readStatusFlagsAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
@@ -1702,7 +1702,8 @@ public class ChipClusters {
     @Override
     public native long initWithDevice(long devicePtr, int endpointId);
 
-    public void launchContent(LaunchContentResponseCallback callback, int autoPlay, String data) {
+    public void launchContent(
+        LaunchContentResponseCallback callback, boolean autoPlay, String data) {
       launchContent(chipClusterPtr, callback, autoPlay, data);
     }
 
@@ -1712,7 +1713,7 @@ public class ChipClusters {
     }
 
     private native void launchContent(
-        long chipClusterPtr, LaunchContentResponseCallback callback, int autoPlay, String data);
+        long chipClusterPtr, LaunchContentResponseCallback callback, boolean autoPlay, String data);
 
     private native void launchURL(
         long chipClusterPtr,
@@ -2632,17 +2633,17 @@ public class ChipClusters {
 
     public static class NetworkInterfacesAttribute {
       public byte[] name;
-      public int fabricConnected;
-      public int offPremiseServicesReachableIPv4;
-      public int offPremiseServicesReachableIPv6;
+      public boolean fabricConnected;
+      public boolean offPremiseServicesReachableIPv4;
+      public boolean offPremiseServicesReachableIPv6;
       public byte[] hardwareAddress;
       public int type;
 
       public NetworkInterfacesAttribute(
           byte[] name,
-          int fabricConnected,
-          int offPremiseServicesReachableIPv4,
-          int offPremiseServicesReachableIPv6,
+          boolean fabricConnected,
+          boolean offPremiseServicesReachableIPv4,
+          boolean offPremiseServicesReachableIPv6,
           byte[] hardwareAddress,
           int type) {
         this.name = name;
@@ -3521,7 +3522,7 @@ public class ChipClusters {
         long currentVersion,
         int protocolsSupported,
         String location,
-        int requestorCanConsent,
+        boolean requestorCanConsent,
         byte[] metadataForProvider) {
       queryImage(
           chipClusterPtr,
@@ -3559,7 +3560,7 @@ public class ChipClusters {
         long currentVersion,
         int protocolsSupported,
         String location,
-        int requestorCanConsent,
+        boolean requestorCanConsent,
         byte[] metadataForProvider);
 
     public interface ApplyUpdateRequestResponseCallback {
@@ -3574,7 +3575,7 @@ public class ChipClusters {
           String imageURI,
           long softwareVersion,
           byte[] updateToken,
-          int userConsentNeeded,
+          boolean userConsentNeeded,
           byte[] metadataForRequestor);
 
       void onError(Exception error);
@@ -4536,7 +4537,7 @@ public class ChipClusters {
       readBooleanAttribute(chipClusterPtr, callback);
     }
 
-    public void writeBooleanAttribute(DefaultClusterCallback callback, int value) {
+    public void writeBooleanAttribute(DefaultClusterCallback callback, boolean value) {
       writeBooleanAttribute(chipClusterPtr, callback, value);
     }
 
@@ -4701,7 +4702,7 @@ public class ChipClusters {
       readUnsupportedAttribute(chipClusterPtr, callback);
     }
 
-    public void writeUnsupportedAttribute(DefaultClusterCallback callback, int value) {
+    public void writeUnsupportedAttribute(DefaultClusterCallback callback, boolean value) {
       writeUnsupportedAttribute(chipClusterPtr, callback, value);
     }
 
@@ -4713,7 +4714,7 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeBooleanAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, int value);
+        long chipClusterPtr, DefaultClusterCallback callback, boolean value);
 
     private native void readBitmap8Attribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
@@ -4824,7 +4825,7 @@ public class ChipClusters {
         long chipClusterPtr, BooleanAttributeCallback callback);
 
     private native void writeUnsupportedAttribute(
-        long chipClusterPtr, DefaultClusterCallback callback, int value);
+        long chipClusterPtr, DefaultClusterCallback callback, boolean value);
 
     private native void readClusterRevisionAttribute(
         long chipClusterPtr, IntegerAttributeCallback callback);
@@ -5072,10 +5073,10 @@ public class ChipClusters {
       public int lastRssi;
       public int frameErrorRate;
       public int messageErrorRate;
-      public int rxOnWhenIdle;
-      public int fullThreadDevice;
-      public int fullNetworkData;
-      public int isChild;
+      public boolean rxOnWhenIdle;
+      public boolean fullThreadDevice;
+      public boolean fullNetworkData;
+      public boolean isChild;
 
       public NeighborTableListAttribute(
           long extAddress,
@@ -5088,10 +5089,10 @@ public class ChipClusters {
           int lastRssi,
           int frameErrorRate,
           int messageErrorRate,
-          int rxOnWhenIdle,
-          int fullThreadDevice,
-          int fullNetworkData,
-          int isChild) {
+          boolean rxOnWhenIdle,
+          boolean fullThreadDevice,
+          boolean fullNetworkData,
+          boolean isChild) {
         this.extAddress = extAddress;
         this.age = age;
         this.rloc16 = rloc16;
@@ -5124,8 +5125,8 @@ public class ChipClusters {
       public int lQIIn;
       public int lQIOut;
       public int age;
-      public int allocated;
-      public int linkEstablished;
+      public boolean allocated;
+      public boolean linkEstablished;
 
       public RouteTableListAttribute(
           long extAddress,
@@ -5136,8 +5137,8 @@ public class ChipClusters {
           int lQIIn,
           int lQIOut,
           int age,
-          int allocated,
-          int linkEstablished) {
+          boolean allocated,
+          boolean linkEstablished) {
         this.extAddress = extAddress;
         this.rloc16 = rloc16;
         this.routerId = routerId;
@@ -5174,32 +5175,32 @@ public class ChipClusters {
     }
 
     public static class OperationalDatasetComponentsAttribute {
-      public int activeTimestampPresent;
-      public int pendingTimestampPresent;
-      public int masterKeyPresent;
-      public int networkNamePresent;
-      public int extendedPanIdPresent;
-      public int meshLocalPrefixPresent;
-      public int delayPresent;
-      public int panIdPresent;
-      public int channelPresent;
-      public int pskcPresent;
-      public int securityPolicyPresent;
-      public int channelMaskPresent;
+      public boolean activeTimestampPresent;
+      public boolean pendingTimestampPresent;
+      public boolean masterKeyPresent;
+      public boolean networkNamePresent;
+      public boolean extendedPanIdPresent;
+      public boolean meshLocalPrefixPresent;
+      public boolean delayPresent;
+      public boolean panIdPresent;
+      public boolean channelPresent;
+      public boolean pskcPresent;
+      public boolean securityPolicyPresent;
+      public boolean channelMaskPresent;
 
       public OperationalDatasetComponentsAttribute(
-          int activeTimestampPresent,
-          int pendingTimestampPresent,
-          int masterKeyPresent,
-          int networkNamePresent,
-          int extendedPanIdPresent,
-          int meshLocalPrefixPresent,
-          int delayPresent,
-          int panIdPresent,
-          int channelPresent,
-          int pskcPresent,
-          int securityPolicyPresent,
-          int channelMaskPresent) {
+          boolean activeTimestampPresent,
+          boolean pendingTimestampPresent,
+          boolean masterKeyPresent,
+          boolean networkNamePresent,
+          boolean extendedPanIdPresent,
+          boolean meshLocalPrefixPresent,
+          boolean delayPresent,
+          boolean panIdPresent,
+          boolean channelPresent,
+          boolean pskcPresent,
+          boolean securityPolicyPresent,
+          boolean channelMaskPresent) {
         this.activeTimestampPresent = activeTimestampPresent;
         this.pendingTimestampPresent = pendingTimestampPresent;
         this.masterKeyPresent = masterKeyPresent;

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -896,7 +896,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Basic_LocalConfigDisabled(ch
 
 chip::ChipError::StorageType chip_ime_WriteAttribute_Basic_LocalConfigDisabled(chip::Controller::Device * device,
                                                                                chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                               uint8_t value)
+                                                                               bool value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::BasicCluster cluster;
@@ -938,7 +938,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_OutOfServic
 
 chip::ChipError::StorageType chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(chip::Controller::Device * device,
                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint8_t value)
+                                                                                   bool value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::BinaryInputBasicCluster cluster;
@@ -971,7 +971,7 @@ chip::ChipError::StorageType chip_ime_ConfigureAttribute_BinaryInputBasic_Presen
 
 chip::ChipError::StorageType chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(chip::Controller::Device * device,
                                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                   uint8_t value)
+                                                                                   bool value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::BinaryInputBasicCluster cluster;
@@ -2137,7 +2137,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ClusterRevision
 
 chip::ChipError::StorageType chip_ime_AppendCommand_ContentLauncher_LaunchContent(chip::Controller::Device * device,
                                                                                   chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t autoPlay, const uint8_t * data,
+                                                                                  bool autoPlay, const uint8_t * data,
                                                                                   uint32_t data_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
@@ -3542,7 +3542,7 @@ chip::ChipError::StorageType chip_ime_AppendCommand_OtaSoftwareUpdateProvider_No
 chip::ChipError::StorageType chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
     chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t vendorId, uint16_t productId,
     uint16_t imageType, uint16_t hardwareVersion, uint32_t currentVersion, uint8_t protocolsSupported, const uint8_t * location,
-    uint32_t location_Len, uint8_t requestorCanConsent, const uint8_t * metadataForProvider, uint32_t metadataForProvider_Len)
+    uint32_t location_Len, bool requestorCanConsent, const uint8_t * metadataForProvider, uint32_t metadataForProvider_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OtaSoftwareUpdateProviderCluster cluster;
@@ -4563,8 +4563,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Boolean(chip::Co
 }
 
 chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Boolean(chip::Controller::Device * device,
-                                                                         chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                         uint8_t value)
+                                                                         chip::EndpointId ZCLendpointId, chip::GroupId, bool value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TestClusterCluster cluster;
@@ -4968,7 +4967,7 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TestCluster_Unsupported(chip
 
 chip::ChipError::StorageType chip_ime_WriteAttribute_TestCluster_Unsupported(chip::Controller::Device * device,
                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                             uint8_t value)
+                                                                             bool value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TestClusterCluster cluster;

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -368,13 +368,13 @@ class ChipClusters:
                 0x00000010: {
                     "attributeName": "LocalConfigDisabled",
                     "attributeId": 0x00000010,
-                    "type": "int",
+                    "type": "bool",
                     "writable": True,
                 },
                 0x00000011: {
                     "attributeName": "Reachable",
                     "attributeId": 0x00000011,
-                    "type": "int",
+                    "type": "bool",
                 },
                 0x0000FFFD: {
                     "attributeName": "ClusterRevision",
@@ -392,13 +392,13 @@ class ChipClusters:
                 0x00000051: {
                     "attributeName": "OutOfService",
                     "attributeId": 0x00000051,
-                    "type": "int",
+                    "type": "bool",
                     "writable": True,
                 },
                 0x00000055: {
                     "attributeName": "PresentValue",
                     "attributeId": 0x00000055,
-                    "type": "int",
+                    "type": "bool",
                     "reportable": True,
                     "writable": True,
                 },
@@ -523,7 +523,7 @@ class ChipClusters:
                 0x00000011: {
                     "attributeName": "Reachable",
                     "attributeId": 0x00000011,
-                    "type": "int",
+                    "type": "bool",
                 },
                 0x0000FFFD: {
                     "attributeName": "ClusterRevision",
@@ -1026,7 +1026,7 @@ class ChipClusters:
                     "commandId": 0x00000000,
                     "commandName": "LaunchContent",
                     "args": {
-                        "autoPlay": "int",
+                        "autoPlay": "bool",
                         "data": "str",
                     },
                 },
@@ -1310,7 +1310,7 @@ class ChipClusters:
                 0x00000002: {
                     "attributeName": "ActuatorEnabled",
                     "attributeId": 0x00000002,
-                    "type": "int",
+                    "type": "bool",
                 },
                 0x0000FFFD: {
                     "attributeName": "ClusterRevision",
@@ -2051,7 +2051,7 @@ class ChipClusters:
                         "currentVersion": "int",
                         "protocolsSupported": "int",
                         "location": "str",
-                        "requestorCanConsent": "int",
+                        "requestorCanConsent": "bool",
                         "metadataForProvider": "bytes",
                     },
                 },
@@ -2143,13 +2143,13 @@ class ChipClusters:
                 0x00000000: {
                     "attributeName": "OnOff",
                     "attributeId": 0x00000000,
-                    "type": "int",
+                    "type": "bool",
                     "reportable": True,
                 },
                 0x00004000: {
                     "attributeName": "GlobalSceneControl",
                     "attributeId": 0x00004000,
-                    "type": "int",
+                    "type": "bool",
                 },
                 0x00004001: {
                     "attributeName": "OnTime",
@@ -2461,7 +2461,7 @@ class ChipClusters:
                 0x00000003: {
                     "attributeName": "SceneValid",
                     "attributeId": 0x00000003,
-                    "type": "int",
+                    "type": "bool",
                 },
                 0x00000004: {
                     "attributeName": "NameSupport",
@@ -2669,7 +2669,7 @@ class ChipClusters:
                 0x00000000: {
                     "attributeName": "Boolean",
                     "attributeId": 0x00000000,
-                    "type": "int",
+                    "type": "bool",
                     "writable": True,
                 },
                 0x00000001: {
@@ -2798,7 +2798,7 @@ class ChipClusters:
                 0x000000FF: {
                     "attributeName": "Unsupported",
                     "attributeId": 0x000000FF,
-                    "type": "int",
+                    "type": "bool",
                     "writable": True,
                 },
                 0x0000FFFD: {
@@ -3782,7 +3782,7 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep(
                 device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
         )
-    def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: int, data: bytes):
+    def ClusterContentLauncher_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: bool, data: bytes):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent(
                 device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
@@ -4090,7 +4090,7 @@ class ChipClusters:
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied(
                 device, ZCLendpoint, ZCLgroupid, updateToken, len(updateToken), currentVersion
         )
-    def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, imageType: int, hardwareVersion: int, currentVersion: int, protocolsSupported: int, location: bytes, requestorCanConsent: int, metadataForProvider: bytes):
+    def ClusterOtaSoftwareUpdateProvider_CommandQueryImage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int, productId: int, imageType: int, hardwareVersion: int, currentVersion: int, protocolsSupported: int, location: bytes, requestorCanConsent: bool, metadataForProvider: bytes):
         location = location.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage(
                 device, ZCLendpoint, ZCLgroupid, vendorId, productId, imageType, hardwareVersion, currentVersion, protocolsSupported, location, len(location), requestorCanConsent, metadataForProvider, len(metadataForProvider)
@@ -4366,7 +4366,7 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_Basic_SerialNumber(device, ZCLendpoint, ZCLgroupid)
     def ClusterBasic_ReadAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid)
-    def ClusterBasic_WriteAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
+    def ClusterBasic_WriteAttributeLocalConfigDisabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterBasic_ReadAttributeReachable(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Reachable(device, ZCLendpoint, ZCLgroupid)
@@ -4374,13 +4374,13 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterBinaryInputBasic_ReadAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid)
-    def ClusterBinaryInputBasic_WriteAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
+    def ClusterBinaryInputBasic_WriteAttributeOutOfService(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterBinaryInputBasic_ReadAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid)
     def ClusterBinaryInputBasic_ConfigureAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
         return self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, minInterval, maxInterval, change)
-    def ClusterBinaryInputBasic_WriteAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
+    def ClusterBinaryInputBasic_WriteAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterBinaryInputBasic_ReadAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, ZCLgroupid)
@@ -4815,7 +4815,7 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterTestCluster_ReadAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid)
-    def ClusterTestCluster_WriteAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
+    def ClusterTestCluster_WriteAttributeBoolean(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterTestCluster_ReadAttributeBitmap8(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8(device, ZCLendpoint, ZCLgroupid)
@@ -4899,7 +4899,7 @@ class ChipClusters:
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterTestCluster_ReadAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid)
-    def ClusterTestCluster_WriteAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
+    def ClusterTestCluster_WriteAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterTestCluster_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
@@ -5318,7 +5318,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
         # Cluster Basic WriteAttribute LocalConfigDisabled
-        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_Basic_LocalConfigDisabled.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute Reachable
         self._chipLib.chip_ime_ReadAttribute_Basic_Reachable.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5331,7 +5331,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic WriteAttribute OutOfService
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute PresentValue
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5340,7 +5340,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic WriteAttribute PresentValue
-        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute StatusFlags
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5677,7 +5677,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ContentLauncher
         # Cluster ContentLauncher Command LaunchContent
-        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchContent.restype = ctypes.c_uint32
         # Cluster ContentLauncher Command LaunchURL
         self._chipLib.chip_ime_AppendCommand_ContentLauncher_LaunchURL.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
@@ -6104,7 +6104,7 @@ class ChipClusters:
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_NotifyUpdateApplied.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider Command QueryImage
-        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_bool, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OtaSoftwareUpdateProvider_QueryImage.restype = ctypes.c_uint32
         # Cluster OtaSoftwareUpdateProvider ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6408,7 +6408,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Boolean
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Boolean.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Bitmap8
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Bitmap8.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6531,7 +6531,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
         # Cluster TestCluster WriteAttribute Unsupported
-        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
         self._chipLib.chip_ime_WriteAttribute_TestCluster_Unsupported.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/controller/python/templates/helper.js
+++ b/src/controller/python/templates/helper.js
@@ -26,6 +26,8 @@ function asPythonType(zclType)
 {
   const type = ChipTypesHelper.asBasicType(zclType);
   switch (type) {
+  case 'bool':
+    return 'bool';
   case 'int8_t':
   case 'int16_t':
   case 'int32_t':
@@ -47,6 +49,7 @@ function asPythonCType(zclType)
 {
   const type = ChipTypesHelper.asBasicType(zclType);
   switch (type) {
+  case 'bool':
   case 'int8_t':
   case 'int16_t':
   case 'int32_t':

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.h
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeProductLabelWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeSerialNumberWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeLocalConfigDisabledWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeLocalConfigDisabledWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeLocalConfigDisabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeReachableWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
@@ -184,9 +184,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CHIPBinaryInputBasic : CHIPCluster
 
 - (void)readAttributeOutOfServiceWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeOutOfServiceWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeOutOfServiceWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributePresentValueWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributePresentValueWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributePresentValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributePresentValueWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
                                       responseHandler:(ResponseHandler)responseHandler;
@@ -459,7 +459,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CHIPContentLauncher : CHIPCluster
 
-- (void)launchContent:(uint8_t)autoPlay data:(NSString *)data responseHandler:(ResponseHandler)responseHandler;
+- (void)launchContent:(bool)autoPlay data:(NSString *)data responseHandler:(ResponseHandler)responseHandler;
 - (void)launchURL:(NSString *)contentURL displayString:(NSString *)displayString responseHandler:(ResponseHandler)responseHandler;
 
 - (void)readAttributeAcceptsHeaderListWithResponseHandler:(ResponseHandler)responseHandler;
@@ -871,7 +871,7 @@ NS_ASSUME_NONNULL_BEGIN
          currentVersion:(uint32_t)currentVersion
      protocolsSupported:(uint8_t)protocolsSupported
                location:(NSString *)location
-    requestorCanConsent:(uint8_t)requestorCanConsent
+    requestorCanConsent:(bool)requestorCanConsent
     metadataForProvider:(NSData *)metadataForProvider
         responseHandler:(ResponseHandler)responseHandler;
 
@@ -1143,7 +1143,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testUnknownCommand:(ResponseHandler)responseHandler;
 
 - (void)readAttributeBooleanWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeBooleanWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeBitmap8WithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeBitmap8WithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeBitmap16WithResponseHandler:(ResponseHandler)responseHandler;
@@ -1184,7 +1184,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeLongCharStringWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)writeAttributeLongCharStringWithValue:(NSString *)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeUnsupportedWithResponseHandler:(ResponseHandler)responseHandler;
-- (void)writeAttributeUnsupportedWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler;
+- (void)writeAttributeUnsupportedWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
 
 @end

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -2229,7 +2229,7 @@ public:
     ~CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge() {};
 
     static void CallbackFn(void * context, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
-        chip::ByteSpan updateToken, uint8_t userConsentNeeded, chip::ByteSpan metadataForRequestor)
+        chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge * callback
             = reinterpret_cast<CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge *>(context);
@@ -5220,7 +5220,7 @@ private:
     }
 }
 
-- (void)writeAttributeLocalConfigDisabledWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeLocalConfigDisabledWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -5341,7 +5341,7 @@ private:
     }
 }
 
-- (void)writeAttributeOutOfServiceWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeOutOfServiceWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -5395,7 +5395,7 @@ private:
     }
 }
 
-- (void)writeAttributePresentValueWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributePresentValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -8736,7 +8736,7 @@ private:
     return &_cppCluster;
 }
 
-- (void)launchContent:(uint8_t)autoPlay data:(NSString *)data responseHandler:(ResponseHandler)responseHandler
+- (void)launchContent:(bool)autoPlay data:(NSString *)data responseHandler:(ResponseHandler)responseHandler
 {
     CHIPContentLauncherClusterLaunchContentResponseCallbackBridge * onSuccess
         = new CHIPContentLauncherClusterLaunchContentResponseCallbackBridge(responseHandler, [self callbackQueue]);
@@ -12831,7 +12831,7 @@ private:
          currentVersion:(uint32_t)currentVersion
      protocolsSupported:(uint8_t)protocolsSupported
                location:(NSString *)location
-    requestorCanConsent:(uint8_t)requestorCanConsent
+    requestorCanConsent:(bool)requestorCanConsent
     metadataForProvider:(NSData *)metadataForProvider
         responseHandler:(ResponseHandler)responseHandler
 {
@@ -15816,7 +15816,7 @@ private:
     }
 }
 
-- (void)writeAttributeBooleanWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeBooleanWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -16936,7 +16936,7 @@ private:
     }
 }
 
-- (void)writeAttributeUnsupportedWithValue:(uint8_t)value responseHandler:(ResponseHandler)responseHandler
+- (void)writeAttributeUnsupportedWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {

--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -78,6 +78,7 @@ function asObjectiveCNumberType(label, type, asLowerCased)
         .then(zclType => {
           const basicType = ChipTypesHelper.asBasicType(zclType);
           switch (basicType) {
+          case 'bool':
           case 'uint8_t':
             return 'UnsignedChar';
           case 'uint16_t':

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -273,7 +273,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t booleanArgument = 1;
+    bool booleanArgument = 1;
     [cluster writeAttributeBooleanWithValue:booleanArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BOOLEAN True Error: %@", err);
@@ -310,7 +310,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t booleanArgument = 0;
+    bool booleanArgument = 0;
     [cluster writeAttributeBooleanWithValue:booleanArgument
                             responseHandler:^(NSError * err, NSDictionary * values) {
                                 NSLog(@"Write attribute BOOLEAN False Error: %@", err);
@@ -2224,7 +2224,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPTestCluster * cluster = [[CHIPTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t unsupportedArgument = 0;
+    bool unsupportedArgument = 0;
     [cluster writeAttributeUnsupportedWithValue:unsupportedArgument
                                 responseHandler:^(NSError * err, NSDictionary * values) {
                                     NSLog(@"Writeattribute UNSUPPORTED Error: %@", err);
@@ -5080,7 +5080,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPBinaryInputBasic * cluster = [[CHIPBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0x00;
+    bool value = 0x00;
     [cluster writeAttributeOutOfServiceWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"BinaryInputBasic OutOfService Error: %@", err);
@@ -5118,7 +5118,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     CHIPBinaryInputBasic * cluster = [[CHIPBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint8_t value = 0;
+    bool value = 0;
     [cluster writeAttributePresentValueWithValue:value
                                  responseHandler:^(NSError * err, NSDictionary * values) {
                                      NSLog(@"BinaryInputBasic PresentValue Error: %@", err);


### PR DESCRIPTION
#### Problem

`Boolean` attributes/command arguments results are emitted as `uint8_t` as the code inherits from C code. This PR change it so `Boolean` are emitted as `bool`.

#### Change overview
 * Emit `bool` instead of `uint8_t` for `Boolean`

#### Testing
I did try by locally running `./scripts/tests/suites/test_suites.sh` and also by manually changing the on/off attribute of the `On/Off` cluster and reading it with `./out/debug/standalone/chip-tool onoff read on-off 1`
