### PR TITLE
warning: default value 120000 on WIFI_AP_IDLE_TIMEOUT clamped to 6553…

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -488,7 +488,7 @@ menu "CHIP Device Layer"
 
         config WIFI_AP_IDLE_TIMEOUT
             int "WiFi AP Idle Timeout (ms)"
-            range 0 65535
+            range 0 600000
             default 120000
             help
                 The amount of time (in milliseconds) after which the CHIP platform will deactivate the soft-AP


### PR DESCRIPTION
…5 due to being outside the active range ([0, 65535])

#### Problem
When running `./scripts/tests/esp32_qemu_tests.sh` there is a warning: 
```
warning: default value 120000 on WIFI_AP_IDLE_TIMEOUT (defined at third_party/connectedhomeip/config/esp32/components/chip/Kconfig:489) clamped to 65535 due to being outside the active range ([0, 65535])
```

#### Change overview
* Make the range `[0, 600000]` since `WIFI_AP_IDLE_TIMEOUT` is stored as an `uint32_t` and `120000` is the default value for others: https://github.com/project-chip/connectedhomeip/blob/3b9c48c8cc496c663eb357ba4b4b1e60134a162f/src/include/platform/CHIPDeviceConfig.h#L347

#### Testing
I have runned `./scripts/tests/esp32_qemu_tests.sh` and observe that the warning has disappeared.
