### PR TITLE
config/esp32/components/chip/component.mk:132: warning: undefined var…

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -101,6 +101,7 @@ COMPONENT_ADD_INCLUDEDIRS +=   $(REL_OUTPUT_DIR)/src/include \
 COMPONENT_OWNBUILDTARGET 	 = 1
 COMPONENT_OWNCLEANTARGET 	 = 1
 
+is_debug ?= true
 
 # ==================================================
 # Build Rules


### PR DESCRIPTION
…iable is_debug

#### Problem
When running `./scripts/tests/esp32_qemu_tests.sh` there is a warning: 
```
src/test_driver/esp32/third_party/connectedhomeip/config/esp32/components/chip/component.mk:132: warning: undefined variable `is_debug'
```

#### Change overview
* Add a default value if `is_debug` is undefined

#### Testing
I have runned `./scripts/tests/esp32_qemu_tests.sh` and observe that the warning has disappeared.