### PR TITLE
Add telink support for script/build/build_examples.py

### DIFF
--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -25,6 +25,7 @@ from builders.host import HostBuilder, HostApp
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 from builders.qpg import QpgBuilder
 from builders.infineon import InfineonBuilder, InfineonApp, InfineonBoard
+from builders.telink import TelinkApp, TelinkBoard, TelinkBuilder
 
 from .targets import Application, Board, Platform
 
@@ -89,6 +90,7 @@ _MATCHERS = {
     Platform.NRF: Matcher(NrfConnectBuilder),
     Platform.ANDROID: Matcher(AndroidBuilder),
     Platform.INFINEON: Matcher(InfineonBuilder),
+    Platform.TELINK: Matcher(TelinkBuilder),
 }
 
 # Matrix of what can be compiled and what build options are required
@@ -129,6 +131,11 @@ _MATCHERS[Platform.NRF].AcceptBoard(Board.NRF52840, board=NrfBoard.NRF52840)
 _MATCHERS[Platform.NRF].AcceptApplication(Application.LOCK, app=NrfApp.LOCK)
 _MATCHERS[Platform.NRF].AcceptApplication(Application.LIGHT, app=NrfApp.LIGHT)
 _MATCHERS[Platform.NRF].AcceptApplication(Application.SHELL, app=NrfApp.SHELL)
+
+_MATCHERS[Platform.TELINK].AcceptBoard(
+    Board.TLSR9518ADK80D, board=TelinkBoard.TLSR9518ADK80D)
+_MATCHERS[Platform.TELINK].AcceptApplication(
+    Application.LIGHT, app=TelinkApp.LIGHT)
 
 _MATCHERS[Platform.ANDROID].AcceptBoard(Board.ARM, board=AndroidBoard.ARM)
 _MATCHERS[Platform.ANDROID].AcceptBoard(Board.ARM64, board=AndroidBoard.ARM64)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -28,6 +28,7 @@ class Platform(IntEnum):
     NRF = auto()
     ANDROID = auto()
     INFINEON = auto()
+    TELINK = auto()
 
     @property
     def ArgName(self):
@@ -60,6 +61,9 @@ class Board(IntEnum):
     # NRF platform
     NRF52840 = auto()
     NRF5340 = auto()
+
+    # Telink platform
+    TLSR9518ADK80D = auto()
 
     # Android platform
     ARM = auto()

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -20,80 +20,93 @@ from enum import Enum, auto
 
 from .builder import Builder
 
+
 class TelinkApp(Enum):
-  LIGHT = auto()
-  LOCK = auto()
-  SHELL = auto()
+    LIGHT = auto()
+    LOCK = auto()
+    SHELL = auto()
 
-  def ExampleName(self):
-    if self == TelinkApp.LIGHT:
-      return 'lighting-app'
-    else:
-      raise Exception('Unknown app type: %r' % self)
+    def ExampleName(self):
+        if self == TelinkApp.LIGHT:
+            return 'lighting-app'
+        else:
+            raise Exception('Unknown app type: %r' % self)
 
-  def AppNamePrefix(self):
-    if self == TelinkApp.LIGHT:
-      return 'chip-telink-lighting-example'
-    else:
-      raise Exception('Unknown app type: %r' % self)
+    def AppNamePrefix(self):
+        if self == TelinkApp.LIGHT:
+            return 'chip-telink-lighting-example'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
 
 class TelinkBoard(Enum):
-  TLSR9518ADK80D = auto()
+    TLSR9518ADK80D = auto()
 
-  def GnArgName(self):
-    if self == TelinkBoard.TLSR9518ADK80D:
-      return 'tlsr9518adk80d'
-    else:
-      raise Exception('Unknown board type: %r' % self)
+    def GnArgName(self):
+        if self == TelinkBoard.TLSR9518ADK80D:
+            return 'tlsr9518adk80d'
+        else:
+            raise Exception('Unknown board type: %r' % self)
 
 
 class TelinkBuilder(Builder):
 
-  def __init__(self,
-               root,
-               runner,
-               output_prefix: str,
-               app: TelinkApp = TelinkApp.LIGHT,
-               board: TelinkBoard = TelinkBoard.TLSR9518ADK80D):
-    super(TelinkBuilder, self).__init__(root, runner, output_prefix)
-    self.app = app
-    self.board = board
+    def __init__(self,
+                 root,
+                 runner,
+                 output_prefix: str,
+                 app: TelinkApp = TelinkApp.LIGHT,
+                 board: TelinkBoard = TelinkBoard.TLSR9518ADK80D):
+        super(TelinkBuilder, self).__init__(root, runner, output_prefix)
+        self.app = app
+        self.board = board
 
-  def generate(self):
+    def generate(self):
 
-    if not os.path.exists(self.output_dir):
+        if not os.path.exists(self.output_dir):
 
-        if not self._runner.dry_run:
+            if not self._runner.dry_run:
 
-          # Check Zephyr base
-          if 'TELINK_ZEPHYR_BASE' not in os.environ:
-              raise Exception("Telink builds require TELINK_ZEPHYR_BASE to be set")
+                # Check Zephyr base
+                if 'TELINK_ZEPHYR_BASE' not in os.environ:
+                    raise Exception(
+                        "Telink builds require TELINK_ZEPHYR_BASE to be set")
 
-          # Check Telink toolchain
-          if 'TELINK_TOOLCHAIN_PATH' not in os.environ:
-              raise Exception("Telink requires TELINK_TOOLCHAIN_PATH to be set")
+                # Check Telink toolchain
+                if 'TELINK_TOOLCHAIN_PATH' not in os.environ:
+                    raise Exception(
+                        "Telink requires TELINK_TOOLCHAIN_PATH to be set")
 
-        cmd = '''
+            cmd = '''
 source "$TELINK_ZEPHYR_BASE/zephyr-env.sh";
 export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile;
 export CROSS_COMPILE=$TELINK_TOOLCHAIN_PATH/riscv32-elf-;
 west build -d {outdir} -b {board} {sourcedir}
         '''.format(
-            outdir = shlex.quote(self.output_dir),
-            board = self.board.GnArgName(),
-            sourcedir=shlex.quote(os.path.join(self.root, 'examples', self.app.ExampleName(), 'telink'))
-        ).strip()
+                outdir=shlex.quote(
+                    self.output_dir), board=self.board.GnArgName(), sourcedir=shlex.quote(
+                    os.path.join(
+                        self.root, 'examples', self.app.ExampleName(), 'telink'))).strip()
 
-        self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
+            self._Execute(['bash', '-c', cmd],
+                          title='Generating ' + self.identifier)
 
+    def _build(self):
+        logging.info('Compiling Telink at %s', self.output_dir)
 
-  def _build(self):
-    logging.info('Compiling Telink at %s', self.output_dir)
+        self._Execute(['ninja', '-C', self.output_dir],
+                      title='Building ' + self.identifier)
 
-    self._Execute(['ninja', '-C', self.output_dir], title='Building ' + self.identifier)
-
-  def build_outputs(self):
-    return {
-        '%s.elf' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),
-        '%s.map' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.map'),
-    }
+    def build_outputs(self):
+        return {
+            '%s.elf' %
+            self.app.AppNamePrefix(): os.path.join(
+                self.output_dir,
+                'zephyr',
+                'zephyr.elf'),
+            '%s.map' %
+            self.app.AppNamePrefix(): os.path.join(
+                self.output_dir,
+                'zephyr',
+                'zephyr.map'),
+        }

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import shlex
+
+from enum import Enum, auto
+
+from .builder import Builder
+
+
+class TelinkApp(Enum):
+  LIGHT = auto()
+  LOCK = auto()
+  SHELL = auto()
+
+  def ExampleName(self):
+    if self == TelinkApp.LIGHT:
+      return 'lighting-app'
+    elif self == TelinkApp.LOCK:
+      return 'lock-app'
+    elif self == TelinkApp.SHELL:
+      return 'shell'
+    else:
+      raise Exception('Unknown app type: %r' % self)
+
+  def AppNamePrefix(self):
+    if self == TelinkApp.LIGHT:
+      return 'chip-telink-lighting-example'
+    elif self == TelinkApp.LOCK:
+      return 'chip-telink-lock-example'
+    elif self == TelinkApp.SHELL:
+      return 'chip-telink-shell'
+    else:
+      raise Exception('Unknown app type: %r' % self)
+
+class TelinkBoard(Enum):
+  TLSR9518ADK80D = auto()
+
+  def GnArgName(self):
+    if self == TelinkBoard.TLSR9518ADK80D:
+      return 'tlsr9518adk80d'
+    else:
+      raise Exception('Unknown board type: %r' % self)
+
+
+class TelinkBuilder(Builder):
+
+  def __init__(self,
+               root,
+               runner,
+               output_prefix: str,
+               app: TelinkApp = TelinkApp.LIGHT,
+               board: TelinkBoard = TelinkBoard.TLSR9518ADK80D):
+    super(TelinkBuilder, self).__init__(root, runner, output_prefix)
+    self.app = app
+    self.board = board
+
+  def generate(self):
+
+    if not os.path.exists(self.output_dir):
+
+        if not self._runner.dry_run:
+
+          # Check Zephyr base
+          if 'TELINK_ZEPHYR_BASE' not in os.environ:
+              raise Exception("Telink builds require TELINK_ZEPHYR_BASE to be set")
+
+          # Check Telink toolchain
+          if 'TELINK_TOOLCHAIN_PATH' not in os.environ:
+              raise Exception("Telink requires TELINK_TOOLCHAIN_PATH to be set")
+
+        cmd = '''
+source "$TELINK_ZEPHYR_BASE/zephyr-env.sh";
+export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile;
+export CROSS_COMPILE=$TELINK_TOOLCHAIN_PATH/riscv32-elf-;
+west build -d {outdir} -b {board} {sourcedir}
+        '''.format(
+            outdir = shlex.quote(self.output_dir),
+            board = self.board.GnArgName(),
+            sourcedir=shlex.quote(os.path.join(self.root, 'examples', self.app.ExampleName(), 'telink'))
+        ).strip()
+
+        self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
+
+
+  def build(self):
+    logging.info('Compiling Telink at %s', self.output_dir)
+
+    self._Execute(['ninja', '-C', self.output_dir], title='Building ' + self.identifier)
+
+  def outputs(self):
+    return {
+        '%s.elf' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),
+        '%s.map' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.map'),
+    }

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -23,8 +23,6 @@ from .builder import Builder
 
 class TelinkApp(Enum):
     LIGHT = auto()
-    LOCK = auto()
-    SHELL = auto()
 
     def ExampleName(self):
         if self == TelinkApp.LIGHT:

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -87,12 +87,12 @@ west build -d {outdir} -b {board} {sourcedir}
         self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
 
 
-  def build(self):
+  def _build(self):
     logging.info('Compiling Telink at %s', self.output_dir)
 
     self._Execute(['ninja', '-C', self.output_dir], title='Building ' + self.identifier)
 
-  def outputs(self):
+  def build_outputs(self):
     return {
         '%s.elf' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),
         '%s.map' % self.app.AppNamePrefix(): os.path.join(self.output_dir, 'zephyr', 'zephyr.map'),

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -20,7 +20,6 @@ from enum import Enum, auto
 
 from .builder import Builder
 
-
 class TelinkApp(Enum):
   LIGHT = auto()
   LOCK = auto()
@@ -29,20 +28,12 @@ class TelinkApp(Enum):
   def ExampleName(self):
     if self == TelinkApp.LIGHT:
       return 'lighting-app'
-    elif self == TelinkApp.LOCK:
-      return 'lock-app'
-    elif self == TelinkApp.SHELL:
-      return 'shell'
     else:
       raise Exception('Unknown app type: %r' % self)
 
   def AppNamePrefix(self):
     if self == TelinkApp.LIGHT:
       return 'chip-telink-lighting-example'
-    elif self == TelinkApp.LOCK:
-      return 'chip-telink-lock-example'
-    elif self == TelinkApp.SHELL:
-      return 'chip-telink-shell'
     else:
       raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -207,3 +207,5 @@ ninja -C /OUTPUT/DIR/infineon-p6board-lock
 
 # Building telink-tlsr9518adk80d-light
 ninja -C {out}/telink-tlsr9518adk80d-light
+
+

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -76,11 +76,6 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
-# Generate telink-tlsr9518adk80d-light
-bash -c 'source "$TELINK_ZEPHYR_BASE/zephyr-env.sh";
-export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile;
-export CROSS_COMPILE=$TELINK_TOOLCHAIN_PATH/riscv32-elf-;
-west build -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting/telink'
 # Generating android-arm-chip_tool
 gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
@@ -101,6 +96,12 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating infineon-p6board-lock
 gn gen --check --fail-on-unused-args --root=/TEST/BUILD/ROOT/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' /OUTPUT/DIR/infineon-p6board-lock
+
+# Generating telink-tlsr9518adk80d-light
+bash -c 'source "$TELINK_ZEPHYR_BASE/zephyr-env.sh";
+export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile;
+export CROSS_COMPILE=$TELINK_TOOLCHAIN_PATH/riscv32-elf-;
+west build -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting-app/telink'
 
 # Building {real_platform}-native-all_clusters
 ninja -C {out}/{real_platform}-native-all_clusters

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -76,6 +76,11 @@ bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d {out}/nrf-nrf5340-shell -b nrf5340dk_nrf5340_cpuapp {root}/examples/shell/nrfconnect'
 
+# Generate telink-tlsr9518adk80d-light
+bash -c 'source "$TELINK_ZEPHYR_BASE/zephyr-env.sh";
+export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile;
+export CROSS_COMPILE=$TELINK_TOOLCHAIN_PATH/riscv32-elf-;
+west build -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting/telink'
 # Generating android-arm-chip_tool
 gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
@@ -199,4 +204,5 @@ cp {out}/android-x64-chip_tool/lib/jni/x86_64/libc++_shared.so {root}/src/androi
 # Building infineon-p6board-lock
 ninja -C /OUTPUT/DIR/infineon-p6board-lock
 
-
+# Building telink-tlsr9518adk80d-light
+ninja -C {out}/telink-tlsr9518adk80d-light


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/8843

#### Change overview
* Update **scripts/build/build/factory** and  **scripts/build/build/targets.py** to make support id by Telink
* Create **scripts/build/builders/telink.py** builder script

#### Testing
Manually:
1. Run chip-build-vscode docker container
2. Check if following command works to build Telink example:
```$ ./scripts/build/build_examples.py --platform telink --board tlsr9518adk80d build```
3. Check if following command works to build all examples (including Telink one):
```$ ./scripts/build/build_examples.py --platform all build```


