### PR TITLE
Remove if (isStrEqual label status) from templates

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -130,7 +130,7 @@ static void OnAccountLoginClusterGetSetupPINResponse(void * context, uint8_t * s
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_t * data)
+static void OnApplicationLauncherClusterLaunchAppResponse(void * context, uint8_t status, uint8_t * data)
 {
     ChipLogProgress(chipTool, "ApplicationLauncherClusterLaunchAppResponse");
 
@@ -154,7 +154,7 @@ static void OnContentLauncherClusterLaunchURLResponse(void * context, uint8_t * 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearAllPinsResponse(void * context)
+static void OnDoorLockClusterClearAllPinsResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearAllPinsResponse");
 
@@ -162,7 +162,7 @@ static void OnDoorLockClusterClearAllPinsResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearAllRfidsResponse(void * context)
+static void OnDoorLockClusterClearAllRfidsResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearAllRfidsResponse");
 
@@ -170,7 +170,7 @@ static void OnDoorLockClusterClearAllRfidsResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearHolidayScheduleResponse(void * context)
+static void OnDoorLockClusterClearHolidayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearHolidayScheduleResponse");
 
@@ -178,7 +178,7 @@ static void OnDoorLockClusterClearHolidayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearPinResponse(void * context)
+static void OnDoorLockClusterClearPinResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearPinResponse");
 
@@ -186,7 +186,7 @@ static void OnDoorLockClusterClearPinResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearRfidResponse(void * context)
+static void OnDoorLockClusterClearRfidResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearRfidResponse");
 
@@ -194,7 +194,7 @@ static void OnDoorLockClusterClearRfidResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearWeekdayScheduleResponse(void * context)
+static void OnDoorLockClusterClearWeekdayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearWeekdayScheduleResponse");
 
@@ -202,7 +202,7 @@ static void OnDoorLockClusterClearWeekdayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterClearYeardayScheduleResponse(void * context)
+static void OnDoorLockClusterClearYeardayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterClearYeardayScheduleResponse");
 
@@ -210,7 +210,7 @@ static void OnDoorLockClusterClearYeardayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t scheduleId, uint32_t localStartTime,
+static void OnDoorLockClusterGetHolidayScheduleResponse(void * context, uint8_t scheduleId, uint8_t status, uint32_t localStartTime,
                                                         uint32_t localEndTime, uint8_t operatingModeDuringHoliday)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetHolidayScheduleResponse");
@@ -252,8 +252,9 @@ static void OnDoorLockClusterGetUserTypeResponse(void * context, uint16_t userId
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetWeekdayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId, uint8_t daysMask,
-                                                        uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
+static void OnDoorLockClusterGetWeekdayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status,
+                                                        uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour,
+                                                        uint8_t endMinute)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetWeekdayScheduleResponse");
 
@@ -261,7 +262,7 @@ static void OnDoorLockClusterGetWeekdayScheduleResponse(void * context, uint8_t 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterGetYeardayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId,
+static void OnDoorLockClusterGetYeardayScheduleResponse(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status,
                                                         uint32_t localStartTime, uint32_t localEndTime)
 {
     ChipLogProgress(chipTool, "DoorLockClusterGetYeardayScheduleResponse");
@@ -270,7 +271,7 @@ static void OnDoorLockClusterGetYeardayScheduleResponse(void * context, uint8_t 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterLockDoorResponse(void * context)
+static void OnDoorLockClusterLockDoorResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterLockDoorResponse");
 
@@ -278,7 +279,7 @@ static void OnDoorLockClusterLockDoorResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetHolidayScheduleResponse(void * context)
+static void OnDoorLockClusterSetHolidayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetHolidayScheduleResponse");
 
@@ -286,7 +287,7 @@ static void OnDoorLockClusterSetHolidayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetPinResponse(void * context)
+static void OnDoorLockClusterSetPinResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetPinResponse");
 
@@ -294,7 +295,7 @@ static void OnDoorLockClusterSetPinResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetRfidResponse(void * context)
+static void OnDoorLockClusterSetRfidResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetRfidResponse");
 
@@ -302,7 +303,7 @@ static void OnDoorLockClusterSetRfidResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetUserTypeResponse(void * context)
+static void OnDoorLockClusterSetUserTypeResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetUserTypeResponse");
 
@@ -310,7 +311,7 @@ static void OnDoorLockClusterSetUserTypeResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetWeekdayScheduleResponse(void * context)
+static void OnDoorLockClusterSetWeekdayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetWeekdayScheduleResponse");
 
@@ -318,7 +319,7 @@ static void OnDoorLockClusterSetWeekdayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterSetYeardayScheduleResponse(void * context)
+static void OnDoorLockClusterSetYeardayScheduleResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterSetYeardayScheduleResponse");
 
@@ -326,7 +327,7 @@ static void OnDoorLockClusterSetYeardayScheduleResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterUnlockDoorResponse(void * context)
+static void OnDoorLockClusterUnlockDoorResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterUnlockDoorResponse");
 
@@ -334,7 +335,7 @@ static void OnDoorLockClusterUnlockDoorResponse(void * context)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnDoorLockClusterUnlockWithTimeoutResponse(void * context)
+static void OnDoorLockClusterUnlockWithTimeoutResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "DoorLockClusterUnlockWithTimeoutResponse");
 
@@ -366,7 +367,7 @@ static void OnGeneralCommissioningClusterSetRegulatoryConfigResponse(void * cont
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGroupsClusterAddGroupResponse(void * context, uint16_t groupId)
+static void OnGroupsClusterAddGroupResponse(void * context, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(chipTool, "GroupsClusterAddGroupResponse");
 
@@ -383,7 +384,7 @@ static void OnGroupsClusterGetGroupMembershipResponse(void * context, uint8_t ca
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGroupsClusterRemoveGroupResponse(void * context, uint16_t groupId)
+static void OnGroupsClusterRemoveGroupResponse(void * context, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(chipTool, "GroupsClusterRemoveGroupResponse");
 
@@ -391,7 +392,7 @@ static void OnGroupsClusterRemoveGroupResponse(void * context, uint16_t groupId)
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnGroupsClusterViewGroupResponse(void * context, uint16_t groupId, uint8_t * groupName)
+static void OnGroupsClusterViewGroupResponse(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
 {
     ChipLogProgress(chipTool, "GroupsClusterViewGroupResponse");
 
@@ -407,7 +408,7 @@ static void OnIdentifyClusterIdentifyQueryResponse(void * context, uint16_t time
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnKeypadInputClusterSendKeyResponse(void * context)
+static void OnKeypadInputClusterSendKeyResponse(void * context, uint8_t status)
 {
     ChipLogProgress(chipTool, "KeypadInputClusterSendKeyResponse");
 
@@ -578,9 +579,10 @@ static void OnOtaSoftwareUpdateProviderClusterApplyUpdateRequestResponse(void * 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnOtaSoftwareUpdateProviderClusterQueryImageResponse(void * context, uint32_t delayedActionTime, uint8_t * imageURI,
-                                                                 uint32_t softwareVersion, chip::ByteSpan updateToken,
-                                                                 bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
+static void OnOtaSoftwareUpdateProviderClusterQueryImageResponse(void * context, uint8_t status, uint32_t delayedActionTime,
+                                                                 uint8_t * imageURI, uint32_t softwareVersion,
+                                                                 chip::ByteSpan updateToken, bool userConsentNeeded,
+                                                                 chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(chipTool, "OtaSoftwareUpdateProviderClusterQueryImageResponse");
 
@@ -614,7 +616,7 @@ static void OnOperationalCredentialsClusterSetFabricResponse(void * context, chi
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterAddSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
+static void OnScenesClusterAddSceneResponse(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(chipTool, "ScenesClusterAddSceneResponse");
 
@@ -622,7 +624,8 @@ static void OnScenesClusterAddSceneResponse(void * context, uint16_t groupId, ui
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterGetSceneMembershipResponse(void * context, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
+static void OnScenesClusterGetSceneMembershipResponse(void * context, uint8_t status, uint8_t capacity, uint16_t groupId,
+                                                      uint8_t sceneCount,
                                                       /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
 {
     ChipLogProgress(chipTool, "ScenesClusterGetSceneMembershipResponse");
@@ -631,7 +634,7 @@ static void OnScenesClusterGetSceneMembershipResponse(void * context, uint8_t ca
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterRemoveAllScenesResponse(void * context, uint16_t groupId)
+static void OnScenesClusterRemoveAllScenesResponse(void * context, uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(chipTool, "ScenesClusterRemoveAllScenesResponse");
 
@@ -639,7 +642,7 @@ static void OnScenesClusterRemoveAllScenesResponse(void * context, uint16_t grou
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterRemoveSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
+static void OnScenesClusterRemoveSceneResponse(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(chipTool, "ScenesClusterRemoveSceneResponse");
 
@@ -647,7 +650,7 @@ static void OnScenesClusterRemoveSceneResponse(void * context, uint16_t groupId,
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterStoreSceneResponse(void * context, uint16_t groupId, uint8_t sceneId)
+static void OnScenesClusterStoreSceneResponse(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(chipTool, "ScenesClusterStoreSceneResponse");
 
@@ -655,8 +658,8 @@ static void OnScenesClusterStoreSceneResponse(void * context, uint16_t groupId, 
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnScenesClusterViewSceneResponse(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                                             uint8_t * sceneName,
+static void OnScenesClusterViewSceneResponse(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId,
+                                             uint16_t transitionTime, uint8_t * sceneName,
                                              /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     ChipLogProgress(chipTool, "ScenesClusterViewSceneResponse");
@@ -675,7 +678,7 @@ static void OnTvChannelClusterChangeChannelResponse(void * context,
     command->SetCommandExitStatus(CHIP_NO_ERROR);
 }
 
-static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8_t * data)
+static void OnTargetNavigatorClusterNavigateTargetResponse(void * context, uint8_t status, uint8_t * data)
 {
     ChipLogProgress(chipTool, "TargetNavigatorClusterNavigateTargetResponse");
 

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -107,7 +107,7 @@ static void OnStringAttributeResponse(void * context, const chip::ByteSpan value
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
+static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
 {
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -843,9 +843,7 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
     {{#chip_cluster_response_arguments}}
-    {{#if (isStrEqual label "status")}}
-    LogStatus(status);
-    {{else if (isOctetString type)}}
+    {{#if (isOctetString type)}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", {{asSymbol label}}.size());
     {{else if (isCharString type)}}
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
@@ -857,19 +855,8 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
 
     GET_CLUSTER_RESPONSE_CALLBACKS("{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback");
 
-    {{#chip_cluster_response_arguments}}
-    {{#if (isStrEqual label "status")}}
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb = Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-    {{/if}}
-    {{/chip_cluster_response_arguments}}
-
     Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback> * cb = Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}});
+    cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}, {{asSymbol label}}{{/chip_cluster_response_arguments}});
     return true;
 }
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -69,7 +69,7 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16
 // Cluster Specific Response Callbacks
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}});
+typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}});
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 {{/if}}

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -1716,23 +1716,15 @@ bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::EndpointId
                                                                 uint8_t status, uint8_t * data)
 {
     ChipLogProgress(Zcl, "LaunchAppResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
     // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ApplicationLauncherClusterLaunchAppResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ApplicationLauncherClusterLaunchAppResponseCallback> * cb =
         Callback::Callback<ApplicationLauncherClusterLaunchAppResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, data);
+    cb->mCall(cb->mContext, status, data);
     return true;
 }
 
@@ -1772,21 +1764,13 @@ bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::EndpointId endpoin
                                                         uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearAllPinsResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearAllPinsResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearAllPinsResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearAllPinsResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1794,21 +1778,13 @@ bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::EndpointId endpoi
                                                          uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearAllRfidsResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearAllRfidsResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearAllRfidsResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearAllRfidsResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1816,21 +1792,13 @@ bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::EndpointId
                                                                 uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearHolidayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearHolidayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearHolidayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearHolidayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1838,21 +1806,13 @@ bool emberAfDoorLockClusterClearPinResponseCallback(chip::EndpointId endpoint, c
                                                     uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearPinResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearPinResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearPinResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearPinResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1860,21 +1820,13 @@ bool emberAfDoorLockClusterClearRfidResponseCallback(chip::EndpointId endpoint, 
                                                      uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearRfidResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearRfidResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearRfidResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearRfidResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1882,21 +1834,13 @@ bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::EndpointId
                                                                 uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearWeekdayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearWeekdayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearWeekdayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearWeekdayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1904,21 +1848,13 @@ bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::EndpointId
                                                                 uint8_t status)
 {
     ChipLogProgress(Zcl, "ClearYeardayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterClearYeardayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterClearYeardayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterClearYeardayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -1928,24 +1864,16 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::EndpointId e
 {
     ChipLogProgress(Zcl, "GetHolidayScheduleResponse:");
     ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", scheduleId);
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  localStartTime: %" PRIu32 "", localStartTime);
     ChipLogProgress(Zcl, "  localEndTime: %" PRIu32 "", localEndTime);
     ChipLogProgress(Zcl, "  operatingModeDuringHoliday: %" PRIu8 "", operatingModeDuringHoliday);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetHolidayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterGetHolidayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterGetHolidayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday);
+    cb->mCall(cb->mContext, scheduleId, status, localStartTime, localEndTime, operatingModeDuringHoliday);
     return true;
 }
 
@@ -2030,7 +1958,7 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::EndpointId e
     ChipLogProgress(Zcl, "GetWeekdayScheduleResponse:");
     ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", scheduleId);
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  daysMask: %" PRIu8 "", daysMask);
     ChipLogProgress(Zcl, "  startHour: %" PRIu8 "", startHour);
     ChipLogProgress(Zcl, "  startMinute: %" PRIu8 "", startMinute);
@@ -2039,17 +1967,9 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::EndpointId e
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetWeekdayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterGetWeekdayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterGetWeekdayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute);
+    cb->mCall(cb->mContext, scheduleId, userId, status, daysMask, startHour, startMinute, endHour, endMinute);
     return true;
 }
 
@@ -2060,23 +1980,15 @@ bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::EndpointId e
     ChipLogProgress(Zcl, "GetYeardayScheduleResponse:");
     ChipLogProgress(Zcl, "  scheduleId: %" PRIu8 "", scheduleId);
     ChipLogProgress(Zcl, "  userId: %" PRIu16 "", userId);
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  localStartTime: %" PRIu32 "", localStartTime);
     ChipLogProgress(Zcl, "  localEndTime: %" PRIu32 "", localEndTime);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterGetYeardayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterGetYeardayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterGetYeardayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, scheduleId, userId, localStartTime, localEndTime);
+    cb->mCall(cb->mContext, scheduleId, userId, status, localStartTime, localEndTime);
     return true;
 }
 
@@ -2084,21 +1996,13 @@ bool emberAfDoorLockClusterLockDoorResponseCallback(chip::EndpointId endpoint, c
                                                     uint8_t status)
 {
     ChipLogProgress(Zcl, "LockDoorResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterLockDoorResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterLockDoorResponseCallback> * cb =
         Callback::Callback<DoorLockClusterLockDoorResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2106,63 +2010,39 @@ bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::EndpointId e
                                                               uint8_t status)
 {
     ChipLogProgress(Zcl, "SetHolidayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetHolidayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetHolidayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetHolidayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
 bool emberAfDoorLockClusterSetPinResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetPinResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetPinResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetPinResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetPinResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
 bool emberAfDoorLockClusterSetRfidResponseCallback(chip::EndpointId endpoint, chip::app::CommandSender * commandObj, uint8_t status)
 {
     ChipLogProgress(Zcl, "SetRfidResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetRfidResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetRfidResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetRfidResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2170,21 +2050,13 @@ bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::EndpointId endpoint
                                                        uint8_t status)
 {
     ChipLogProgress(Zcl, "SetUserTypeResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetUserTypeResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetUserTypeResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetUserTypeResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2192,21 +2064,13 @@ bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::EndpointId e
                                                               uint8_t status)
 {
     ChipLogProgress(Zcl, "SetWeekdayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetWeekdayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetWeekdayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetWeekdayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2214,21 +2078,13 @@ bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::EndpointId e
                                                               uint8_t status)
 {
     ChipLogProgress(Zcl, "SetYeardayScheduleResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterSetYeardayScheduleResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterSetYeardayScheduleResponseCallback> * cb =
         Callback::Callback<DoorLockClusterSetYeardayScheduleResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2236,21 +2092,13 @@ bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::EndpointId endpoint,
                                                       uint8_t status)
 {
     ChipLogProgress(Zcl, "UnlockDoorResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterUnlockDoorResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterUnlockDoorResponseCallback> * cb =
         Callback::Callback<DoorLockClusterUnlockDoorResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2258,21 +2106,13 @@ bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::EndpointId en
                                                              uint8_t status)
 {
     ChipLogProgress(Zcl, "UnlockWithTimeoutResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("DoorLockClusterUnlockWithTimeoutResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<DoorLockClusterUnlockWithTimeoutResponseCallback> * cb =
         Callback::Callback<DoorLockClusterUnlockWithTimeoutResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2330,22 +2170,14 @@ bool emberAfGroupsClusterAddGroupResponseCallback(chip::EndpointId endpoint, chi
                                                   uint16_t groupId)
 {
     ChipLogProgress(Zcl, "AddGroupResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GroupsClusterAddGroupResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<GroupsClusterAddGroupResponseCallback> * cb =
         Callback::Callback<GroupsClusterAddGroupResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId);
+    cb->mCall(cb->mContext, status, groupId);
     return true;
 }
 
@@ -2370,22 +2202,14 @@ bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::EndpointId endpoint, 
                                                      uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(Zcl, "RemoveGroupResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GroupsClusterRemoveGroupResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<GroupsClusterRemoveGroupResponseCallback> * cb =
         Callback::Callback<GroupsClusterRemoveGroupResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId);
+    cb->mCall(cb->mContext, status, groupId);
     return true;
 }
 
@@ -2393,24 +2217,16 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::EndpointId endpoint, ch
                                                    uint16_t groupId, uint8_t * groupName)
 {
     ChipLogProgress(Zcl, "ViewGroupResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
     // ChipLogProgress(Zcl, "  groupName: %.*s", groupName.size(), groupName.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("GroupsClusterViewGroupResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<GroupsClusterViewGroupResponseCallback> * cb =
         Callback::Callback<GroupsClusterViewGroupResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId, groupName);
+    cb->mCall(cb->mContext, status, groupId, groupName);
     return true;
 }
 
@@ -2432,21 +2248,13 @@ bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::EndpointId endpoint,
                                                       uint8_t status)
 {
     ChipLogProgress(Zcl, "SendKeyResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("KeypadInputClusterSendKeyResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<KeypadInputClusterSendKeyResponseCallback> * cb =
         Callback::Callback<KeypadInputClusterSendKeyResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext);
+    cb->mCall(cb->mContext, status);
     return true;
 }
 
@@ -2766,7 +2574,7 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::End
                                                                        bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
 {
     ChipLogProgress(Zcl, "QueryImageResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  delayedActionTime: %" PRIu32 "", delayedActionTime);
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
     // ChipLogProgress(Zcl, "  imageURI: %.*s", imageURI.size(), imageURI.data());
@@ -2777,17 +2585,10 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageResponseCallback(chip::End
 
     GET_CLUSTER_RESPONSE_CALLBACKS("OtaSoftwareUpdateProviderClusterQueryImageResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback> * cb =
         Callback::Callback<OtaSoftwareUpdateProviderClusterQueryImageResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, delayedActionTime, imageURI, softwareVersion, updateToken, userConsentNeeded, metadataForRequestor);
+    cb->mCall(cb->mContext, status, delayedActionTime, imageURI, softwareVersion, updateToken, userConsentNeeded,
+              metadataForRequestor);
     return true;
 }
 
@@ -2840,23 +2641,15 @@ bool emberAfScenesClusterAddSceneResponseCallback(chip::EndpointId endpoint, chi
                                                   uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "AddSceneResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterAddSceneResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterAddSceneResponseCallback> * cb =
         Callback::Callback<ScenesClusterAddSceneResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId, sceneId);
+    cb->mCall(cb->mContext, status, groupId, sceneId);
     return true;
 }
 
@@ -2865,7 +2658,7 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::EndpointId end
                                                             /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
 {
     ChipLogProgress(Zcl, "GetSceneMembershipResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  capacity: %" PRIu8 "", capacity);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneCount: %" PRIu8 "", sceneCount);
@@ -2873,17 +2666,9 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::EndpointId end
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterGetSceneMembershipResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterGetSceneMembershipResponseCallback> * cb =
         Callback::Callback<ScenesClusterGetSceneMembershipResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, capacity, groupId, sceneCount, sceneList);
+    cb->mCall(cb->mContext, status, capacity, groupId, sceneCount, sceneList);
     return true;
 }
 
@@ -2891,22 +2676,14 @@ bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::EndpointId endpoi
                                                          uint8_t status, uint16_t groupId)
 {
     ChipLogProgress(Zcl, "RemoveAllScenesResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterRemoveAllScenesResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterRemoveAllScenesResponseCallback> * cb =
         Callback::Callback<ScenesClusterRemoveAllScenesResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId);
+    cb->mCall(cb->mContext, status, groupId);
     return true;
 }
 
@@ -2914,23 +2691,15 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::EndpointId endpoint, 
                                                      uint8_t status, uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "RemoveSceneResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterRemoveSceneResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterRemoveSceneResponseCallback> * cb =
         Callback::Callback<ScenesClusterRemoveSceneResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId, sceneId);
+    cb->mCall(cb->mContext, status, groupId, sceneId);
     return true;
 }
 
@@ -2938,23 +2707,15 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::EndpointId endpoint, c
                                                     uint8_t status, uint16_t groupId, uint8_t sceneId)
 {
     ChipLogProgress(Zcl, "StoreSceneResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterStoreSceneResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterStoreSceneResponseCallback> * cb =
         Callback::Callback<ScenesClusterStoreSceneResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId, sceneId);
+    cb->mCall(cb->mContext, status, groupId, sceneId);
     return true;
 }
 
@@ -2963,7 +2724,7 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::EndpointId endpoint, ch
                                                    /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
 {
     ChipLogProgress(Zcl, "ViewSceneResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     ChipLogProgress(Zcl, "  groupId: %" PRIu16 "", groupId);
     ChipLogProgress(Zcl, "  sceneId: %" PRIu8 "", sceneId);
     ChipLogProgress(Zcl, "  transitionTime: %" PRIu16 "", transitionTime);
@@ -2973,17 +2734,9 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::EndpointId endpoint, ch
 
     GET_CLUSTER_RESPONSE_CALLBACKS("ScenesClusterViewSceneResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<ScenesClusterViewSceneResponseCallback> * cb =
         Callback::Callback<ScenesClusterViewSceneResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, groupId, sceneId, transitionTime, sceneName, extensionFieldSets);
+    cb->mCall(cb->mContext, status, groupId, sceneId, transitionTime, sceneName, extensionFieldSets);
     return true;
 }
 
@@ -3007,23 +2760,15 @@ bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::EndpointI
                                                                  uint8_t status, uint8_t * data)
 {
     ChipLogProgress(Zcl, "NavigateTargetResponse:");
-    LogStatus(status);
+    ChipLogProgress(Zcl, "  status: %" PRIu8 "", status);
     // Currently the generated code emits `uint8_t *` for CHAR_STRING, it needs to emits chip::ByteSpan
     // ChipLogProgress(Zcl, "  data: %.*s", data.size(), data.data());
 
     GET_CLUSTER_RESPONSE_CALLBACKS("TargetNavigatorClusterNavigateTargetResponseCallback");
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        Callback::Callback<DefaultFailureCallback> * cb =
-            Callback::Callback<DefaultFailureCallback>::FromCancelable(onFailureCallback);
-        cb->mCall(cb->mContext, status);
-        return true;
-    }
-
     Callback::Callback<TargetNavigatorClusterNavigateTargetResponseCallback> * cb =
         Callback::Callback<TargetNavigatorClusterNavigateTargetResponseCallback>::FromCancelable(onSuccessCallback);
-    cb->mCall(cb->mContext, data);
+    cb->mCall(cb->mContext, status, data);
     return true;
 }
 

--- a/src/controller/data_model/gen/CHIPClientCallbacks.h
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.h
@@ -85,18 +85,19 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void * context, uint1
 
 // Cluster Specific Response Callbacks
 typedef void (*AccountLoginClusterGetSetupPINResponseCallback)(void * context, uint8_t * setupPIN);
-typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t * data);
+typedef void (*ApplicationLauncherClusterLaunchAppResponseCallback)(void * context, uint8_t status, uint8_t * data);
 typedef void (*ContentLauncherClusterLaunchContentResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
 typedef void (*ContentLauncherClusterLaunchURLResponseCallback)(void * context, uint8_t * data, uint8_t contentLaunchStatus);
-typedef void (*DoorLockClusterClearAllPinsResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearAllRfidsResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearHolidayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearPinResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearRfidResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearWeekdayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterClearYeardayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterGetHolidayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint32_t localStartTime,
-                                                                  uint32_t localEndTime, uint8_t operatingModeDuringHoliday);
+typedef void (*DoorLockClusterClearAllPinsResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearAllRfidsResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearHolidayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearPinResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearRfidResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearWeekdayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterClearYeardayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterGetHolidayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint8_t status,
+                                                                  uint32_t localStartTime, uint32_t localEndTime,
+                                                                  uint8_t operatingModeDuringHoliday);
 typedef void (*DoorLockClusterGetLogRecordResponseCallback)(void * context, uint16_t logEntryId, uint32_t timestamp,
                                                             uint8_t eventType, uint8_t source, uint8_t eventIdOrAlarmCode,
                                                             uint16_t userId, uint8_t * pin);
@@ -106,31 +107,31 @@ typedef void (*DoorLockClusterGetRfidResponseCallback)(void * context, uint16_t 
                                                        uint8_t * rfid);
 typedef void (*DoorLockClusterGetUserTypeResponseCallback)(void * context, uint16_t userId, uint8_t userType);
 typedef void (*DoorLockClusterGetWeekdayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint16_t userId,
-                                                                  uint8_t daysMask, uint8_t startHour, uint8_t startMinute,
-                                                                  uint8_t endHour, uint8_t endMinute);
+                                                                  uint8_t status, uint8_t daysMask, uint8_t startHour,
+                                                                  uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
 typedef void (*DoorLockClusterGetYeardayScheduleResponseCallback)(void * context, uint8_t scheduleId, uint16_t userId,
-                                                                  uint32_t localStartTime, uint32_t localEndTime);
-typedef void (*DoorLockClusterLockDoorResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetHolidayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetPinResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetRfidResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetUserTypeResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetWeekdayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterSetYeardayScheduleResponseCallback)(void * context);
-typedef void (*DoorLockClusterUnlockDoorResponseCallback)(void * context);
-typedef void (*DoorLockClusterUnlockWithTimeoutResponseCallback)(void * context);
+                                                                  uint8_t status, uint32_t localStartTime, uint32_t localEndTime);
+typedef void (*DoorLockClusterLockDoorResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetHolidayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetPinResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetRfidResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetUserTypeResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetWeekdayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterSetYeardayScheduleResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterUnlockDoorResponseCallback)(void * context, uint8_t status);
+typedef void (*DoorLockClusterUnlockWithTimeoutResponseCallback)(void * context, uint8_t status);
 typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallback)(void * context, uint8_t errorCode, uint8_t * debugText);
 typedef void (*GeneralCommissioningClusterCommissioningCompleteResponseCallback)(void * context, uint8_t errorCode,
                                                                                  uint8_t * debugText);
 typedef void (*GeneralCommissioningClusterSetRegulatoryConfigResponseCallback)(void * context, uint8_t errorCode,
                                                                                uint8_t * debugText);
-typedef void (*GroupsClusterAddGroupResponseCallback)(void * context, uint16_t groupId);
+typedef void (*GroupsClusterAddGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
 typedef void (*GroupsClusterGetGroupMembershipResponseCallback)(void * context, uint8_t capacity, uint8_t groupCount,
                                                                 /* TYPE WARNING: array array defaults to */ uint8_t * groupList);
-typedef void (*GroupsClusterRemoveGroupResponseCallback)(void * context, uint16_t groupId);
-typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint16_t groupId, uint8_t * groupName);
+typedef void (*GroupsClusterRemoveGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId);
+typedef void (*GroupsClusterViewGroupResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName);
 typedef void (*IdentifyClusterIdentifyQueryResponseCallback)(void * context, uint16_t timeout);
-typedef void (*KeypadInputClusterSendKeyResponseCallback)(void * context);
+typedef void (*KeypadInputClusterSendKeyResponseCallback)(void * context, uint8_t status);
 typedef void (*MediaPlaybackClusterMediaFastForwardResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaNextResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
 typedef void (*MediaPlaybackClusterMediaPauseResponseCallback)(void * context, uint8_t mediaPlaybackStatus);
@@ -156,29 +157,30 @@ typedef void (*NetworkCommissioningClusterUpdateWiFiNetworkResponseCallback)(voi
                                                                              uint8_t * debugText);
 typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateRequestResponseCallback)(void * context, uint8_t action,
                                                                                    uint32_t delayedActionTime);
-typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(void * context, uint32_t delayedActionTime,
-                                                                           uint8_t * imageURI, uint32_t softwareVersion,
-                                                                           chip::ByteSpan updateToken, bool userConsentNeeded,
+typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallback)(void * context, uint8_t status,
+                                                                           uint32_t delayedActionTime, uint8_t * imageURI,
+                                                                           uint32_t softwareVersion, chip::ByteSpan updateToken,
+                                                                           bool userConsentNeeded,
                                                                            chip::ByteSpan metadataForRequestor);
 typedef void (*OperationalCredentialsClusterNOCResponseCallback)(void * context, uint8_t StatusCode, uint8_t FabricIndex,
                                                                  chip::ByteSpan DebugText);
 typedef void (*OperationalCredentialsClusterOpCSRResponseCallback)(void * context, chip::ByteSpan NOCSRElements,
                                                                    chip::ByteSpan AttestationSignature);
 typedef void (*OperationalCredentialsClusterSetFabricResponseCallback)(void * context, chip::FabricId FabricId);
-typedef void (*ScenesClusterAddSceneResponseCallback)(void * context, uint16_t groupId, uint8_t sceneId);
-typedef void (*ScenesClusterGetSceneMembershipResponseCallback)(void * context, uint8_t capacity, uint16_t groupId,
+typedef void (*ScenesClusterAddSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+typedef void (*ScenesClusterGetSceneMembershipResponseCallback)(void * context, uint8_t status, uint8_t capacity, uint16_t groupId,
                                                                 uint8_t sceneCount,
                                                                 /* TYPE WARNING: array array defaults to */ uint8_t * sceneList);
-typedef void (*ScenesClusterRemoveAllScenesResponseCallback)(void * context, uint16_t groupId);
-typedef void (*ScenesClusterRemoveSceneResponseCallback)(void * context, uint16_t groupId, uint8_t sceneId);
-typedef void (*ScenesClusterStoreSceneResponseCallback)(void * context, uint16_t groupId, uint8_t sceneId);
-typedef void (*ScenesClusterViewSceneResponseCallback)(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                                                       uint8_t * sceneName,
+typedef void (*ScenesClusterRemoveAllScenesResponseCallback)(void * context, uint8_t status, uint16_t groupId);
+typedef void (*ScenesClusterRemoveSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+typedef void (*ScenesClusterStoreSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId);
+typedef void (*ScenesClusterViewSceneResponseCallback)(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId,
+                                                       uint16_t transitionTime, uint8_t * sceneName,
                                                        /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets);
 typedef void (*TvChannelClusterChangeChannelResponseCallback)(void * context,
                                                               /* TYPE WARNING: array array defaults to */ uint8_t * ChannelMatch,
                                                               uint8_t ErrorType);
-typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t * data);
+typedef void (*TargetNavigatorClusterNavigateTargetResponseCallback)(void * context, uint8_t status, uint8_t * data);
 typedef void (*TestClusterClusterTestAddArgumentsResponseCallback)(void * context, uint8_t returnValue);
 typedef void (*TestClusterClusterTestSpecificResponseCallback)(void * context, uint8_t returnValue);
 

--- a/src/controller/java/gen/CHIPClusters-JNI.cpp
+++ b/src/controller/java/gen/CHIPClusters-JNI.cpp
@@ -960,7 +960,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -979,10 +979,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr.jniValue());
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1172,7 +1172,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1189,10 +1189,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1240,7 +1240,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1257,10 +1257,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1309,7 +1309,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1326,10 +1326,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1377,7 +1377,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1394,10 +1394,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1445,7 +1445,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1462,10 +1462,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1514,7 +1514,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1531,10 +1531,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1583,7 +1583,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1600,10 +1600,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -1652,7 +1652,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t scheduleId, uint32_t localStartTime, uint32_t localEndTime,
+    static void CallbackFn(void * context, uint8_t scheduleId, uint8_t status, uint32_t localStartTime, uint32_t localEndTime,
                            uint8_t operatingModeDuringHoliday)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
@@ -1670,11 +1670,12 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJJI)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJI)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jlong>(localStartTime),
-                            static_cast<jlong>(localEndTime), static_cast<jint>(operatingModeDuringHoliday));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(status),
+                            static_cast<jlong>(localStartTime), static_cast<jlong>(localEndTime),
+                            static_cast<jint>(operatingModeDuringHoliday));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2007,7 +2008,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t daysMask, uint8_t startHour,
+    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint8_t daysMask, uint8_t startHour,
                            uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
@@ -2025,12 +2026,12 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIII)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIIIIII)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
-                            static_cast<jint>(daysMask), static_cast<jint>(startHour), static_cast<jint>(startMinute),
-                            static_cast<jint>(endHour), static_cast<jint>(endMinute));
+                            static_cast<jint>(status), static_cast<jint>(daysMask), static_cast<jint>(startHour),
+                            static_cast<jint>(startMinute), static_cast<jint>(endHour), static_cast<jint>(endMinute));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2079,7 +2080,8 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint32_t localStartTime, uint32_t localEndTime)
+    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint32_t localStartTime,
+                           uint32_t localEndTime)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2096,11 +2098,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIJJ)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIJJ)V", &javaMethod);
         SuccessOrExit(err);
 
         env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(scheduleId), static_cast<jint>(userId),
-                            static_cast<jlong>(localStartTime), static_cast<jlong>(localEndTime));
+                            static_cast<jint>(status), static_cast<jlong>(localStartTime), static_cast<jlong>(localEndTime));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2148,7 +2150,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2165,10 +2167,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2217,7 +2219,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2234,10 +2236,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2285,7 +2287,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2302,10 +2304,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2353,7 +2355,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2370,10 +2372,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2421,7 +2423,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2438,10 +2440,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2490,7 +2492,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2507,10 +2509,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2559,7 +2561,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2576,10 +2578,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2627,7 +2629,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2644,10 +2646,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2696,7 +2698,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2713,10 +2715,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -2977,7 +2979,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2994,10 +2996,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -3118,7 +3120,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3135,10 +3137,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -3186,7 +3188,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t * groupName)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3205,10 +3207,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), groupNameStr.jniValue());
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
+                            groupNameStr.jniValue());
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -3324,7 +3327,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -3341,10 +3344,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "()V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -4791,7 +4794,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
+    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
                            chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
@@ -4813,8 +4816,8 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err =
-            JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(JLjava/lang/String;J[BZ[B)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IJLjava/lang/String;J[BZ[B)V",
+                                                      &javaMethod);
         SuccessOrExit(err);
 
         updateTokenArr = env->NewByteArray(updateToken.size());
@@ -4829,9 +4832,9 @@ public:
                                 reinterpret_cast<const jbyte *>(metadataForRequestor.data()));
         VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jlong>(delayedActionTime), imageURIStr.jniValue(),
-                            static_cast<jlong>(softwareVersion), updateTokenArr, static_cast<jboolean>(userConsentNeeded),
-                            metadataForRequestorArr);
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jlong>(delayedActionTime),
+                            imageURIStr.jniValue(), static_cast<jlong>(softwareVersion), updateTokenArr,
+                            static_cast<jboolean>(userConsentNeeded), metadataForRequestorArr);
 
         env->DeleteLocalRef(updateTokenArr);
         env->DeleteLocalRef(metadataForRequestorArr);
@@ -5116,7 +5119,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5133,10 +5136,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
+                            static_cast<jint>(sceneId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5185,7 +5189,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
+    static void CallbackFn(void * context, uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
                            /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
@@ -5203,11 +5207,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIII)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(capacity), static_cast<jint>(groupId),
-                            static_cast<jint>(sceneCount)
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(capacity),
+                            static_cast<jint>(groupId), static_cast<jint>(sceneCount)
                             // sceneList: /* TYPE WARNING: array array defaults to */ uint8_t *
                             // Conversion from this type to Java is not properly implemented yet
         );
@@ -5258,7 +5262,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5275,10 +5279,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(I)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5326,7 +5330,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5343,10 +5347,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
+                            static_cast<jint>(sceneId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5394,7 +5399,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5411,10 +5416,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(II)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(III)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId));
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
+                            static_cast<jint>(sceneId));
 
     exit:
         if (err != CHIP_NO_ERROR)
@@ -5462,8 +5468,8 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-                           /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+                           uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5482,11 +5488,11 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIILjava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(IIIILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(groupId), static_cast<jint>(sceneId),
-                            static_cast<jint>(transitionTime), sceneNameStr.jniValue()
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), static_cast<jint>(groupId),
+                            static_cast<jint>(sceneId), static_cast<jint>(transitionTime), sceneNameStr.jniValue()
                             // extensionFieldSets: /* TYPE WARNING: array array defaults to */ uint8_t *
                             // Conversion from this type to Java is not properly implemented yet
         );
@@ -5611,7 +5617,7 @@ public:
         env->DeleteGlobalRef(javaCallbackRef);
     };
 
-    static void CallbackFn(void * context, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
     {
         StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -5630,10 +5636,10 @@ public:
         javaCallbackRef = cppCallback->javaCallbackRef;
         VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(Ljava/lang/String;)V", &javaMethod);
+        err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "(ILjava/lang/String;)V", &javaMethod);
         SuccessOrExit(err);
 
-        env->CallVoidMethod(javaCallbackRef, javaMethod, dataStr.jniValue());
+        env->CallVoidMethod(javaCallbackRef, javaMethod, static_cast<jint>(status), dataStr.jniValue());
 
     exit:
         if (err != CHIP_NO_ERROR)

--- a/src/controller/java/gen/ChipClusters.java
+++ b/src/controller/java/gen/ChipClusters.java
@@ -278,7 +278,7 @@ public class ChipClusters {
         String applicationId);
 
     public interface LaunchAppResponseCallback {
-      void onSuccess(String data);
+      void onSuccess(int status, String data);
 
       void onError(Exception error);
     }
@@ -2122,50 +2122,54 @@ public class ChipClusters {
         String pin);
 
     public interface ClearAllPinsResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearAllRfidsResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearHolidayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearPinResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearRfidResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearWeekdayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface ClearYeardayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface GetHolidayScheduleResponseCallback {
       void onSuccess(
-          int scheduleId, long localStartTime, long localEndTime, int operatingModeDuringHoliday);
+          int scheduleId,
+          int status,
+          long localStartTime,
+          long localEndTime,
+          int operatingModeDuringHoliday);
 
       void onError(Exception error);
     }
@@ -2205,6 +2209,7 @@ public class ChipClusters {
       void onSuccess(
           int scheduleId,
           int userId,
+          int status,
           int daysMask,
           int startHour,
           int startMinute,
@@ -2215,61 +2220,62 @@ public class ChipClusters {
     }
 
     public interface GetYeardayScheduleResponseCallback {
-      void onSuccess(int scheduleId, int userId, long localStartTime, long localEndTime);
+      void onSuccess(
+          int scheduleId, int userId, int status, long localStartTime, long localEndTime);
 
       void onError(Exception error);
     }
 
     public interface LockDoorResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetHolidayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetPinResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetRfidResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetUserTypeResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetWeekdayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface SetYeardayScheduleResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface UnlockDoorResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
 
     public interface UnlockWithTimeoutResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
@@ -2812,7 +2818,7 @@ public class ChipClusters {
         long chipClusterPtr, ViewGroupResponseCallback callback, int groupId);
 
     public interface AddGroupResponseCallback {
-      void onSuccess(int groupId);
+      void onSuccess(int status, int groupId);
 
       void onError(Exception error);
     }
@@ -2827,13 +2833,13 @@ public class ChipClusters {
     }
 
     public interface RemoveGroupResponseCallback {
-      void onSuccess(int groupId);
+      void onSuccess(int status, int groupId);
 
       void onError(Exception error);
     }
 
     public interface ViewGroupResponseCallback {
-      void onSuccess(int groupId, String groupName);
+      void onSuccess(int status, int groupId, String groupName);
 
       void onError(Exception error);
     }
@@ -2917,7 +2923,7 @@ public class ChipClusters {
     private native void sendKey(long chipClusterPtr, SendKeyResponseCallback callback, int keyCode);
 
     public interface SendKeyResponseCallback {
-      void onSuccess();
+      void onSuccess(int status);
 
       void onError(Exception error);
     }
@@ -3571,6 +3577,7 @@ public class ChipClusters {
 
     public interface QueryImageResponseCallback {
       void onSuccess(
+          int status,
           long delayedActionTime,
           String imageURI,
           long softwareVersion,
@@ -4127,13 +4134,13 @@ public class ChipClusters {
         long chipClusterPtr, ViewSceneResponseCallback callback, int groupId, int sceneId);
 
     public interface AddSceneResponseCallback {
-      void onSuccess(int groupId, int sceneId);
+      void onSuccess(int status, int groupId, int sceneId);
 
       void onError(Exception error);
     }
 
     public interface GetSceneMembershipResponseCallback {
-      void onSuccess(int capacity, int groupId, int sceneCount
+      void onSuccess(int status, int capacity, int groupId, int sceneCount
           // sceneList: /* TYPE WARNING: array array defaults to */ uint8_t *
           // Conversion from this type to Java is not properly implemented yet
           );
@@ -4142,25 +4149,25 @@ public class ChipClusters {
     }
 
     public interface RemoveAllScenesResponseCallback {
-      void onSuccess(int groupId);
+      void onSuccess(int status, int groupId);
 
       void onError(Exception error);
     }
 
     public interface RemoveSceneResponseCallback {
-      void onSuccess(int groupId, int sceneId);
+      void onSuccess(int status, int groupId, int sceneId);
 
       void onError(Exception error);
     }
 
     public interface StoreSceneResponseCallback {
-      void onSuccess(int groupId, int sceneId);
+      void onSuccess(int status, int groupId, int sceneId);
 
       void onError(Exception error);
     }
 
     public interface ViewSceneResponseCallback {
-      void onSuccess(int groupId, int sceneId, int transitionTime, String sceneName
+      void onSuccess(int status, int groupId, int sceneId, int transitionTime, String sceneName
           // extensionFieldSets: /* TYPE WARNING: array array defaults to */ uint8_t *
           // Conversion from this type to Java is not properly implemented yet
           );
@@ -4381,7 +4388,7 @@ public class ChipClusters {
         long chipClusterPtr, NavigateTargetResponseCallback callback, int target, String data);
 
     public interface NavigateTargetResponseCallback {
-      void onSuccess(String data);
+      void onSuccess(int status, String data);
 
       void onError(Exception error);
     }

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -316,7 +316,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             env->DeleteGlobalRef(javaCallbackRef);
         };
 
-        static void CallbackFn(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
+        static void CallbackFn(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
         {
             StackUnlockGuard unlockGuard(JniReferences::GetInstance().GetStackLock());
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -325,14 +325,12 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             jmethodID javaMethod;
             CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback * cppCallback = nullptr;
             {{#chip_cluster_response_arguments}}
-            {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
             {{else if (isShortString type)}}
             // ByteSpan is not properly returned yet, temporarily use empty string
             UtfString {{asSymbol label}}Str(env, "");
             {{/if}}
-            {{/unless}}
             {{/chip_cluster_response_arguments}}
 
             VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
@@ -343,11 +341,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             javaCallbackRef = cppCallback->javaCallbackRef;
             VerifyOrExit(javaCallbackRef != nullptr, err = CHIP_NO_ERROR);
 
-            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type}}{{/if}}{{/unless}}{{/chip_cluster_response_arguments}})V", &javaMethod);
+            err = JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "({{#chip_cluster_response_arguments}}{{#if isArray}}{{else if (isOctetString type)}}[B{{else if (isShortString type)}}Ljava/lang/String;{{else}}{{asJniSignature type}}{{/if}}{{/chip_cluster_response_arguments}})V", &javaMethod);
             SuccessOrExit(err);
 
             {{#chip_cluster_response_arguments}}
-            {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             {{asSymbol label}}Arr = env->NewByteArray({{asSymbol label}}.size());
             VerifyOrExit({{asSymbol label}}Arr != nullptr, err = CHIP_ERROR_NO_MEMORY);
@@ -355,12 +352,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             env->SetByteArrayRegion({{asSymbol label}}Arr, 0, {{asSymbol label}}.size(), reinterpret_cast<const jbyte *>({{asSymbol label}}.data()));
             VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
             {{/if}}
-            {{/unless}}
             {{/chip_cluster_response_arguments}}
 
             env->CallVoidMethod(javaCallbackRef, javaMethod
                 {{#chip_cluster_response_arguments}}
-                {{#unless (isStrEqual label "status")}}
                 {{#if isArray}}
                 // {{asSymbol label}}: {{asUnderlyingZclType type}}
                 // Conversion from this type to Java is not properly implemented yet
@@ -371,16 +366,13 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
                 {{else}}
                 , static_cast<{{asJniBasicTypeForZclType type}}>({{asSymbol label}})
                 {{/if}}
-                {{/unless}}
                 {{/chip_cluster_response_arguments}}
             );
 
             {{#chip_cluster_response_arguments}}
-            {{#unless (isStrEqual label "status")}}
             {{#if (isOctetString type)}}
             env->DeleteLocalRef({{asSymbol label}}Arr);
             {{/if}}
-            {{/unless}}
             {{/chip_cluster_response_arguments}}
 
         exit:

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -96,7 +96,6 @@ public class ChipClusters {
     public interface {{asCamelCased name false}}Callback {
       void onSuccess(
 {{#chip_cluster_response_arguments}}
-{{#unless (isStrEqual label "status")}}
 {{#if isArray}}
       // {{asSymbol label}}: {{asUnderlyingZclType type}}
       // Conversion from this type to Java is not properly implemented yet
@@ -107,7 +106,6 @@ public class ChipClusters {
 {{else}}
       {{omitCommaForFirstNonStatusCommand parent.id index}}{{asJavaBasicTypeForZclType type false}} {{asSymbol label}}
 {{/if}}
-{{/unless}}
 {{/chip_cluster_response_arguments}}
       );
       

--- a/src/controller/java/templates/helper.js
+++ b/src/controller/java/templates/helper.js
@@ -180,7 +180,7 @@ function omitCommaForFirstNonStatusCommand(id, index)
                     .catch(err => console.log(err))
                     .then((result) => {
                       // Currently, we omit array types, so don't count it as a valid non-status command.
-                      let firstNonStatusCommandIndex = result.findIndex((command) => command.label != "status" && !command.isArray);
+                      let firstNonStatusCommandIndex = result.findIndex((command) => !command.isArray);
                       if (firstNonStatusCommandIndex == -1 || firstNonStatusCommandIndex != index) {
                         return ", ";
                       }

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -463,13 +463,14 @@ public:
 
     ~CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
     {
         CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge * callback
             = reinterpret_cast<CHIPApplicationLauncherClusterLaunchAppResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"data" : [NSString stringWithFormat:@"%s", data],
                 });
                 callback->Cancel();
@@ -561,13 +562,15 @@ public:
 
     ~CHIPDoorLockClusterClearAllPinsResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearAllPinsResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearAllPinsResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -591,13 +594,15 @@ public:
 
     ~CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearAllRfidsResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -621,13 +626,15 @@ public:
 
     ~CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearHolidayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -650,13 +657,15 @@ public:
 
     ~CHIPDoorLockClusterClearPinResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearPinResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearPinResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -679,13 +688,15 @@ public:
 
     ~CHIPDoorLockClusterClearRfidResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearRfidResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearRfidResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -709,13 +720,15 @@ public:
 
     ~CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearWeekdayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -739,13 +752,15 @@ public:
 
     ~CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterClearYeardayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -769,8 +784,8 @@ public:
 
     ~CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(
-        void * context, uint8_t scheduleId, uint32_t localStartTime, uint32_t localEndTime, uint8_t operatingModeDuringHoliday)
+    static void CallbackFn(void * context, uint8_t scheduleId, uint8_t status, uint32_t localStartTime, uint32_t localEndTime,
+        uint8_t operatingModeDuringHoliday)
     {
         CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterGetHolidayScheduleResponseCallbackBridge *>(context);
@@ -778,6 +793,7 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
                     @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"localStartTime" : [NSNumber numberWithUnsignedLong:localStartTime],
                     @"localEndTime" : [NSNumber numberWithUnsignedLong:localEndTime],
                     @"operatingModeDuringHoliday" : [NSNumber numberWithUnsignedChar:operatingModeDuringHoliday],
@@ -944,7 +960,7 @@ public:
 
     ~CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t daysMask, uint8_t startHour,
+    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint8_t daysMask, uint8_t startHour,
         uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
     {
         CHIPDoorLockClusterGetWeekdayScheduleResponseCallbackBridge * callback
@@ -954,6 +970,7 @@ public:
                 callback->mHandler(nil, @ {
                     @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
                     @"userId" : [NSNumber numberWithUnsignedShort:userId],
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"daysMask" : [NSNumber numberWithUnsignedChar:daysMask],
                     @"startHour" : [NSNumber numberWithUnsignedChar:startHour],
                     @"startMinute" : [NSNumber numberWithUnsignedChar:startMinute],
@@ -983,7 +1000,8 @@ public:
 
     ~CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t scheduleId, uint16_t userId, uint32_t localStartTime, uint32_t localEndTime)
+    static void CallbackFn(
+        void * context, uint8_t scheduleId, uint16_t userId, uint8_t status, uint32_t localStartTime, uint32_t localEndTime)
     {
         CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterGetYeardayScheduleResponseCallbackBridge *>(context);
@@ -992,6 +1010,7 @@ public:
                 callback->mHandler(nil, @ {
                     @"scheduleId" : [NSNumber numberWithUnsignedChar:scheduleId],
                     @"userId" : [NSNumber numberWithUnsignedShort:userId],
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"localStartTime" : [NSNumber numberWithUnsignedLong:localStartTime],
                     @"localEndTime" : [NSNumber numberWithUnsignedLong:localEndTime],
                 });
@@ -1017,13 +1036,15 @@ public:
 
     ~CHIPDoorLockClusterLockDoorResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterLockDoorResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterLockDoorResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1047,13 +1068,15 @@ public:
 
     ~CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetHolidayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1076,13 +1099,15 @@ public:
 
     ~CHIPDoorLockClusterSetPinResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetPinResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetPinResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1105,13 +1130,15 @@ public:
 
     ~CHIPDoorLockClusterSetRfidResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetRfidResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetRfidResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1134,13 +1161,15 @@ public:
 
     ~CHIPDoorLockClusterSetUserTypeResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetUserTypeResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetUserTypeResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1164,13 +1193,15 @@ public:
 
     ~CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetWeekdayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1194,13 +1225,15 @@ public:
 
     ~CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterSetYeardayScheduleResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1223,13 +1256,15 @@ public:
 
     ~CHIPDoorLockClusterUnlockDoorResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterUnlockDoorResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterUnlockDoorResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1253,13 +1288,15 @@ public:
 
     ~CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge * callback
             = reinterpret_cast<CHIPDoorLockClusterUnlockWithTimeoutResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -1381,13 +1418,14 @@ public:
 
     ~CHIPGroupsClusterAddGroupResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         CHIPGroupsClusterAddGroupResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGroupsClusterAddGroupResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                 });
                 callback->Cancel();
@@ -1448,13 +1486,14 @@ public:
 
     ~CHIPGroupsClusterRemoveGroupResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         CHIPGroupsClusterRemoveGroupResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGroupsClusterRemoveGroupResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                 });
                 callback->Cancel();
@@ -1479,13 +1518,14 @@ public:
 
     ~CHIPGroupsClusterViewGroupResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t * groupName)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t * groupName)
     {
         CHIPGroupsClusterViewGroupResponseCallbackBridge * callback
             = reinterpret_cast<CHIPGroupsClusterViewGroupResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"groupName" : [NSString stringWithFormat:@"%s", groupName],
                 });
@@ -1543,13 +1583,15 @@ public:
 
     ~CHIPKeypadInputClusterSendKeyResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context)
+    static void CallbackFn(void * context, uint8_t status)
     {
         CHIPKeypadInputClusterSendKeyResponseCallbackBridge * callback
             = reinterpret_cast<CHIPKeypadInputClusterSendKeyResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
-                callback->mHandler(nil, @ {});
+                callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
+                });
                 callback->Cancel();
                 delete callback;
             });
@@ -2228,7 +2270,7 @@ public:
 
     ~CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
+    static void CallbackFn(void * context, uint8_t status, uint32_t delayedActionTime, uint8_t * imageURI, uint32_t softwareVersion,
         chip::ByteSpan updateToken, bool userConsentNeeded, chip::ByteSpan metadataForRequestor)
     {
         CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge * callback
@@ -2236,6 +2278,7 @@ public:
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"delayedActionTime" : [NSNumber numberWithUnsignedLong:delayedActionTime],
                     @"imageURI" : [NSString stringWithFormat:@"%s", imageURI],
                     @"softwareVersion" : [NSNumber numberWithUnsignedLong:softwareVersion],
@@ -2364,13 +2407,14 @@ public:
 
     ~CHIPScenesClusterAddSceneResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         CHIPScenesClusterAddSceneResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterAddSceneResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
                 });
@@ -2397,7 +2441,7 @@ public:
 
     ~CHIPScenesClusterGetSceneMembershipResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
+    static void CallbackFn(void * context, uint8_t status, uint8_t capacity, uint16_t groupId, uint8_t sceneCount,
         /* TYPE WARNING: array array defaults to */ uint8_t * sceneList)
     {
         CHIPScenesClusterGetSceneMembershipResponseCallbackBridge * callback
@@ -2405,6 +2449,7 @@ public:
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"capacity" : [NSNumber numberWithUnsignedChar:capacity],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneCount" : [NSNumber numberWithUnsignedChar:sceneCount],
@@ -2434,13 +2479,14 @@ public:
 
     ~CHIPScenesClusterRemoveAllScenesResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId)
     {
         CHIPScenesClusterRemoveAllScenesResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterRemoveAllScenesResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                 });
                 callback->Cancel();
@@ -2465,13 +2511,14 @@ public:
 
     ~CHIPScenesClusterRemoveSceneResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         CHIPScenesClusterRemoveSceneResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterRemoveSceneResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
                 });
@@ -2497,13 +2544,14 @@ public:
 
     ~CHIPScenesClusterStoreSceneResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId)
     {
         CHIPScenesClusterStoreSceneResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterStoreSceneResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
                 });
@@ -2529,14 +2577,15 @@ public:
 
     ~CHIPScenesClusterViewSceneResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, uint8_t * sceneName,
-        /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
+    static void CallbackFn(void * context, uint8_t status, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
+        uint8_t * sceneName, /* TYPE WARNING: array array defaults to */ uint8_t * extensionFieldSets)
     {
         CHIPScenesClusterViewSceneResponseCallbackBridge * callback
             = reinterpret_cast<CHIPScenesClusterViewSceneResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"groupId" : [NSNumber numberWithUnsignedShort:groupId],
                     @"sceneId" : [NSNumber numberWithUnsignedChar:sceneId],
                     @"transitionTime" : [NSNumber numberWithUnsignedShort:transitionTime],
@@ -2601,13 +2650,14 @@ public:
 
     ~CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge() {};
 
-    static void CallbackFn(void * context, uint8_t * data)
+    static void CallbackFn(void * context, uint8_t status, uint8_t * data)
     {
         CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge * callback
             = reinterpret_cast<CHIPTargetNavigatorClusterNavigateTargetResponseCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @ {
+                    @"status" : [NSNumber numberWithUnsignedChar:status],
                     @"data" : [NSString stringWithFormat:@"%s", data],
                 });
                 callback->Cancel();

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -425,7 +425,7 @@ public:
 
     ~CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge() {};
 
-    static void CallbackFn(void * context{{#chip_cluster_response_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/chip_cluster_response_arguments}})
+    static void CallbackFn(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
     {
         CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge * callback = reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackBridge *>(context);
         if (callback && callback->mQueue)
@@ -433,7 +433,6 @@ public:
             dispatch_async(callback->mQueue, ^{
                 callback->mHandler(nil, @{
                   {{#chip_cluster_response_arguments}}
-                  {{#unless (isStrEqual label "status")}}
                   {{#if isArray}}
                   // {{asSymbol label}}: {{asUnderlyingZclType type}}
                   // Conversion from this type to Objc is not properly implemented yet
@@ -444,7 +443,6 @@ public:
                   {{else}}
                   @"{{asSymbol label}}": [NSNumber numberWith{{asObjectiveCNumberType label type false}}:{{asSymbol label}}],
                   {{/if}}
-                  {{/unless}}
                   {{/chip_cluster_response_arguments}}
                 });
                 callback->Cancel();


### PR DESCRIPTION
#### Problem
A while ago, when I did the first version of the template, there was some checks on the name of the parameter to see if it is called status and generate some special code for it. There is no need for it anymore and the check has creeped into various places.

#### Change overview
* Remove `{{#unless (isStrEqual label "status")}}` in various templates

#### Testing
`./scripts/tests/test_suites.sh -I 1` locally on Mac.
