### PR TITLE
dns-sd: S sub 4-bit number.

### DIFF
--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -98,8 +98,8 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
     switch (subtype.type)
     {
     case DiscoveryFilterType::kShort:
-        // 8-bit number
-        if (subtype.code >= 1 << 8)
+        // 4-bit number
+        if (subtype.code >= 1 << 4)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -87,7 +87,7 @@ TxtResourceRecord txtOperational2       = TxtResourceRecord(kInstanceName2, kTxt
 // Commissionable node records and queries.
 const QNamePart kMatterCommissionableNodeQueryParts[3] = { "_matterc", "_udp", "local" };
 const QNamePart kLongSubPartsFullLen[]                 = { "_L4094", "_sub", "_matterc", "_udp", "local" };
-const QNamePart kShortSubPartsFullLen[]                = { "_S254", "_sub", "_matterc", "_udp", "local" };
+const QNamePart kShortSubPartsFullLen[]                = { "_S15", "_sub", "_matterc", "_udp", "local" };
 const QNamePart kCmSubParts0[]                         = { "_C0", "_sub", "_matterc", "_udp", "local" };
 const QNamePart kLongSubParts[]                        = { "_L22", "_sub", "_matterc", "_udp", "local" };
 const QNamePart kShortSubParts[]                       = { "_S2", "_sub", "_matterc", "_udp", "local" };
@@ -129,7 +129,7 @@ CommissionAdvertisingParameters commissionableNodeParamsSmall =
         .SetCommissionAdvertiseMode(CommssionAdvertiseMode::kCommissionableNode)
         .SetMac(ByteSpan(kMac))
         .SetLongDiscriminator(0xFFE)
-        .SetShortDiscriminator(0xFE)
+        .SetShortDiscriminator(0xF)
         .SetCommissioningMode(false, false);
 const QNamePart txtCommissionableNodeParamsSmallParts[] = { "CM=0", "D=4094" };
 FullQName txtCommissionableNodeParamsSmallName          = FullQName(txtCommissionableNodeParamsSmallParts);

--- a/src/lib/mdns/tests/TestServiceNaming.cpp
+++ b/src/lib/mdns/tests/TestServiceNaming.cpp
@@ -120,11 +120,11 @@ void TestMakeServiceNameSubtype(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S3") == 0);
 
-    filter.code = (1 << 8) - 1;
+    filter.code = (1 << 4) - 1;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S255") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S15") == 0);
 
-    filter.code = 1 << 8;
+    filter.code = 1 << 4;
     NL_TEST_ASSERT(inSuite, MakeServiceSubtype(buffer, sizeof(buffer), filter) != CHIP_NO_ERROR);
 
     // Vendor tests
@@ -202,15 +202,14 @@ void TestMakeServiceTypeName(nlTestSuite * inSuite, void * inContext)
     filter.code = 3;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    printf("buffer: %s\n", buffer);
     NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S3._sub._matterc") == 0);
 
-    filter.code = (1 << 8) - 1;
+    filter.code = (1 << 4) - 1;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S255._sub._matterc") == 0);
+    NL_TEST_ASSERT(inSuite, strcmp(buffer, "_S15._sub._matterc") == 0);
 
-    filter.code = 1 << 8;
+    filter.code = 1 << 4;
     NL_TEST_ASSERT(inSuite,
                    MakeServiceTypeName(buffer, sizeof(buffer), filter, DiscoveryType::kCommissionableNode) != CHIP_NO_ERROR);
 


### PR DESCRIPTION
#### Problem
* Short discriminator subtype is 4 bits - code checks for 8.
* Fixes #8884

#### Change overview
Changes short discriminator check to be 4 bits rather than 8 and fixes tests to check the same.

#### Testing
Unit tests updated.
