### PR TITLE
Remove transitional ChipError functions

### DIFF
--- a/examples/lighting-app/telink/src/main.cpp
+++ b/examples/lighting-app/telink/src/main.cpp
@@ -74,6 +74,6 @@ int main(void)
     err = GetAppTask().StartApp();
 
 exit:
-    LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, ChipError::FormatError(err));
+    LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, err.Format());
     return (err == CHIP_NO_ERROR) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -65,7 +65,7 @@ extern "C" void vApplicationIdleHook(void)
 
 void appError(CHIP_ERROR err)
 {
-    // appError(static_cast<int>(error.AsInteger()));
+    // appError(static_cast<int>(err.AsInteger()));
     EFR32_LOG("!!!!!!!!!!!! App Critical Error: %d !!!!!!!!!!!", err);
     portDISABLE_INTERRUPTS();
     while (1)

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1948,8 +1948,8 @@
 /**
  *  @def CHIP_CONFIG_ERROR_FORMAT_AS_STRING
  *
- *  If 0, then .Format() returns an integer (ChipError::BaseType).
- *  If 1, then .Format() returns a const char *, from chip::ErrorStr().
+ *  If 0, then ChipError::Format() returns an integer (ChipError::StorageType).
+ *  If 1, then ChipError::Format() returns a const char *, from chip::ErrorStr().
  *  In either case, the macro CHIP_ERROR_FORMAT expands to a suitable printf format.
  */
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -57,9 +57,6 @@ public:
     /// Type for encapsulated error values.
     using ValueType = StorageType;
 
-    // DO NOT USE. This is transitional and will be removed soon. Instead, use ChipError.
-    using ErrorType = ChipError;
-
     /// Integer `printf` format for errors. This is a C macro in order to allow for string literal concatenation.
 #define CHIP_ERROR_INTEGER_FORMAT PRIx32
 
@@ -182,10 +179,6 @@ public:
      */
     constexpr StorageType AsInteger() const { return mError; }
 
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `AsInteger(status)` use `status.AsInteger()`.
-    static constexpr StorageType AsInteger(StorageType error) { return error; }
-    static constexpr StorageType AsInteger(ChipError error) { return error.mError; }
-
     /*
      * IsSuccess() is intended to support macros that can take either a ChipError or an integer error code.
      * The latter follows the C convention that a non-zero integer indicates an error.
@@ -223,18 +216,6 @@ public:
         return ErrorStr(*this);
     }
 
-#if CHIP_CONFIG_ERROR_FORMAT_AS_STRING
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `FormatError(status)` use `status.Format()`.
-    static FormatType FormatError(ChipError error)
-    {
-        extern const char * ErrorStr(ChipError);
-        return ErrorStr(error);
-    }
-#else  // CHIP_CONFIG_ERROR_FORMAT_AS_STRING
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `FormatError(status)` use `status.Format()`.
-    static FormatType FormatError(ChipError error) { return error.mError; }
-#endif // CHIP_CONFIG_ERROR_FORMAT_AS_STRING
-
     /**
      * Test whether @a error belongs to the Range @a range.
      */
@@ -243,30 +224,15 @@ public:
         return (mError & MakeMask(kRangeStart, kRangeLength)) == MakeField(kRangeStart, static_cast<StorageType>(range));
     }
 
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `IsRange(status)` use `status.IsRange()`.
-    static constexpr bool IsRange(Range range, ChipError error)
-    {
-        return (error.mError & MakeMask(kRangeStart, kRangeLength)) == MakeField(kRangeStart, static_cast<StorageType>(range));
-    }
-
     /**
      * Get the Range to which the @a error belongs.
      */
     constexpr Range GetRange() const { return static_cast<Range>(GetField(kRangeStart, kRangeLength, mError)); }
 
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `GetRange(status)` use `status.GetRange()`.
-    static constexpr Range GetRange(ChipError error)
-    {
-        return static_cast<Range>(GetField(kRangeStart, kRangeLength, error.mError));
-    }
-
     /**
      * Get the encapsulated value of an @a error.
      */
     constexpr ValueType GetValue() const { return GetField(kValueStart, kValueLength, mError); }
-
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `GetValue(status)` use `status.GetValue()`.
-    static constexpr ValueType GetValue(ChipError error) { return GetField(kValueStart, kValueLength, error.mError); }
 
     /**
      * Test whether type @a T can always be losslessly encapsulated in a CHIP_ERROR.
@@ -286,27 +252,12 @@ public:
         return CanEncapsulate<T>() || FitsInField(kValueLength, static_cast<ValueType>(value));
     }
 
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `Encapsulate(r, v)` use `ChipError(r, v)`.
-    static constexpr ChipError Encapsulate(Range range, ValueType value)
-    {
-        StorageType e = MakeInteger(range, (value & MakeMask(0, kValueLength)));
-        return ChipError(e);
-    }
-
     /**
      * Test whether @a error is an SDK error belonging to the SdkPart @a part.
      */
     constexpr bool IsPart(SdkPart part) const
     {
         return (mError & (MakeMask(kRangeStart, kRangeLength) | MakeMask(kSdkPartStart, kSdkPartLength))) ==
-            (MakeField(kRangeStart, static_cast<StorageType>(Range::kSDK)) |
-             MakeField(kSdkPartStart, static_cast<StorageType>(part)));
-    }
-
-    // DO NOT USE. This is transitional and will be removed soon. Instead of `IsPart(status)` use `status.IsPart()`.
-    static constexpr bool IsPart(SdkPart part, ChipError error)
-    {
-        return (error.mError & (MakeMask(kRangeStart, kRangeLength) | MakeMask(kSdkPartStart, kSdkPartLength))) ==
             (MakeField(kRangeStart, static_cast<StorageType>(Range::kSDK)) |
              MakeField(kSdkPartStart, static_cast<StorageType>(part)));
     }


### PR DESCRIPTION
#### Problem

In the course of converting CHIP_ERROR from integer to class
representation, some transitional code was added. This is now
no longer needed.

#### Change overview

- Remove transitional code from `ChipError`.
- Convert remaining use of the transitional functions.

#### Testing

No functional changes.
