### PR TITLE
BDX: Remove TransferSession::RejectTransfer()

### DIFF
--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -190,17 +190,6 @@ public:
 
     /**
      * @brief
-     *   Reject a TransferInit message. Use Reset() to prepare this object for another transfer.
-     *
-     * @param reason A StatusCode indicating the reason for rejecting the transfer
-     *
-     * @return CHIP_ERROR The result of the preparation of a StatusReport message. May also indicate if the TransferSession object
-     *                    is unable to handle this request.
-     */
-    CHIP_ERROR RejectTransfer(StatusCode reason);
-
-    /**
-     * @brief
      *   Prepare a BlockQuery message. The Block counter will be populated automatically.
      *
      * @return CHIP_ERROR The result of the preparation of a BlockQuery message. May also indicate if the TransferSession object


### PR DESCRIPTION
#### Problem
`TransferSession::RejectTransfer()` does not have an implementation and duplicates existing `AbortTransfer()`
* Fixes #8935 

#### Change overview
remove declaration of `RejectTransfer()`

#### Testing
n/a