### PR TITLE
Remove CHIP_ERROR parameter from timer OnCompleteFunct

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -198,7 +198,7 @@ exit:
 }
 #endif
 
-void IdentifyTimerHandler(Layer * systemLayer, void * appState, CHIP_ERROR error)
+void IdentifyTimerHandler(Layer * systemLayer, void * appState)
 {
     statusLED1.Animate();
 

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -414,7 +414,7 @@ void Command::WaitForResponse(uint16_t seconds)
 
 #else // CONFIG_USE_SEPARATE_EVENTLOOP
 
-static void OnResponseTimeout(chip::System::Layer *, void *, CHIP_ERROR)
+static void OnResponseTimeout(chip::System::Layer *, void *)
 {
     ChipLogError(chipTool, "No response from device");
 

--- a/examples/lighting-app/qpg/include/AppTask.h
+++ b/examples/lighting-app/qpg/include/AppTask.h
@@ -61,7 +61,7 @@ private:
     static void FunctionHandler(AppEvent * aEvent);
 
     static void LightingActionEventHandler(AppEvent * aEvent);
-    static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, CHIP_ERROR aError);
+    static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState);
 
     void StartTimer(uint32_t aTimeoutMs);
 

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -250,7 +250,7 @@ void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
     sAppTask.PostEvent(&button_event);
 }
 
-void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState)
 {
     AppEvent event;
     event.Type               = AppEvent::kEventType_Timer;
@@ -374,7 +374,6 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 {
     CHIP_ERROR err;
 
-    SystemLayer.CancelTimer(TimerEventHandler, this);
     err = SystemLayer.StartTimer(aTimeoutInMs, TimerEventHandler, this);
     SuccessOrExit(err);
 

--- a/examples/lock-app/qpg/include/AppTask.h
+++ b/examples/lock-app/qpg/include/AppTask.h
@@ -63,7 +63,7 @@ private:
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void FunctionHandler(AppEvent * aEvent);
     static void LockActionEventHandler(AppEvent * aEvent);
-    static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, CHIP_ERROR aError);
+    static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState);
 
     void StartTimer(uint32_t aTimeoutMs);
 

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -244,7 +244,7 @@ void AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
     }
 }
 
-void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void AppTask::TimerEventHandler(chip::System::Layer * aLayer, void * aAppState)
 {
     AppEvent event;
     event.Type               = AppEvent::kEventType_Timer;

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -132,7 +132,7 @@ Protocols::Echo::EchoClient gEchoClient;
 Transport::FabricTable gFabrics;
 
 CHIP_ERROR SendEchoRequest(streamer_t * stream);
-void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
+void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
 Transport::PeerAddress GetEchoPeerAddress()
 {
@@ -166,7 +166,7 @@ void Shutdown()
     gSessionManager.Shutdown();
 }
 
-void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     if (gPingArguments.GetEchoRespCount() != gPingArguments.GetEchoCount())
     {

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -298,7 +298,7 @@ exit:
     return err;
 }
 
-void Engine::Run(System::Layer * aSystemLayer, void * apAppState, CHIP_ERROR)
+void Engine::Run(System::Layer * aSystemLayer, void * apAppState)
 {
     Engine * const pEngine = reinterpret_cast<Engine *>(apAppState);
     pEngine->Run();

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -100,7 +100,7 @@ private:
      * Generate and send the report data request when there exists subscription or read request
      *
      */
-    static void Run(System::Layer * aSystemLayer, void * apAppState, CHIP_ERROR);
+    static void Run(System::Layer * aSystemLayer, void * apAppState);
 
     /**
      * Boolean to show if more chunk message on the way

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -359,7 +359,7 @@ chip::Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient gUDC
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
-void HandlePairingWindowTimeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void HandlePairingWindowTimeout(System::Layer * aSystemLayer, void * aAppState)
 {
     ClosePairingWindow();
 }

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -160,7 +160,7 @@ CHIP_ERROR MockEventGeneratorImpl::Init(chip::Messaging::ExchangeManager * apExc
     return err;
 }
 
-void MockEventGeneratorImpl::HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState, CHIP_ERROR aErr)
+void MockEventGeneratorImpl::HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState)
 {
     MockEventGeneratorImpl * generator = static_cast<MockEventGeneratorImpl *>(apAppState);
     if (gMockEventStop)

--- a/src/app/tests/integration/MockEvents.h
+++ b/src/app/tests/integration/MockEvents.h
@@ -66,7 +66,7 @@ public:
     bool IsEventGeneratorStopped();
 
 private:
-    static void HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState, CHIP_ERROR aErr);
+    static void HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState);
     chip::Messaging::ExchangeManager * mpExchangeMgr;
     uint32_t mTimeBetweenEvents; //< delay, in miliseconds, between events.
     bool mEventWraparound;       //< does the event generator run indefinitely, or does it stop after iterating through its states

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -85,10 +85,10 @@ enum class TestCommandResult : uint8_t
 
 TestCommandResult gLastCommandResult = TestCommandResult::kUndefined;
 
-void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
-void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
-void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
-void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
+void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
+void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
+void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
+void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
 CHIP_ERROR SendCommandRequest(chip::app::CommandSender * commandSender)
 {
@@ -296,7 +296,7 @@ void HandleWriteComplete()
            static_cast<double>(gWriteRespCount) * 100 / gWriteCount, static_cast<double>(transitTime) / 1000);
 }
 
-void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -333,7 +333,7 @@ exit:
     }
 }
 
-void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     // Test with invalid endpoint / cluster / command combination.
     chip::app::CommandSender * commandSender;
@@ -353,7 +353,7 @@ exit:
     }
 }
 
-void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -386,7 +386,7 @@ exit:
     }
 }
 
-void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -97,7 +97,7 @@ EmberEventData emAfEvents[] = {
     { NULL, NULL }
 };
 
-void EventControlHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void EventControlHandler(chip::System::Layer * systemLayer, void * appState)
 {
     EmberEventControl * control = reinterpret_cast<EmberEventControl *>(appState);
     if (control->status != EMBER_EVENT_INACTIVE)

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1525,7 +1525,7 @@ void BLEEndPoint::StopUnsubscribeTimer()
     mTimerStateFlags.Clear(TimerStateFlag::kUnsubscribeTimerRunning);
 }
 
-void BLEEndPoint::HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err)
+void BLEEndPoint::HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState)
 {
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
@@ -1538,7 +1538,7 @@ void BLEEndPoint::HandleConnectTimeout(chip::System::Layer * systemLayer, void *
     }
 }
 
-void BLEEndPoint::HandleReceiveConnectionTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err)
+void BLEEndPoint::HandleReceiveConnectionTimeout(chip::System::Layer * systemLayer, void * appState)
 {
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
@@ -1551,7 +1551,7 @@ void BLEEndPoint::HandleReceiveConnectionTimeout(chip::System::Layer * systemLay
     }
 }
 
-void BLEEndPoint::HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err)
+void BLEEndPoint::HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState)
 {
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
@@ -1565,7 +1565,7 @@ void BLEEndPoint::HandleAckReceivedTimeout(chip::System::Layer * systemLayer, vo
     }
 }
 
-void BLEEndPoint::HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err)
+void BLEEndPoint::HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState)
 {
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
@@ -1587,7 +1587,7 @@ void BLEEndPoint::HandleSendAckTimeout(chip::System::Layer * systemLayer, void *
     }
 }
 
-void BLEEndPoint::HandleUnsubscribeTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err)
+void BLEEndPoint::HandleUnsubscribeTimeout(chip::System::Layer * systemLayer, void * appState)
 {
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -214,11 +214,11 @@ private:
     void StopUnsubscribeTimer();       // Stop unsubscribe timer.
 
     // Timer expired callbacks:
-    static void HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err);
-    static void HandleReceiveConnectionTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err);
-    static void HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err);
-    static void HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err);
-    static void HandleUnsubscribeTimeout(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR err);
+    static void HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleReceiveConnectionTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleUnsubscribeTimeout(chip::System::Layer * systemLayer, void * appState);
 
     // Close functions:
     void DoCloseCallback(uint8_t state, uint8_t flags, CHIP_ERROR err);

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -187,7 +187,7 @@ void ChannelContext::EnterAddressResolve()
     }
 }
 
-void ChannelContext::AddressResolveTimeout(System::Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void ChannelContext::AddressResolveTimeout(System::Layer * aLayer, void * aAppState)
 {
     ChannelContext * me = static_cast<ChannelContext *>(aAppState);
     me->AddressResolveTimeout();

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -165,7 +165,7 @@ private:
 
     // Preparing sub-states
     void EnterAddressResolve();
-    static void AddressResolveTimeout(System::Layer * aLayer, void * aAppState, CHIP_ERROR aError);
+    static void AddressResolveTimeout(System::Layer * aLayer, void * aAppState);
     void AddressResolveTimeout();
     void ExitAddressResolve() {}
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1551,7 +1551,7 @@ void DeviceCommissioner::OnSessionEstablishmentTimeout()
     }
 }
 
-void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState)
 {
     static_cast<DeviceCommissioner *>(aAppState)->OnSessionEstablishmentTimeout();
 }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -620,7 +620,7 @@ private:
 
     void OnSessionEstablishmentTimeout();
 
-    static void OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState, CHIP_ERROR aError);
+    static void OnSessionEstablishmentTimeoutCallback(System::Layer * aLayer, void * aAppState);
 
     /* This function sends an OpCSR request to the device.
        The function does not hold a refernce to the device object.

--- a/src/include/platform/internal/DeviceControlServer.h
+++ b/src/include/platform/internal/DeviceControlServer.h
@@ -45,8 +45,8 @@ public:
 private:
     // ===== Members for internal use by the following friends.
     static DeviceControlServer sInstance;
-    friend void CommissioningTimerFunction(System::Layer * layer, void * aAppState, CHIP_ERROR aError);
-    void CommissioningFailedTimerComplete(CHIP_ERROR aErrror);
+    friend void CommissioningTimerFunction(System::Layer * layer, void * aAppState);
+    void CommissioningFailedTimerComplete();
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -297,7 +297,7 @@ void AsyncDNSResolverSockets::Resolve(DNSResolver & resolver)
 }
 
 /* Event handler function for asynchronous DNS notification */
-void AsyncDNSResolverSockets::DNSResultEventHandler(chip::System::Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void AsyncDNSResolverSockets::DNSResultEventHandler(chip::System::Layer * aLayer, void * aAppState)
 {
     DNSResolver * resolver = static_cast<DNSResolver *>(aAppState);
 

--- a/src/inet/AsyncDNSResolverSockets.h
+++ b/src/inet/AsyncDNSResolverSockets.h
@@ -74,8 +74,8 @@ private:
     volatile DNSResolver * mAsyncDNSQueueHead; /* The head of the asynchronous DNSResolver object queue. */
     volatile DNSResolver * mAsyncDNSQueueTail; /* The tail of the asynchronous DNSResolver object queue. */
     InetLayer * mInet;                         /* The pointer to the InetLayer. */
-    static void DNSResultEventHandler(chip::System::Layer * aLayer, void * aAppState,
-                                      CHIP_ERROR aError); /* Timer event handler function for asynchronous DNS notification */
+    static void DNSResultEventHandler(chip::System::Layer * aLayer,
+                                      void * aAppState); /* Timer event handler function for asynchronous DNS notification */
 
     CHIP_ERROR DequeueRequest(DNSResolver ** outResolver);
 

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -986,7 +986,7 @@ bool InetLayer::MatchLocalIPv6Subnet(const IPAddress & addr)
 }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL > 0
-void InetLayer::HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void InetLayer::HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, void * aAppState)
 {
     InetLayer & lInetLayer = *reinterpret_cast<InetLayer *>(aAppState);
     bool lTimerRequired    = lInetLayer.IsIdleTimerRunning();

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -285,7 +285,7 @@ public:
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL > 0
-    static void HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+    static void HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, void * aAppState);
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT && INET_TCP_IDLE_CHECK_INTERVAL > 0
 
 private:

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -577,7 +577,7 @@ void TCPEndPoint::StopConnectTimer()
     lSystemLayer.CancelTimer(TCPConnectTimeoutHandler, this);
 }
 
-void TCPEndPoint::TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void TCPEndPoint::TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
 {
     TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
 
@@ -1743,7 +1743,7 @@ CHIP_ERROR TCPEndPoint::DoClose(CHIP_ERROR err, bool suppressCallback)
 }
 
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
-void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void TCPEndPoint::TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
 {
     TCPEndPoint * tcpEndPoint = reinterpret_cast<TCPEndPoint *>(aAppState);
 

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -612,7 +612,7 @@ private:
 
     bool mUserTimeoutTimerRunning; // Indicates whether the TCP UserTimeout timer has been started.
 
-    static void TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+    static void TCPUserTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState);
 
     void StartTCPUserTimeoutTimer();
 
@@ -649,7 +649,7 @@ private:
     CHIP_ERROR DoClose(CHIP_ERROR err, bool suppressCallback);
     static bool IsConnected(int state);
 
-    static void TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+    static void TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState);
 
     void StartConnectTimerIfSet();
     void StopConnectTimer();

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -73,7 +73,7 @@ void HandleDNSResolveComplete(void * appState, CHIP_ERROR err, uint8_t addrCount
         printf("    DNS name resolution return no addresses\n");
 }
 
-void HandleTimer(Layer * aLayer, void * aAppState, CHIP_ERROR aError)
+void HandleTimer(Layer * aLayer, void * aAppState)
 {
     printf("    timer handler\n");
 }

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -340,10 +340,8 @@ bool HandleTCPDataReceived(const PacketBufferHandle & aBuffer, TransferStats & a
 
 // Timer Callback Handler
 
-void HandleSendTimerComplete(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void HandleSendTimerComplete(System::Layer * aSystemLayer, void * aAppState)
 {
-    INET_FAIL_ERROR(aError, "Send timer completed with error");
-
     gSendIntervalExpired = true;
 
     DriveSend();

--- a/src/inet/tests/TestInetLayerCommon.hpp
+++ b/src/inet/tests/TestInetLayerCommon.hpp
@@ -145,7 +145,7 @@ extern bool HandleICMPv6DataReceived(chip::System::PacketBufferHandle && aBuffer
 
 // Timer Callback Handler
 
-extern void HandleSendTimerComplete(chip::System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+extern void HandleSendTimerComplete(chip::System::Layer * aSystemLayer, void * aAppState);
 
 // Raw Endpoint Callback Handlers
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -366,7 +366,7 @@ void ExchangeContext::CancelResponseTimer()
     lSystemLayer->CancelTimer(HandleResponseTimeout, this);
 }
 
-void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState)
 {
     ExchangeContext * ec = reinterpret_cast<ExchangeContext *>(aAppState);
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -247,7 +247,7 @@ private:
     CHIP_ERROR StartResponseTimer();
 
     void CancelResponseTimer();
-    static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+    static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState);
 
     void DoClose(bool clearRetransTable);
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -234,7 +234,7 @@ void ReliableMessageMgr::ExpireTicks()
 #endif
 }
 
-void ReliableMessageMgr::Timeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError)
+void ReliableMessageMgr::Timeout(System::Layer * aSystemLayer, void * aAppState)
 {
     ReliableMessageMgr * manager = reinterpret_cast<ReliableMessageMgr *>(aAppState);
 

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -102,7 +102,7 @@ public:
      * Handle physical wakeup of system due to ReliableMessageProtocol wakeup.
      *
      */
-    static void Timeout(System::Layer * aSystemLayer, void * aAppState, CHIP_ERROR aError);
+    static void Timeout(System::Layer * aSystemLayer, void * aAppState);
 
     /**
      *  Add a CHIP message into the retransmission table to be subsequently resent if a corresponding acknowledgment

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -277,7 +277,7 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was dropped, and is still there in the retransmit table
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
@@ -287,7 +287,7 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
 
     // sleep another 65 ms to trigger second re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was NOT dropped, and the retransmit table is empty, as we should have gotten an ack
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 3);
@@ -339,7 +339,7 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was dropped, and is still there in the retransmit table
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
@@ -349,7 +349,7 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
 
     // sleep another 65 ms to trigger second re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was NOT dropped, and the retransmit table is empty, as we should have gotten an ack
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 3);
@@ -400,7 +400,7 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit table is empty, as we did not provide a message to retain
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -495,7 +495,7 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was not dropped, and is no longer in the retransmit table
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 2);
@@ -567,7 +567,7 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared
@@ -635,7 +635,7 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was not dropped, and is no longer in the retransmit table
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 2);
@@ -719,7 +719,7 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit
     test_os_sleep_ms(65);
-    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm, CHIP_NO_ERROR);
+    ReliableMessageMgr::Timeout(&ctx.GetSystemLayer(), rm);
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -73,7 +73,7 @@ uint64_t gEchoRespCount = 0;
 bool gUseTCP = false;
 
 CHIP_ERROR SendEchoRequest();
-void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
+void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
 void Shutdown()
 {
@@ -82,7 +82,7 @@ void Shutdown()
     ShutdownChip();
 }
 
-void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     if (gEchoRespCount != gEchoCount)
     {

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -28,10 +28,10 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-void CommissioningTimerFunction(System::Layer * layer, void * aAppState, CHIP_ERROR aError)
+void CommissioningTimerFunction(System::Layer * layer, void * aAppState)
 {
     DeviceControlServer * server = reinterpret_cast<DeviceControlServer *>(aAppState);
-    server->CommissioningFailedTimerComplete(aError);
+    server->CommissioningFailedTimerComplete();
 }
 
 DeviceControlServer DeviceControlServer::sInstance;
@@ -41,7 +41,7 @@ DeviceControlServer & DeviceControlServer::DeviceControlSvr()
     return sInstance;
 }
 
-void DeviceControlServer::CommissioningFailedTimerComplete(CHIP_ERROR aError)
+void DeviceControlServer::CommissioningFailedTimerComplete()
 {
     ChipDeviceEvent event;
     event.Type                         = DeviceEventType::kCommissioningComplete;

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -200,9 +200,9 @@ private:
     static constexpr uint32_t kFastAdvertiseTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     uint64_t mAdvertiseStartTime;
 
-    static void HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError);
+    static void HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context);
     void HandleFastAdvertisementTimer();
-    static void HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError);
+    static void HandleAdvertisementTimer(System::Layer * systemLayer, void * context);
     void HandleAdvertisementTimer();
 
 #if CONFIG_BT_BLUEDROID_ENABLED

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -695,7 +695,7 @@ void ConnectivityManagerImpl::ChangeWiFiStationState(WiFiStationState newState)
     }
 }
 
-void ConnectivityManagerImpl::DriveStationState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError)
+void ConnectivityManagerImpl::DriveStationState(::chip::System::Layer * aLayer, void * aAppState)
 {
     sInstance.DriveStationState();
 }
@@ -874,7 +874,7 @@ void ConnectivityManagerImpl::ChangeWiFiAPState(WiFiAPState newState)
     }
 }
 
-void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError)
+void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState)
 {
     sInstance.DriveAPState();
 }

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -114,12 +114,12 @@ private:
     void OnStationConnected(void);
     void OnStationDisconnected(void);
     void ChangeWiFiStationState(WiFiStationState newState);
-    static void DriveStationState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError);
+    static void DriveStationState(::chip::System::Layer * aLayer, void * aAppState);
 
     void DriveAPState(void);
     CHIP_ERROR ConfigureWiFiAP(void);
     void ChangeWiFiAPState(WiFiAPState newState);
-    static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError);
+    static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState);
 
     void UpdateInternetConnectivityState(void);
     void OnStationIPv4AddressAvailable(const ip_event_got_ip_t & got_ip);

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -188,7 +188,7 @@ exit:
     return err;
 }
 
-void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
+void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context)
 {
     static_cast<BLEManagerImpl *>(context)->HandleAdvertisementTimer();
 }
@@ -204,7 +204,7 @@ void BLEManagerImpl::HandleAdvertisementTimer()
     }
 }
 
-void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
+void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context)
 {
     static_cast<BLEManagerImpl *>(context)->HandleFastAdvertisementTimer();
 }

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -183,7 +183,7 @@ exit:
     return err;
 }
 
-void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
+void BLEManagerImpl::HandleAdvertisementTimer(System::Layer * systemLayer, void * context)
 {
     static_cast<BLEManagerImpl *>(context)->HandleAdvertisementTimer();
 }
@@ -199,7 +199,7 @@ void BLEManagerImpl::HandleAdvertisementTimer()
     }
 }
 
-void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context, CHIP_ERROR aError)
+void BLEManagerImpl::HandleFastAdvertisementTimer(System::Layer * systemLayer, void * context)
 {
     static_cast<BLEManagerImpl *>(context)->HandleFastAdvertisementTimer();
 }

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -54,7 +54,7 @@ const ChipBleUUID ChipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0
 const ChipBleUUID ChipUUID_CHIPoBLEChar_TX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
                                                  0x9D, 0x12 } };
 
-void HandleConnectTimeout(chip::System::Layer *, void * apEndpoint, CHIP_ERROR)
+void HandleConnectTimeout(chip::System::Layer *, void * apEndpoint)
 {
     assert(apEndpoint != nullptr);
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -831,7 +831,7 @@ void ConnectivityManagerImpl::ChangeWiFiAPState(WiFiAPState newState)
     }
 }
 
-void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError)
+void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState)
 {
     sInstance.DriveAPState();
 }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -158,7 +158,7 @@ private:
     void DriveAPState();
     CHIP_ERROR ConfigureWiFiAP();
     void ChangeWiFiAPState(WiFiAPState newState);
-    static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState, ::CHIP_ERROR aError);
+    static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState);
 #endif
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(unsigned timeoutMs)
     return CHIP_NO_ERROR;
 }
 
-void ChipDeviceScanner::TimerExpiredCallback(chip::System::Layer * layer, void * appState, CHIP_ERROR error)
+void ChipDeviceScanner::TimerExpiredCallback(chip::System::Layer * layer, void * appState)
 {
     static_cast<ChipDeviceScanner *>(appState)->StopScan();
 }

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -75,7 +75,7 @@ public:
     static std::unique_ptr<ChipDeviceScanner> Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate);
 
 private:
-    static void TimerExpiredCallback(chip::System::Layer * layer, void * appState, CHIP_ERROR error);
+    static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
     static int MainLoopStartScan(ChipDeviceScanner * self);
     static int MainLoopStopScan(ChipDeviceScanner * self);
     static void SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self);

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -510,13 +510,13 @@ CHIP_ERROR BLEManagerImpl::HandleTXCharComplete(const ChipDeviceEvent * event)
     return CHIP_NO_ERROR;
 }
 
-void BLEManagerImpl::HandleBLEAdvertisementTimeout(System::Layer * layer, void * param, CHIP_ERROR error)
+void BLEManagerImpl::HandleBLEAdvertisementTimeout(System::Layer * layer, void * param)
 {
     BLEMgr().SetAdvertisingEnabled(false);
     ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because of timeout expired");
 }
 
-void BLEManagerImpl::HandleBLEAdvertisementIntervalChange(System::Layer * layer, void * param, CHIP_ERROR error)
+void BLEManagerImpl::HandleBLEAdvertisementIntervalChange(System::Layer * layer, void * param)
 {
     BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);
     ChipLogProgress(DeviceLayer, "CHIPoBLE advertising mode changed to slow");

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -122,8 +122,8 @@ private:
     static void HandleTXCompleted(bt_conn * conn, void * param);
     static void HandleConnect(bt_conn * conn, uint8_t err);
     static void HandleDisconnect(bt_conn * conn, uint8_t reason);
-    static void HandleBLEAdvertisementTimeout(System::Layer * layer, void * param, CHIP_ERROR error);
-    static void HandleBLEAdvertisementIntervalChange(System::Layer * layer, void * param, CHIP_ERROR error);
+    static void HandleBLEAdvertisementTimeout(System::Layer * layer, void * param);
+    static void HandleBLEAdvertisementIntervalChange(System::Layer * layer, void * param);
 
     // ===== Members for internal use by the following friends.
 

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -63,7 +63,7 @@ void TransferFacilitator::OnResponseTimeout(Messaging::ExchangeContext * ec)
     mTransfer.Reset();
 }
 
-void TransferFacilitator::PollTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error)
+void TransferFacilitator::PollTimerHandler(chip::System::Layer * systemLayer, void * appState)
 {
     VerifyOrReturn(appState != nullptr);
     static_cast<TransferFacilitator *>(appState)->PollForOutput();

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -67,7 +67,7 @@ protected:
     /**
      * The callback for when the poll timer expires. The poll timer regulates how often the TransferSession is polled.
      */
-    static void PollTimerHandler(chip::System::Layer * systemLayer, void * appState, CHIP_ERROR error);
+    static void PollTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
     /**
      * Polls the TransferSession object and calls HandleTransferSessionOutput.

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -56,7 +56,7 @@ class PASETestLoopbackTransport : public Test::LoopbackTransport
         {
             test_os_sleep_ms(65);
             ReliableMessageMgr * rm = mContext->GetExchangeManager().GetReliableMessageMgr();
-            ReliableMessageMgr::Timeout(&mContext->GetSystemLayer(), rm, CHIP_NO_ERROR);
+            ReliableMessageMgr::Timeout(&mContext->GetSystemLayer(), rm);
         }
     }
 

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -133,7 +133,7 @@ void Timer::HandleComplete()
 
     // Invoke the app's callback, if it's still valid.
     if (lOnComplete != nullptr)
-        lOnComplete(&lLayer, lAppState, CHIP_NO_ERROR);
+        lOnComplete(&lLayer, lAppState);
 }
 
 Timer * Timer::List::Add(Timer * add)

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -52,7 +52,7 @@ namespace System {
 
 namespace Timers {
 
-typedef void (*OnCompleteFunct)(Layer * aLayer, void * appState, CHIP_ERROR aError);
+typedef void (*OnCompleteFunct)(Layer * aLayer, void * appState);
 
 } // namespace Timers
 

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -110,13 +110,13 @@ void TimerFailed(void * aState)
     sOverflowTestDone = true;
 }
 
-void HandleTimerFailed(Layer * inetLayer, void * aState, CHIP_ERROR aError)
+void HandleTimerFailed(Layer * inetLayer, void * aState)
 {
-    (void) inetLayer, (void) aError;
+    (void) inetLayer;
     TimerFailed(aState);
 }
 
-void HandleTimer10Success(Layer * inetLayer, void * aState, CHIP_ERROR aError)
+void HandleTimer10Success(Layer * inetLayer, void * aState)
 {
     TestContext & lContext = *static_cast<TestContext *>(aState);
     NL_TEST_ASSERT(lContext.mTestSuite, true);
@@ -149,7 +149,7 @@ static void CheckOverflow(nlTestSuite * inSuite, void * aContext)
     lSys.CancelTimer(HandleTimer10Success, aContext);
 }
 
-void HandleGreedyTimer(Layer * aLayer, void * aState, CHIP_ERROR aError)
+void HandleGreedyTimer(Layer * aLayer, void * aState)
 {
     static uint32_t sNumTimersHandled = 0;
     TestContext & lContext            = *static_cast<TestContext *>(aState);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -506,7 +506,7 @@ void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionSt
     mTransportMgr->Disconnect(state.GetPeerAddress());
 }
 
-void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param, CHIP_ERROR error)
+void SecureSessionMgr::ExpiryTimerCallback(System::Layer * layer, void * param)
 {
     SecureSessionMgr * mgr = reinterpret_cast<SecureSessionMgr *>(param);
 #if CHIP_CONFIG_SESSION_REKEYING

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -304,7 +304,7 @@ private:
     /**
      * Callback for timer expiry check
      */
-    static void ExpiryTimerCallback(System::Layer * layer, void * param, CHIP_ERROR error);
+    static void ExpiryTimerCallback(System::Layer * layer, void * param);
 
     void SecureMessageDispatch(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                System::PacketBufferHandle && msg);


### PR DESCRIPTION
#### Problem

The timer completion callback type `OnCompleteFunct` has a `CHIP_ERROR`
parameter which is always called with `CHIP_NO_ERROR` and never checked
outside a single test case.

#### Change overview

Remove it.

#### Testing

CI. No functional change intended.
