### PR TITLE
Properly set CASE salt span sizes and CASE cleanups

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -438,7 +438,6 @@ public:
      *                                      TLVBackingStore.
      *
      */
-    CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize);
     CHIP_ERROR GetBytes(uint8_t * buf, size_t bufSize);
 
     /**
@@ -488,7 +487,6 @@ public:
      *                                      TLVBackingStore.
      *
      */
-    CHIP_ERROR GetString(char * buf, uint32_t bufSize);
     CHIP_ERROR GetString(char * buf, size_t bufSize);
 
     /**
@@ -2213,7 +2211,6 @@ public:
     CHIP_ERROR Get(double & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR Get(chip::ByteSpan & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize) { return mUpdaterReader.GetBytes(buf, bufSize); }
-    CHIP_ERROR GetBytes(uint8_t * buf, size_t bufSize) { return GetBytes(buf, static_cast<uint32_t>(bufSize)); }
     CHIP_ERROR DupBytes(uint8_t *& buf, uint32_t & dataLen) { return mUpdaterReader.DupBytes(buf, dataLen); }
     CHIP_ERROR GetString(char * buf, uint32_t bufSize) { return mUpdaterReader.GetString(buf, bufSize); }
     CHIP_ERROR DupString(char *& buf) { return mUpdaterReader.DupString(buf); }

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -439,6 +439,7 @@ public:
      *
      */
     CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize);
+    CHIP_ERROR GetBytes(uint8_t * buf, size_t bufSize);
 
     /**
      * Allocates and returns a buffer containing the value of the current byte or UTF8 string.
@@ -488,6 +489,7 @@ public:
      *
      */
     CHIP_ERROR GetString(char * buf, uint32_t bufSize);
+    CHIP_ERROR GetString(char * buf, size_t bufSize);
 
     /**
      * Allocates and returns a buffer containing the null-terminated value of the current byte or UTF8
@@ -2211,6 +2213,7 @@ public:
     CHIP_ERROR Get(double & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR Get(chip::ByteSpan & v) { return mUpdaterReader.Get(v); }
     CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize) { return mUpdaterReader.GetBytes(buf, bufSize); }
+    CHIP_ERROR GetBytes(uint8_t * buf, size_t bufSize) { return GetBytes(buf, static_cast<uint32_t>(bufSize)); }
     CHIP_ERROR DupBytes(uint8_t *& buf, uint32_t & dataLen) { return mUpdaterReader.DupBytes(buf, dataLen); }
     CHIP_ERROR GetString(char * buf, uint32_t bufSize) { return mUpdaterReader.GetString(buf, bufSize); }
     CHIP_ERROR DupString(char *& buf) { return mUpdaterReader.DupString(buf); }

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -264,7 +264,7 @@ CHIP_ERROR TLVReader::Get(ByteSpan & v)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, uint32_t bufSize)
+CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, size_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
         return CHIP_ERROR_WRONG_TLV_TYPE;
@@ -281,12 +281,7 @@ CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, uint32_t bufSize)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, size_t bufSize)
-{
-    return GetBytes(buf, static_cast<uint32_t>(bufSize));
-}
-
-CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
+CHIP_ERROR TLVReader::GetString(char * buf, size_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
         return CHIP_ERROR_WRONG_TLV_TYPE;
@@ -297,11 +292,6 @@ CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
     buf[mElemLenOrVal] = 0;
 
     return GetBytes(reinterpret_cast<uint8_t *>(buf), bufSize - 1);
-}
-
-CHIP_ERROR TLVReader::GetString(char * buf, size_t bufSize)
-{
-    return GetString(buf, static_cast<uint32_t>(bufSize));
 }
 
 CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -281,6 +281,11 @@ CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, uint32_t bufSize)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, size_t bufSize)
+{
+    return GetBytes(buf, static_cast<uint32_t>(bufSize));
+}
+
 CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -292,6 +297,11 @@ CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
     buf[mElemLenOrVal] = 0;
 
     return GetBytes(reinterpret_cast<uint8_t *>(buf), bufSize - 1);
+}
+
+CHIP_ERROR TLVReader::GetString(char * buf, size_t bufSize)
+{
+    return GetString(buf, static_cast<uint32_t>(bufSize));
 }
 
 CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -681,7 +681,12 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
 
     SuccessOrExit(err = decryptedDataTlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
+
     responderOpCertLen = static_cast<size_t>(decryptedDataTlvReader.GetLength());
+    // We use `sizeof(responderOpCert)` rather than `responderOpCertLen` since GetBytes()
+    // validates that the destination buffer is large enough for the equivalent of GetLength().
+    // If we used untrusted `responderOpCertLen` directly, and a bad value was provided,
+    // it could overrun stack without being caught.
     SuccessOrExit(err = decryptedDataTlvReader.GetBytes(responderOpCert, sizeof(responderOpCert)));
 
     // Validate responder identity located in msg_r2_encrypted
@@ -926,7 +931,12 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
 
     SuccessOrExit(err = decryptedDataTlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
+
     initiatorOpCertLen = static_cast<size_t>(decryptedDataTlvReader.GetLength());
+    // We use `sizeof(initiatorOpCert)` rather than `initiatorOpCertLen` since GetBytes()
+    // validates that the destination buffer is large enough for the equivalent of GetLength().
+    // If we used untrusted `initiatorOpCertLen` directly, and a bad value was provided,
+    // it could overrun stack without being caught.
     SuccessOrExit(err = decryptedDataTlvReader.GetBytes(initiatorOpCert, sizeof(initiatorOpCert)));
 
     // Step 5/6

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -307,8 +307,7 @@ CHIP_ERROR CASESession::DeriveSecureSession(SecureSession & session, SecureSessi
 
 CHIP_ERROR CASESession::SendSigmaR1()
 {
-    uint16_t data_len = EstimateTLVStructOverhead(
-        static_cast<uint16_t>(kSigmaParamRandomNumberSize + sizeof(uint16_t) + kSHA256_Hash_Length + kP256_PublicKey_Length), 4);
+    size_t data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize + sizeof(uint16_t) + kSHA256_Hash_Length + kP256_PublicKey_Length, 4);
 
     System::PacketBufferTLVWriter tlvWriter;
     System::PacketBufferHandle msg_R1;
@@ -440,31 +439,23 @@ CHIP_ERROR CASESession::SendSigmaR2()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     System::PacketBufferHandle msg_R2;
-    uint16_t data_len;
+    size_t data_len;
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_rand;
+    uint8_t msg_rand[kSigmaParamRandomNumberSize];
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Signed;
-    uint16_t msg_r2_signed_len;
+    size_t msg_r2_signed_len;
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Encrypted;
-    uint16_t msg_r2_signed_enc_len;
+    size_t msg_r2_signed_enc_len;
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
-    uint16_t saltlen;
+    uint8_t msg_salt[kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length];
 
     uint8_t sr2k[kAEADKeySize];
     P256ECDSASignature tbsData2Signature;
 
-    HKDF_sha_crypto mHKDF;
-
-    saltlen = kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length;
-
-    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
-    VerifyOrExit(msg_rand.Alloc(kSigmaParamRandomNumberSize), err = CHIP_ERROR_NO_MEMORY);
-
     // Fill in the random value
-    err = DRBG_get_bytes(msg_rand.Get(), kSigmaParamRandomNumberSize);
+    err = DRBG_get_bytes(&msg_rand[0], sizeof(msg_rand));
     SuccessOrExit(err);
 
     // Generate an ephemeral keypair
@@ -479,19 +470,18 @@ CHIP_ERROR CASESession::SendSigmaR2()
     SuccessOrExit(err);
 
     {
-        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
-        err = ConstructSaltSigmaR2(ByteSpan(msg_rand.Get(), kSigmaParamRandomNumberSize), mEphemeralKey.Pubkey(), ByteSpan(mIPK),
-                                   saltSpan);
+        MutableByteSpan saltSpan(msg_salt);
+        err = ConstructSaltSigmaR2(ByteSpan(msg_rand), mEphemeralKey.Pubkey(), ByteSpan(mIPK), saltSpan);
+        SuccessOrExit(err);
+
+        HKDF_sha_crypto mHKDF;
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR2Info, kKDFInfoLength, sr2k,
+                            kAEADKeySize);
         SuccessOrExit(err);
     }
 
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR2Info, kKDFInfoLength, sr2k,
-                            kAEADKeySize);
-    SuccessOrExit(err);
-
     // Construct Sigma2 TBS Data
-    msg_r2_signed_len = EstimateTLVStructOverhead(
-        static_cast<uint16_t>(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2), 3);
+    msg_r2_signed_len = EstimateTLVStructOverhead(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R2_Signed.Alloc(msg_r2_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
@@ -499,7 +489,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         TLV::TLVWriter tlvWriter;
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-        tlvWriter.Init(msg_R2_Signed.Get(), msg_r2_signed_len);
+        tlvWriter.Init(msg_R2_Signed.Get(), static_cast<uint32_t>(msg_r2_signed_len));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), mOpCredSet->GetDevOpCred(mTrustedRootId),
                                                mOpCredSet->GetDevOpCredLen(mTrustedRootId)));
@@ -508,7 +498,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mRemotePubKey, static_cast<uint32_t>(mRemotePubKey.Length())));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize());
-        msg_r2_signed_len = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+        msg_r2_signed_len = static_cast<size_t>(tlvWriter.GetLengthWritten());
     }
 
     // Generate a Signature
@@ -516,8 +506,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
     SuccessOrExit(err);
 
     // Construct Sigma2 TBE Data
-    msg_r2_signed_enc_len = EstimateTLVStructOverhead(
-        static_cast<uint16_t>(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + tbsData2Signature.Length()), 2);
+    msg_r2_signed_enc_len = EstimateTLVStructOverhead(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + tbsData2Signature.Length(), 2);
 
     VerifyOrExit(msg_R2_Encrypted.Alloc(msg_r2_signed_enc_len + kTAGSize), err = CHIP_ERROR_NO_MEMORY);
 
@@ -525,7 +514,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         TLV::TLVWriter tlvWriter;
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-        tlvWriter.Init(msg_R2_Encrypted.Get(), msg_r2_signed_enc_len);
+        tlvWriter.Init(msg_R2_Encrypted.Get(), static_cast<uint32_t>(msg_r2_signed_enc_len));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), mOpCredSet->GetDevOpCred(mTrustedRootId),
                                                mOpCredSet->GetDevOpCredLen(mTrustedRootId)));
@@ -533,7 +522,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
             err = tlvWriter.PutBytes(TLV::ContextTag(2), tbsData2Signature, static_cast<uint32_t>(tbsData2Signature.Length())));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize());
-        msg_r2_signed_enc_len = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+        msg_r2_signed_enc_len = static_cast<size_t>(tlvWriter.GetLengthWritten());
     }
 
     // Generate the encrypted data blob
@@ -542,8 +531,8 @@ CHIP_ERROR CASESession::SendSigmaR2()
     SuccessOrExit(err);
 
     // Construct Sigma2 Msg
-    data_len = EstimateTLVStructOverhead(static_cast<uint16_t>(kSigmaParamRandomNumberSize + sizeof(uint16_t) +
-                                                               kP256_PublicKey_Length + msg_r2_signed_enc_len + kTAGSize),
+    data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize + sizeof(uint16_t) +
+                                         kP256_PublicKey_Length + msg_r2_signed_enc_len + kTAGSize,
                                          4);
 
     msg_R2 = System::PacketBufferHandle::New(data_len);
@@ -555,7 +544,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
 
         tlvWriter.Init(std::move(msg_R2));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
-        SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), msg_rand.Get(), kSigmaParamRandomNumberSize));
+        SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), &msg_rand[0], sizeof(msg_rand)));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), mConnectionState.GetLocalKeyID(), true));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(),
                                                static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
@@ -604,15 +593,14 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     const uint8_t * buf = msg->Start();
     size_t buflen       = msg->DataLength();
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
-    uint16_t saltlen;
+    uint8_t msg_salt[kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length];
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Encrypted;
     size_t msg_r2_encrypted_len          = 0;
     size_t msg_r2_encrypted_len_with_tag = 0;
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Signed;
-    uint16_t msg_r2_signed_len;
+    size_t msg_r2_signed_len;
 
     uint8_t sr2k[kAEADKeySize];
 
@@ -621,12 +609,11 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     P256PublicKey remoteCredential;
 
     uint8_t responderRandom[kSigmaParamRandomNumberSize];
-    uint8_t responderOpCert[1024];
-    uint16_t responderOpCertLen;
+    // Responder opCert must fit up to 2x TLV certificates in an array
+    uint8_t responderOpCert[EstimateTLVStructOverhead((2 * kMaxCHIPCertLength), 2)];
+    size_t responderOpCertLen;
 
     uint16_t responderSessionId = 0;
-
-    HKDF_sha_crypto mHKDF;
 
     uint32_t decodeTagIdSeq = 0;
 
@@ -660,17 +647,16 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     SuccessOrExit(err = mEphemeralKey.ECDH_derive_secret(mRemotePubKey, mSharedSecret));
 
     // Generate the S2K key
-    saltlen = kIPKSize + kSigmaParamRandomNumberSize + kP256_PublicKey_Length + kSHA256_Hash_Length;
-
-    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
-
     {
-        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
-        SuccessOrExit(err = ConstructSaltSigmaR2(ByteSpan(responderRandom), mRemotePubKey, ByteSpan(mIPK), saltSpan));
-    }
+        MutableByteSpan saltSpan(msg_salt);
+        err = ConstructSaltSigmaR2(ByteSpan(responderRandom), mRemotePubKey, ByteSpan(mIPK), saltSpan);
+        SuccessOrExit(err);
 
-    SuccessOrExit(err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR2Info,
-                                          kKDFInfoLength, sr2k, kAEADKeySize));
+        HKDF_sha_crypto mHKDF;
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(),
+                                              kKDFSR2Info, kKDFInfoLength, sr2k, kAEADKeySize);
+        SuccessOrExit(err);
+    }
 
     SuccessOrExit(err = mCommissioningHash.AddData(ByteSpan{ buf, buflen }));
 
@@ -695,8 +681,8 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
 
     SuccessOrExit(err = decryptedDataTlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
-    responderOpCertLen = static_cast<uint16_t>(decryptedDataTlvReader.GetLength());
-    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(responderOpCert, responderOpCertLen));
+    responderOpCertLen = static_cast<size_t>(decryptedDataTlvReader.GetLength());
+    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(responderOpCert, sizeof(responderOpCert)));
 
     // Validate responder identity located in msg_r2_encrypted
     // Constructing responder identity
@@ -704,7 +690,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
 
     // Construct msg_R2_Signed and validate the signature in msg_r2_encrypted
     msg_r2_signed_len =
-        EstimateTLVStructOverhead(static_cast<uint16_t>(sizeof(uint16_t) + responderOpCertLen + kP256_PublicKey_Length * 2), 3);
+        EstimateTLVStructOverhead(sizeof(uint16_t) + responderOpCertLen + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R2_Signed.Alloc(msg_r2_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
@@ -714,7 +700,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
     VerifyOrExit(tbsData2Signature.Capacity() >= decryptedDataTlvReader.GetLength(), err = CHIP_ERROR_INVALID_TLV_ELEMENT);
     tbsData2Signature.SetLength(decryptedDataTlvReader.GetLength());
-    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(tbsData2Signature, static_cast<uint32_t>(tbsData2Signature.Length())));
+    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(tbsData2Signature, tbsData2Signature.Length()));
 
     // Validate signature
     SuccessOrExit(err = remoteCredential.ECDSA_validate_msg_signature(msg_R2_Signed.Get(), msg_r2_signed_len, tbsData2Signature));
@@ -737,37 +723,24 @@ CHIP_ERROR CASESession::SendSigmaR3()
 
     MutableByteSpan messageDigestSpan(mMessageDigest);
     System::PacketBufferHandle msg_R3;
-    uint16_t data_len;
+    size_t data_len;
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Encrypted;
-    uint16_t msg_r3_encrypted_len;
+    size_t msg_r3_encrypted_len;
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
-    uint16_t saltlen;
+    uint8_t msg_salt[kIPKSize + kSHA256_Hash_Length];
 
     uint8_t sr3k[kAEADKeySize];
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Signed;
-    uint16_t msg_r3_signed_len;
+    size_t msg_r3_signed_len;
 
     P256ECDSASignature tbsData3Signature;
 
-    HKDF_sha_crypto mHKDF;
-
     ChipLogDetail(SecureChannel, "Sending SigmaR3");
 
-    saltlen = kIPKSize + kSHA256_Hash_Length;
-    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
-
-    {
-        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
-        err = ConstructSaltSigmaR3(ByteSpan(mIPK), saltSpan);
-        SuccessOrExit(err);
-    }
-
     // Prepare SigmaR3 TBS Data Blob
-    msg_r3_signed_len = EstimateTLVStructOverhead(
-        static_cast<uint16_t>(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2), 3);
+    msg_r3_signed_len = EstimateTLVStructOverhead(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R3_Signed.Alloc(msg_r3_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
@@ -775,7 +748,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
         TLV::TLVWriter tlvWriter;
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-        tlvWriter.Init(msg_R3_Signed.Get(), msg_r3_signed_len);
+        tlvWriter.Init(msg_R3_Signed.Get(), static_cast<uint32_t>(msg_r3_signed_len));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), mOpCredSet->GetDevOpCred(mTrustedRootId),
                                                mOpCredSet->GetDevOpCredLen(mTrustedRootId)));
@@ -784,7 +757,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mRemotePubKey, static_cast<uint32_t>(mRemotePubKey.Length())));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize());
-        msg_r3_signed_len = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+        msg_r3_signed_len = static_cast<size_t>(tlvWriter.GetLengthWritten());
     }
 
     // Generate a signature
@@ -792,8 +765,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
     SuccessOrExit(err);
 
     // Prepare SigmaR3 TBE Data Blob
-    msg_r3_encrypted_len = EstimateTLVStructOverhead(
-        static_cast<uint16_t>(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + static_cast<uint16_t>(tbsData3Signature.Length())), 2);
+    msg_r3_encrypted_len = EstimateTLVStructOverhead(mOpCredSet->GetDevOpCredLen(mTrustedRootId) + tbsData3Signature.Length(), 2);
 
     VerifyOrExit(msg_R3_Encrypted.Alloc(msg_r3_encrypted_len + kTAGSize), err = CHIP_ERROR_NO_MEMORY);
 
@@ -801,7 +773,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
         TLV::TLVWriter tlvWriter;
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-        tlvWriter.Init(msg_R3_Encrypted.Get(), msg_r3_encrypted_len);
+        tlvWriter.Init(msg_R3_Encrypted.Get(), static_cast<uint32_t>(msg_r3_encrypted_len));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), mOpCredSet->GetDevOpCred(mTrustedRootId),
                                                mOpCredSet->GetDevOpCredLen(mTrustedRootId)));
@@ -809,13 +781,20 @@ CHIP_ERROR CASESession::SendSigmaR3()
             err = tlvWriter.PutBytes(TLV::ContextTag(2), tbsData3Signature, static_cast<uint32_t>(tbsData3Signature.Length())));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize());
-        msg_r3_encrypted_len = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+        msg_r3_encrypted_len = static_cast<size_t>(tlvWriter.GetLengthWritten());
     }
 
     // Generate S3K key
-    err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR3Info, kKDFInfoLength, sr3k,
-                            kAEADKeySize);
-    SuccessOrExit(err);
+    {
+        MutableByteSpan saltSpan(msg_salt);
+        err = ConstructSaltSigmaR3(ByteSpan(mIPK), saltSpan);
+        SuccessOrExit(err);
+
+        HKDF_sha_crypto mHKDF;
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR3Info,
+                                kKDFInfoLength, sr3k, kAEADKeySize);
+        SuccessOrExit(err);
+    }
 
     // Generated Encrypted data blob
     err = AES_CCM_encrypt(msg_R3_Encrypted.Get(), msg_r3_encrypted_len, nullptr, 0, sr3k, kAEADKeySize, kTBEData3_Nonce,
@@ -823,7 +802,7 @@ CHIP_ERROR CASESession::SendSigmaR3()
     SuccessOrExit(err);
 
     // Generate Sigma3 Msg
-    data_len = EstimateTLVStructOverhead(static_cast<uint16_t>(kTAGSize + msg_r3_encrypted_len), 1);
+    data_len = EstimateTLVStructOverhead(kTAGSize + msg_r3_encrypted_len, 1);
 
     msg_R3 = System::PacketBufferHandle::New(data_len);
     VerifyOrExit(!msg_R3.IsNull(), err = CHIP_ERROR_NO_MEMORY);
@@ -888,7 +867,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
     size_t msg_r3_encrypted_len          = 0;
     size_t msg_r3_encrypted_len_with_tag = 0;
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R3_Signed;
-    uint16_t msg_r3_signed_len;
+    size_t msg_r3_signed_len;
 
     uint8_t sr3k[kAEADKeySize];
 
@@ -896,13 +875,11 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
 
     P256PublicKey remoteCredential;
 
-    uint8_t responderOpCert[1024];
-    uint16_t responderOpCertLen;
+    // Initiator opCert must fit up to 2x TLV certificates in an array
+    uint8_t initiatorOpCert[EstimateTLVStructOverhead((2 * kMaxCHIPCertLength), 2)];
+    size_t initiatorOpCertLen;
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> msg_salt;
-    uint16_t saltlen;
-
-    HKDF_sha_crypto mHKDF;
+    uint8_t msg_salt[kIPKSize + kSHA256_Hash_Length];
 
     uint32_t decodeTagIdSeq = 0;
 
@@ -924,17 +901,16 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
     msg_r3_encrypted_len = msg_r3_encrypted_len_with_tag - kTAGSize;
 
     // Step 1
-    saltlen = kIPKSize + kSHA256_Hash_Length;
-
-    VerifyOrExit(msg_salt.Alloc(saltlen), err = CHIP_ERROR_NO_MEMORY);
-
     {
-        MutableByteSpan saltSpan(msg_salt.Get(), saltlen);
-        SuccessOrExit(err = ConstructSaltSigmaR3(ByteSpan(mIPK), saltSpan));
-    }
+        MutableByteSpan saltSpan(msg_salt);
+        err = ConstructSaltSigmaR3(ByteSpan(mIPK), saltSpan);
+        SuccessOrExit(err);
 
-    SuccessOrExit(err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), msg_salt.Get(), saltlen, kKDFSR3Info,
-                                          kKDFInfoLength, sr3k, kAEADKeySize));
+        HKDF_sha_crypto mHKDF;
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR3Info,
+                                 kKDFInfoLength, sr3k, kAEADKeySize);
+        SuccessOrExit(err);
+    }
 
     SuccessOrExit(err = mCommissioningHash.AddData(ByteSpan{ buf, bufLen }));
 
@@ -951,27 +927,27 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
 
     SuccessOrExit(err = decryptedDataTlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
-    responderOpCertLen = static_cast<uint16_t>(decryptedDataTlvReader.GetLength());
-    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(responderOpCert, responderOpCertLen));
+    initiatorOpCertLen = static_cast<size_t>(decryptedDataTlvReader.GetLength());
+    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(initiatorOpCert, sizeof(initiatorOpCert)));
 
     // Step 5/6
     // Validate initiator identity located in msg->Start()
     // Constructing responder identity
-    SuccessOrExit(err = Validate_and_RetrieveResponderID(ByteSpan(responderOpCert, responderOpCertLen), remoteCredential));
+    SuccessOrExit(err = Validate_and_RetrieveResponderID(ByteSpan(initiatorOpCert, initiatorOpCertLen), remoteCredential));
 
     // Step 4 - Construct SigmaR3 TBS Data
     msg_r3_signed_len =
-        EstimateTLVStructOverhead(static_cast<uint16_t>(sizeof(uint16_t) + responderOpCertLen + kP256_PublicKey_Length * 2), 3);
+        EstimateTLVStructOverhead(sizeof(uint16_t) + initiatorOpCertLen + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R3_Signed.Alloc(msg_r3_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
-    SuccessOrExit(err = ConstructTBS3Data(ByteSpan(responderOpCert, responderOpCertLen), msg_R3_Signed.Get(), msg_r3_signed_len));
+    SuccessOrExit(err = ConstructTBS3Data(ByteSpan(initiatorOpCert, initiatorOpCertLen), msg_R3_Signed.Get(), msg_r3_signed_len));
 
     SuccessOrExit(err = decryptedDataTlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(decryptedDataTlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
     VerifyOrExit(tbsData3Signature.Capacity() >= decryptedDataTlvReader.GetLength(), err = CHIP_ERROR_INVALID_TLV_ELEMENT);
     tbsData3Signature.SetLength(decryptedDataTlvReader.GetLength());
-    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(tbsData3Signature, static_cast<uint32_t>(tbsData3Signature.Length())));
+    SuccessOrExit(err = decryptedDataTlvReader.GetBytes(tbsData3Signature, tbsData3Signature.Length()));
 
     // Step 7 - Validate Signature
     SuccessOrExit(err = remoteCredential.ECDSA_validate_msg_signature(msg_R3_Signed.Get(), msg_r3_signed_len, tbsData3Signature));
@@ -1098,7 +1074,9 @@ CHIP_ERROR CASESession::ConstructSaltSigmaR2(const ByteSpan & rand, const Crypto
     ReturnErrorOnFailure(mCommissioningHash.GetDigest(messageDigestSpan));
     bbuf.Put(messageDigestSpan.data(), messageDigestSpan.size());
 
-    VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    size_t saltWritten = 0;
+    VerifyOrReturnError(bbuf.Fit(saltWritten), CHIP_ERROR_BUFFER_TOO_SMALL);
+    salt = salt.SubSpan(0, saltWritten);
 
     return CHIP_NO_ERROR;
 }
@@ -1114,7 +1092,9 @@ CHIP_ERROR CASESession::ConstructSaltSigmaR3(const ByteSpan & ipk, MutableByteSp
     ReturnErrorOnFailure(mCommissioningHash.GetDigest(messageDigestSpan));
     bbuf.Put(messageDigestSpan.data(), messageDigestSpan.size());
 
-    VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    size_t saltWritten = 0;
+    VerifyOrReturnError(bbuf.Fit(saltWritten), CHIP_ERROR_BUFFER_TOO_SMALL);
+    salt = salt.SubSpan(0, saltWritten);
 
     return CHIP_NO_ERROR;
 }
@@ -1161,12 +1141,12 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const ByteSpan & respon
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::ConstructTBS2Data(const ByteSpan & responderOpCert, uint8_t * tbsData, uint16_t & tbsDataLen)
+CHIP_ERROR CASESession::ConstructTBS2Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen)
 {
     TLV::TLVWriter tlvWriter;
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-    tlvWriter.Init(tbsData, tbsDataLen);
+    tlvWriter.Init(tbsData, static_cast<uint32_t>(tbsDataLen));
     ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(
         tlvWriter.PutBytes(TLV::ContextTag(1), responderOpCert.data(), static_cast<uint32_t>(responderOpCert.size())));
@@ -1175,17 +1155,17 @@ CHIP_ERROR CASESession::ConstructTBS2Data(const ByteSpan & responderOpCert, uint
         tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(), static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize());
-    tbsDataLen = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+    tbsDataLen = static_cast<size_t>(tlvWriter.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CASESession::ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, uint16_t & tbsDataLen)
+CHIP_ERROR CASESession::ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen)
 {
     TLV::TLVWriter tlvWriter;
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
 
-    tlvWriter.Init(tbsData, tbsDataLen);
+    tlvWriter.Init(tbsData, static_cast<uint32_t>(tbsDataLen));
     ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(
         tlvWriter.PutBytes(TLV::ContextTag(1), responderOpCert.data(), static_cast<uint32_t>(responderOpCert.size())));
@@ -1194,7 +1174,7 @@ CHIP_ERROR CASESession::ConstructTBS3Data(const ByteSpan & responderOpCert, uint
         tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(), static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize());
-    tbsDataLen = static_cast<uint16_t>(tlvWriter.GetLengthWritten());
+    tbsDataLen = static_cast<size_t>(tlvWriter.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -307,7 +307,8 @@ CHIP_ERROR CASESession::DeriveSecureSession(SecureSession & session, SecureSessi
 
 CHIP_ERROR CASESession::SendSigmaR1()
 {
-    size_t data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize + sizeof(uint16_t) + kSHA256_Hash_Length + kP256_PublicKey_Length, 4);
+    size_t data_len =
+        EstimateTLVStructOverhead(kSigmaParamRandomNumberSize + sizeof(uint16_t) + kSHA256_Hash_Length + kP256_PublicKey_Length, 4);
 
     System::PacketBufferTLVWriter tlvWriter;
     System::PacketBufferHandle msg_R1;
@@ -475,8 +476,8 @@ CHIP_ERROR CASESession::SendSigmaR2()
         SuccessOrExit(err);
 
         HKDF_sha_crypto mHKDF;
-        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR2Info, kKDFInfoLength, sr2k,
-                            kAEADKeySize);
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR2Info,
+                                kKDFInfoLength, sr2k, kAEADKeySize);
         SuccessOrExit(err);
     }
 
@@ -531,9 +532,8 @@ CHIP_ERROR CASESession::SendSigmaR2()
     SuccessOrExit(err);
 
     // Construct Sigma2 Msg
-    data_len = EstimateTLVStructOverhead(kSigmaParamRandomNumberSize + sizeof(uint16_t) +
-                                         kP256_PublicKey_Length + msg_r2_signed_enc_len + kTAGSize,
-                                         4);
+    data_len = EstimateTLVStructOverhead(
+        kSigmaParamRandomNumberSize + sizeof(uint16_t) + kP256_PublicKey_Length + msg_r2_signed_enc_len + kTAGSize, 4);
 
     msg_R2 = System::PacketBufferHandle::New(data_len);
     VerifyOrExit(!msg_R2.IsNull(), err = CHIP_ERROR_NO_MEMORY);
@@ -653,8 +653,8 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
         SuccessOrExit(err);
 
         HKDF_sha_crypto mHKDF;
-        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(),
-                                              kKDFSR2Info, kKDFInfoLength, sr2k, kAEADKeySize);
+        err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR2Info,
+                                kKDFInfoLength, sr2k, kAEADKeySize);
         SuccessOrExit(err);
     }
 
@@ -689,8 +689,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
     SuccessOrExit(err = Validate_and_RetrieveResponderID(ByteSpan(responderOpCert, responderOpCertLen), remoteCredential));
 
     // Construct msg_R2_Signed and validate the signature in msg_r2_encrypted
-    msg_r2_signed_len =
-        EstimateTLVStructOverhead(sizeof(uint16_t) + responderOpCertLen + kP256_PublicKey_Length * 2, 3);
+    msg_r2_signed_len = EstimateTLVStructOverhead(sizeof(uint16_t) + responderOpCertLen + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R2_Signed.Alloc(msg_r2_signed_len), err = CHIP_ERROR_NO_MEMORY);
 
@@ -908,7 +907,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
 
         HKDF_sha_crypto mHKDF;
         err = mHKDF.HKDF_SHA256(mSharedSecret, mSharedSecret.Length(), saltSpan.data(), saltSpan.size(), kKDFSR3Info,
-                                 kKDFInfoLength, sr3k, kAEADKeySize);
+                                kKDFInfoLength, sr3k, kAEADKeySize);
         SuccessOrExit(err);
     }
 
@@ -936,8 +935,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
     SuccessOrExit(err = Validate_and_RetrieveResponderID(ByteSpan(initiatorOpCert, initiatorOpCertLen), remoteCredential));
 
     // Step 4 - Construct SigmaR3 TBS Data
-    msg_r3_signed_len =
-        EstimateTLVStructOverhead(sizeof(uint16_t) + initiatorOpCertLen + kP256_PublicKey_Length * 2, 3);
+    msg_r3_signed_len = EstimateTLVStructOverhead(sizeof(uint16_t) + initiatorOpCertLen + kP256_PublicKey_Length * 2, 3);
 
     VerifyOrExit(msg_R3_Signed.Alloc(msg_r3_signed_len), err = CHIP_ERROR_NO_MEMORY);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -235,13 +235,13 @@ private:
                                     MutableByteSpan & salt);
     CHIP_ERROR Validate_and_RetrieveResponderID(const ByteSpan & responderOpCert, Crypto::P256PublicKey & responderID);
     CHIP_ERROR ConstructSaltSigmaR3(const ByteSpan & ipk, MutableByteSpan & salt);
-    CHIP_ERROR ConstructTBS2Data(const ByteSpan & responderOpCert, uint8_t * tbsData, uint16_t & tbsDataLen);
-    CHIP_ERROR ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, uint16_t & tbsDataLen);
+    CHIP_ERROR ConstructTBS2Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen);
+    CHIP_ERROR ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen);
     CHIP_ERROR RetrieveIPK(FabricId fabricId, MutableByteSpan & ipk);
 
-    uint16_t EstimateTLVStructOverhead(uint16_t dataLen, uint16_t nFields)
+    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields)
     {
-        return static_cast<uint16_t>(dataLen + sizeof(uint64_t) * nFields);
+        return dataLen + (sizeof(uint64_t) * nFields);
     }
 
     void SendErrorMsg(SigmaErrorType errorCode);

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -239,10 +239,7 @@ private:
     CHIP_ERROR ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen);
     CHIP_ERROR RetrieveIPK(FabricId fabricId, MutableByteSpan & ipk);
 
-    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields)
-    {
-        return dataLen + (sizeof(uint64_t) * nFields);
-    }
+    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields) { return dataLen + (sizeof(uint64_t) * nFields); }
 
     void SendErrorMsg(SigmaErrorType errorCode);
 


### PR DESCRIPTION
#### Problem
- Caller and callee code for Sigma2/Sigma3 salt
  generation need to stay in sync for correct
  usage. If salt buffer grows, but output doesn't
  it can cause garbage data to be used since the
  salt output MutableByteSpan is assumed correct-sized
  rather than ensured to be of correct size.
- Several buffers are read based not on stack buffer size, but on wire size, without bound checks
- Scoping of many constructs is too wide and could be reduced

Fixes: #8913
Issue: #8924

#### Change overview
- This change makes use of the computed final size
  of salts to make sure it stays in sync.
- This change also cleans-up:
  - Random Sigma1 buffer was on heap now on stack
  - Opcert (NOC) buffers reduced on stack to match legal max size
  - No longer trusting some sizes on wire where
    a max buffer size on stack is used
  - De-uint16-ify several variables
  - Reduce scope of HKDF for SR2K/SR3K
  - Remove some superfluous size variables

#### Testing
Testing done: cert tests and CASE unit tests run successfully
