### PR TITLE
Fixes for hue calculations for Color Control cluster

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1611,7 +1611,7 @@ static uint8_t addHue(uint8_t hue1, uint8_t hue2)
 
     if (hue16 > MAX_HUE_VALUE)
     {
-        hue16 = static_cast<uint16_t>(hue16 - UINT8_MAX);
+        hue16 = static_cast<uint16_t>(hue16 - MAX_HUE_VALUE - 1);
     }
 
     return ((uint8_t) hue16);
@@ -1624,7 +1624,7 @@ static uint8_t subtractHue(uint8_t hue1, uint8_t hue2)
     hue16 = ((uint16_t) hue1);
     if (hue2 > hue1)
     {
-        hue16 = static_cast<uint16_t>(hue16 + UINT8_MAX);
+        hue16 = static_cast<uint16_t>(hue16 + MAX_HUE_VALUE + 1);
     }
 
     hue16 = static_cast<uint16_t>(hue16 - static_cast<uint16_t>(hue2));

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1722,7 +1722,7 @@ static bool computeNewHueValue(ColorHueTransitionState * p)
             {
                 if (p->isEnhancedHue)
                 {
-                    newHue = subtractEnhancedHue(p->finalEnhancedHue, p->initialEnhancedHue);
+                    newHue = subtractEnhancedHue(p->initialEnhancedHue, p->finalEnhancedHue);
                     newHue = subtractEnhancedHue(p->finalEnhancedHue, newHue);
 
                     p->initialEnhancedHue = p->finalEnhancedHue;

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1611,7 +1611,7 @@ static uint8_t addHue(uint8_t hue1, uint8_t hue2)
 
     if (hue16 > MAX_HUE_VALUE)
     {
-        hue16 = static_cast<uint16_t>(hue16 - MAX_HUE_VALUE);
+        hue16 = static_cast<uint16_t>(hue16 - UINT8_MAX);
     }
 
     return ((uint8_t) hue16);
@@ -1624,7 +1624,7 @@ static uint8_t subtractHue(uint8_t hue1, uint8_t hue2)
     hue16 = ((uint16_t) hue1);
     if (hue2 > hue1)
     {
-        hue16 = static_cast<uint16_t>(hue16 + MAX_HUE_VALUE);
+        hue16 = static_cast<uint16_t>(hue16 + UINT8_MAX);
     }
 
     hue16 = static_cast<uint16_t>(hue16 - static_cast<uint16_t>(hue2));


### PR DESCRIPTION
#### Problem
* Calculation Error for finalHue when using EnhancedMoveHue with hue decreasing (moveMode = 3)
The incorrect finalHue is calculated when recalculting it when the first move hue is complete. This cause delta between two hues to be incorrect.
To reproduce:
`zcl ColorControl EnhancedMoveHue 12344321 1 0 moveMode=3 rate=100 optionsMask=0 optionsOverride=0`
* Fixes #8828 


#### Change overview
* For issue 8828, changes constants to max uint8 for wrap arround
* For finalhue error, switched initial and final hue in substract function

#### Testing
For finalHue error, 
Used following command to validate delta between two hues was correct after recalculation:
`zcl ColorControl EnhancedMoveHue 12344321 1 0 moveMode=3 rate=100 optionsMask=0 optionsOverride=0`

For issue 8828,
Used following commands to valiadate that wrap around was not skipping a value
`zcl ColorControl StepHue 12344321 1 0 stepMode=1 stepSize=10 transitionTime=300 optionsMask=0 optionsOverride=0`
`zcl ColorControl StepHue 12344321 1 0 stepMode=3 stepSize=10 transitionTime=300 optionsMask=0 optionsOverride=0`
