### PR TITLE
Improve Build example - Med OS workflow

### DIFF
--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build examples - Mbed OS
+name: Build example - Mbed OS
 
 on:
     push:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build example - Mbed OS
+name: Build examples - Mbed OS
 
 on:
     push:
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
     mbedos:
-        name: MbedOS application build
+        name: Mbed OS examples building
         timeout-minutes: 30
         
         env:
@@ -63,7 +63,7 @@ jobs:
                   cp examples/lighting-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-lighting-app-example.hex \
                      /tmp/output_binaries/$BUILD_TYPE-build/lighting-app-$APP_TARGET-$APP_PROFILE.hex
 
-            - name: Binary artifact suffix
+            - name: Binary artifacts suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0
               with:
@@ -71,7 +71,7 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
 
-            - name: Uploading Binaries
+            - name: Uploading binaries as artifacts
               uses: actions/upload-artifact@v1
               with:
                   name:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -25,17 +25,13 @@ concurrency:
 
 jobs:
     mbedos:
-        strategy:
-            fail-fast: False
-            matrix:
-                EXAMPLE_APP:    [lock-app, lighting-app]
-                EXAMPLE_TARGET: [CY8CPROTO_062_4343W]
-        
-        name: "${{matrix.EXAMPLE_APP}}: ${{matrix.EXAMPLE_TARGET}}"
+        name: MbedOS application build
+        timeout-minutes: 30
         
         env:
             BUILD_TYPE: mbedos
-            EXAMPLE_PROFILE: release
+            APP_PROFILE: release
+            APP_TARGET: CY8CPROTO_062_4343W
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -44,7 +40,6 @@ jobs:
             image: connectedhomeip/chip-build-mbed-os:latest
             volumes:
                 - "/tmp/output_binaries:/tmp/output_binaries"
-            
 
         steps:
             - name: Checkout
@@ -52,14 +47,21 @@ jobs:
               with:
                   submodules: true
 
-            - name: Build example
-              run: scripts/examples/mbed_example.sh -a=${{matrix.EXAMPLE_APP}} -b=${{matrix.EXAMPLE_TARGET}} -p=$EXAMPLE_PROFILE
+            - name: Build lock-app example
+              timeout-minutes: 10
+              run: scripts/examples/mbed_example.sh -a=lock-app -b=$APP_TARGET -p=$APP_PROFILE
+
+            - name: Build lighting-app example
+              timeout-minutes: 10
+              run: scripts/examples/mbed_example.sh -a=lighting-app -b=$APP_TARGET -p=$APP_PROFILE
 
             - name: Copy aside build products
               run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build/
-                  cp examples/${{matrix.EXAMPLE_APP}}/mbed/build-${{matrix.EXAMPLE_TARGET}}/$EXAMPLE_PROFILE/chip-mbed-${{matrix.EXAMPLE_APP}}-example.hex \
-                     example_binaries/$BUILD_TYPE-build/${{matrix.EXAMPLE_APP}}_${{matrix.EXAMPLE_TARGET}}_$EXAMPLE_PROFILE.hex
+                  mkdir -p /tmp/output_binaries/$BUILD_TYPE-build
+                  cp examples/lock-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-lock-app-example.hex \
+                     /tmp/output_binaries/$BUILD_TYPE-build/lock-app-$APP_TARGET-$APP_PROFILE.hex
+                  cp examples/lighting-app/mbed/build-$APP_TARGET/$APP_PROFILE/chip-mbed-lighting-app-example.hex \
+                     /tmp/output_binaries/$BUILD_TYPE-build/lighting-app-$APP_TARGET-$APP_PROFILE.hex
 
             - name: Binary artifact suffix
               id: outsuffix
@@ -69,14 +71,10 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
 
-            - name: Copy aside binaries
-              run: |
-                  cp -r example_binaries/$BUILD_TYPE-build/ /tmp/output_binaries/
-
             - name: Uploading Binaries
               uses: actions/upload-artifact@v1
               with:
                   name:
-                      ${{ env.BUILD_TYPE }}-${{matrix.EXAMPLE_APP}}-example-${{matrix.EXAMPLE_TARGET}}-${{ env.EXAMPLE_PROFILE}}-build-${{
+                      ${{ env.BUILD_TYPE }}-binaries-${{env.APP_TARGET}}-${{ env.APP_PROFILE}}-build-${{
                       steps.outsuffix.outputs.value }}
-                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build/${{matrix.EXAMPLE_APP}}_${{matrix.EXAMPLE_TARGET}}_${{ env.EXAMPLE_PROFILE }}.hex
+                  path: /tmp/output_binaries/${{ env.BUILD_TYPE }}-build


### PR DESCRIPTION
#### Problem
Improve Build examples - Mbed OS workflow to reduce performance time and computing power consumption for it.

#### Change overview
Replace build matrix with separate job's steps - each example is separate job's steps

#### Testing
Execute Github actions with these changes on the ARMmbed fork. We save about 2 minutes on each step (initialization, checkout, etc.)
