### PR TITLE
Use CHIP Crypto API to generate CA keypair for Darwin

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -67,7 +67,8 @@ private:
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
     const NSString * kCHIPCADeprecatedKeyLabel = @"chip.nodeopcerts.CA:0";
     const NSData * kCHIPCADeprecatedKeyTag = [@"com.zigbee.chip.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
-    const NSString * kCHIPCAKeyLabel = @"matter.nodeopcerts.CA:0";
+    const NSString * kCHIPCAKeyGenLabel = @"matter.nodeopcerts.CA.keygen:0";
+    const NSString * kCHIPCAKeyChainLabel = @"matter.nodeopcerts.CA:0";
     const NSData * kCHIPCAKeyTag = [@"com.zigbee.matter.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
 
     id mKeyType = (id) kSecAttrKeyTypeECSECPrimeRandom;

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -50,12 +50,8 @@ public:
 
 private:
     CHIP_ERROR GenerateKeys();
-    CHIP_ERROR StoreKeysInKeyChain(NSData * keypairData);
     CHIP_ERROR LoadKeysFromKeyChain();
-    CHIP_ERROR LoadDeprecatedKeysFromKeyChain();
     CHIP_ERROR DeleteKeys();
-
-    CHIP_ERROR ConvertToP256Keypair(NSData * keypairData);
 
     CHIP_ERROR SetIssuerID(CHIPPersistentStorageDelegateBridge * storage);
 
@@ -65,14 +61,7 @@ private:
     uint32_t mIssuerId = 1234;
 
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
-    const NSString * kCHIPCADeprecatedKeyLabel = @"chip.nodeopcerts.CA:0";
-    const NSData * kCHIPCADeprecatedKeyTag = [@"com.zigbee.chip.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
-    const NSString * kCHIPCAKeyGenLabel = @"matter.nodeopcerts.CA.keygen:0";
     const NSString * kCHIPCAKeyChainLabel = @"matter.nodeopcerts.CA:0";
-    const NSData * kCHIPCAKeyTag = [@"com.zigbee.matter.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
-
-    id mKeyType = (id) kSecAttrKeyTypeECSECPrimeRandom;
-    id mKeySize = @256;
 
     CHIPPersistentStorageDelegateBridge * mStorage;
 

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -51,12 +51,6 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
 
     CHIP_ERROR err = LoadKeysFromKeyChain();
 
-    // TODO - Remove use of deprecated storage for Darwin keys
-    if (err != CHIP_NO_ERROR) {
-        // Try loading the deprecated keys.
-        err = LoadDeprecatedKeysFromKeyChain();
-    }
-
     if (err != CHIP_NO_ERROR) {
         // Generate keys if keys could not be loaded
         err = GenerateKeys();
@@ -93,21 +87,6 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::SetIssuerID(CHIPPersistentStorage
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::ConvertToP256Keypair(NSData * keypairData)
-{
-    chip::Crypto::P256SerializedKeypair serialized;
-    if ([keypairData length] != serialized.Capacity()) {
-        NSLog(@"Keypair length %zu does not match expected length %zu", [keypairData length], serialized.Capacity());
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    std::memmove((uint8_t *) serialized, [keypairData bytes], [keypairData length]);
-    serialized.SetLength([keypairData length]);
-
-    CHIP_LOG_ERROR("Deserializing the key");
-    return mIssuerKey.Deserialize(serialized);
-}
-
 CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
 {
     const NSDictionary * query = @{
@@ -127,47 +106,34 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
     CHIP_LOG_ERROR("Found an existing keypair in the keychain");
     NSData * keyData = CFBridgingRelease(keyDataRef);
 
-    NSData * privateKey = [[NSData alloc] initWithBase64EncodedData:keyData options:0];
-    return ConvertToP256Keypair(privateKey);
-}
+    NSData * keypairData = [[NSData alloc] initWithBase64EncodedData:keyData options:0];
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadDeprecatedKeysFromKeyChain()
-{
-    SecKeyRef privateKey;
-
-    const NSDictionary * query = @ {
-        (id) kSecClass : (id) kSecClassKey,
-        (id) kSecAttrKeyType : mKeyType,
-        (id) kSecAttrKeySizeInBits : mKeySize,
-        (id) kSecAttrLabel : kCHIPCADeprecatedKeyLabel,
-        (id) kSecAttrApplicationTag : kCHIPCADeprecatedKeyTag,
-        (id) kSecReturnRef : (id) kCFBooleanTrue
-    };
-
-    OSStatus status = SecItemCopyMatching((CFDictionaryRef) query, (CFTypeRef *) &privateKey);
-    if (status == errSecItemNotFound || privateKey == nil) {
-        CHIP_LOG_ERROR("Did not find an existing key in the keychain");
-        return CHIP_ERROR_KEY_NOT_FOUND;
-    }
-
-    NSData * keypairData = (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation(privateKey, nil);
-    if (keypairData == nil) {
-        NSLog(@"Failed in getting keypair data");
+    chip::Crypto::P256SerializedKeypair serialized;
+    if ([keypairData length] != serialized.Capacity()) {
+        NSLog(@"Keypair length %zu does not match expected length %zu", [keypairData length], serialized.Capacity());
         return CHIP_ERROR_INTERNAL;
     }
 
-    // Store the key in the new format, so that henceforth the deprecated key storage won't be needed
-    CHIP_ERROR errorCode = StoreKeysInKeyChain(keypairData);
+    std::memmove((uint8_t *) serialized, [keypairData bytes], [keypairData length]);
+    serialized.SetLength([keypairData length]);
+
+    CHIP_LOG_ERROR("Deserializing the key");
+    return mIssuerKey.Deserialize(serialized);
+}
+
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
+{
+    CHIP_LOG_ERROR("Generating keys for the CA");
+    CHIP_ERROR errorCode = mIssuerKey.Initialize();
     if (errorCode != CHIP_NO_ERROR) {
         return errorCode;
     }
 
-    CHIP_LOG_ERROR("Found an existing keypair in deprecated format in the keychain");
-    return ConvertToP256Keypair(keypairData);
-}
+    chip::Crypto::P256SerializedKeypair serializedKey;
+    errorCode = mIssuerKey.Serialize(serializedKey);
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::StoreKeysInKeyChain(NSData * keypairData)
-{
+    NSData * keypairData = [NSData dataWithBytes:serializedKey.Bytes() length:serializedKey.Length()];
+
     const NSDictionary * addParams = @{
         (id) kSecClass : (id) kSecClassGenericPassword,
         (id) kSecAttrService : kCHIPCAKeyChainLabel,
@@ -184,42 +150,6 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::StoreKeysInKeyChain(NSData * keyp
 
     NSLog(@"Stored the keys");
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
-{
-    SecKeyRef publicKey = nil;
-    SecKeyRef privateKey = nil;
-
-    CHIP_LOG_ERROR("Generating keys for the CA");
-    OSStatus status = noErr;
-
-    const NSDictionary * keygenParams = @{
-        (id) kSecAttrKeyType : mKeyType,
-        (id) kSecAttrKeySizeInBits : mKeySize,
-        (id) kSecAttrLabel : kCHIPCAKeyGenLabel,
-        (id) kSecAttrApplicationTag : kCHIPCAKeyTag,
-        (id) kSecAttrIsPermanent : @NO,
-    };
-
-    status = SecKeyGeneratePair((__bridge CFDictionaryRef) keygenParams, &publicKey, &privateKey);
-    if (status != noErr || publicKey == nil || privateKey == nil) {
-        NSLog(@"Failed in keygen. status %d, pubkey %p, privkey %p", status, publicKey, privateKey);
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    NSData * keypairData = (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation(privateKey, nil);
-    if (keypairData == nil) {
-        NSLog(@"Failed in getting keypair data");
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    CHIP_ERROR errorCode = StoreKeysInKeyChain(keypairData);
-    if (errorCode != CHIP_NO_ERROR) {
-        return errorCode;
-    }
-
-    return ConvertToP256Keypair(keypairData);
 }
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()


### PR DESCRIPTION
#### Problem
Darwin CI is flaky due to failing CA key generation.

#### Change overview
The key tag for the generated key overlapped with the key that's saved in keychain. However, the saved key is serialized and is in a different format. This leads to failing in keypair lookup from the keychain, but also prohibits generation of keypair with the given key tag.

This PR changes the code to use Matter's crypto API to generate the keypair, and store the generated keypair in the keychain.

#### Testing
Ran this PR through failing/flaky CI, running multiple runs of the failing steps.
Also, tested the overall commissioning flow using iOS CHIPTool app.