### PR TITLE
Do a better job of not suppressing rejected promises in ZAP helpers.

### DIFF
--- a/examples/chip-tool/templates/helper.js
+++ b/examples/chip-tool/templates/helper.js
@@ -55,7 +55,10 @@ function asTypeMinValue(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise);
 }
 
@@ -87,7 +90,10 @@ function asTypeMaxValue(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise);
 }
 

--- a/src/app/zap-templates/common/ClustersHelper.js
+++ b/src/app/zap-templates/common/ClustersHelper.js
@@ -502,7 +502,7 @@ Clusters.init = function(context, packageId) {
     this._attributes = enhancedAttributes(attributes, globalAttributes, types);
 
     return this.ready.resolve();
-  });
+  }, err => this.ready.reject(err));
 }
 
 
@@ -512,13 +512,13 @@ Clusters.init = function(context, packageId) {
 function asBlocks(promise, options)
 {
   const fn = pkgId => Clusters.init(this, pkgId).then(() => promise.then(data => templateUtil.collectBlocks(data, options, this)));
-  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => console.log(err));
+  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => { console.log(err); throw err; });
 }
 
 function asPromise(promise)
 {
   const fn = pkgId => Clusters.init(this, pkgId).then(() => promise);
-  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => console.log(err));
+  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => { console.log(err); throw err; });
 }
 
 //

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -67,7 +67,10 @@ function asReadTypeLength(type)
     return typeResolver.then(types => (types.find(type => type)).size);
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise)
 }
 
@@ -118,7 +121,10 @@ function asReadType(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise)
 }
 
@@ -282,7 +288,10 @@ function asPrintFormat(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise)
 }
 

--- a/src/controller/java/templates/helper.js
+++ b/src/controller/java/templates/helper.js
@@ -127,7 +127,10 @@ function asJniBasicTypeForZclType(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise)
 }
 
@@ -141,7 +144,10 @@ function asJniSignature(type)
     })
   }
 
-  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => {
+    console.log(err);
+    throw err;
+  });
   return templateUtil.templatePromise(this.global, promise)
 }
 
@@ -177,7 +183,10 @@ function omitCommaForFirstNonStatusCommand(id, index)
 {
   let promise = templateUtil.ensureZclPackageId(this)
                     .then((pkgId) => { return queryCommand.selectCommandArgumentsByCommandId(this.global.db, id, pkgId) })
-                    .catch(err => console.log(err))
+                    .catch(err => {
+                      console.log(err);
+                      throw err;
+                    })
                     .then((result) => {
                       // Currently, we omit array types, so don't count it as a valid non-status command.
                       let firstNonStatusCommandIndex = result.findIndex((command) => command.label != "status" && !command.isArray);
@@ -186,7 +195,10 @@ function omitCommaForFirstNonStatusCommand(id, index)
                       }
                       return "";
                     })
-                    .catch(err => console.log(err));
+                    .catch(err => {
+                      console.log(err);
+                      throw err;
+                    });
 
   return templateUtil.templatePromise(this.global, promise);
 }


### PR DESCRIPTION
There are two fundamental changes here:

1) Make Clusters.init actually reject this.ready on errors.

2) Make the various catch() bits we have re-throw the error after
   logging.  The only reason we need these at all is that there are
   outstanding ZAP bugs that end up suppressing these errors
   somewhere, so if we don't log them we don't notice them happening
   at all.

#### Problem
We are suppressing some errors when we should not.

#### Change overview
Make sure to propagate them.

#### Testing
Tried adding various exceptions to the code and ensured that they got logged better, and in some cases failed codegen when we used to not fail it.