### PR TITLE
Restore timeout in JNI event loop

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1066,7 +1066,10 @@ void * IOThreadMain(void * arg)
     // Loop until we are told to exit.
     while (!quit.load(std::memory_order_relaxed))
     {
-        // TODO(#5556): add a timer for `sleepTime.tv_sec  = 10; sleepTime.tv_usec = 0;`
+        // Wait no more than 10 seconds.
+        constexpr uint32_t k10secondsInMilliseconds = 10000;
+        sSystemLayer.StartTimer(k10secondsInMilliseconds, [](System::Layer *, void *, CHIP_ERROR) -> void {}, nullptr);
+
         watchState.PrepareEvents();
 
         // Unlock the stack so that Java threads can make API calls.

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1068,7 +1068,8 @@ void * IOThreadMain(void * arg)
     {
         // Wait no more than 10 seconds.
         constexpr uint32_t k10secondsInMilliseconds = 10000;
-        sSystemLayer.StartTimer(k10secondsInMilliseconds, [](System::Layer *, void *, CHIP_ERROR) -> void {}, nullptr);
+        sSystemLayer.StartTimer(
+            k10secondsInMilliseconds, [](System::Layer *, void *, CHIP_ERROR) -> void {}, nullptr);
 
         watchState.PrepareEvents();
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -116,9 +116,7 @@ bool GenericPlatformManagerImpl_POSIX<ImplClass>::_IsChipStackLockedByCurrentThr
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartChipTimer(int64_t aMilliseconds)
 {
-    // TODO(#5556): Integrate timer platform details with WatchableEventManager.
-
-    // Let SystemLayer.PrepareSelect() handle timers.
+    // Let WatchableEventManager.PrepareEvents() handle timers.
     return CHIP_NO_ERROR;
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -82,9 +82,7 @@ void GenericPlatformManagerImpl_Zephyr<ImplClass>::_UnlockChipStack(void)
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StartChipTimer(uint32_t aMilliseconds)
 {
-    // TODO(#5556): Integrate timer platform details with WatchableEventManager.
-
-    // Let SystemLayer.PrepareSelect() handle timers.
+    // Let WatchableEventManager.PrepareEvents() handle timers.
     return CHIP_NO_ERROR;
 }
 

--- a/src/system/WatchableEventManagerLibevent.cpp
+++ b/src/system/WatchableEventManagerLibevent.cpp
@@ -81,7 +81,6 @@ CHIP_ERROR WatchableEventManager::Init(System::Layer & systemLayer)
 
 void WatchableEventManager::PrepareEvents()
 {
-    // TODO(#5556): Integrate timer platform details with WatchableEventManager.
     timeval nextTimeout = { 0, 0 };
     PrepareEventsWithTimeout(nextTimeout);
 }


### PR DESCRIPTION
#### Problem

The event loop in JNI `IOThreadMain()` used to wait no more than ten
seconds on each iteration. This timeout was temporarily removed in
PR #6561.

#### Change overview

Add an explicit timer.

Also removes another obsolete TODO.

Fixes #7756 _add a timer for sleepTime.tv_sec = 10; sleepTime.tv_usec = 0;_
Fixes #7757 _Integrate timer platform details with WatchableEventManager._

#### Testing

Passes Android workflow.
