### PR TITLE
Fake platform for tests.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -138,16 +138,16 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   group("fake_platform_tests") {
     if (chip_link_tests) {
-      deps = [ "//src:fake_platform_tests_run"]
+      deps = [ "//src:fake_platform_tests_run" ]
     }
   }
 
   group("check") {
     if (chip_link_tests) {
       deps = [
+        "//:fake_platform_tests",
         "//scripts/build:build_examples.tests",
         "//src:tests_run",
-        "//:fake_platform_tests"
       ]
     }
   }
@@ -258,7 +258,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     # Build the k32w shell app example.
     enable_k32w_shell_app_build = enable_k32w_builds
 
-    enable_fake_tests = (enable_default_builds && host_os == "linux")
+    enable_fake_tests = enable_default_builds && host_os == "linux"
   }
 
   if (enable_host_clang_build) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -136,11 +136,18 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
   }
 
+  group("fake_platform_tests") {
+    if (chip_link_tests) {
+      deps = [ "//src:fake_platform_tests_run"]
+    }
+  }
+
   group("check") {
     if (chip_link_tests) {
       deps = [
         "//scripts/build:build_examples.tests",
         "//src:tests_run",
+        "//:fake_platform_tests"
       ]
     }
   }
@@ -250,6 +257,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
     # Build the k32w shell app example.
     enable_k32w_shell_app_build = enable_k32w_builds
+
+    enable_fake_tests = (enable_default_builds && host_os == "linux")
   }
 
   if (enable_host_clang_build) {
@@ -285,6 +294,12 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
     chip_build("android_x86") {
       toolchain = "${build_root}/toolchain/android:android_x86"
+    }
+  }
+
+  if (enable_fake_tests) {
+    chip_build("fake_platform") {
+      toolchain = "${build_root}/toolchain/host:fake_${host_cpu}_gcc"
     }
   }
 
@@ -492,6 +507,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
     if (enable_host_gcc_mbedtls_build) {
       deps += [ ":check_host_gcc_mbedtls" ]
+    }
+    if (enable_fake_tests) {
+      deps += [ ":check_fake_platform" ]
     }
   }
 }

--- a/build/chip/tools.gni
+++ b/build/chip/tools.gni
@@ -15,5 +15,6 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/src/platform/device.gni")
 declare_args() {
   # Build CHIP tools.
-  chip_build_tools = current_os != "freertos" && current_os != "android" && chip_device_platform != "fake"
+  chip_build_tools = current_os != "freertos" && current_os != "android" &&
+                     chip_device_platform != "fake"
 }

--- a/build/toolchain/host/BUILD.gn
+++ b/build/toolchain/host/BUILD.gn
@@ -32,3 +32,13 @@ gcc_toolchain("${host_os}_${host_cpu}_clang") {
     is_clang = true
   }
 }
+
+gcc_toolchain("fake_${host_cpu}_gcc") {
+  toolchain_args = {
+    current_os = host_os
+    current_os = host_os
+    current_cpu = host_cpu
+    is_clang = true
+    fake_platform = true
+  }
+}

--- a/build/toolchain/host/BUILD.gn
+++ b/build/toolchain/host/BUILD.gn
@@ -38,7 +38,7 @@ gcc_toolchain("fake_${host_cpu}_gcc") {
     current_os = host_os
     current_os = host_os
     current_cpu = host_cpu
-    is_clang = true
-    fake_platform = true
+    is_clang = false
+    chip_fake_platform = true
   }
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -111,7 +111,7 @@ if (chip_build_tests) {
     }
   }
 
-  chip_test_group ("fake_platform_tests") {
+  chip_test_group("fake_platform_tests") {
     deps = [ "${chip_root}/src/lib/mdns/platform/tests" ]
   }
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,6 +55,10 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
     ]
 
+    if (chip_device_platform != "fake") {
+      deps += [ "${chip_root}/src/protocols/secure_channel/tests" ]
+    }
+
     if (current_os != "zephyr") {
       deps += [ "${chip_root}/src/lib/mdns/minimal/records/tests" ]
     }
@@ -105,5 +109,9 @@ if (chip_build_tests) {
         "${chip_root}/src/test_driver/happy/tests/standalone/inet:inet_tests",
       ]
     }
+  }
+
+  chip_test_group ("fake_platform_tests") {
+    deps = [ "${chip_root}/src/lib/mdns/platform/tests" ]
   }
 }

--- a/src/lib/mdns/platform/tests/BUILD.gn
+++ b/src/lib/mdns/platform/tests/BUILD.gn
@@ -21,9 +21,7 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libMdnsFakePlatformTests"
   if (chip_device_platform == "fake") {
-    test_sources = [
-      "TestPlatform.cpp",
-    ]
+    test_sources = [ "TestPlatform.cpp" ]
     public_deps = [
       "${chip_root}/src/lib/mdns",
       "${nlunit_test_root}:nlunit-test",

--- a/src/lib/mdns/platform/tests/BUILD.gn
+++ b/src/lib/mdns/platform/tests/BUILD.gn
@@ -11,9 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("${chip_root}/src/platform/device.gni")
-declare_args() {
-  # Build CHIP tools.
-  chip_build_tools = current_os != "freertos" && current_os != "android" && chip_device_platform != "fake"
+import("//build_overrides/nlunit_test.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libMdnsFakePlatformTests"
+  if (chip_device_platform == "fake") {
+    test_sources = [
+      "TestPlatform.cpp",
+    ]
+    public_deps = [
+      "${chip_root}/src/lib/mdns",
+      "${nlunit_test_root}:nlunit-test",
+    ]
+  }
 }

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <mdns/Discovery_ImplPlatform.h>
+#include <support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+using namespace chip::Mdns;
+
+void TestStub(nlTestSuite * inSuite, void * inContext)
+{
+    DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+    OperationalAdvertisingParameters params;
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_NOT_IMPLEMENTED);
+}
+
+const nlTest sTests[] = {
+    NL_TEST_DEF("TestStub", TestStub), //
+    NL_TEST_SENTINEL()                 //
+};
+
+} // namespace
+
+int TestMdnsPlatform(void)
+{
+    nlTestSuite theSuite = { "MdnsPlatform", &sTests[0], nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestMdnsPlatform)

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -179,11 +179,14 @@ if (chip_device_platform != "none") {
         "CHIP_DEVICE_LAYER_TARGET_MBED=1",
         "CHIP_DEVICE_LAYER_TARGET=mbed",
       ]
+    } else if (chip_device_platform == "fake") {
+      defines += [
+        "CHIP_DEVICE_LAYER_TARGET_FAKE=1",
+        "CHIP_DEVICE_LAYER_TARGET=fake",
+      ]
     }
   }
 } else {
-  chip_device_config_enable_mdns = chip_mdns != "none"
-
   buildconfig_header("platform_buildconfig") {
     header = "CHIPDeviceBuildConfig.h"
     header_dir = "platform"
@@ -194,6 +197,7 @@ if (chip_device_platform != "none") {
     ]
 
     if (current_os == "android") {
+      chip_device_config_enable_mdns = chip_mdns != "none"
       defines += [
         "CHIP_DEVICE_CONFIG_ENABLE_MDNS=${chip_device_config_enable_mdns}",
         "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"",
@@ -293,6 +297,8 @@ if (chip_device_platform != "none") {
       _platform_target = chip_platform_target
     } else if (chip_device_platform == "p6") {
       _platform_target = "P6"
+    } else if (chip_device_platform == "fake") {
+      _platform_target = "fake"
     } else {
       assert(false, "Unknown chip_device_platform: ${chip_device_platform}")
     }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -19,6 +19,7 @@ declare_args() {
   # Device platform layer: cc13x2_26x2, darwin, efr32, esp32, external, freertos, linux, nrfconnect, k32w, qpg, none.
   chip_device_platform = "auto"
   chip_platform_target = ""
+
   # Substitue fake platform when building with chip_device_platform=auto.
   chip_fake_platform = false
 }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -19,10 +19,13 @@ declare_args() {
   # Device platform layer: cc13x2_26x2, darwin, efr32, esp32, external, freertos, linux, nrfconnect, k32w, qpg, none.
   chip_device_platform = "auto"
   chip_platform_target = ""
+  fake_platform = false
 }
 
 if (chip_device_platform == "auto") {
-  if (current_os == "mac" || current_os == "ios") {
+  if (fake_platform) {
+    chip_device_platform = "fake"
+  } else if (current_os == "mac" || current_os == "ios") {
     chip_device_platform = "darwin"
   } else if (current_os == "linux") {
     chip_device_platform = "linux"
@@ -43,7 +46,11 @@ declare_args() {
       chip_device_platform == "mbed"
 
   # Enable ble support.
-  chip_enable_ble = chip_config_network_layer_ble
+  if (chip_device_platform == "fake") {
+    chip_enable_ble = false
+  } else {
+    chip_enable_ble = chip_config_network_layer_ble
+  }
 
   # Enable NFC support
   chip_enable_nfc = false
@@ -53,7 +60,8 @@ declare_args() {
       chip_device_platform == "mbed" || chip_device_platform == "p6") {
     chip_mdns = "minimal"
   } else if (chip_device_platform == "darwin" ||
-             chip_device_platform == "cc13x2_26x2" || current_os == "android") {
+             chip_device_platform == "cc13x2_26x2" || current_os == "android" ||
+             chip_device_platform == "fake") {
     chip_mdns = "platform"
   } else {
     chip_mdns = "none"
@@ -119,6 +127,7 @@ if (_chip_device_layer != "none" && chip_device_platform != "external") {
 
 assert(
     (current_os != "freertos" && chip_device_platform == "none") ||
+        chip_device_platform == "fake" ||
         chip_device_platform == "cc13x2_26x2" ||
         chip_device_platform == "darwin" || chip_device_platform == "efr32" ||
         chip_device_platform == "esp32" || chip_device_platform == "external" ||

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -19,11 +19,12 @@ declare_args() {
   # Device platform layer: cc13x2_26x2, darwin, efr32, esp32, external, freertos, linux, nrfconnect, k32w, qpg, none.
   chip_device_platform = "auto"
   chip_platform_target = ""
-  fake_platform = false
+  # Substitue fake platform when building with chip_device_platform=auto.
+  chip_fake_platform = false
 }
 
 if (chip_device_platform == "auto") {
-  if (fake_platform) {
+  if (chip_fake_platform) {
     chip_device_platform = "fake"
   } else if (current_os == "mac" || current_os == "ios") {
     chip_device_platform = "darwin"

--- a/src/platform/fake/BUILD.gn
+++ b/src/platform/fake/BUILD.gn
@@ -27,12 +27,12 @@ static_library("fake") {
     "ConnectivityManagerImpl.h",
     "KeyValueStoreManagerImpl.cpp",
     "KeyValueStoreManagerImpl.h",
+    "MdnsImpl.cpp",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
-    "MdnsImpl.cpp",
   ]
   public_deps = [
-    "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/lib/mdns:platform_header",
+    "${chip_root}/src/platform:platform_base",
   ]
 }

--- a/src/platform/fake/BUILD.gn
+++ b/src/platform/fake/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import("//build_overrides/chip.gni")
+
 import("${chip_root}/src/platform/device.gni")
-declare_args() {
-  # Build CHIP tools.
-  chip_build_tools = current_os != "freertos" && current_os != "android" && chip_device_platform != "fake"
+
+assert(chip_device_platform == "fake")
+
+static_library("fake") {
+  sources = [
+    "CHIPDevicePlatformEvent.h",
+    "ConfigurationManagerImpl.cpp",
+    "ConfigurationManagerImpl.h",
+    "ConnectivityManagerImpl.cpp",
+    "ConnectivityManagerImpl.h",
+    "KeyValueStoreManagerImpl.cpp",
+    "KeyValueStoreManagerImpl.h",
+    "PlatformManagerImpl.cpp",
+    "PlatformManagerImpl.h",
+    "MdnsImpl.cpp",
+  ]
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${chip_root}/src/lib/mdns:platform_header",
+  ]
 }

--- a/src/platform/fake/CHIPDevicePlatformEvent.h
+++ b/src/platform/fake/CHIPDevicePlatformEvent.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub file for platform events for fake platform.
+ */
+
+#pragma once
+
+namespace chip {
+namespace DeviceLayer {
+
+struct ChipDevicePlatformEvent final
+{
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/CHIPDevicePlatformEvent.h
+++ b/src/platform/fake/CHIPDevicePlatformEvent.h
@@ -15,11 +15,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Stub file for platform events for fake platform.
- */
-
 #pragma once
 
 namespace chip {

--- a/src/platform/fake/ConfigurationManagerImpl.cpp
+++ b/src/platform/fake/ConfigurationManagerImpl.cpp
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub for ConfigurationManagerImpl for fake platform.
+ */
+#include <platform/ConfigurationManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/** Singleton instance of the ConfigurationManager implementation object.
+ */
+ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/ConfigurationManagerImpl.cpp
+++ b/src/platform/fake/ConfigurationManagerImpl.cpp
@@ -16,10 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Stub for ConfigurationManagerImpl for fake platform.
- */
 #include <platform/ConfigurationManager.h>
 
 namespace chip {

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -1,0 +1,196 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the ConfigurationManager object
+ */
+
+#pragma once
+#include <platform/ConfigurationManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * Concrete implementation of the ConfigurationManager singleton object for the ESP32 platform.
+ */
+class ConfigurationManagerImpl final : public ConfigurationManager
+{
+    // Allow the ConfigurationManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class ConfigurationManager;
+
+private:
+    CHIP_ERROR _Init() { return CHIP_NO_ERROR; }
+    CHIP_ERROR _GetVendorName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetVendorId(uint16_t & vendorId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetProductName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetProductId(uint16_t & productId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetProductRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetProductRevision(uint16_t & productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreProductRevision(uint16_t productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetFirmwareRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetFirmwareRevision(uint32_t & firmwareRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour, uint8_t & minute,
+                                     uint8_t & second)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreSerialNumber(const char * serialNum, size_t serialNumLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StorePrimaryWiFiMACAddress(const uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetPollPeriod(uint32_t & buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StorePrimary802154MACAddress(const uint8_t * buf) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetDeviceId(uint64_t & deviceId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetDeviceCertificate(uint8_t * buf, size_t bufSize, size_t & certLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetDeviceIntermediateCACerts(uint8_t * buf, size_t bufSize, size_t & certsLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _GetDevicePrivateKey(uint8_t * buf, size_t bufSize, size_t & keyLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+    CHIP_ERROR _StoreDeviceId(uint64_t deviceId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreDeviceCertificate(const uint8_t * cert, size_t certLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreDeviceIntermediateCACerts(const uint8_t * certs, size_t certsLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreDevicePrivateKey(const uint8_t * key, size_t keyLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _ClearOperationalDeviceCredentials(void) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#endif
+    CHIP_ERROR _GetManufacturerDeviceId(uint64_t & deviceId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreManufacturerDeviceId(uint64_t deviceId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetManufacturerDeviceCertificate(uint8_t * buf, size_t bufSize, size_t & certLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _StoreManufacturerDeviceCertificate(const uint8_t * cert, size_t certLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetManufacturerDeviceIntermediateCACerts(uint8_t * buf, size_t bufSize, size_t & certsLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _StoreManufacturerDeviceIntermediateCACerts(const uint8_t * certs, size_t certsLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _GetManufacturerDevicePrivateKey(uint8_t * buf, size_t bufSize, size_t & keyLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _StoreManufacturerDevicePrivateKey(const uint8_t * key, size_t keyLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetSetupPinCode(uint32_t & setupPinCode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreSetupPinCode(uint32_t setupPinCode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetSetupDiscriminator(uint16_t & setupDiscriminator) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreSetupDiscriminator(uint16_t setupDiscriminator) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetFabricId(uint64_t & fabricId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreFabricId(uint64_t fabricId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
+    CHIP_ERROR _GetLifetimeCounter(uint16_t & lifetimeCounter) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _IncrementLifetimeCounter() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#endif
+    CHIP_ERROR _GetServiceId(uint64_t & serviceId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetServiceConfig(uint8_t * buf, size_t bufSize, size_t & serviceConfigLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreServiceConfig(const uint8_t * serviceConfig, size_t serviceConfigLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetPairedAccountId(char * buf, size_t bufSize, size_t & accountIdLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StorePairedAccountId(const char * accountId, size_t accountIdLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreServiceProvisioningData(uint64_t serviceId, const uint8_t * serviceConfig, size_t serviceConfigLen,
+                                             const char * accountId, size_t accountIdLen)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _ClearServiceProvisioningData() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetFailSafeArmed(bool & val) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _SetFailSafeArmed(bool val) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetQRCodeString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetWiFiAPSSID(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo);
+    bool _IsCommissionableDeviceTypeEnabled() { return false; }
+    CHIP_ERROR _GetDeviceType(uint16_t & deviceType) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    bool _IsCommissionableDeviceNameEnabled() { return false; }
+    CHIP_ERROR _GetDeviceName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetInitialPairingHint(uint16_t & pairingHint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetInitialPairingInstruction(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetSecondaryPairingHint(uint16_t & pairingHint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetSecondaryPairingInstruction(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetRegulatoryLocation(uint32_t & location) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreRegulatoryLocation(uint32_t location) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreCountryCode(const char * code, size_t codeLen) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _GetBreadcrumb(uint64_t & breadcrumb) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreBreadcrumb(uint64_t breadcrumb) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _ConfigureChipStack() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if !defined(NDEBUG)
+    CHIP_ERROR _RunUnitTests(void) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#endif
+    bool _IsServiceProvisioned() { return false; }
+    bool _IsMemberOfFabric() { return false; }
+    bool _IsPairedToAccount() { return false; }
+    bool _IsFullyProvisioned() { return false; }
+    CHIP_ERROR _ComputeProvisioningHash(uint8_t * hashBuf, size_t hashBufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+    bool _OperationalDeviceCredentialsProvisioned() { return false; }
+    void _UseManufacturerCredentialsAsOperational(bool val) { return false; }
+#endif
+    void _UseManufacturerCredentialsAsOperational(bool val) {}
+    void _LogDeviceConfig() {}
+    bool _CanFactoryReset() { return true; }
+    void _InitiateFactoryReset() {}
+    CHIP_ERROR _ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
+    // ===== Members for internal use by the following friends.
+
+    friend ConfigurationManager & ConfigurationMgr(void);
+    friend ConfigurationManagerImpl & ConfigurationMgrImpl(void);
+
+    static ConfigurationManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the ConfigurationManager singleton object.
+ *
+ * Chip applications should use this to access features of the ConfigurationManager object
+ * that are common to all platforms.
+ */
+inline ConfigurationManager & ConfigurationMgr(void)
+{
+    return ConfigurationManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager singleton object.
+ *
+ * Chip applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the ESP32 platform.
+ */
+inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
+{
+    return ConfigurationManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -16,11 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Provides an implementation of the ConfigurationManager object
- */
-
 #pragma once
 #include <platform/ConfigurationManager.h>
 
@@ -28,7 +23,7 @@ namespace chip {
 namespace DeviceLayer {
 
 /**
- * Concrete implementation of the ConfigurationManager singleton object for the ESP32 platform.
+ * Concrete implementation of the ConfigurationManager singleton object for the fake platform.
  */
 class ConfigurationManagerImpl final : public ConfigurationManager
 {

--- a/src/platform/fake/ConnectivityManagerImpl.cpp
+++ b/src/platform/fake/ConnectivityManagerImpl.cpp
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub for ConnectivityManagerImpl for fake platform.
+ */
+#include <platform/ConnectivityManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/** Singleton instance of the ConnectivityManager implementation object.
+ */
+ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/ConnectivityManagerImpl.cpp
+++ b/src/platform/fake/ConnectivityManagerImpl.cpp
@@ -16,10 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Stub for ConnectivityManagerImpl for fake platform.
- */
 #include <platform/ConnectivityManager.h>
 
 namespace chip {

--- a/src/platform/fake/ConnectivityManagerImpl.h
+++ b/src/platform/fake/ConnectivityManagerImpl.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/ConnectivityManager.h>
+#include <platform/internal/GenericConnectivityManagerImpl.h>
+#include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
+#include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
+#include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class ConnectivityManagerImpl final : public ConnectivityManager,
+                                      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_NoBLE<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_NoThread<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_NoWiFi<ConnectivityManagerImpl>
+{
+    // Allow the ConnectivityManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class ConnectivityManager;
+
+private:
+    // ===== Members that implement the ConnectivityManager abstract interface.
+    bool _HaveServiceConnectivity(void) { return false; }
+    CHIP_ERROR _Init(void) { return CHIP_NO_ERROR; }
+    void _OnPlatformEvent(const ChipDeviceEvent * event) {}
+
+    // ===== Members for internal use by the following friends.
+    friend ConnectivityManager & ConnectivityMgr(void);
+    friend ConnectivityManagerImpl & ConnectivityMgrImpl(void);
+
+    static ConnectivityManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the ConnectivityManager singleton object.
+ *
+ * chip applications should use this to access features of the ConnectivityManager object
+ * that are common to all platforms.
+ */
+inline ConnectivityManager & ConnectivityMgr(void)
+{
+    return ConnectivityManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the ConnectivityManager singleton object.
+ *
+ * chip applications can use this to gain access to features of the ConnectivityManager
+ * that are specific to the ESP32 platform.
+ */
+inline ConnectivityManagerImpl & ConnectivityMgrImpl(void)
+{
+    return ConnectivityManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/fake/KeyValueStoreManagerImpl.cpp
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub for KeyValueStoreManagerImpl for fake platform.
+ */
+#include <platform/KeyValueStoreManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+/** Singleton instance of the KeyValueStoreManager implementation object.
+ */
+KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/fake/KeyValueStoreManagerImpl.cpp
@@ -16,10 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Stub for KeyValueStoreManagerImpl for fake platform.
- */
 #include <platform/KeyValueStoreManager.h>
 
 namespace chip {

--- a/src/platform/fake/KeyValueStoreManagerImpl.h
+++ b/src/platform/fake/KeyValueStoreManagerImpl.h
@@ -1,0 +1,74 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific implementation of KVS for linux.
+ */
+
+#pragma once
+
+#include <platform/KeyValueStoreManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+class KeyValueStoreManagerImpl : public KeyValueStoreManager
+{
+public:
+    CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR _Delete(const char * key) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _Put(const char * key, const void * value, size_t value_size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+private:
+    // ===== Members for internal use by the following friends.
+    friend KeyValueStoreManager & KeyValueStoreMgr();
+    friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
+
+    static KeyValueStoreManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications should use this to access features of the KeyValueStoreManager object
+ * that are common to all platforms.
+ */
+inline KeyValueStoreManager & KeyValueStoreMgr(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications can use this to gain access to features of the KeyValueStoreManager
+ * that are specific to the ESP32 platform.
+ */
+inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/KeyValueStoreManagerImpl.h
+++ b/src/platform/fake/KeyValueStoreManagerImpl.h
@@ -16,11 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Platform-specific implementation of KVS for linux.
- */
-
 #pragma once
 
 #include <platform/KeyValueStoreManager.h>

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -1,0 +1,60 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "lib/mdns/platform/Mdns.h"
+
+namespace chip {
+namespace Mdns {
+
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsStopPublish()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
+                          chip::Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsResolve(MdnsService * browseResult, chip::Inet::InterfaceId interface, MdnsResolveCallback callback,
+                           void * context)
+
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+void GetMdnsTimeout(timeval & timeout) {}
+void HandleMdnsTimeout() {}
+
+} // namespace Mdns
+} // namespace chip

--- a/src/platform/fake/PlatformManagerImpl.cpp
+++ b/src/platform/fake/PlatformManagerImpl.cpp
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub for PlatformManagerImpl for fake platform.
+ */
+#include <platform/PlatformManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/** Singleton instance of the KeyValueStoreManager implementation object.
+ */
+PlatformManagerImpl PlatformManagerImpl::sInstance;
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -1,0 +1,94 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Stub platform manager for fake platform.
+ */
+
+#pragma once
+
+#include <platform/PlatformManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * Concrete implementation of the PlatformManager singleton object for Linux platforms.
+ */
+class PlatformManagerImpl final : public PlatformManager
+{
+    // Allow the PlatformManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend PlatformManager;
+
+public:
+    // ===== Platform-specific members that may be accessed directly by the application.
+
+private:
+    // ===== Methods that implement the PlatformManager abstract interface.
+
+    CHIP_ERROR _InitChipStack() { return CHIP_NO_ERROR; }
+
+    CHIP_ERROR _AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    void _RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0) {}
+    void _ScheduleWork(AsyncWorkFunct workFunct, intptr_t arg = 0) {}
+    void _RunEventLoop() {}
+    CHIP_ERROR _StartEventLoopTask() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StopEventLoopTask() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    void _PostEvent(const ChipDeviceEvent * event) {}
+    void _DispatchEvent(const ChipDeviceEvent * event) {}
+    CHIP_ERROR _StartChipTimer(int64_t durationMS) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    void _LockChipStack() {}
+    bool _TryLockChipStack() { return true; }
+    void _UnlockChipStack() {}
+    CHIP_ERROR _Shutdown() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    // ===== Members for internal use by the following friends.
+
+    friend PlatformManager & PlatformMgr();
+    friend PlatformManagerImpl & PlatformMgrImpl();
+    friend class Internal::BLEManagerImpl;
+
+    static PlatformManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the PlatformManager singleton object.
+ *
+ * chip applications should use this to access features of the PlatformManager object
+ * that are common to all platforms.
+ */
+inline PlatformManager & PlatformMgr()
+{
+    return PlatformManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the PlatformManager singleton object.
+ *
+ * chip applications can use this to gain access to features of the PlatformManager
+ * that are specific to the ESP32 platform.
+ */
+inline PlatformManagerImpl & PlatformMgrImpl()
+{
+    return PlatformManagerImpl::sInstance;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -18,7 +18,7 @@ import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
-if (chip_device_platform != "none") {
+if (chip_device_platform != "none" && chip_device_platform != "fake") {
   import("${chip_root}/build/chip/chip_test_suite.gni")
 
   chip_test_suite("tests") {


### PR DESCRIPTION
#### Problem
Right now, we don't have a good way to test what gets passed to the
platform layer. Ex. for MDNS, we want to verify that the calls to
Publish, Stop etc. are correct. 

#### Change overview
This adds a very stubbed out fake
platform that can be used to catch and verify calls. Right now,
it does nothing. Developers are welcome to add functionality as
they require. Mdns tests coming in an upcoming PR.

#### Testing
Fake platform builds correctly and passes presubmits. Added very basic example test (TestPlatform) to show the fake platform in use. 
https://github.com/cecille/connectedhomeip/tree/mdns_platform_tests shows how the platform can be used to write unit tests.
