### PR TITLE
./scripts/tests/esp32_qemu_tests.sh: line 52: syntax error near unexp…

### DIFF
--- a/scripts/tests/esp32_qemu_tests.sh
+++ b/scripts/tests/esp32_qemu_tests.sh
@@ -49,7 +49,7 @@ run_suite() {
     if [[ -d "${log_dir}" ]]; then
         suite=${1%.a}
         suite=${suite#lib}
-        really_run_suite "$@" |& tee "$log_dir/$suite.log"
+        really_run_suite "$@" 2>&1 | tee "$log_dir/$suite.log"
     else
         really_run_suite "$@"
     fi


### PR DESCRIPTION
…ected token &

#### Problem

It seems like some shell does not like the `|&` shortcut for `2>&1 |` . I did not spent time digging into why as just using the longer version works.


#### Change overview
* Replace `|&` by `2>&1 |` into `./scripts/tests/esp32_qemu_tests.sh`

#### Testing
It was tested by running `./scripts/tests/esp32_qemu_tests.sh` locally. It is not working with the shortcut, but works without.