### PR TITLE
Change TLV reader/writer init methods to take buffer size as size_t

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -114,7 +114,7 @@ public:
      * @param[in]   dataLen The length of the TLV data to be parsed.
      *
      */
-    void Init(const uint8_t * data, uint32_t dataLen);
+    void Init(const uint8_t * data, size_t dataLen);
 
     /**
      * Initializes a TLVReader object to read from a TLVBackingStore.
@@ -849,7 +849,7 @@ public:
      * @param[in]   maxLen  The maximum number of bytes that should be written to the output buffer.
      *
      */
-    void Init(uint8_t * buf, uint32_t maxLen);
+    void Init(uint8_t * buf, size_t maxLen);
 
     /**
      * Initializes a TLVWriter object to write into memory provided by a TLVBackingStore.

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -38,13 +38,15 @@ using namespace chip::Encoding;
 
 static const uint8_t sTagSizes[] = { 0, 1, 2, 4, 2, 4, 6, 8 };
 
-void TLVReader::Init(const uint8_t * data, uint32_t dataLen)
+void TLVReader::Init(const uint8_t * data, size_t dataLen)
 {
-    mBackingStore = nullptr;
-    mReadPoint    = data;
-    mBufEnd       = data + dataLen;
-    mLenRead      = 0;
-    mMaxLen       = dataLen;
+    // TODO: Maybe we can just make mMaxLen and mLenRead size_t instead?
+    uint32_t actualDataLen = dataLen > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(dataLen);
+    mBackingStore          = nullptr;
+    mReadPoint             = data;
+    mBufEnd                = data + actualDataLen;
+    mLenRead               = 0;
+    mMaxLen                = actualDataLen;
     ClearElementState();
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -48,13 +48,15 @@ namespace TLV {
 
 using namespace chip::Encoding;
 
-NO_INLINE void TLVWriter::Init(uint8_t * buf, uint32_t maxLen)
+NO_INLINE void TLVWriter::Init(uint8_t * buf, size_t maxLen)
 {
-    mBackingStore = nullptr;
+    // TODO: Maybe we can just make mMaxLen, mLenWritten, mRemainingLen size_t instead?
+    uint32_t actualMaxLen = maxLen > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(maxLen);
+    mBackingStore         = nullptr;
     mBufStart = mWritePoint = buf;
-    mRemainingLen           = maxLen;
+    mRemainingLen           = actualMaxLen;
     mLenWritten             = 0;
-    mMaxLen                 = maxLen;
+    mMaxLen                 = actualMaxLen;
     mContainerType          = kTLVType_NotSpecified;
     SetContainerOpen(false);
     SetCloseContainerReserved(true);


### PR DESCRIPTION
#### Problem
TLVReader/Writer want uint32_t lengths.  This makes various callers have to cast size_t sizes to uint32_t.

Issue #8952 

#### Change overview
Have them accept size_t lengths.

#### Testing
Tree compiles.