### PR TITLE
[script/build] Add --create-flashbundle flag for creating flashbundle files.

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -5,8 +5,8 @@ steps:
       entrypoint: "./scripts/run_in_build_env.sh"
       args:
           [
-              "./scripts/build/build_examples.py --platform all build
-              --create-archives /workspace/artifacts/",
+              "./scripts/build/build_examples.py --platform all
+              --enable-flashbundle build --create-archives /workspace/artifacts/",
           ]
       timeout: 7200s
 

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -39,7 +39,8 @@ class Context:
 
   def SetupBuilders(self, platforms: Sequence[Platform],
                     boards: Sequence[Board],
-                    applications: Sequence[Application]):
+                    applications: Sequence[Application],
+                    enable_flashbundle: bool):
     """Configures internal builders for the given platform/board/app combination.
 
         Handles smart default selection, so that users only need to specify
@@ -86,7 +87,7 @@ class Context:
     for platform in sorted(platforms):
       for board in sorted(boards):
         for application in sorted(applications):
-          builder = self.builder_factory.Create(platform, board, application)
+          builder = self.builder_factory.Create(platform, board, application, enable_flashbundle=enable_flashbundle)
           if not builder:
             logging.debug('Builder not supported for tuple %s/%s/%s', platform,
                           board, application)

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -129,7 +129,7 @@ class BuilderFactory:
     self.repository_path = repository_path
     self.output_prefix = output_prefix
 
-  def Create(self, platform: Platform, board: Board, app: Application):
+  def Create(self, platform: Platform, board: Board, app: Application, enable_flashbundle: bool = False):
     """Creates a builder object for the specified arguments. """
 
     builder = _MATCHERS[platform].Create(
@@ -141,6 +141,7 @@ class BuilderFactory:
 
     if builder:
       builder.SetIdentifier(platform.name.lower(), board.name.lower(), app.name.lower())
+      builder.enable_flashbundle(enable_flashbundle)
 
     return builder
 

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -78,6 +78,12 @@ def ValidateRepoPath(context, parameter, value):
     help='What example application to build. Empty will find suitable applications.'
 )
 @click.option(
+    '--enable-flashbundle',
+    default=False,
+    is_flag=True,
+    help='Also generate the flashbundles for the app.'
+)
+@click.option(
     '--repo',
     default='.',
     callback=ValidateRepoPath,
@@ -104,7 +110,7 @@ def ValidateRepoPath(context, parameter, value):
     help='Where to write the dry run output')
 @click.pass_context
 def main(context, log_level, platform, board, app, repo, out_prefix, clean,
-         dry_run, dry_run_output):
+         dry_run, dry_run_output, enable_flashbundle):
   # Ensures somewhat pretty logging of what is going on
   coloredlogs.install(
       level=__LOG_LEVELS__[log_level],
@@ -132,7 +138,8 @@ before running this script.
   context.obj.SetupBuilders(
       platforms=[build.Platform.FromArgName(name) for name in platform],
       boards=[build.Board.FromArgName(name) for name in board],
-      applications=[build.Application.FromArgName(name) for name in app])
+      applications=[build.Application.FromArgName(name) for name in app],
+      enable_flashbundle=enable_flashbundle)
 
   if clean:
     context.obj.CleanOutputDirectories()

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -27,14 +27,18 @@ class Builder(ABC):
 
   """
 
-  def __init__(self, root, runner, output_prefix: str ='out'):
+  def __init__(self, root, runner, output_prefix: str = 'out'):
     self.root = os.path.abspath(root)
     self._runner = runner
     self.output_prefix = output_prefix
+    self._enable_flashbundle = False
 
     # Set post-init once actual build target is known
     self.identifier = None
     self.output_dir = None
+
+  def enable_flashbundle(self, enable_flashbundle: bool):
+    self._enable_flashbundle = enable_flashbundle
 
   @abstractmethod
   def generate(self):
@@ -42,18 +46,50 @@ class Builder(ABC):
     raise NotImplementedError()
 
   @abstractmethod
-  def build(self):
+  def _build(self):
     """Perform an actual build"""
     raise NotImplementedError()
 
+  def _generate_flashbundle(self):
+    """Perform an actual generating of flashbundle
+
+       May do nothing (and builder can choose not to implement this) if the
+       app does not need special steps for generating flashbundle. (e.g. the
+       example apps on Linux platform can run the ELF files directly.)
+    """
+    pass
+
   @abstractmethod
-  def outputs(self):
+  def build_outputs(self):
     """Return a list of relevant output files after a build.
 
        May use build output data (e.g. manifests), so this should be invoked
        only after a build has succeeded.
     """
     raise NotImplementedError()
+
+  def flashbundle(self):
+    """Return the files in flashbundle.
+
+       Return an empty dict (and builder can choose not to implement this) if the
+       app does not need special files as flashbundle. (e.g. the example apps on
+       Linux platform can run the ELF files directly.)
+
+       May use data from do_generate_flashbundle, so this should be invoked only
+       after do_generate_flashbundle has succeeded.
+    """
+    return {}
+
+  def outputs(self):
+    artifacts = self.build_outputs()
+    if self._enable_flashbundle:
+      artifacts.update(self.flashbundle())
+    return artifacts
+
+  def build(self):
+    self._build()
+    if self._enable_flashbundle:
+      self._generate_flashbundle()
 
   def _Execute(self, cmdarray, cwd=None, title=None):
     self._runner.Run(cmdarray, cwd=cwd, title=title)

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -79,7 +79,7 @@ class Efr32Builder(GnBuilder):
     self.app = app
     self.gn_build_args = ['efr32_board="%s"' % board.GnArgName()]
 
-  def outputs(self):
+  def build_outputs(self):
     items = {
         '%s.out' % self.app.AppNamePrefix():
             os.path.join(self.output_dir, '%s.out' % self.app.AppNamePrefix()),

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -110,13 +110,13 @@ class Esp32Builder(Builder):
     self._IdfEnvExecute(
         cmd, cwd=self.root, title='Generating ' + self.identifier)
 
-  def build(self):
+  def _build(self):
     logging.info('Compiling Esp32 at %s', self.output_dir)
 
     self._IdfEnvExecute(
         "ninja -C '%s'" % self.output_dir, title='Building ' + self.identifier)
 
-  def outputs(self):
+  def build_outputs(self):
     return {
         self.app.AppNamePrefix + '.elf':
             os.path.join(self.output_dir, self.app.AppNamePrefix + '.elf'),

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -46,6 +46,6 @@ class GnBuilder(Builder):
 
       self._Execute(cmd, title='Generating ' + self.identifier)
 
-  def build(self):
+  def _build(self):
     self._Execute(['ninja', '-C', self.output_dir],
                   title='Building ' + self.identifier)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -54,7 +54,7 @@ class HostBuilder(GnBuilder):
     self.app_name = app.BinaryName()
     self.map_name = self.app_name + '.map'
 
-  def outputs(self):
+  def build_outputs(self):
     return {
         self.app_name: os.path.join(self.output_dir, self.app_name),
         self.map_name : os.path.join(self.output_dir, self.map_name)

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -26,7 +26,7 @@ class QpgBuilder(GnBuilder):
         runner=runner,
         output_prefix=output_prefix)
 
-  def outputs(self):
+  def build_outputs(self):
     return {
         'chip-qpg-lock-example.out':
             os.path.join(self.output_dir, 'chip-qpg6100-lock-example.out'),


### PR DESCRIPTION
#### Problem
Make build artifacts directly usable by enabling 'flash script' generation.

#### Change overview

- Adds `--create-flashbundle` flag to `build_examples.py`
- Update various builders, now they will have "do_build", and "do_generate_flashbundle", called by "build" by builder base, so the builder don't have to care about the "create-flashbundle".
- `do_generate_flashbundle` is an optional step in case some platform does not need to create flashbundle seperately.
- This commit contains flashbundle generation for nrf platform, the flashbundle for other platforms will be added later.

#### Testing

* Manually tested locally, with same command in `integrations/cloudbuild/build-all.yaml`

