### PR TITLE
ESP32: Fix with pigweed config options to support multiple esp32 variants.

### DIFF
--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -103,10 +103,12 @@ menu "Demo"
 endmenu
 
 menu "PW RPC Debug channel"
+depends on ENABLE_PW_RPC
     config EXAMPLE_UART_PORT_NUM
         int "UART port number"
         range 0 2 if IDF_TARGET_ESP32
-        default 0 if IDF_TARGET_ESP32
+        range 0 1 if IDF_TARGET_ESP32C3
+        default 0
         help
             UART communication port number for the example.
             See UART documentation for available port numbers.
@@ -121,7 +123,8 @@ menu "PW RPC Debug channel"
     config EXAMPLE_UART_RXD
         int "UART RXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 3
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 5
         help
             GPIO number for UART RX pin. See UART documentation for more information
             about available pin numbers for UART.
@@ -129,7 +132,8 @@ menu "PW RPC Debug channel"
     config EXAMPLE_UART_TXD
         int "UART TXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 1
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 4
         help
             GPIO number for UART TX pin. See UART documentation for more information
             about available pin numbers for UART.

--- a/examples/ipv6only-app/esp32/main/Kconfig.projbuild
+++ b/examples/ipv6only-app/esp32/main/Kconfig.projbuild
@@ -1,9 +1,11 @@
 menu "PW RPC Example Configuration"
 
+depends on ENABLE_PW_RPC
     config EXAMPLE_UART_PORT_NUM
         int "UART port number"
         range 0 2 if IDF_TARGET_ESP32
-        default 0 if IDF_TARGET_ESP32
+        range 0 1 if IDF_TARGET_ESP32C3
+        default 0
         help
             UART communication port number for the example.
             See UART documentation for available port numbers.
@@ -18,7 +20,8 @@ menu "PW RPC Example Configuration"
     config EXAMPLE_UART_RXD
         int "UART RXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 3
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 5
         help
             GPIO number for UART RX pin. See UART documentation for more information
             about available pin numbers for UART.
@@ -26,7 +29,8 @@ menu "PW RPC Example Configuration"
     config EXAMPLE_UART_TXD
         int "UART TXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 1
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 4
         help
             GPIO number for UART TX pin. See UART documentation for more information
             about available pin numbers for UART.

--- a/examples/lock-app/esp32/main/Kconfig.projbuild
+++ b/examples/lock-app/esp32/main/Kconfig.projbuild
@@ -68,7 +68,8 @@ depends on ENABLE_PW_RPC
     config EXAMPLE_UART_PORT_NUM
         int "UART port number"
         range 0 2 if IDF_TARGET_ESP32
-        default 0 if IDF_TARGET_ESP32
+        range 0 1 if IDF_TARGET_ESP32C3
+        default 0
         help
             UART communication port number for the example.
             See UART documentation for available port numbers.
@@ -83,7 +84,8 @@ depends on ENABLE_PW_RPC
     config EXAMPLE_UART_RXD
         int "UART RXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 3
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 5
         help
             GPIO number for UART RX pin. See UART documentation for more information
             about available pin numbers for UART.
@@ -91,7 +93,8 @@ depends on ENABLE_PW_RPC
     config EXAMPLE_UART_TXD
         int "UART TXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 1
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 4
         help
             GPIO number for UART TX pin. See UART documentation for more information
             about available pin numbers for UART.

--- a/examples/pigweed-app/esp32/main/Kconfig.projbuild
+++ b/examples/pigweed-app/esp32/main/Kconfig.projbuild
@@ -1,9 +1,11 @@
 menu "PW RPC Example Configuration"
 
+depends on ENABLE_PW_RPC
     config EXAMPLE_UART_PORT_NUM
         int "UART port number"
         range 0 2 if IDF_TARGET_ESP32
-        default 0 if IDF_TARGET_ESP32
+        range 0 1 if IDF_TARGET_ESP32C3
+        default 0
         help
             UART communication port number for the example.
             See UART documentation for available port numbers.
@@ -18,7 +20,8 @@ menu "PW RPC Example Configuration"
     config EXAMPLE_UART_RXD
         int "UART RXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 3
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 5
         help
             GPIO number for UART RX pin. See UART documentation for more information
             about available pin numbers for UART.
@@ -26,7 +29,8 @@ menu "PW RPC Example Configuration"
     config EXAMPLE_UART_TXD
         int "UART TXD pin number"
         range 0 34 if IDF_TARGET_ESP32
-        default 1
+        range 0 19 if IDF_TARGET_ESP32C3
+        default 4
         help
             GPIO number for UART TX pin. See UART documentation for more information
             about available pin numbers for UART.


### PR DESCRIPTION
#### Problem
`idf.py set-target esp32c3` throws below error for esp32c3. 
```
Adding "set-target"'s dependency "fullclean" to list of commands with default set of options.
Executing action: fullclean
Build directory '/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/build' not found. Nothing to clean.
Executing action: set-target
Set Target to: esp32c3, new sdkconfig created. Existing sdkconfig renamed to sdkconfig.old.
Running cmake in directory /home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/build
Executing "cmake -G Ninja -DPYTHON_DEPS_CHECKED=1 -DESP_PLATFORM=1 -DIDF_TARGET=esp32c3 -DCCACHE_ENABLE=0 /home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32"...
-- Found Git: /usr/bin/git (found version "2.25.1") 
-- Component directory /home/sweety/Espressif/esp-idf/components/esp_phy does not contain a CMakeLists.txt file. No component will be added
-- Component directory /home/sweety/Espressif/esp-idf/components/openthread does not contain a CMakeLists.txt file. No component will be added
-- The C compiler identification is GNU 8.4.0
-- The CXX compiler identification is GNU 8.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/sweety/.espressif/tools/riscv32-esp-elf/1.24.0.123_64eb9ff-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/sweety/.espressif/tools/riscv32-esp-elf/1.24.0.123_64eb9ff-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/sweety/.espressif/tools/riscv32-esp-elf/1.24.0.123_64eb9ff-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ESP-IDF components for target esp32c3
-- Project sdkconfig file /home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/sdkconfig
Loading defaults file /home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/sdkconfig.defaults...
warning: default value 120000 on WIFI_AP_IDLE_TIMEOUT (defined at /home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/third_party/connectedhomeip/config/esp32/components/chip/Kconfig:489) clamped to 65535 due to being outside the active range ([0, 65535])
Traceback (most recent call last):
  File "/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py", line 637, in <module>
    main()
  File "/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py", line 323, in main
    output_function(deprecated_options, config, temp_file)
  File "/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py", line 470, in write_json
    config_dict = get_json_values(config)
  File "/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py", line 465, in get_json_values
    write_node(n)
  File "/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py", line 462, in write_node
    val = int(val)
ValueError: invalid literal for int() with base 10: ''
CMake Error at /home/sweety/Espressif/esp-idf/tools/cmake/kconfig.cmake:228 (message):
  Failed to run confgen.py
  (/home/sweety/Espressif/connectedhomeip/.environment/pigweed-venv/bin/python;/home/sweety/Espressif/esp-idf/tools/kconfig_new/confgen.py;--kconfig;/home/sweety/Espressif/esp-idf/Kconfig;--sdkconfig-rename;/home/sweety/Espressif/esp-idf/sdkconfig.rename;--config;/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/sdkconfig;--defaults;/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/sdkconfig.defaults;--env-file;/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/build/config.env).
  Error 1
Call Stack (most recent call first):
  /home/sweety/Espressif/esp-idf/tools/cmake/build.cmake:451 (__kconfig_generate_config)
  /home/sweety/Espressif/esp-idf/tools/cmake/project.cmake:396 (idf_build_process)
  CMakeLists.txt:35 (project)


-- Configuring incomplete, errors occurred!
See also "/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/build/CMakeFiles/CMakeOutput.log".
See also "/home/sweety/Espressif/connectedhomeip/examples/all-clusters-app/esp32/build/CMakeFiles/CMakeError.log".
cmake failed with exit code 1
```

#### Change overview
The problem was with `EXAMPLE_UART_PORT_NUM` config option in case of esp32c3. Set the default value as 0, so in future any esp32 variant can be supported.

#### Testing
`idf.py set-target esp32c3` command was successful for all-clusters-app, pigweed app, lock-app and ipV6-only app.
