### PR TITLE
dns-sd: Fix leading 0 on D txt in platform.

### DIFF
--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -202,7 +202,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     // Following fields are for nodes and not for commissioners
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
-        snprintf(discriminatorBuf, sizeof(discriminatorBuf), "%04u", params.GetLongDiscriminator());
+        snprintf(discriminatorBuf, sizeof(discriminatorBuf), "%u", params.GetLongDiscriminator());
         textEntries[textEntrySize++] = { "D", reinterpret_cast<const uint8_t *>(discriminatorBuf),
                                          strnlen(discriminatorBuf, sizeof(discriminatorBuf)) };
 


### PR DESCRIPTION
Sneaky little leading 0 snuck through. We aren't doing this anymore.

#### Problem
TXT records no longer have leading 0's.

#### Change overview
Removed leading 0's from D txt record in the platform impl.

#### Testing
Tested on linux lighting app with platform mdns. Also tested in unit tests in an upcoming PR
