### PR TITLE
Replace asCamelCased usage by asUpperCamelCase/asLowerCamelCase

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -121,9 +121,9 @@ static void OnCharStringAttributeResponse(void * context, const chip::ByteSpan v
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
+static void On{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
 {
-    ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
+    ChipLogProgress(chipTool, "{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}");
 
     ModelCommand * command = static_cast<ModelCommand *>(context);
     command->SetCommandExitStatus(CHIP_NO_ERROR);
@@ -135,9 +135,9 @@ static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-static void On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse(void * context, uint16_t count, {{chipType}} * entries)
+static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse(void * context, uint16_t count, {{chipType}} * entries)
 {
-    ChipLogProgress(chipTool, "On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse: %" PRIu16 " entries", count);
+    ChipLogProgress(chipTool, "On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse: %" PRIu16 " entries", count);
 
     for (uint16_t i = 0; i < count; i++)
     {
@@ -175,7 +175,7 @@ static void On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListA
 {{> clusters_header}}
 
 {{#chip_client_clusters}}
-constexpr chip::ClusterId k{{asCamelCased name false}}ClusterId = {{asHex code 4}};
+constexpr chip::ClusterId k{{asUpperCamelCase name}}ClusterId = {{asHex code 4}};
 {{/chip_client_clusters}}
 
 {{#chip_client_clusters}}
@@ -183,23 +183,23 @@ constexpr chip::ClusterId k{{asCamelCased name false}}ClusterId = {{asHex code 4
 
 {{#chip_cluster_commands}}
 /*
- * Command {{asCamelCased name false}}
+ * Command {{asUpperCamelCase name}}
  */
-class {{asCamelCased clusterName false}}{{asCamelCased name false}}: public ModelCommand
+class {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    {{asCamelCased clusterName false}}{{asCamelCased name false}}(): ModelCommand("{{asDelimitedCommand name}}")
+    {{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}(): ModelCommand("{{asDelimitedCommand name}}")
     {
         {{#chip_cluster_command_arguments}}
         {{#if (isString type)}}
-        AddArgument("{{asCamelCased label false}}", &m{{asCamelCased label false}});
+        AddArgument("{{asUpperCamelCase label}}", &m{{asUpperCamelCase label}});
         {{else}}
-        AddArgument("{{asCamelCased label false}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asCamelCased label false}});
+        AddArgument("{{asUpperCamelCase label}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asUpperCamelCase label}});
         {{/if}}
         {{/chip_cluster_command_arguments}}
         ModelCommand::AddArguments();
     }
-    ~{{asCamelCased clusterName false}}{{asCamelCased name false}}()
+    ~{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}()
     {
       delete onSuccessCallback;
       delete onFailureCallback;
@@ -209,23 +209,23 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command ({{asHex code 2}}) on endpoint %" PRIu8, endpointId);
 
-        chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asCamelCased label false}}), strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_cluster_command_arguments}});
+        return cluster.{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(m{{asUpperCamelCase label}}), strlen(m{{asUpperCamelCase label}})){{else}}m{{asUpperCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
     }
 
 private:
     {{#if hasSpecificResponse}}
-    chip::Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback> * onSuccessCallback = new chip::Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback>(On{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}, this);
+    chip::Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Callback> * onSuccessCallback = new chip::Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Callback>(On{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}, this);
     {{else}}
     chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback = new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
     {{/if}}
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback = new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
     {{#chip_cluster_command_arguments}}
     {{#if (isCharString type)}}
-    char * m{{asCamelCased label false}};
+    char * m{{asUpperCamelCase label}};
     {{else}}
-    {{chipType}} m{{asCamelCased label false}};
+    {{chipType}} m{{asUpperCamelCase label}};
     {{/if}}
     {{/chip_cluster_command_arguments}}
 };
@@ -235,15 +235,15 @@ private:
 /*
  * Discover Attributes
  */
-class Discover{{asCamelCased name false}}Attributes: public ModelCommand
+class Discover{{asUpperCamelCase name}}Attributes: public ModelCommand
 {
 public:
-    Discover{{asCamelCased name false}}Attributes(): ModelCommand("discover")
+    Discover{{asUpperCamelCase name}}Attributes(): ModelCommand("discover")
     {
         ModelCommand::AddArguments();
     }
 
-    ~Discover{{asCamelCased name false}}Attributes()
+    ~Discover{{asUpperCamelCase name}}Attributes()
     {
       delete onSuccessCallback;
       delete onFailureCallback;
@@ -253,7 +253,7 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x0C) on endpoint %" PRIu8, endpointId);
 
-        chip::Controller::{{asCamelCased name false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase name}}Cluster cluster;
         cluster.Associate(device, endpointId);
         return cluster.DiscoverAttributes(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
     }
@@ -265,18 +265,18 @@ private:
 
 {{#chip_server_cluster_attributes}}
 /*
- * Attribute {{asCamelCased name false}}
+ * Attribute {{asUpperCamelCase name}}
  */
-class Read{{asCamelCased parent.name false}}{{asCamelCased name false}}: public ModelCommand
+class Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    Read{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("read")
+    Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("read")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         ModelCommand::AddArguments();
     }
 
-    ~Read{{asCamelCased parent.name false}}{{asCamelCased name false}}()
+    ~Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
     {
       delete onSuccessCallback;
       delete onFailureCallback;
@@ -286,14 +286,14 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x00) on endpoint %" PRIu8, endpointId);
 
-        chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.ReadAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
+        return cluster.ReadAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
     }
 
 private:
 {{#if isList}}
-    chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>(On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse, this);
+    chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse, this);
 {{else}}
     chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
 {{/if}}
@@ -301,12 +301,12 @@ private:
 };
 
 {{#if isWritableAttribute}}
-class Write{{asCamelCased parent.name false}}{{asCamelCased name false}}: public ModelCommand
+class Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    Write{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("write")
+    Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("write")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         {{#if (isString type)}}
         AddArgument("attr-value", &mValue);
         {{else}}
@@ -315,7 +315,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~Write{{asCamelCased parent.name false}}{{asCamelCased name false}}()
+    ~Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
     {
       delete onSuccessCallback;
       delete onFailureCallback;
@@ -325,9 +325,9 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x01) on endpoint %" PRIu8, endpointId);
 
-        chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.WriteAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)){{else}}mValue{{/if}});
+        return cluster.WriteAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), {{#if (isCharString type)}} chip::ByteSpan(chip::Uint8::from_char(mValue), strlen(mValue)){{else}}mValue{{/if}});
     }
 
 private:
@@ -342,12 +342,12 @@ private:
 
 {{/if}}
 {{#if isReportableAttribute}}
-class Report{{asCamelCased parent.name false}}{{asCamelCased name false}}: public ModelCommand
+class Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}: public ModelCommand
 {
 public:
-    Report{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("report")
+    Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}(): ModelCommand("report")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asUpperCamelCase name)}}");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
         {{#if isAnalog}}
@@ -356,7 +356,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    ~Report{{asCamelCased parent.name false}}{{asCamelCased name false}}()
+    ~Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}()
     {
       delete onSuccessCallback;
       delete onFailureCallback;
@@ -367,16 +367,16 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 4}}) command (0x06) on endpoint %" PRIu8, endpointId);
 
-        chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
         cluster.Associate(device, endpointId);
 
-        CHIP_ERROR err = cluster.ReportAttribute{{asCamelCased name false}}(onReportCallback->Cancel());
+        CHIP_ERROR err = cluster.ReportAttribute{{asUpperCamelCase name}}(onReportCallback->Cancel());
         if (err != CHIP_NO_ERROR)
         {
             return err;
         }
 
-        return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval, mMaxInterval{{#if isAnalog}}, mChange{{/if}});
+        return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval, mMaxInterval{{#if isAnalog}}, mChange{{/if}});
     }
 
 private:
@@ -398,22 +398,22 @@ private:
 | Register all Clusters commands                                               |
 \*----------------------------------------------------------------------------*/
 {{#chip_client_clusters}}
-void registerCluster{{asCamelCased name false}}(Commands & commands)
+void registerCluster{{asUpperCamelCase name}}(Commands & commands)
 {
-    const char * clusterName = "{{asCamelCased name false}}";
+    const char * clusterName = "{{asUpperCamelCase name}}";
 
     commands_list clusterCommands = {
         {{#chip_cluster_commands}}
-        make_unique<{{asCamelCased clusterName false}}{{asCamelCased name false}}>(), //
+        make_unique<{{asUpperCamelCase clusterName}}{{asUpperCamelCase name}}>(), //
         {{/chip_cluster_commands}}
-        make_unique<Discover{{asCamelCased name false}}Attributes>(), //
+        make_unique<Discover{{asUpperCamelCase name}}Attributes>(), //
         {{#chip_server_cluster_attributes}}
-        make_unique<Read{{asCamelCased parent.name false}}{{asCamelCased name false}}>(), //
+        make_unique<Read{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{#if isWritableAttribute}}
-        make_unique<Write{{asCamelCased parent.name false}}{{asCamelCased name false}}>(), //
+        make_unique<Write{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
         {{#if isReportableAttribute}}
-        make_unique<Report{{asCamelCased parent.name false}}{{asCamelCased name false}}>(), //
+        make_unique<Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}>(), //
         {{/if}}
         {{/chip_server_cluster_attributes}}
     };
@@ -425,6 +425,6 @@ void registerCluster{{asCamelCased name false}}(Commands & commands)
 void registerClusters(Commands & commands)
 {
 {{#chip_client_clusters}}
-    registerCluster{{asCamelCased name false}}(commands);
+    registerCluster{{asUpperCamelCase name}}(commands);
 {{/chip_client_clusters}}
 }

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -23,7 +23,7 @@ class {{filename}}: public TestCommand
       {
         {{#chip_tests_items}}
         case {{index}}:
-          err = TestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}();
+          err = TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}();
           break;
         {{/chip_tests_items}}
       }
@@ -46,16 +46,16 @@ class {{filename}}: public TestCommand
 
     {{#chip_tests_items}}
     // Test {{label}}
-    using SuccessCallback_{{index}} = void (*)(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asCamelCased name true}}{{/chip_tests_item_response_parameters}});
-    chip::Callback::Callback<SuccessCallback_{{index}}> mOnSuccessCallback_{{index}} { OnTestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}_SuccessResponse, this };
-    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_{{index}} { OnTestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}_FailureResponse, this };
+    using SuccessCallback_{{index}} = void (*)(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
+    chip::Callback::Callback<SuccessCallback_{{index}}> mOnSuccessCallback_{{index}} { OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_SuccessResponse, this };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_{{index}} { OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_FailureResponse, this };
     bool mIsFailureExpected_{{index}} = {{response.error}};
 
-    CHIP_ERROR TestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}()
+    CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
     {
         ChipLogProgress(chipTool, "{{cluster}} - {{label}}: Sending command...");
 
-        chip::Controller::{{asCamelCased cluster false}}Cluster cluster;
+        chip::Controller::{{asUpperCamelCase cluster}}Cluster cluster;
         cluster.Associate(mDevice, {{endpoint}});
 
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -63,23 +63,23 @@ class {{filename}}: public TestCommand
         {{#if isCommand}}
         {{#chip_tests_item_parameters}}
         {{#if (isString type)}}
-        {{chipType}} {{asCamelCased name true}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"));
+        {{chipType}} {{asLowerCamelCase name}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"));
         {{else}}
-        {{chipType}} {{asCamelCased name true}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
+        {{chipType}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
         {{/if}}
         {{/chip_tests_item_parameters}}
-        err = cluster.{{asCamelCased command false}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(){{#chip_tests_item_parameters}}, {{asCamelCased name true}}Argument{{/chip_tests_item_parameters}});
+        err = cluster.{{asUpperCamelCase command}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(){{#chip_tests_item_parameters}}, {{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}});
         {{else if isReadAttribute}}
-        err = cluster.ReadAttribute{{asCamelCased attribute false}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel());
+        err = cluster.ReadAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel());
         {{else if isWriteAttribute}}
         {{#chip_tests_item_parameters}}
         {{#if (isString type)}}
-        {{chipType}} {{asCamelCased name true}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"));
+        {{chipType}} {{asLowerCamelCase name}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{definedValue}}"), strlen("{{definedValue}}"));
         {{else}}
-        {{chipType}} {{asCamelCased name true}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
+        {{chipType}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
         {{/if}}
         {{/chip_tests_item_parameters}}
-        err = cluster.WriteAttribute{{asCamelCased attribute false}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(), {{#chip_tests_item_parameters}}{{asCamelCased name true}}Argument{{/chip_tests_item_parameters}});
+        err = cluster.WriteAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(), {{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}});
         {{else}}
         err = CHIP_ERROR_NOT_IMPLEMENTED;
         {{/if}}
@@ -87,7 +87,7 @@ class {{filename}}: public TestCommand
         return err;
     }
 
-    static void OnTestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_FailureResponse(void * context, uint8_t status)
     {
         ChipLogProgress(chipTool, "{{cluster}} - {{label}}: Failure Response");
 
@@ -109,7 +109,7 @@ class {{filename}}: public TestCommand
         runner->NextTest();
     }
 
-    static void OnTestSendCluster{{asCamelCased cluster false}}Command{{asCamelCased command false}}_{{index}}_SuccessResponse(void * context {{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asCamelCased name true}}{{/chip_tests_item_response_parameters}})
+    static void OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_SuccessResponse(void * context {{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}})
     {
         ChipLogProgress(chipTool, "{{cluster}} - {{label}}: Success Response");
 
@@ -133,10 +133,10 @@ class {{filename}}: public TestCommand
         }
         {{else}}
         {{#if (isString type)}}
-        {{chipType}} {{asCamelCased name true}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{expectedValue}}"), strlen("{{expectedValue}}"));
-        if (!{{asCamelCased name true}}.data_equal({{asCamelCased name true}}Argument))
+        {{chipType}} {{asLowerCamelCase name}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{expectedValue}}"), strlen("{{expectedValue}}"));
+        if (!{{asLowerCamelCase name}}.data_equal({{asLowerCamelCase name}}Argument))
         {{else}}
-        if ({{asCamelCased name true}} != {{expectedValue}}{{asTypeLiteralSuffix chipType}})
+        if ({{asLowerCamelCase name}} != {{expectedValue}}{{asTypeLiteralSuffix chipType}})
         {{/if}}
         {
             ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
@@ -147,26 +147,26 @@ class {{filename}}: public TestCommand
         {{/if}}
         {{#if hasExpectedConstraints}}
         {{#if expectedConstraints.type}}
-        ChipLogError(chipTool, "Warning: {{asCamelCased name true}} type checking is not implemented yet. Expected type: '%s'", "{{expectedConstraints.type}}");
+        ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} type checking is not implemented yet. Expected type: '%s'", "{{expectedConstraints.type}}");
         {{/if}}
 
         {{#if expectedConstraints.format}}
-        ChipLogError(chipTool, "Warning: {{asCamelCased name true}} format checking is not implemented yet. Expected format: '%s'", "{{expectedConstraints.format}}");
+        ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} format checking is not implemented yet. Expected format: '%s'", "{{expectedConstraints.format}}");
         {{/if}}
 
         {{#if expectedConstraints.minLength}}
-          if ({{asCamelCased name true}}.size() < {{expectedConstraints.minLength}})
+          if ({{asLowerCamelCase name}}.size() < {{expectedConstraints.minLength}})
           {
-            ChipLogError(chipTool, "Error: {{asCamelCased name true}} is too short. Min size is {{expectedConstraints.minLength}} but got '%zu'", {{asCamelCased name true}}.size());
+            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too short. Min size is {{expectedConstraints.minLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
           }
         {{/if}}
 
         {{#if expectedConstraints.maxLength}}
-          if ({{asCamelCased name true}}.size() > {{expectedConstraints.maxLength}})
+          if ({{asLowerCamelCase name}}.size() > {{expectedConstraints.maxLength}})
           {
-            ChipLogError(chipTool, "Error: {{asCamelCased name true}} is too long. Max size is {{expectedConstraints.maxLength}} but got '%zu'", {{asCamelCased name true}}.size());
+            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too long. Max size is {{expectedConstraints.maxLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
           }

--- a/examples/chip-tool/templates/reporting-commands.zapt
+++ b/examples/chip-tool/templates/reporting-commands.zapt
@@ -19,7 +19,7 @@ public:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
-    delete onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback;
+    delete onReport{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Callback;
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
@@ -31,7 +31,7 @@ public:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
-        callbacksMgr.AddReportCallback(GetExecContext()->storage->GetRemoteNodeId(), endpointId, {{asHex parent.code 4}}, {{asHex code 4}}, onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback->Cancel());
+        callbacksMgr.AddReportCallback(GetExecContext()->storage->GetRemoteNodeId(), endpointId, {{asHex parent.code 4}}, {{asHex code 4}}, onReport{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Callback->Cancel());
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
@@ -76,7 +76,7 @@ private:
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isReportableAttribute}}
-    chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onReport{{asCamelCased parent.name false}}{{asCamelCased name false}}Callback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
+    chip::Callback::Callback<{{chipCallback.name}}AttributeCallback> * onReport{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Callback = new chip::Callback::Callback<{{chipCallback.name}}AttributeCallback>(On{{chipCallback.name}}AttributeResponse, this);
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}

--- a/src/app/zap-templates/partials/cluster_header.zapt
+++ b/src/app/zap-templates/partials/cluster_header.zapt
@@ -1,13 +1,13 @@
 {{pad '/*' 78 '-'}}*\
-{{pad (concat "| Cluster " (asCamelCased name false)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
+{{pad (concat "| Cluster " (asUpperCamelCase name)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
 {{pad "|" 79 '-'}}|
 {{pad "| Commands: " 70 ' '}}{{pad "| " 9 ' '}}|
 {{#chip_cluster_commands}}
-{{pad (concat "| * " (asCamelCased name false)) 70 ' '}}{{pad (concat "|   " (asHex code 2)) 9 ' '}}|
+{{pad (concat "| * " (asUpperCamelCase name)) 70 ' '}}{{pad (concat "|   " (asHex code 2)) 9 ' '}}|
 {{/chip_cluster_commands}}
 {{pad "|" 79 '-'}}|
 {{pad "| Attributes: " 70 ' '}}{{pad "| " 9 ' '}}|
 {{#chip_server_cluster_attributes}}
-{{pad (concat "| * " (asCamelCased name false)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
+{{pad (concat "| * " (asUpperCamelCase name)) 70 ' '}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
 {{/chip_server_cluster_attributes}}
 {{pad '\*' 78 '-'}}*/

--- a/src/app/zap-templates/partials/clusters_header.zapt
+++ b/src/app/zap-templates/partials/clusters_header.zapt
@@ -2,6 +2,6 @@
 {{pad "| Cluster Name" 70 ' '}}{{pad "|   ID" 9 ' '}}|
 {{pad "|" 70 '-'}}{{pad "+" 9 '-'}}|
 {{#chip_clusters}}
-{{pad (concat "| " (asCamelCased name false)) 70  " "}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
+{{pad (concat "| " (asUpperCamelCase name)) 70  " "}}{{pad (concat "| " (asHex code 4)) 9 ' '}}|
 {{/chip_clusters}}
 {{pad '\*' 78 '-'}}*/

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -71,7 +71,7 @@ if (CHIP_END_OF_TLV == TLVError)
 if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && {{zcl_command_arguments_count this.id}} == validArgumentCount)
 {
 {{/if}}
-wasHandled = emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(aEndpointId, apCommandObj{{#zcl_command_arguments}}, {{#if (isCharString type)}}const_cast<uint8_t*>({{asSymbol label}}){{else}}{{asSymbol label}}{{/if}}{{/zcl_command_arguments}});
+wasHandled = emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(aEndpointId, apCommandObj{{#zcl_command_arguments}}, {{#if (isCharString type)}}const_cast<uint8_t*>({{asSymbol label}}){{else}}{{asSymbol label}}{{/if}}{{/zcl_command_arguments}});
 {{#if (zcl_command_arguments_count this.id)}}
 }
 {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -782,7 +782,7 @@ static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t 
 {{#if (chip_server_has_list_attributes)}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAttributeFilter(TLV::TLVReader * tlvData, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
+void {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttributeFilter(TLV::TLVReader * tlvData, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     // TODO: Add actual support for array and lists.
     const uint8_t * message = nullptr;
@@ -824,7 +824,7 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
         {{/if}}
         {{/if}}
     }
-    Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback> * cb = Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>::FromCancelable(onSuccessCallback);
+    Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> * cb = Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>::FromCancelable(onSuccessCallback);
     cb->mCall(cb->mContext, count, data);
 }
 
@@ -835,9 +835,9 @@ void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAtt
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(EndpointId endpoint, app::CommandSender * commandObj{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
+bool emberAf{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(EndpointId endpoint, app::CommandSender * commandObj{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}})
 {
-    ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
+    ChipLogProgress(Zcl, "{{asUpperCamelCase name}}:");
     {{#chip_cluster_response_arguments}}
     {{#if (isOctetString type)}}
     ChipLogProgress(Zcl, "  {{asSymbol label}}: %zu", {{asSymbol label}}.size());
@@ -849,9 +849,9 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
     {{/if}}
     {{/chip_cluster_response_arguments}}
 
-    GET_CLUSTER_RESPONSE_CALLBACKS("{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback");
+    GET_CLUSTER_RESPONSE_CALLBACKS("{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback");
 
-    Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback> * cb = Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>::FromCancelable(onSuccessCallback);
+    Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback> * cb = Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>::FromCancelable(onSuccessCallback);
     cb->mCall(cb->mContext{{#chip_cluster_response_arguments}}, {{asSymbol label}}{{/chip_cluster_response_arguments}});
     return true;
 }

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks.zapt
@@ -67,7 +67,7 @@ typedef void (*ReadReportingConfigurationReceivedCallback)(void* context, uint16
 // Cluster Specific Response Callbacks
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback)(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}});
+typedef void (*{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback)(void * context{{#chip_cluster_response_arguments}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/chip_cluster_response_arguments}});
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 {{/if}}
@@ -76,8 +76,8 @@ typedef void (*{{asCamelCased parent.name false}}Cluster{{asCamelCased name fals
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-void {{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}ListAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccessCallback, chip::Callback::Cancelable * onFailureCallback);
-typedef void (*{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback)(void * context, uint16_t count, {{chipType}} * entries);
+void {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttributeFilter(chip::TLV::TLVReader * data, chip::Callback::Cancelable * onSuccessCallback, chip::Callback::Cancelable * onFailureCallback);
+typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback)(void * context, uint16_t count, {{chipType}} * entries);
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -120,7 +120,7 @@ exit:
 
 {{/chip_cluster_commands}}
 // {{asUpperCamelCase name}} Cluster Attributes
-CHIP_ERROR {{asCamelCased name false}}Cluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
+CHIP_ERROR {{asUpperCamelCase name}}Cluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     COMMAND_HEADER("Discover{{asUpperCamelCase name}}Attributes", {{asUpperCamelCase name}}::Id);
     buf.Put8(kFrameControlGlobalCommand)

--- a/src/app/zap-templates/templates/app/attribute-size-src.zapt
+++ b/src/app/zap-templates/templates/app/attribute-size-src.zapt
@@ -105,20 +105,20 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                     return 0;
                 }
 
-                ByteSpan * {{asCamelCased name}}Span   = reinterpret_cast<ByteSpan *>(write ? src : dest); // {{type}}
-                uint16_t {{asCamelCased name}}RemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
-                if (CHIP_NO_ERROR != (write ? WriteByteSpan(dest + entryOffset, {{asCamelCased name}}RemainingSpace, {{asCamelCased name}}Span) : ReadByteSpan(src + entryOffset, {{asCamelCased name}}RemainingSpace, {{asCamelCased name}}Span)))
+                ByteSpan * {{asLowerCamelCase name}}Span   = reinterpret_cast<ByteSpan *>(write ? src : dest); // {{type}}
+                uint16_t {{asLowerCamelCase name}}RemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
+                if (CHIP_NO_ERROR != (write ? WriteByteSpan(dest + entryOffset, {{asLowerCamelCase name}}RemainingSpace, {{asLowerCamelCase name}}Span) : ReadByteSpan(src + entryOffset, {{asLowerCamelCase name}}RemainingSpace, {{asLowerCamelCase name}}Span)))
                 {
                     ChipLogError(Zcl, "Index %" PRId32 " is invalid. Not enough remaining space", index);
                     return 0;
                 }
 
-                if (!CanCastTo<uint16_t>({{asCamelCased name}}Span->size()))
+                if (!CanCastTo<uint16_t>({{asLowerCamelCase name}}Span->size()))
                 {
-                    ChipLogError(Zcl, "Span size %zu is too large", {{asCamelCased name}}Span->size());
+                    ChipLogError(Zcl, "Span size %zu is too large", {{asLowerCamelCase name}}Span->size());
                     return 0;
                 }
-                entryLength = static_cast<uint16_t>({{asCamelCased name}}Span->size());
+                entryLength = static_cast<uint16_t>({{asLowerCamelCase name}}Span->size());
                 {{else}}
                 copyListMember(dest, src, write, &entryOffset, entryLength); // {{type}}
                 {{/if}}

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -13,7 +13,7 @@ void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
     {
     {{#all_user_clusters_names}}
      case ZCL_{{asDelimitedMacro define}}_ID :
-        emberAf{{asCamelCased name false}}ClusterInitCallback(endpoint);
+        emberAf{{asUpperCamelCase name}}ClusterInitCallback(endpoint);
         break;
     {{/all_user_clusters_names}}
     default:
@@ -23,7 +23,7 @@ void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
 }
 
 {{#all_user_clusters_names}}
-void __attribute__((weak)) emberAf{{asCamelCased name false}}ClusterInitCallback(EndpointId endpoint)
+void __attribute__((weak)) emberAf{{asUpperCamelCase name}}ClusterInitCallback(EndpointId endpoint)
 {
     // To prevent warning
     (void) endpoint;

--- a/src/app/zap-templates/templates/app/ids/Commands.zapt
+++ b/src/app/zap-templates/templates/app/ids/Commands.zapt
@@ -22,7 +22,7 @@ static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode
 
 {{#zcl_commands}}
 {{#first}}
-namespace {{asCamelCased parent.label false}} {
+namespace {{asUpperCamelCase parent.label}} {
 namespace Commands {
 namespace Ids {
 {{/first}}
@@ -30,7 +30,7 @@ static constexpr CommandId {{asUpperCamelCase label}} = {{asMEI manufacturerCode
 {{#last}}
 } // namespace Ids
 } // namespace Commands
-} // namespace {{asCamelCased parent.label false}}
+} // namespace {{asUpperCamelCase parent.label}}
 {{/last}}
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -37,9 +37,9 @@ namespace clusters {
 
 {{#all_user_clusters}}
 {{#if (user_cluster_has_enabled_command name side)}}
-namespace {{asCamelCased name false}} {
+namespace {{asUpperCamelCase name}} {
 
-void Dispatch{{asCamelCased side false}}Command({{#if (isServer side)}}CommandHandler{{else}}CommandSender{{/if}} * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
+void Dispatch{{asUpperCamelCase side}}Command({{#if (isServer side)}}CommandHandler{{else}}CommandSender{{/if}} * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {{#chip_available_cluster_commands}}
     {{#first}}
@@ -111,7 +111,7 @@ void DispatchSingleClusterCommand(ClusterId aClusterId, CommandId aCommandId, En
     {{#chip_server_clusters}}
     {{#if (user_cluster_has_enabled_command name side)}}
     case Clusters::{{asUpperCamelCase name}}::Id:
-        clusters::{{asCamelCased name false}}::Dispatch{{asCamelCased side false}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
+        clusters::{{asUpperCamelCase name}}::Dispatch{{asUpperCamelCase side}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
     {{/if}}
     {{/chip_server_clusters}}
@@ -145,7 +145,7 @@ void DispatchSingleClusterResponseCommand(ClusterId aClusterId, CommandId aComma
     {{#chip_client_clusters}}
     {{#if (user_cluster_has_enabled_command name side)}}
     case Clusters::{{asUpperCamelCase name}}::Id:
-        clusters::{{asCamelCased name false}}::Dispatch{{asCamelCased side false}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
+        clusters::{{asUpperCamelCase name}}::Dispatch{{asUpperCamelCase side}}Command(apCommandObj, aCommandId, aEndPointId, aReader);
         break;
     {{/if}}
     {{/chip_client_clusters}}

--- a/src/controller/java/templates/CHIPClusters-JNI.zapt
+++ b/src/controller/java/templates/CHIPClusters-JNI.zapt
@@ -289,10 +289,10 @@ class CHIP{{chipCallback.name}}AttributeCallback : public Callback::Callback<{{c
 
 {{#chip_client_clusters}}
 {{#chip_cluster_responses}}
-class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback : public Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>
+class CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback : public Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>
 {
     public:
-        CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(jobject javaCallback): Callback::Callback<{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback>(CallbackFn, this)
+        CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback(jobject javaCallback): Callback::Callback<{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback>(CallbackFn, this)
         {
             JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
@@ -305,7 +305,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
                 ChipLogError(Zcl, "Could not create global reference for Java callback");
             }
         }
-        ~CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback()
+        ~CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback()
         {
             JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
@@ -322,7 +322,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
             JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             jobject javaCallbackRef;
             jmethodID javaMethod;
-            CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback * cppCallback = nullptr;
+            CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback * cppCallback = nullptr;
             {{#chip_cluster_response_arguments}}
             {{#if (isOctetString type)}}
             jbyteArray {{asSymbol label}}Arr;
@@ -334,7 +334,7 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
 
             VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
-            cppCallback = reinterpret_cast<CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback *>(context);
+            cppCallback = reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Callback *>(context);
             VerifyOrExit(cppCallback != nullptr, err = CHIP_JNI_ERROR_NULL_OBJECT);
 
             javaCallbackRef = cppCallback->javaCallbackRef;
@@ -394,10 +394,10 @@ class CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Ca
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback : public Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>
+class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback : public Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>
 {
     public:
-        CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback(jobject javaCallback): Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>(CallbackFn, this)
+        CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback(jobject javaCallback): Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(CallbackFn, this)
         {
             JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
             if (env == nullptr) {
@@ -420,7 +420,7 @@ class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}Attribute
 
             VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNI env"));
 
-            std::unique_ptr<CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback> cppCallback(reinterpret_cast<CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback *>(context));
+            std::unique_ptr<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback> cppCallback(reinterpret_cast<CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback *>(context));
 
             // It's valid for javaCallbackRef to be nullptr if the Java code passed in a null callback.
             javaCallbackRef = cppCallback.get()->javaCallbackRef;
@@ -442,12 +442,12 @@ class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}Attribute
 
             {{#if isStruct}}
             jclass attributeClass;
-            err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipClusters${{asCamelCased parent.name false}}Cluster${{asCamelCased name false}}Attribute", attributeClass);
-            VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters${{asCamelCased parent.name false}}Cluster${{asCamelCased name false}}Attribute"));
+            err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipClusters${{asUpperCamelCase parent.name}}Cluster${{asUpperCamelCase name}}Attribute", attributeClass);
+            VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find class chip/devicecontroller/ChipClusters${{asUpperCamelCase parent.name}}Cluster${{asUpperCamelCase name}}Attribute"));
             JniClass attributeJniClass(attributeClass);
             jmethodID attributeCtor = env->GetMethodID(attributeClass, "<init>"
                 , "({{#chip_attribute_list_entryTypes}}{{#if (isString type)}}{{#if (isOctetString type)}}[B{{else}}Ljava/lang/String;{{/if}}{{else}}{{asJniSignature type}}{{/if}}{{/chip_attribute_list_entryTypes}})V");
-            VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find {{asCamelCased name false}}Attribute constructor"));
+            VerifyOrReturn(attributeCtor != nullptr, ChipLogError(Zcl, "Could not find {{asUpperCamelCase name}}Attribute constructor"));
             {{/if}}
 
             for (uint16_t i = 0; i < count; i++)
@@ -455,36 +455,36 @@ class CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}Attribute
                 {{#if isStruct}}
                 {{#chip_attribute_list_entryTypes}}
                 {{#if (isOctetString type)}}
-                jbyteArray {{asCamelCased name true}} = env->NewByteArray(entries[i].{{name}}.size());
-                env->SetByteArrayRegion({{asCamelCased name true}}, 0, entries[i].{{name}}.size(), reinterpret_cast<const jbyte *>(entries[i].{{name}}.data()));
+                jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entries[i].{{name}}.size());
+                env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entries[i].{{name}}.size(), reinterpret_cast<const jbyte *>(entries[i].{{name}}.data()));
                 {{else if (isCharString type)}}
                 // Implement after ByteSpan is emitted instead of uint8_t *.
                 {{else}}
-                {{asJniBasicType type}} {{asCamelCased name true}} = entries[i].{{name}};
+                {{asJniBasicType type}} {{asLowerCamelCase name}} = entries[i].{{name}};
                 {{/if}}
                 {{/chip_attribute_list_entryTypes}}
 
                 jobject attributeObj = env->NewObject(attributeClass, attributeCtor,
                     {{#chip_attribute_list_entryTypes}}
-                    {{asCamelCased name true}}{{#not_last}}, {{/not_last}}
+                    {{asLowerCamelCase name}}{{#not_last}}, {{/not_last}}
                     {{/chip_attribute_list_entryTypes}}
                 );
-                VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create {{asCamelCased name false}}Attribute object"));
+                VerifyOrReturn(attributeObj != nullptr, ChipLogError(Zcl, "Could not create {{asUpperCamelCase name}}Attribute object"));
 
                 env->CallBooleanMethod(arrayListObj, arrayListAddMethod, attributeObj);
                 {{else}}
                 {{#if (isOctetString type)}}
-                jbyteArray {{asCamelCased name true}} = env->NewByteArray(entries[i].size());
-                env->SetByteArrayRegion({{asCamelCased name true}}, 0, entries[i].size(), reinterpret_cast<const jbyte *>(entries[i].data()));
+                jbyteArray {{asLowerCamelCase name}} = env->NewByteArray(entries[i].size());
+                env->SetByteArrayRegion({{asLowerCamelCase name}}, 0, entries[i].size(), reinterpret_cast<const jbyte *>(entries[i].data()));
                 {{else if (isCharString type)}}
                 // Implement after ByteSpan is emitted instead of uint8_t *
                 {{else}}
                 jclass entryTypeCls;
                 JniReferences::GetInstance().GetClassRef(env, "java/lang/{{asJavaBasicTypeForZclType type true}}", entryTypeCls);
                 jmethodID entryTypeCtor = env->GetMethodID(entryTypeCls, "<init>", "({{asJniSignature type}})V");
-                jobject {{asCamelCased name true}} = env->NewObject(entryTypeCls, entryTypeCtor, entries[i]);
+                jobject {{asLowerCamelCase name}} = env->NewObject(entryTypeCls, entryTypeCtor, entries[i]);
                 {{/if}}
-                env->CallBooleanMethod(arrayListObj, arrayListAddMethod, {{asCamelCased name true}});
+                env->CallBooleanMethod(arrayListObj, arrayListAddMethod, {{asLowerCamelCase name}});
                 {{/if}}
             }
 
@@ -510,10 +510,10 @@ JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlo
 }
 
 {{#chip_client_clusters}}
-JNI_METHOD(jlong, {{asCamelCased name false}}Cluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
+JNI_METHOD(jlong, {{asUpperCamelCase name}}Cluster, initWithDevice)(JNIEnv * env, jobject self, jlong devicePtr, jint endpointId)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    {{asCamelCased name false}}Cluster * cppCluster = new {{asCamelCased name false}}Cluster();
+    {{asUpperCamelCase name}}Cluster * cppCluster = new {{asUpperCamelCase name}}Cluster();
 
     cppCluster->Associate(reinterpret_cast<Device *>(devicePtr), endpointId);
     return reinterpret_cast<jlong>(cppCluster);
@@ -521,34 +521,34 @@ JNI_METHOD(jlong, {{asCamelCased name false}}Cluster, initWithDevice)(JNIEnv * e
 
 {{#chip_cluster_commands}}
 {{#if (zcl_command_arguments_count this.id)}}
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_cluster_command_arguments}}{{asJniBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}})
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{#chip_cluster_command_arguments}}{{asJniBasicType type}} {{asLowerCamelCase label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}})
 {{else}}
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, {{asLowerCamelCase name}})(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {{/if}}
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err = CHIP_NO_ERROR;
-    {{asCamelCased ../name false}}Cluster * cppCluster;
+    {{asUpperCamelCase ../name}}Cluster * cppCluster;
     
     {{#chip_cluster_command_arguments}}
     {{#if (isOctetString type)}}
-    JniByteArray {{asCamelCased label}}Arr(env, {{asCamelCased label}});
+    JniByteArray {{asLowerCamelCase label}}Arr(env, {{asLowerCamelCase label}});
     {{else if (isCharString type)}}
-    JniUtfString {{asCamelCased label}}Str(env, {{asCamelCased label}});
+    JniUtfString {{asLowerCamelCase label}}Str(env, {{asLowerCamelCase label}});
     {{/if}}
     {{/chip_cluster_command_arguments}}
     {{#if hasSpecificResponse}}
-    CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback * onSuccess;
+    CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Callback * onSuccess;
     {{else}}
     CHIPDefaultSuccessCallback * onSuccess;
     {{/if}}
     CHIPDefaultFailureCallback * onFailure;
 
-    cppCluster = reinterpret_cast<{{asCamelCased ../name false}}Cluster *>(clusterPtr);
+    cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     VerifyOrExit(cppCluster != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {{#if hasSpecificResponse}}
-    onSuccess = new CHIP{{asCamelCased parent.name false}}Cluster{{asCamelCased responseName false}}Callback(callback);
+    onSuccess = new CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}Callback(callback);
     {{else}}
     onSuccess = new CHIPDefaultSuccessCallback(callback);
     {{/if}}
@@ -556,7 +556,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, {{asCamelCased name}})(J
     onFailure = new CHIPDefaultFailureCallback(callback);
     VerifyOrExit(onFailure != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = cppCluster->{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asCamelCased label}}Arr.data(), {{asCamelCased label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asCamelCased label}}, strlen({{asCamelCased label}}Str.c_str())){{else}}{{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}});
+    err = cppCluster->{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(){{#chip_cluster_command_arguments}}, {{#if (isOctetString type)}}{{asUnderlyingZclType type}}((const uint8_t*) {{asLowerCamelCase label}}Arr.data(), {{asLowerCamelCase label}}Arr.size()){{else if (isCharString type)}}chip::ByteSpan((const uint8_t*) {{asLowerCamelCase label}}, strlen({{asLowerCamelCase label}}Str.c_str())){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}});
     SuccessOrExit(err);
 
 exit: 
@@ -584,11 +584,11 @@ exit:
 {{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}
 
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, read{{asCamelCased name false}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, read{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
 {{#if isList}}
-    CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback * onSuccess = new CHIP{{asCamelCased parent.name false}}{{asCamelCased name false}}AttributeCallback(callback);
+    CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback * onSuccess = new CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback(callback);
 {{else}}
     CHIP{{chipCallback.name}}AttributeCallback * onSuccess = new CHIP{{chipCallback.name}}AttributeCallback(callback);
 {{/if}}
@@ -605,7 +605,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, read{{asCamelCased name 
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    {{asCamelCased ../name false}}Cluster * cppCluster = reinterpret_cast<{{asCamelCased ../name false}}Cluster *>(clusterPtr);
+    {{asUpperCamelCase ../name}}Cluster * cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     if (cppCluster == nullptr) {
         delete onSuccess;
         delete onFailure;
@@ -613,7 +613,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, read{{asCamelCased name 
         return;
     }
 
-    err = cppCluster->ReadAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel());
+    err = cppCluster->ReadAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel());
     if (err != CHIP_NO_ERROR) {
         delete onSuccess;
         delete onFailure;
@@ -622,7 +622,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, read{{asCamelCased name 
 }
 {{#if isWritableAttribute}}
 
-JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, write{{asCamelCased name false}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type}} value)
+JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase name}}Attribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, {{asJniBasicType type}} value)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIPDefaultSuccessCallback * onSuccess = new CHIPDefaultSuccessCallback(callback);
@@ -639,7 +639,7 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, write{{asCamelCased name
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    {{asCamelCased ../name false}}Cluster * cppCluster = reinterpret_cast<{{asCamelCased ../name false}}Cluster *>(clusterPtr);
+    {{asUpperCamelCase ../name}}Cluster * cppCluster = reinterpret_cast<{{asUpperCamelCase ../name}}Cluster *>(clusterPtr);
     if (cppCluster == nullptr) {
         delete onSuccess;
         delete onFailure;
@@ -649,12 +649,12 @@ JNI_METHOD(void, {{asCamelCased ../name false}}Cluster, write{{asCamelCased name
 
     {{#if (isOctetString type)}}
     JniByteArray jniArr(env, value);
-    err = cppCluster->WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) jniArr.data(), jniArr.size()));
+    err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) jniArr.data(), jniArr.size()));
     {{else if (isCharString type)}}
     JniUtfString valueStr(env, value);
-    err = cppCluster->WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) valueStr.c_str(), strlen(valueStr.c_str())));
+    err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), chip::ByteSpan((const uint8_t*) valueStr.c_str(), strlen(valueStr.c_str())));
     {{else}}
-    err = cppCluster->WriteAttribute{{asCamelCased name false}}(onSuccess->Cancel(), onFailure->Cancel(), static_cast<{{chipCallback.type}}>(value));
+    err = cppCluster->WriteAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), static_cast<{{chipCallback.type}}>(value));
     {{/if}}
     if (err != CHIP_NO_ERROR) {
         delete onSuccess;

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -62,8 +62,8 @@ public class ChipClusters {
   }
 
   {{#chip_client_clusters}}
-  public static class {{asCamelCased name false}}Cluster extends BaseChipCluster {
-    public {{asCamelCased name false}}Cluster(long devicePtr, int endpointId) {
+  public static class {{asUpperCamelCase name}}Cluster extends BaseChipCluster {
+    public {{asUpperCamelCase name}}Cluster(long devicePtr, int endpointId) {
       super(devicePtr, endpointId);
     }
 
@@ -72,28 +72,28 @@ public class ChipClusters {
   {{#chip_cluster_commands}}
 
   {{#if (zcl_command_arguments_count this.id)}}
-    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}}) {
+    public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asLowerCamelCase label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}}) {
   {{else}}
-    public void {{asCamelCased name}}({{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback) {
+    public void {{asLowerCamelCase name}}({{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback) {
   {{/if}}
   {{#if (zcl_command_arguments_count this.id)}}
-      {{asCamelCased name}}(chipClusterPtr, callback, {{#chip_cluster_command_arguments}}{{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
+      {{asLowerCamelCase name}}(chipClusterPtr, callback, {{#chip_cluster_command_arguments}}{{asLowerCamelCase label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
   {{else}}
-      {{asCamelCased name}}(chipClusterPtr, callback);
+      {{asLowerCamelCase name}}(chipClusterPtr, callback);
   {{/if}}    
     }
 
   {{/chip_cluster_commands}}
   {{#chip_cluster_commands}}
   {{#if (zcl_command_arguments_count this.id)}}
-    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asCamelCased label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
+    private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback, {{#chip_cluster_command_arguments}}{{asJavaBasicType type}} {{asLowerCamelCase label}}{{#not_last}}, {{/not_last}}{{/chip_cluster_command_arguments}});
   {{else}}
-    private native void {{asCamelCased name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asCamelCased responseName false}}Callback{{else}}DefaultClusterCallback{{/if}} callback);
+    private native void {{asLowerCamelCase name}}(long chipClusterPtr, {{#if hasSpecificResponse}}{{asUpperCamelCase responseName}}Callback{{else}}DefaultClusterCallback{{/if}} callback);
   {{/if}}
 
   {{/chip_cluster_commands}}
   {{#chip_cluster_responses}}
-    public interface {{asCamelCased name false}}Callback {
+    public interface {{asUpperCamelCase name}}Callback {
       void onSuccess(
 {{#chip_cluster_response_arguments}}
 {{#if isArray}}
@@ -117,39 +117,39 @@ public class ChipClusters {
   {{#chip_server_cluster_attributes}}
   {{#if isList}}
   {{#if isStruct}}
-    public static class {{asCamelCased name false}}Attribute {
+    public static class {{asUpperCamelCase name}}Attribute {
     {{#chip_attribute_list_entryTypes}}
       {{#if (isOctetString type)}}
-      public byte[] {{asCamelCased name true}};
+      public byte[] {{asLowerCamelCase name}};
       {{else if (isCharString type)}}
       // Add String member here after ByteSpan is properly emitted in C++ layer
       {{else}}
-      public {{asJavaBasicType label type}} {{asCamelCased name true}};
+      public {{asJavaBasicType label type}} {{asLowerCamelCase name}};
       {{/if}}
     {{/chip_attribute_list_entryTypes}}
 
-      public {{asCamelCased name false}}Attribute(
+      public {{asUpperCamelCase name}}Attribute(
         {{#chip_attribute_list_entryTypes}}
         {{#if (isOctetString type)}}
-        byte[] {{asCamelCased name true}}{{#not_last}},{{/not_last}}
+        byte[] {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{else if (isCharString type)}}
         // Add String field here after ByteSpan is properly emitted in C++ layer
         {{else}}
-        {{asJavaBasicType label type}} {{asCamelCased name true}}{{#not_last}},{{/not_last}}
+        {{asJavaBasicType label type}} {{asLowerCamelCase name}}{{#not_last}},{{/not_last}}
         {{/if}}
         {{/chip_attribute_list_entryTypes}}
       ) {
         {{#chip_attribute_list_entryTypes}}
-        this.{{asCamelCased name true}} = {{asCamelCased name true}};
+        this.{{asLowerCamelCase name}} = {{asLowerCamelCase name}};
         {{/chip_attribute_list_entryTypes}}
       }
     }
 {{/if}}
 
-    public interface {{asCamelCased name false}}AttributeCallback {
+    public interface {{asUpperCamelCase name}}AttributeCallback {
       void onSuccess(List<
       {{#if isStruct}}
-      {{asCamelCased name false}}Attribute
+      {{asUpperCamelCase name}}Attribute
       {{else}}
         {{#if (isOctetString type)}}
         byte[]
@@ -166,34 +166,34 @@ public class ChipClusters {
   {{/chip_server_cluster_attributes}}
   {{#chip_server_cluster_attributes}}
 
-    public void read{{asCamelCased name false}}Attribute(
+    public void read{{asUpperCamelCase name}}Attribute(
 {{#if isList}}
-      {{asCamelCased name false}}AttributeCallback callback
+      {{asUpperCamelCase name}}AttributeCallback callback
 {{else}}
       {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
 {{/if}}
     ) {
-      read{{asCamelCased name false}}Attribute(chipClusterPtr, callback);
+      read{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback);
     }
   {{#if isWritableAttribute}}
 
-    public void write{{asCamelCased name false}}Attribute(DefaultClusterCallback callback, {{asJavaBasicType type}} value) {
-      write{{asCamelCased name false}}Attribute(chipClusterPtr, callback, value);
+    public void write{{asUpperCamelCase name}}Attribute(DefaultClusterCallback callback, {{asJavaBasicType type}} value) {
+      write{{asUpperCamelCase name}}Attribute(chipClusterPtr, callback, value);
     }
   {{/if}}
   {{/chip_server_cluster_attributes}}
   {{#chip_server_cluster_attributes}}
   
-    private native void read{{asCamelCased name false}}Attribute(long chipClusterPtr,
+    private native void read{{asUpperCamelCase name}}Attribute(long chipClusterPtr,
 {{#if isList}}
-      {{asCamelCased name false}}AttributeCallback callback
+      {{asUpperCamelCase name}}AttributeCallback callback
 {{else}}
       {{convertAttributeCallbackTypeToJavaName chipCallback.type}}AttributeCallback callback
 {{/if}}
     );
   {{#if isWritableAttribute}}
 
-    private native void write{{asCamelCased name false}}Attribute(long chipClusterPtr, DefaultClusterCallback callback, {{asJavaBasicType type}} value);
+    private native void write{{asUpperCamelCase name}}Attribute(long chipClusterPtr, DefaultClusterCallback callback, {{asJavaBasicType type}} value);
   {{/if}}
   {{/chip_server_cluster_attributes}}
   }

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -72,13 +72,13 @@ void OnAttributeResponse<bool>(void * /* context */, bool value)
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
 {{#if isList}}
-static void On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse(void * context, uint16_t count, {{chipType}} * entries)
+static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse(void * context, uint16_t count, {{chipType}} * entries)
 {
     ChipLogProgress(Zcl, "  attributeValue: List of length %" PRIu16, count);
     if (gSuccessResponseDelegate != nullptr)
         gSuccessResponseDelegate();
 }
-chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback> g{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback{On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse, nullptr};
+chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> g{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback{On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse, nullptr};
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
@@ -112,58 +112,58 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 }
 
 {{#chip_client_clusters}}
-// Cluster {{asCamelCased name false}}
+// Cluster {{asUpperCamelCase name}}
 
 {{#chip_cluster_commands}}
-chip::ChipError::StorageType chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asCamelCased label}}, uint32_t {{asCamelCased label}}_Len{{else}}{{chipType}} {{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}})
+chip::ChipError::StorageType chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asLowerCamelCase label}}, uint32_t {{asLowerCamelCase label}}_Len{{else}}{{chipType}} {{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asCamelCased clusterName false}}Cluster cluster;
+    chip::Controller::{{asUpperCamelCase clusterName}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.{{asCamelCased name false}}(nullptr, nullptr{{#chip_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asCamelCased label}}, {{asCamelCased label}}_Len){{else}}{{asCamelCased label}}{{/if}}{{/chip_cluster_command_arguments}}).AsInteger();
+    return cluster.{{asUpperCamelCase name}}(nullptr, nullptr{{#chip_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asLowerCamelCase label}}, {{asLowerCamelCase label}}_Len){{else}}{{asLowerCamelCase label}}{{/if}}{{/chip_cluster_command_arguments}}).AsInteger();
 }
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-chip::ChipError::StorageType chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
+chip::ChipError::StorageType chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId /* ZCLgroupId */)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+    chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
 {{#if isList}}
-    return cluster.ReadAttribute{{asCamelCased name false}}(g{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
+    return cluster.ReadAttribute{{asUpperCamelCase name}}(g{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 {{else}}
-    return cluster.ReadAttribute{{asCamelCased name false}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
+    return cluster.ReadAttribute{{asUpperCamelCase name}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 {{/if}}
 }
 
 {{#if isReportableAttribute}}
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
+chip::ChipError::StorageType chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+    chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
 {{#if isList}}
-    chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeCallback>(On{{asCamelCased parent.name false}}{{asCamelCased name false}}ListAttributeResponse, nullptr);
-    return cluster.ConfigureAttribute{{asCamelCased name false}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
+    chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse, nullptr);
+    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
 {{else}}
-    return cluster.ConfigureAttribute{{asCamelCased name false}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
+    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
 {{/if}}
 }
 {{/if}}
 
 {{#if isWritableAttribute}}
-chip::ChipError::StorageType chip_ime_WriteAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId, {{#if (isString type)}} uint8_t * value, size_t len{{else}}{{chipType}} value{{/if}})
+chip::ChipError::StorageType chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId, {{#if (isString type)}} uint8_t * value, size_t len{{else}}{{chipType}} value{{/if}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+    chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
-    return cluster.WriteAttribute{{asCamelCased name false}}(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), {{#if (isString type)}} chip::ByteSpan(value, len){{else}}value{{/if}}).AsInteger();
+    return cluster.WriteAttribute{{asUpperCamelCase name}}(gDefaultSuccessCallback.Cancel(), gDefaultFailureCallback.Cancel(), {{#if (isString type)}} chip::ByteSpan(value, len){{else}}value{{/if}}).AsInteger();
 }
 {{/if}}
 {{/chip_server_cluster_attributes}}
 
-// End of Cluster {{asCamelCased name false}}
+// End of Cluster {{asUpperCamelCase name}}
 {{/chip_client_clusters}}
 
 }

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -14,16 +14,16 @@ class ChipClusters:
 
 {{#chip_client_clusters}}
     _{{asDelimitedMacro name}}_CLUSTER_INFO = {
-            "clusterName": "{{asCamelCased name false}}",
+            "clusterName": "{{asUpperCamelCase name}}",
             "clusterId": {{asHex code 8}},
             "commands": {
 {{#chip_cluster_commands}}
             {{asHex code 8}}: {
                     "commandId": {{asHex code 8}},
-                    "commandName": "{{asCamelCased name false}}",
+                    "commandName": "{{asUpperCamelCase name}}",
                     "args": {
 {{#chip_cluster_command_arguments}}
-                        "{{asCamelCased label}}": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
+                        "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
 {{/chip_cluster_command_arguments}}
                     },
                 },
@@ -32,7 +32,7 @@ class ChipClusters:
             "attributes": {
 {{#chip_server_cluster_attributes}}
                 {{asHex code 8}}: {
-                    "attributeName": "{{asCamelCased name false}}",
+                    "attributeName": "{{asUpperCamelCase name}}",
                     "attributeId": {{asHex code 8}},
                     "type": "{{#if (isCharString type)}}str{{else}}{{asPythonType chipType}}{{/if}}",
                     {{#if isReportableAttribute}}
@@ -55,7 +55,7 @@ class ChipClusters:
 
     _CLUSTER_NAME_DICT = {
 {{#chip_client_clusters}}
-        "{{asCamelCased name false}}": _{{asDelimitedMacro name}}_CLUSTER_INFO,
+        "{{asUpperCamelCase name}}": _{{asDelimitedMacro name}}_CLUSTER_INFO,
 {{/chip_client_clusters}}
     }
 
@@ -117,14 +117,14 @@ class ChipClusters:
 
 {{#chip_client_clusters}}
 {{#chip_cluster_commands}}
-    def Cluster{{asCamelCased clusterName false}}_Command{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments}}, {{asCamelCased label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments}}):
+    def Cluster{{asUpperCamelCase clusterName}}_Command{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}: {{asPythonType chipType}}{{/chip_cluster_command_arguments}}):
 {{#chip_cluster_command_arguments}}
 {{#if (isCharString type)}}
-        {{asCamelCased label}} = {{asCamelCased label}}.encode("utf-8") + b'\x00'
+        {{asLowerCamelCase label}} = {{asLowerCamelCase label}}.encode("utf-8") + b'\x00'
 {{/if}}
 {{/chip_cluster_command_arguments}}
-        return self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(
-                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments}}, {{asCamelCased label}}{{#if (isString type)}}, len({{asCamelCased label}}){{/if}}{{/chip_cluster_command_arguments}}
+        return self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}(
+                device, ZCLendpoint, ZCLgroupid{{#chip_cluster_command_arguments}}, {{asLowerCamelCase label}}{{#if (isString type)}}, len({{asLowerCamelCase label}}){{/if}}{{/chip_cluster_command_arguments}}
         )
 {{/chip_cluster_commands}}
 {{/chip_client_clusters}}
@@ -133,18 +133,18 @@ class ChipClusters:
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_attributes}}
-    def Cluster{{asCamelCased parent.name false}}_ReadAttribute{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
-        return self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(device, ZCLendpoint, ZCLgroupid)
+    def Cluster{{asUpperCamelCase parent.name}}_ReadAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+        return self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLgroupid)
 {{#if isReportableAttribute}}
-    def Cluster{{asCamelCased parent.name false}}_ConfigureAttribute{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(device, ZCLendpoint, minInterval, maxInterval, change)
+    def Cluster{{asUpperCamelCase parent.name}}_ConfigureAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, minInterval, maxInterval, change)
 {{/if}}
 {{#if isWritableAttribute}}
-    def Cluster{{asCamelCased parent.name false}}_WriteAttribute{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: {{ asPythonType chipType }}):
+    def Cluster{{asUpperCamelCase parent.name}}_WriteAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: {{ asPythonType chipType }}):
 {{#if (isCharString type)}}
         value = value.encode("utf-8") + b'\x00'
 {{/if}}
-        return self._chipLib.chip_ime_WriteAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(device, ZCLendpoint, ZCLgroupid, value{{#if (isString type)}}, len(value){{/if}})
+        return self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLgroupid, value{{#if (isString type)}}, len(value){{/if}})
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
@@ -159,25 +159,25 @@ class ChipClusters:
         self._chipLib.chip_ime_SetFailureResponseDelegate.argtypes = [ChipClusters.FAILURE_DELEGATE]
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
 {{#chip_client_clusters}}
-        # Cluster {{asCamelCased name false}}
+        # Cluster {{asUpperCamelCase name}}
 {{#chip_cluster_commands}}
-        # Cluster {{asCamelCased clusterName false}} Command {{asCamelCased name false}}
-        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments}}]
-        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+        # Cluster {{asUpperCamelCase clusterName}} Command {{asUpperCamelCase name}}
+        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_cluster_command_arguments}}]
+        self._chipLib.chip_ime_AppendCommand_{{asUpperCamelCase clusterName}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/chip_cluster_commands}}
 {{#chip_server_cluster_attributes}}
-        # Cluster {{asCamelCased parent.name false}} ReadAttribute {{asCamelCased name false}}
-        self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
-        self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+        # Cluster {{asUpperCamelCase parent.name}} ReadAttribute {{asUpperCamelCase name}}
+        self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{#if isReportableAttribute}}
-        # Cluster {{asCamelCased parent.name false}} ConfigureAttribute {{asCamelCased name false}}
-        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#if isAnalog}}, ctypes.{{asPythonCType chipType}}{{/if}}]
-        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+        # Cluster {{asUpperCamelCase parent.name}} ConfigureAttribute {{asUpperCamelCase name}}
+        self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#if isAnalog}}, ctypes.{{asPythonCType chipType}}{{/if}}]
+        self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/if}}
 {{#if isWritableAttribute}}
-        # Cluster {{asCamelCased parent.name false}} WriteAttribute {{asCamelCased name false}}
-        self._chipLib.chip_ime_WriteAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, {{#if (isString type)}}ctypes.c_char_p, ctypes.c_uint32{{else}}ctypes.{{asPythonCType chipType}}{{/if}}]
-        self._chipLib.chip_ime_WriteAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+        # Cluster {{asUpperCamelCase parent.name}} WriteAttribute {{asUpperCamelCase name}}
+        self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, {{#if (isString type)}}ctypes.c_char_p, ctypes.c_uint32{{else}}ctypes.{{asPythonCType chipType}}{{/if}}]
+        self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}

--- a/src/controller/python/templates/templates.json
+++ b/src/controller/python/templates/templates.json
@@ -4,6 +4,7 @@
     "helpers": [
         "../../../../src/app/zap-templates/partials/helper.js",
         "../../../../src/app/zap-templates/common/StringHelper.js",
+        "../../../../src/app/zap-templates/templates/app/helper.js",
         "../../../../src/app/zap-templates/templates/chip/helper.js",
         "helper.js"
     ],


### PR DESCRIPTION
#### Problem

The `asCamelCased` macro is used in 3 ways: 
 * `asCamelCased name false`
 * `asCamelCased name true`
 * `asCamelCased name`

This is not always easy to spot, and long to type.

#### Change overview
* `asCamelCased name false` => `asUpperCamelCase name`
 * `asCamelCased name true` => `asLowerCamelCase name`
 * `asCamelCased name` => `asLowerCamelCase name`
 
#### Testing
`./scripts/tools/zap_regen_all.py` has not changed the output.