### PR TITLE
[git] mark all files in the gen folders as auto-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Mark all files in the "gen" folders as auto-generated to hide them in diffs
+**/gen/** linguist-generated


### PR DESCRIPTION
#### Problem
Changes in the auto-generated ZAP files hinder the review process.

#### Change overview
This PR ensures that GitHub does not load the diff from auto-generated ZAP files in the pull request by default. This is achieved by marking all files in the `gen` folders as auto-generated using the official GitHub's library called [linguist](https://github.com/github/linguist). While this is not a perfect solution, it may increase the focus on important logic changes during code review.

#### Testing
Manually modified few files in `gen` folders and a few not auto-generated and inspect Github's diff view.
Check it here: https://github.com/LuDuda/connectedhomeip/commit/66538f1db25c936b420c7f84f62a3499b8d8cd25