### PR TITLE
Ensure licenses folder exists in dockerfile (fix after #8864)

### DIFF
--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -26,7 +26,10 @@ COPY --from=mbedos /opt/openocd/ /opt/openocd/
 # Android license file "acceping" is done by writing license hashes
 # into the 'licenses' subfolder. This allows any user (in particular
 # 'vscode' to accept licenses)
-RUN chmod -R a+w /opt/android/sdk/licenses
+RUN set -x \
+    && mkdir -p /opt/android/sdk/licenses \
+    && chmod -R a+w /opt/android/sdk/licenses \
+    && : # last line
 
 ENV IDF_PATH=/opt/espressif/esp-idf/
 ENV IDF_TOOLS_PATH=/opt/espressif/tools


### PR DESCRIPTION
#### Problem
Dockerfile fails to build after #8864 due to license folder not yet having been created when trying to chmod

#### Change overview
Update android license dir commands to create & update permissions

#### Testing
Built the docker image and pushed as latest version (actually  completed this time on a separate machine. When trying #8864 I left it run in background without caching and it took too long, hence me failing to notice the error).