### PR TITLE
Initialize Commissioner object with operational credentials

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -29,6 +29,7 @@
 
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 
 void Commands::Register(const char * clusterName, commands_list commandsList)
 {
@@ -45,6 +46,10 @@ int Commands::Run(int argc, char ** argv)
     Command * command = nullptr;
     NodeId localId;
     NodeId remoteId;
+
+    chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
+    chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
 
     err = chip::Platform::MemoryInit();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Memory failure: %s", chip::ErrorStr(err)));
@@ -74,8 +79,29 @@ int Commands::Run(int argc, char ** argv)
     err = mController.SetUdpListenPort(mStorage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", chip::ErrorStr(err)));
 
-    err = mController.Init(localId, initParams);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", chip::ErrorStr(err)));
+    VerifyOrExit(rcac.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(icac.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+
+    {
+        chip::MutableByteSpan nocSpan(noc.Get(), chip::Controller::kMaxCHIPDERCertLength);
+        chip::MutableByteSpan icacSpan(icac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+        chip::MutableByteSpan rcacSpan(rcac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+
+        chip::Crypto::P256Keypair ephemeralKey;
+        SuccessOrExit(err = ephemeralKey.Initialize());
+
+        err = mOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
+        SuccessOrExit(err);
+
+        initParams.ephemeralKeypair = &ephemeralKey;
+        initParams.controllerRCAC   = rcacSpan;
+        initParams.controllerICAC   = icacSpan;
+        initParams.controllerNOC    = nocSpan;
+
+        err = mController.Init(initParams);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", chip::ErrorStr(err)));
+    }
 
 #if CONFIG_USE_SEPARATE_EVENTLOOP
     // ServiceEvents() calls StartEventLoopTask(), which is paired with the

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -91,6 +91,9 @@ int Commands::Run(int argc, char ** argv)
         chip::Crypto::P256Keypair ephemeralKey;
         SuccessOrExit(err = ephemeralKey.Initialize());
 
+        // TODO - OpCreds should only be generated for pairing command
+        //        store the credentials in persistent storage, and
+        //        generate when not available in the storage.
         err = mOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
         SuccessOrExit(err);
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -200,12 +200,13 @@ CHIP_ERROR InitCommissioner()
     chip::Crypto::P256Keypair ephemeralKey;
     ReturnErrorOnFailure(ephemeralKey.Initialize());
 
-    ReturnErrorOnFailure(mOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
+    ReturnErrorOnFailure(
+        gOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
 
-    initParams.ephemeralKeypair = &ephemeralKey;
-    initParams.controllerRCAC   = rcacSpan;
-    initParams.controllerICAC   = icacSpan;
-    initParams.controllerNOC    = nocSpan;
+    params.ephemeralKeypair = &ephemeralKey;
+    params.controllerRCAC   = rcacSpan;
+    params.controllerICAC   = icacSpan;
+    params.controllerNOC    = nocSpan;
 
     ReturnErrorOnFailure(gCommissioner.Init(params));
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -30,6 +30,7 @@
 #include <setup_payload/SetupPayload.h>
 #include <support/CHIPMem.h>
 #include <support/RandUtils.h>
+#include <support/ScopedBuffer.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 #include <ControllerShellCommands.h>
@@ -183,7 +184,30 @@ CHIP_ERROR InitCommissioner()
 
     ReturnErrorOnFailure(gCommissioner.SetUdpListenPort(CHIP_PORT + 2));
     ReturnErrorOnFailure(gCommissioner.SetUdcListenPort(CHIP_PORT + 3));
-    ReturnErrorOnFailure(gCommissioner.Init(localId, params));
+
+    chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
+    VerifyOrReturnError(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
+    chip::MutableByteSpan nocSpan(noc.Get(), chip::Controller::kMaxCHIPDERCertLength);
+
+    chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
+    VerifyOrReturnError(icac.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
+    chip::MutableByteSpan icacSpan(icac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+
+    chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
+    VerifyOrReturnError(rcac.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
+    chip::MutableByteSpan rcacSpan(rcac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+
+    chip::Crypto::P256Keypair ephemeralKey;
+    ReturnErrorOnFailure(ephemeralKey.Initialize());
+
+    ReturnErrorOnFailure(mOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
+
+    initParams.ephemeralKeypair = &ephemeralKey;
+    initParams.controllerRCAC   = rcacSpan;
+    initParams.controllerICAC   = icacSpan;
+    initParams.controllerNOC    = nocSpan;
+
+    ReturnErrorOnFailure(gCommissioner.Init(params));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -102,9 +102,7 @@ using namespace chip::Protocols::UserDirectedCommissioning;
 
 constexpr uint32_t kSessionEstablishmentTimeout = 30 * kMillisecondsPerSecond;
 
-constexpr uint32_t kMaxCHIPCSRLength = 1024;
-
-DeviceController::DeviceController() : mLocalNOCChainCallback(OnLocalNOCChainGeneration, this)
+DeviceController::DeviceController()
 {
     mState                    = State::NotInitialized;
     mSessionMgr               = nullptr;
@@ -115,7 +113,7 @@ DeviceController::DeviceController() : mLocalNOCChainCallback(OnLocalNOCChainGen
     mListenPort               = CHIP_PORT;
 }
 
-CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams params)
+CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 {
     VerifyOrReturnError(mState == State::NotInitialized, CHIP_ERROR_INCORRECT_STATE);
 
@@ -196,147 +194,54 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, ControllerInitParams par
 
     InitDataModelHandler(mExchangeMgr);
 
-    mState         = State::Initialized;
-    mLocalDeviceId = localDeviceId;
-
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mOperationalCredentialsDelegate = params.operationalCredentialsDelegate;
 
-    if (LoadLocalCredentials() != CHIP_NO_ERROR)
-    {
-        ReturnErrorOnFailure(GenerateLocalCredentials());
-    }
+    ReturnErrorOnFailure(ProcessControllerNOCChain(params));
+
+    mState = State::Initialized;
 
     ReleaseAllDevices();
 
     return CHIP_NO_ERROR;
 }
 
-void DeviceController::OnLocalNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                                 const ByteSpan & rcac)
+CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParams & params)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    DeviceController * controller = static_cast<DeviceController *>(context);
-
     Transport::FabricInfo newFabric;
 
-    newFabric.SetEphemeralKey(&controller->mOperationalKey);
+    ReturnErrorCodeIf(params.ephemeralKeypair == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    newFabric.SetEphemeralKey(params.ephemeralKeypair);
 
     constexpr uint32_t chipCertAllocatedLen = kMaxCHIPCertLength * 2;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
 
+    ReturnErrorCodeIf(!chipCert.Alloc(chipCertAllocatedLen), CHIP_ERROR_NO_MEMORY);
+
     uint32_t chipCertLen = 0;
+    ReturnErrorOnFailure(ConvertX509CertToChipCert(params.controllerRCAC, chipCert.Get(), chipCertAllocatedLen, chipCertLen));
+    ReturnErrorOnFailure(newFabric.SetRootCert(ByteSpan(chipCert.Get(), chipCertLen)));
 
-    Transport::FabricInfo * fabric = nullptr;
-
-    // Check if the callback returned a failure
-    VerifyOrExit(status == CHIP_NO_ERROR, err = status);
-
-    VerifyOrExit(chipCert.Alloc(chipCertAllocatedLen), err = CHIP_ERROR_NO_MEMORY);
-
-    err = ConvertX509CertToChipCert(rcac, chipCert.Get(), chipCertAllocatedLen, chipCertLen);
-    SuccessOrExit(err);
-
-    err = newFabric.SetRootCert(ByteSpan(chipCert.Get(), chipCertLen));
-    SuccessOrExit(err);
-
-    if (icac.empty())
+    if (params.controllerICAC.empty())
     {
         ChipLogProgress(Controller, "Intermediate CA is not needed");
     }
 
-    {
-        MutableByteSpan chipCertSpan(chipCert.Get(), chipCertAllocatedLen);
+    MutableByteSpan chipCertSpan(chipCert.Get(), chipCertAllocatedLen);
 
-        err = ConvertX509CertsToChipCertArray(noc, icac, chipCertSpan);
-        SuccessOrExit(err);
-
-        err = newFabric.SetOperationalCertsFromCertArray(chipCertSpan);
-        SuccessOrExit(err);
-    }
-
-    err = controller->mFabrics.AddNewFabric(newFabric, &controller->mFabricIndex);
-    SuccessOrExit(err);
-    ChipLogProgress(Controller, "Added new fabric %d", controller->mFabricIndex);
-
-    ChipLogProgress(Controller, "Storing controller credentials");
-    err = controller->mFabrics.Store(controller->mFabricIndex);
-    SuccessOrExit(err);
-
-    fabric = controller->mFabrics.FindFabricWithIndex(controller->mFabricIndex);
-    VerifyOrExit(fabric != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-
-    err = fabric->GetCredentials(controller->mCredentials, controller->mCertificates, controller->mRootKeyId,
-                                 controller->mCredentialsIndex);
-    SuccessOrExit(err);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Failed in generating local operational credentials. Error %s", ErrorStr(err));
-        controller->mState = State::NotInitialized;
-    }
-}
-
-CHIP_ERROR DeviceController::GenerateLocalCredentials()
-{
-    ChipLogProgress(Controller, "Generating new local credentials");
-    mOperationalKey.Initialize();
-
-    chip::Platform::ScopedMemoryBuffer<uint8_t> CSR;
-    size_t csrLength = kMaxCHIPCSRLength;
-    ReturnErrorCodeIf(!CSR.Alloc(csrLength), CHIP_ERROR_NO_MEMORY);
-
-    ReturnErrorOnFailure(mOperationalKey.NewCertificateSigningRequest(CSR.Get(), csrLength));
-
-    ChipLogProgress(Controller, "Getting certificate chain for the controller from the issuer");
-
-    // As per specifications section 11.22.5.1. Constant RESP_MAX
-    constexpr uint16_t kMaxRspLen = 900;
-    chip::Platform::ScopedMemoryBuffer<uint8_t> csrElements;
-    ReturnErrorCodeIf(!csrElements.Alloc(kMaxRspLen), CHIP_ERROR_NO_MEMORY);
-
-    TLV::TLVWriter csrElementWriter;
-    TLV::TLVType containerType;
-    csrElementWriter.Init(csrElements.Get(), kMaxRspLen);
-    ReturnErrorOnFailure(csrElementWriter.StartContainer(TLV::AnonymousTag, TLV::TLVType::kTLVType_Structure, containerType));
-    ReturnErrorOnFailure(csrElementWriter.Put(TLV::ContextTag(1), ByteSpan(CSR.Get(), csrLength)));
-
-    // TODO - Need a mechanism to generate CSRNonce for commissioner's CSR
-    ReturnErrorOnFailure(csrElementWriter.Put(TLV::ContextTag(2), ByteSpan()));
-    ReturnErrorOnFailure(csrElementWriter.Put(TLV::ContextTag(3), ByteSpan()));
-    ReturnErrorOnFailure(csrElementWriter.Put(TLV::ContextTag(4), ByteSpan()));
-    ReturnErrorOnFailure(csrElementWriter.Put(TLV::ContextTag(5), ByteSpan()));
-    ReturnErrorOnFailure(csrElementWriter.EndContainer(containerType));
-    ReturnErrorOnFailure(csrElementWriter.Finalize());
-
-    mOperationalCredentialsDelegate->SetNodeIdForNextNOCRequest(mLocalDeviceId);
-    mOperationalCredentialsDelegate->SetFabricIdForNextNOCRequest(0);
-
-    // TODO - Need a mechanism to generate signature for commissioner's CSR
-    ReturnErrorOnFailure(
-        mOperationalCredentialsDelegate->GenerateNOCChain(ByteSpan(csrElements.Get(), csrElementWriter.GetLengthWritten()),
-                                                          ByteSpan(), ByteSpan(), ByteSpan(), ByteSpan(), &mLocalNOCChainCallback));
-
-    ChipLogProgress(Controller, "Called credentials delegate to generate credentials");
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DeviceController::LoadLocalCredentials()
-{
-    ChipLogProgress(Controller, "Loading local credentials for fabric %d from the storage", mFabricIndex);
-    ReturnErrorOnFailure(mFabrics.LoadFromStorage(mFabricIndex));
+    ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(params.controllerNOC, params.controllerICAC, chipCertSpan));
+    ReturnErrorOnFailure(newFabric.SetOperationalCertsFromCertArray(chipCertSpan));
+    newFabric.SetVendorId(params.controllerVendorId);
+    ReturnErrorOnFailure(mFabrics.AddNewFabric(newFabric, &mFabricIndex));
+    ChipLogProgress(Controller, "Joined new fabric at index %d", mFabricIndex);
 
     Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    ReturnErrorCodeIf(!fabric->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorCodeIf(!fabric->AreCredentialsAvailable(), CHIP_ERROR_INCORRECT_STATE);
-
     ReturnErrorOnFailure(fabric->GetCredentials(mCredentials, mCertificates, mRootKeyId, mCredentialsIndex));
 
-    ChipLogProgress(Controller, "Loaded credentials successfully");
+    mLocalDeviceId = fabric->GetNodeId();
+    mVendorId      = fabric->GetVendorId();
+
     return CHIP_NO_ERROR;
 }
 
@@ -844,9 +749,9 @@ DeviceCommissioner::DeviceCommissioner() :
     mPairedDevicesUpdated = false;
 }
 
-CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, CommissionerInitParams params)
+CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 {
-    ReturnErrorOnFailure(DeviceController::Init(localDeviceId, params));
+    ReturnErrorOnFailure(DeviceController::Init(params));
 
     uint16_t nextKeyID = 0;
     uint16_t size      = sizeof(nextKeyID);
@@ -1298,7 +1203,7 @@ void DeviceCommissioner::OnDeviceNOCChainGeneration(void * context, CHIP_ERROR s
 
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
-    ChipLogError(Controller, "Received callback from the CA for NOC Chain generation. Status %s", ErrorStr(status));
+    ChipLogProgress(Controller, "Received callback from the CA for NOC Chain generation. Status %s", ErrorStr(status));
     Device * device = nullptr;
     VerifyOrExit(commissioner->mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(commissioner->mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
@@ -1368,7 +1273,8 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(Device * device, const
     Callback::Cancelable * successCallback = mNOCResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCertFailureCallback.Cancel();
 
-    ReturnErrorOnFailure(cluster.AddNOC(successCallback, failureCallback, opCertBuf, ByteSpan(nullptr, 0), mLocalDeviceId, 0));
+    ReturnErrorOnFailure(
+        cluster.AddNOC(successCallback, failureCallback, opCertBuf, ByteSpan(nullptr, 0), mLocalDeviceId, mVendorId));
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
     ChipLogProgress(Controller, "Sent operational certificate to the device");

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -92,10 +92,15 @@ struct ControllerInitParams
 #endif
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 
+    /* The following keypair must correspond to the public key used for generating
+       controllerNOC. It's used by controller to establish CASE sessions with devices */
     Crypto::P256Keypair * ephemeralKeypair = nullptr;
+
+    /* The following certificates must be in x509 DER format */
     ByteSpan controllerNOC;
     ByteSpan controllerICAC;
     ByteSpan controllerRCAC;
+
     uint16_t controllerVendorId;
 };
 
@@ -353,8 +358,6 @@ protected:
 
     FabricIndex mFabricIndex = 1;
     Transport::FabricTable mFabrics;
-
-    Crypto::P256Keypair mOperationalKey;
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -91,6 +91,12 @@ struct ControllerInitParams
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
 #endif
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
+
+    Crypto::P256Keypair * ephemeralKeypair = nullptr;
+    ByteSpan controllerNOC;
+    ByteSpan controllerICAC;
+    ByteSpan controllerRCAC;
+    uint16_t controllerVendorId;
 };
 
 enum CommissioningStage : uint8_t
@@ -210,7 +216,7 @@ public:
     DeviceController();
     virtual ~DeviceController() {}
 
-    CHIP_ERROR Init(NodeId localDeviceId, ControllerInitParams params);
+    CHIP_ERROR Init(ControllerInitParams params);
 
     /**
      * @brief
@@ -359,6 +365,8 @@ protected:
 
     SessionIDAllocator mIDAllocator;
 
+    uint16_t mVendorId;
+
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     //////////// ResolverDelegate Implementation ///////////////
     void OnNodeIdResolved(const chip::Mdns::ResolvedNodeData & nodeData) override;
@@ -378,13 +386,7 @@ private:
 
     void ReleaseAllDevices();
 
-    CHIP_ERROR LoadLocalCredentials();
-
-    CHIP_ERROR GenerateLocalCredentials();
-
-    static void OnLocalNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                          const ByteSpan & rcac);
-    Callback::Callback<OnNOCChainGeneration> mLocalNOCChainCallback;
+    CHIP_ERROR ProcessControllerNOCChain(const ControllerInitParams & params);
 };
 
 /**
@@ -436,7 +438,7 @@ public:
     /**
      * Commissioner-specific initialization, includes parameters such as the pairing delegate.
      */
-    CHIP_ERROR Init(NodeId localDeviceId, CommissionerInitParams params);
+    CHIP_ERROR Init(CommissionerInitParams params);
 
     /**
      * @brief

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -89,6 +89,49 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId,
+                                                                                const Crypto::P256PublicKey & pubkey,
+                                                                                MutableByteSpan & rcac, MutableByteSpan & icac,
+                                                                                MutableByteSpan & noc)
+{
+    uint32_t nocLen = static_cast<uint32_t>(std::min(noc.size(), static_cast<size_t>(UINT32_MAX)));
+    ChipLogProgress(Controller, "Generating NOC");
+    X509CertRequestParams noc_request = { 1, mIntermediateIssuerId, mNow, mNow + mValidity, true, fabricId, true, nodeId };
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey,
+                                                    mIntermediateIssuer, noc.data(), nocLen, nocLen));
+    noc.reduce_size(nocLen);
+
+    uint32_t icacLen = static_cast<uint32_t>(std::min(icac.size(), static_cast<size_t>(UINT32_MAX)));
+    ChipLogProgress(Controller, "Generating ICAC");
+    X509CertRequestParams icac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    ReturnErrorOnFailure(
+        NewICAX509Cert(icac_request, mIntermediateIssuerId, mIntermediateIssuer.Pubkey(), mIssuer, icac.data(), icacLen, icacLen));
+    icac.reduce_size(icacLen);
+
+    uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+                      err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+    if (err == CHIP_NO_ERROR)
+    {
+        // Found root certificate in the storage.
+        rcac.reduce_size(rcacBufLen);
+        return CHIP_NO_ERROR;
+    }
+
+    uint32_t rcacLen = static_cast<uint32_t>(std::min(rcac.size(), static_cast<size_t>(UINT32_MAX)));
+    ChipLogProgress(Controller, "Generating RCAC");
+    X509CertRequestParams rcac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac.data(), rcacLen, rcacLen));
+    rcac.reduce_size(rcacLen);
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+                      err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+
+    return err;
+}
+
 CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan & csrElements,
                                                                  const ByteSpan & attestationSignature, const ByteSpan & DAC,
                                                                  const ByteSpan & PAI, const ByteSpan & PAA,
@@ -105,8 +148,6 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
     {
         assignedId = mNextAvailableNodeId++;
     }
-
-    X509CertRequestParams noc_request = { 1, mIntermediateIssuerId, mNow, mNow + mValidity, true, mNextFabricId, true, assignedId };
 
     ChipLogProgress(Controller, "Verifying Certificate Signing Request");
     TLVReader reader;
@@ -132,47 +173,20 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
     ReturnErrorCodeIf(!noc.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    uint32_t nocLen = 0;
-
-    ChipLogProgress(Controller, "Generating NOC");
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey,
-                                                    mIntermediateIssuer, noc.Get(), kMaxCHIPDERCertLength, nocLen));
-
-    X509CertRequestParams icac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, mNextFabricId, false, 0 };
+    MutableByteSpan nocSpan(noc.Get(), kMaxCHIPDERCertLength);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
     ReturnErrorCodeIf(!icac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    uint32_t icacLen = 0;
-
-    ChipLogProgress(Controller, "Generating ICAC");
-    ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuerId, mIntermediateIssuer.Pubkey(), mIssuer, icac.Get(),
-                                        kMaxCHIPDERCertLength, icacLen));
+    MutableByteSpan icacSpan(icac.Get(), kMaxCHIPDERCertLength);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
     ReturnErrorCodeIf(!rcac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    uint16_t rootCertBufLen = kMaxCHIPDERCertLength;
+    MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    PERSISTENT_KEY_OP(mNextFabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = mStorage->SyncGetKeyValue(key, rcac.Get(), rootCertBufLen));
-    if (err != CHIP_NO_ERROR)
-    {
-        // Storage doesn't have an existing root certificate. Let's create one and add it to the storage.
-        X509CertRequestParams request = { 0, mIssuerId, mNow, mNow + mValidity, true, mNextFabricId, false, 0 };
-        uint32_t outCertLen           = 0;
-        ChipLogProgress(Controller, "Generating RCAC");
-        ReturnErrorOnFailure(NewRootX509Cert(request, mIssuer, rcac.Get(), kMaxCHIPDERCertLength, outCertLen));
-
-        VerifyOrReturnError(CanCastTo<uint16_t>(outCertLen), CHIP_ERROR_INVALID_ARGUMENT);
-        rootCertBufLen = static_cast<uint16_t>(outCertLen);
-        PERSISTENT_KEY_OP(mNextFabricId, kOperationalCredentialsRootCertificateStorage, key,
-                          err = mStorage->SyncSetKeyValue(key, rcac.Get(), rootCertBufLen));
-        ReturnErrorOnFailure(err);
-    }
+    ReturnErrorOnFailure(GenerateNOCChainAfterValidation(assignedId, mNextFabricId, pubkey, rcacSpan, icacSpan, nocSpan));
 
     ChipLogProgress(Controller, "Providing certificate chain to the commissioner");
-    onCompletion->mCall(onCompletion->mContext, CHIP_NO_ERROR, ByteSpan(noc.Get(), nocLen), ByteSpan(icac.Get(), icacLen),
-                        ByteSpan(rcac.Get(), rootCertBufLen));
+    onCompletion->mCall(onCompletion->mContext, CHIP_NO_ERROR, nocSpan, icacSpan, rcacSpan);
     return CHIP_NO_ERROR;
 }
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -94,19 +94,14 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
                                                                                 MutableByteSpan & rcac, MutableByteSpan & icac,
                                                                                 MutableByteSpan & noc)
 {
-    uint32_t nocLen = static_cast<uint32_t>(std::min(noc.size(), static_cast<size_t>(UINT32_MAX)));
     ChipLogProgress(Controller, "Generating NOC");
     X509CertRequestParams noc_request = { 1, mIntermediateIssuerId, mNow, mNow + mValidity, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey,
-                                                    mIntermediateIssuer, noc.data(), nocLen, nocLen));
-    noc.reduce_size(nocLen);
+    ReturnErrorOnFailure(
+        NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey, mIntermediateIssuer, noc));
 
-    uint32_t icacLen = static_cast<uint32_t>(std::min(icac.size(), static_cast<size_t>(UINT32_MAX)));
     ChipLogProgress(Controller, "Generating ICAC");
     X509CertRequestParams icac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
-    ReturnErrorOnFailure(
-        NewICAX509Cert(icac_request, mIntermediateIssuerId, mIntermediateIssuer.Pubkey(), mIssuer, icac.data(), icacLen, icacLen));
-    icac.reduce_size(icacLen);
+    ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuerId, mIntermediateIssuer.Pubkey(), mIssuer, icac));
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
     CHIP_ERROR err      = CHIP_NO_ERROR;
@@ -119,11 +114,9 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         return CHIP_NO_ERROR;
     }
 
-    uint32_t rcacLen = static_cast<uint32_t>(std::min(rcac.size(), static_cast<size_t>(UINT32_MAX)));
     ChipLogProgress(Controller, "Generating RCAC");
     X509CertRequestParams rcac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
-    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac.data(), rcacLen, rcacLen));
-    rcac.reduce_size(rcacLen);
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -34,6 +34,7 @@
 #include <core/CHIPPersistentStorageDelegate.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <support/CodeUtils.h>
+#include <support/Span.h>
 
 namespace chip {
 namespace Controller {
@@ -82,6 +83,12 @@ public:
      * On error no guarantees are made about the state of aNodeId.
      */
     static CHIP_ERROR GetRandomOperationalNodeId(NodeId * aNodeId);
+
+    /**
+     * This is a utility method that generates a operational certificate chain for the given public key.
+     */
+    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & ephemeralKey,
+                                               MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc);
 
 private:
     Crypto::P256Keypair mIssuer;

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -86,6 +86,8 @@ public:
 
     /**
      * This is a utility method that generates a operational certificate chain for the given public key.
+     * This method is expected to be called once all the checks (e.g. device attestation, CSR verification etc)
+     * have been completed, or not required (e.g. for self trusted devices such as commissioner apps).
      */
     CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & ephemeralKey,
                                                MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc);

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -247,8 +247,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
         return nullptr;
     }
 
-    *errInfoOnFailure =
-        mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
+    *errInfoOnFailure = wrapper->GenerateNOCChainAfterValidation(nodeId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {
         return nullptr;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -61,6 +61,41 @@ void AndroidDeviceControllerWrapper::CallJavaMethod(const char * methodName, jin
                                              argument);
 }
 
+CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & ephemeralKey,
+                                           MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc)
+{
+    uint32_t nocLen = static_cast<uint32_t>(std::min(noc.size(), static_cast<size_t>(UINT32_MAX)));
+    ChipLogProgress(Controller, "Generating NOC");
+    X509CertRequestParams noc_request = { 1, mIntermediateIssuerId, mNow, mNow + mValidity, true, fabricId, true, nodeId };
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsIntermediateCA, pubkey,
+                                                    mIntermediateIssuer, noc.data(), nocLen, nocLen));
+    noc.reduce_size(nocLen);
+    icac.reduce_size(0);
+
+    uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+                      err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+    if (err == CHIP_NO_ERROR)
+    {
+        // Found root certificate in the storage.
+        rcac.reduce_size(rcacBufLen);
+        return CHIP_NO_ERROR;
+    }
+
+    uint32_t rcacLen = static_cast<uint32_t>(std::min(rcac.size(), static_cast<size_t>(UINT32_MAX)));
+    ChipLogProgress(Controller, "Generating RCAC");
+    X509CertRequestParams rcac_request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac.data(), rcacLen, rcacLen));
+    rcac.reduce_size(rcacLen);
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+                      err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+
+    return err;
+}
+
 // TODO Refactor this API to match latest spec, so that GenerateNodeOperationalCertificate receives the full CSR Elements data
 // payload.
 CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csrElements, const ByteSpan & attestationSignature,
@@ -80,7 +115,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csr
     // Initializing the KeyPair.
     Initialize();
 
-    chip::NodeId assignedId;
+    NodeId assignedId;
     if (mNodeIdRequested)
     {
         assignedId       = mNextRequestedNodeId;
@@ -90,10 +125,6 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csr
     {
         assignedId = mNextAvailableNodeId++;
     }
-
-    chip::Credentials::X509CertRequestParams request = {
-        1, mIssuerId, mNow, mNow + mValidity, true, mNextFabricId, true, assignedId
-    };
 
     TLVReader reader;
     reader.Init(csrElements.data(), static_cast<uint32_t>(csrElements.size()));
@@ -113,39 +144,23 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csr
     ByteSpan csr(reader.GetReadPoint(), reader.GetLength());
     reader.ExitContainer(containerType);
 
-    chip::P256PublicKey pubkey;
+    P256PublicKey pubkey;
     ReturnErrorOnFailure(VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));
 
     ChipLogProgress(chipTool, "VerifyCertificateSigningRequest");
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
+    Platform::ScopedMemoryBuffer<uint8_t> noc;
     ReturnErrorCodeIf(!noc.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    uint32_t nocLen = 0;
+    MutableByteSpan nocSpan(noc.Get(), kMaxCHIPDERCertLength);
 
-    CHIP_ERROR generateCert = NewNodeOperationalX509Cert(request, chip::Credentials::CertificateIssuerLevel::kIssuerIsRootCA,
-                                                         pubkey, mIssuer, noc.Get(), kMaxCHIPDERCertLength, nocLen);
-
-    chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
+    Platform::ScopedMemoryBuffer<uint8_t> rcac;
     ReturnErrorCodeIf(!rcac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    uint16_t rootCertBufLen = kMaxCHIPDERCertLength;
+    MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
 
-    PERSISTENT_KEY_OP(mNextFabricId, kOperationalCredentialsRootCertificateStorage, key,
-                      err = SyncGetKeyValue(key, rcac.Get(), rootCertBufLen));
-    if (err != CHIP_NO_ERROR)
-    {
-        // Storage doesn't have an existing root certificate. Let's create one and add it to the storage.
-        chip::Credentials::X509CertRequestParams rcac_request = { 0,    mIssuerId,     mNow,  mNow + mValidity,
-                                                                  true, mNextFabricId, false, 0 };
+    MutableByteSpan icacSpan;
 
-        uint32_t outCertLen = 0;
-        ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac.Get(), kMaxCHIPDERCertLength, outCertLen));
+    ReturnErrorOnFailure(GenerateNOCChainAfterValidation(assignedId, mNextFabricId, pubkey, rcacSpan, icacSpan, nocSpan));
 
-        VerifyOrReturnError(CanCastTo<uint16_t>(outCertLen), CHIP_ERROR_INVALID_ARGUMENT);
-        rootCertBufLen = static_cast<uint16_t>(outCertLen);
-        PERSISTENT_KEY_OP(mNextFabricId, kOperationalCredentialsRootCertificateStorage, key,
-                          err = SyncSetKeyValue(key, rcac.Get(), rootCertBufLen));
-        ReturnErrorOnFailure(err);
-    }
 
     onCompletion->mCall(onCompletion->mContext, generateCert, ByteSpan(noc.Get(), nocLen), ByteSpan(),
                         ByteSpan(rcac.Get(), rootCertBufLen));
@@ -211,7 +226,27 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
         return nullptr;
     }
 
-    *errInfoOnFailure = wrapper->Controller()->Init(nodeId, initParams);
+    Platform::ScopedMemoryBuffer<uint8_t> noc;
+    VerifyOrReturnError(noc.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan nocSpan(noc.Get(), kMaxCHIPDERCertLength);
+
+    MutableByteSpan icacSpan;
+
+    Platform::ScopedMemoryBuffer<uint8_t> rcac;
+    VerifyOrReturnError(rcac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
+
+    Crypto::P256Keypair ephemeralKey;
+    ReturnErrorOnFailure(ephemeralKey.Initialize());
+
+    ReturnErrorOnFailure(mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan));
+
+    initParams.ephemeralKeypair = &ephemeralKey;
+    initParams.controllerRCAC   = rcacSpan;
+    initParams.controllerICAC   = icacSpan;
+    initParams.controllerNOC    = nocSpan;
+
+    *errInfoOnFailure = wrapper->Controller()->Init(initParams);
 
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -88,8 +88,9 @@ public:
                                                         chip::NodeId nodeId, chip::System::Layer * systemLayer,
                                                         chip::Inet::InetLayer * inetLayer, CHIP_ERROR * errInfoOnFailure);
 
-    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId, const chip::Crypto::P256PublicKey & ephemeralKey,
-                                               chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac, chip::MutableByteSpan & noc);
+    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId,
+                                               const chip::Crypto::P256PublicKey & ephemeralKey, chip::MutableByteSpan & rcac,
+                                               chip::MutableByteSpan & icac, chip::MutableByteSpan & noc);
 
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -88,6 +88,9 @@ public:
                                                         chip::NodeId nodeId, chip::System::Layer * systemLayer,
                                                         chip::Inet::InetLayer * inetLayer, CHIP_ERROR * errInfoOnFailure);
 
+    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId, const chip::Crypto::P256PublicKey & ephemeralKey,
+                                               chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac, chip::MutableByteSpan & noc);
+
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
     chip::Crypto::P256Keypair mIssuer;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -21,6 +21,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
 #include <support/CodeUtils.h>
+#include <support/ScopedBuffer.h>
 #include <support/ThreadOperationalDataset.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -101,17 +102,43 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         params.inetLayer       = &chip::DeviceLayer::InetLayer;
         params.pairingDelegate = &gPairingDelegate;
 
+        chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
+        chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
+        chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
+
+        chip::Crypto::P256Keypair ephemeralKey;
+        err = ephemeralKey.Initialize();
+        SuccessOrExit(err);
+
         err = gOperationalCredentialsIssuer.Initialize(gServerStorage);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Operational credentials issuer initialization failed: %s", chip::ErrorStr(err));
+            ExitNow();
         }
-        else
-        {
-            params.operationalCredentialsDelegate = &gOperationalCredentialsIssuer;
 
-            err = result->Init(localDeviceId, params);
+        VerifyOrExit(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(icac.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+        VerifyOrExit(rcac.Alloc(chip::Controller::kMaxCHIPDERCertLength), err = CHIP_ERROR_NO_MEMORY);
+
+        {
+            chip::MutableByteSpan nocSpan(noc.Get(), chip::Controller::kMaxCHIPDERCertLength);
+            chip::MutableByteSpan icacSpan(icac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+            chip::MutableByteSpan rcacSpan(rcac.Get(), chip::Controller::kMaxCHIPDERCertLength);
+            err = gOperationalCredentialsIssuer.GenerateNOCChainAfterValidation(localDeviceId, 0, ephemeralKey.Pubkey(), rcacSpan,
+                                                                                icacSpan, nocSpan);
+            SuccessOrExit(err);
+
+            params.operationalCredentialsDelegate = &gOperationalCredentialsIssuer;
+            params.ephemeralKeypair               = &ephemeralKey;
+            params.controllerRCAC                 = rcacSpan;
+            params.controllerICAC                 = icacSpan;
+            params.controllerNOC                  = nocSpan;
+
+            err = result->Init(params);
         }
+    exit:
+        ChipLogProgress(Controller, "Commissioner initialization status: %s", chip::ErrorStr(err));
     });
 
     if (err != CHIP_NO_ERROR)

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -36,6 +36,7 @@
 #include <lib/core/PeerId.h>
 #include <support/BitFlags.h>
 #include <support/DLLUtil.h>
+#include <support/Span.h>
 
 namespace chip {
 namespace Credentials {
@@ -718,14 +719,12 @@ enum CertificateIssuerLevel
  *
  * @param requestParams   Certificate request parameters.
  * @param issuerKeypair   The certificate signing key
- * @param x509CertBuf     Buffer to store signed certificate in X.509 DER format.
- * @param x509CertBufSize The size of the buffer to store converted certificate.
- * @param x509CertLen     The length of the converted certificate.
+ * @param x509Cert        Buffer to store signed certificate in X.509 DER format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR NewRootX509Cert(const X509CertRequestParams & requestParams, Crypto::P256Keypair & issuerKeypair, uint8_t * x509CertBuf,
-                           uint32_t x509CertBufSize, uint32_t & x509CertLen);
+CHIP_ERROR NewRootX509Cert(const X509CertRequestParams & requestParams, Crypto::P256Keypair & issuerKeypair,
+                           MutableByteSpan & x509Cert);
 
 /**
  * @brief Generate a new X.509 DER encoded Intermediate CA certificate
@@ -734,15 +733,13 @@ CHIP_ERROR NewRootX509Cert(const X509CertRequestParams & requestParams, Crypto::
  * @param subject         The requested subject ID
  * @param subjectPubkey   The public key of subject
  * @param issuerKeypair   The certificate signing key
- * @param x509CertBuf     Buffer to store signed certificate in X.509 DER format.
- * @param x509CertBufSize The size of the buffer to store converted certificate.
- * @param x509CertLen     The length of the converted certificate.
+ * @param x509Cert        Buffer to store signed certificate in X.509 DER format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 CHIP_ERROR NewICAX509Cert(const X509CertRequestParams & requestParams, uint64_t subject,
-                          const Crypto::P256PublicKey & subjectPubkey, Crypto::P256Keypair & issuerKeypair, uint8_t * x509CertBuf,
-                          uint32_t x509CertBufSize, uint32_t & x509CertLen);
+                          const Crypto::P256PublicKey & subjectPubkey, Crypto::P256Keypair & issuerKeypair,
+                          MutableByteSpan & x509Cert);
 
 /**
  * @brief Generate a new X.509 DER encoded Node operational certificate
@@ -751,15 +748,13 @@ CHIP_ERROR NewICAX509Cert(const X509CertRequestParams & requestParams, uint64_t 
  * @param issuerLevel     Indicates if the issuer is a root CA or an intermediate CA
  * @param subjectPubkey   The public key of subject
  * @param issuerKeypair   The certificate signing key
- * @param x509CertBuf     Buffer to store signed certificate in X.509 DER format.
- * @param x509CertBufSize The size of the buffer to store converted certificate.
- * @param x509CertLen     The length of the converted certificate.
+ * @param x509Cert        Buffer to store signed certificate in X.509 DER format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
 CHIP_ERROR NewNodeOperationalX509Cert(const X509CertRequestParams & requestParams, CertificateIssuerLevel issuerLevel,
                                       const Crypto::P256PublicKey & subjectPubkey, Crypto::P256Keypair & issuerKeypair,
-                                      uint8_t * x509CertBuf, uint32_t x509CertBufSize, uint32_t & x509CertLen);
+                                      MutableByteSpan & x509Cert);
 
 /**
  * @brief

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -731,35 +731,30 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
-    uint32_t signed_len = 0;
 
     ChipCertificateData certData;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, false, 0, false, 0 };
-
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert, sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
+    MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(signed_cert_span, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
     // Test that root cert cannot be provided a node ID
     root_params.HasNodeID = true;
-    NL_TEST_ASSERT(inSuite,
-                   NewRootX509Cert(root_params, keypair, signed_cert, sizeof(signed_cert), signed_len) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    MutableByteSpan signed_cert_span1(signed_cert, sizeof(signed_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
     root_params.HasNodeID    = false;
     root_params.SerialNumber = -1;
-    NL_TEST_ASSERT(inSuite,
-                   NewRootX509Cert(root_params, keypair, signed_cert, sizeof(signed_cert), signed_len) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inContext)
@@ -769,7 +764,6 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
-    uint32_t signed_len = 0;
 
     ChipCertificateData certData;
 
@@ -778,12 +772,11 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
 
     X509CertRequestParams root_params_fabric = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0xabcd, false, 0 };
 
-    NL_TEST_ASSERT(inSuite,
-                   NewRootX509Cert(root_params_fabric, keypair, signed_cert, sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
+    MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params_fabric, keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(signed_cert_span, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 }
@@ -795,7 +788,6 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
-    uint32_t signed_len = 0;
 
     uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
@@ -806,28 +798,25 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert, sizeof(signed_cert), signed_len) ==
-                       CHIP_NO_ERROR);
+    MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(signed_cert_span, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
     // Test that ICA cert cannot be provided a node ID
     ica_params.HasNodeID = true;
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert, sizeof(signed_cert), signed_len) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    MutableByteSpan signed_cert_span1(signed_cert, sizeof(signed_cert));
+    NL_TEST_ASSERT(
+        inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
     ica_params.HasNodeID    = false;
     ica_params.SerialNumber = -1;
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert, sizeof(signed_cert), signed_len) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(
+        inSuite, NewICAX509Cert(ica_params, 4321, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext)
@@ -837,7 +826,6 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
-    uint32_t signed_len = 0;
 
     uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
@@ -848,36 +836,37 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert,
-                                              sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(signed_cert_span, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 
     // Test that NOC cert must be provided a node ID
     noc_params.HasNodeID = false;
+    MutableByteSpan signed_cert_span1(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert,
-                                              sizeof(signed_cert), signed_len) == CHIP_ERROR_INVALID_ARGUMENT);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that NOC cert must be provided a fabric ID
     noc_params.HasNodeID   = true;
     noc_params.HasFabricID = false;
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert,
-                                              sizeof(signed_cert), signed_len) == CHIP_ERROR_INVALID_ARGUMENT);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
     noc_params.HasNodeID    = true;
     noc_params.HasFabricID  = true;
     noc_params.SerialNumber = -1;
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert,
-                                              sizeof(signed_cert), signed_len) == CHIP_ERROR_INVALID_ARGUMENT);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
@@ -887,7 +876,6 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
-    uint32_t signed_len = 0;
 
     uint8_t outCertBuf[kMaxCHIPCertLength];
     uint32_t outCertLen;
@@ -898,13 +886,13 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), keypair, signed_cert,
-                                              sizeof(signed_cert), signed_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), keypair,
+                                              signed_cert_span) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(signed_cert, signed_len), outCertBuf, sizeof(outCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(signed_cert_span, outCertBuf, sizeof(outCertBuf), outCertLen) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCertBuf, outCertLen, certData) == CHIP_NO_ERROR);
 }
@@ -916,32 +904,30 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
-    uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
-                       CHIP_NO_ERROR);
+    MutableByteSpan ica_cert_span(ica_cert, sizeof(ica_cert));
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair,
+                                              noc_cert_span) == CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
     NL_TEST_ASSERT(inSuite, certSet.Init(3) == CHIP_NO_ERROR);
@@ -952,18 +938,13 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     uint32_t outCertLen;
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(root_cert_span, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(rootCertBuf, outCertLen, sTrustAnchorFlag) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(ica_cert, ica_len), icaCertBuf, sizeof(icaCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(ica_cert_span, icaCertBuf, sizeof(icaCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(icaCertBuf, outCertLen, sGenTBSHashFlag) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(noc_cert, noc_len), nocCertBuf, sizeof(nocCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(noc_cert_span, nocCertBuf, sizeof(nocCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(nocCertBuf, outCertLen, sGenTBSHashFlag) == CHIP_NO_ERROR);
 
     ValidationContext validContext;
@@ -989,38 +970,34 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
-    uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
-                       CHIP_NO_ERROR);
+    MutableByteSpan ica_cert_span(ica_cert, sizeof(ica_cert));
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair,
+                                              noc_cert_span) == CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCert) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, ica_cert_span, outCert) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
@@ -1033,8 +1010,7 @@ static void TestChipCert_X509ToChipArray(nlTestSuite * inSuite, void * inContext
 
     uint32_t outCertLen;
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(root_cert_span, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(rootCertBuf, outCertLen, sTrustAnchorFlag) == CHIP_NO_ERROR);
 
     ValidationContext validContext;
@@ -1060,27 +1036,26 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert_span) ==
+                       CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(nullptr, 0), outCert) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, ByteSpan(), outCert) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, outCert.size() <= sizeof(outCertBuf));
 
     ChipCertificateSet certSet;
@@ -1092,8 +1067,7 @@ static void TestChipCert_X509ToChipArrayNoICA(nlTestSuite * inSuite, void * inCo
     static uint8_t rootCertBuf[kMaxCHIPCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(root_cert_span, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(rootCertBuf, outCertLen, sTrustAnchorFlag) == CHIP_NO_ERROR);
 
     ValidationContext validContext;
@@ -1119,54 +1093,47 @@ static void TestChipCert_X509ToChipArrayErrorScenarios(nlTestSuite * inSuite, vo
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
-    uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
-                       CHIP_NO_ERROR);
+    MutableByteSpan ica_cert_span(ica_cert, sizeof(ica_cert));
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair,
+                                              noc_cert_span) == CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
     // Test that NOC is mandatory
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(nullptr, 0), ByteSpan(ica_cert, ica_len), outCert) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(ByteSpan(), ica_cert_span, outCert) == CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that NOC issuer must match ICA
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(root_cert, root_len), outCert) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, root_cert_span, outCert) == CHIP_ERROR_INVALID_ARGUMENT);
 
     X509CertRequestParams ica_params_wrong_fabric = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x9999, false, 0 };
 
+    MutableByteSpan ica_cert_span1(ica_cert, sizeof(ica_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params_wrong_fabric, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert),
-                                  ica_len) == CHIP_NO_ERROR);
+                   NewICAX509Cert(ica_params_wrong_fabric, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span1) ==
+                       CHIP_NO_ERROR);
     // Test that NOC fabric must match ICA fabric
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCert) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, ica_cert_span, outCert) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
 static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inContext)
@@ -1176,39 +1143,35 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
-    uint32_t ica_len = 0;
 
     X509CertRequestParams ica_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
     P256Keypair ica_keypair;
     NL_TEST_ASSERT(inSuite, ica_keypair.Initialize() == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert, sizeof(ica_cert), ica_len) ==
-                       CHIP_NO_ERROR);
+    MutableByteSpan ica_cert_span(ica_cert, sizeof(ica_cert));
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, 0xaabbccdd, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xaabbccdd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsIntermediateCA, noc_keypair.Pubkey(), ica_keypair,
+                                              noc_cert_span) == CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(ica_cert, ica_len), outCert) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, ica_cert_span, outCert) == CHIP_NO_ERROR);
 
     ByteSpan noc_chip_cert;
     ByteSpan ica_chip_cert;
@@ -1228,8 +1191,7 @@ static void TestChipCert_ChipArrayToChipCerts(nlTestSuite * inSuite, void * inCo
     static uint8_t rootCertBuf[kMaxDERCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(root_cert_span, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(rootCertBuf, outCertLen, sTrustAnchorFlag) == CHIP_NO_ERROR);
 
     ValidationContext validContext;
@@ -1254,27 +1216,26 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
-    uint32_t root_len = 0;
 
     X509CertRequestParams root_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, false, 0 };
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert, sizeof(root_cert), root_len) == CHIP_NO_ERROR);
+    MutableByteSpan root_cert_span(root_cert, sizeof(root_cert));
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
-    uint32_t noc_len = 0;
 
     X509CertRequestParams noc_params = { 1234, 0xabcdabcd, 631161876, 729942000, true, 0x8888, true, 0x1234 };
     P256Keypair noc_keypair;
     NL_TEST_ASSERT(inSuite, noc_keypair.Initialize() == CHIP_NO_ERROR);
 
+    MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
     NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert,
-                                              sizeof(noc_cert), noc_len) == CHIP_NO_ERROR);
+                   NewNodeOperationalX509Cert(noc_params, kIssuerIsRootCA, noc_keypair.Pubkey(), keypair, noc_cert_span) ==
+                       CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength * 2];
     uint32_t outCertLen;
     MutableByteSpan outCert(outCertBuf, sizeof(outCertBuf));
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(noc_cert, noc_len), ByteSpan(nullptr, 0), outCert) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, ConvertX509CertsToChipCertArray(noc_cert_span, ByteSpan(), outCert) == CHIP_NO_ERROR);
 
     ByteSpan noc_chip_cert;
     ByteSpan ica_chip_cert;
@@ -1292,8 +1253,7 @@ static void TestChipCert_ChipArrayToChipCertsNoICA(nlTestSuite * inSuite, void *
     static uint8_t rootCertBuf[kMaxDERCertLength];
 
     NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertToChipCert(ByteSpan(root_cert, root_len), rootCertBuf, sizeof(rootCertBuf), outCertLen) ==
-                       CHIP_NO_ERROR);
+                   ConvertX509CertToChipCert(root_cert_span, rootCertBuf, sizeof(rootCertBuf), outCertLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certSet.LoadCert(rootCertBuf, outCertLen, sTrustAnchorFlag) == CHIP_NO_ERROR);
 
     ValidationContext validContext;

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -70,7 +70,7 @@ CHIPDeviceController * InitializeCHIP(void)
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
         storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        [controller startup:storage];
+        [controller startup:storage vendorId:0];
     });
 
     return controller;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -96,8 +96,9 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  * check if the stack needs to be started up.
  *
  * @param[in] storageDelegate The delegate for persistent storage
+ * @param[in] vendorId The vendor ID of the commissioner application
  */
-- (BOOL)startup:(nullable id<CHIPPersistentStorageDelegate>)storageDelegate;
+- (BOOL)startup:(nullable id<CHIPPersistentStorageDelegate>)storageDelegate vendorId:(uint16_t)vendorId;
 
 /**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -48,6 +48,10 @@ public:
     void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
     void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 
+    CHIP_ERROR GenerateNOCChainAfterValidation(chip::NodeId nodeId, chip::FabricId fabricId,
+        const chip::Crypto::P256PublicKey & pubkey, chip::MutableByteSpan & rcac, chip::MutableByteSpan & icac,
+        chip::MutableByteSpan & noc);
+
 private:
     CHIP_ERROR GenerateKeys();
     CHIP_ERROR LoadKeysFromKeyChain();

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -190,11 +190,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
         return CHIP_ERROR_INTERNAL;
     }
 
-    uint32_t nocLen = static_cast<uint32_t>(std::min(noc.size(), static_cast<size_t>(UINT32_MAX)));
     X509CertRequestParams noc_request = { 1, mIssuerId, validityStart, validityEnd, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(
-        noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuerKey, noc.data(), nocLen, nocLen));
-    noc.reduce_size(nocLen);
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuerKey, noc));
     icac.reduce_size(0);
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
@@ -207,10 +204,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
         return CHIP_NO_ERROR;
     }
 
-    uint32_t rcacLen = static_cast<uint32_t>(std::min(rcac.size(), static_cast<size_t>(UINT32_MAX)));
     X509CertRequestParams rcac_request = { 0, mIssuerId, validityStart, validityEnd, true, fabricId, false, 0 };
-    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuerKey, rcac.data(), rcacLen, rcacLen));
-    rcac.reduce_size(rcacLen);
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuerKey, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -34,6 +34,8 @@ constexpr const char kOperationalCredentialsRootCertificateStorage[] = "MatterCA
 
 using namespace chip;
 using namespace TLV;
+using namespace Credentials;
+using namespace Crypto;
 
 static BOOL isRunningTests(void)
 {
@@ -173,9 +175,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::ByteSpan & csrElements,
-    const chip::ByteSpan & attestationSignature, const chip::ByteSpan & DAC, const chip::ByteSpan & PAI, const chip::ByteSpan & PAA,
-    chip::Callback::Callback<chip::Controller::OnNOCChainGeneration> * onCompletion)
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId,
+    const Crypto::P256PublicKey & pubkey, MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc)
 {
     uint32_t validityStart, validityEnd;
 
@@ -189,6 +190,39 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::Byte
         return CHIP_ERROR_INTERNAL;
     }
 
+    uint32_t nocLen = static_cast<uint32_t>(std::min(noc.size(), static_cast<size_t>(UINT32_MAX)));
+    X509CertRequestParams noc_request = { 1, mIssuerId, validityStart, validityEnd, true, fabricId, true, nodeId };
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(
+        noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuerKey, noc.data(), nocLen, nocLen));
+    noc.reduce_size(nocLen);
+    icac.reduce_size(0);
+
+    uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+        err = mStorage->SyncGetKeyValue(key, rcac.data(), rcacBufLen));
+    if (err == CHIP_NO_ERROR) {
+        // Found root certificate in the storage.
+        rcac.reduce_size(rcacBufLen);
+        return CHIP_NO_ERROR;
+    }
+
+    uint32_t rcacLen = static_cast<uint32_t>(std::min(rcac.size(), static_cast<size_t>(UINT32_MAX)));
+    X509CertRequestParams rcac_request = { 0, mIssuerId, validityStart, validityEnd, true, fabricId, false, 0 };
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuerKey, rcac.data(), rcacLen, rcacLen));
+    rcac.reduce_size(rcacLen);
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+    PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,
+        err = mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size())));
+
+    return err;
+}
+
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::ByteSpan & csrElements,
+    const chip::ByteSpan & attestationSignature, const chip::ByteSpan & DAC, const chip::ByteSpan & PAI, const chip::ByteSpan & PAA,
+    chip::Callback::Callback<chip::Controller::OnNOCChainGeneration> * onCompletion)
+{
     chip::NodeId assignedId;
     if (mNodeIdRequested) {
         assignedId = mNextRequestedNodeId;
@@ -199,9 +233,6 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::Byte
         }
         assignedId = mDeviceBeingPaired;
     }
-
-    chip::Credentials::X509CertRequestParams noc_request
-        = { 1, mIssuerId, validityStart, validityEnd, true, mNextFabricId, true, assignedId };
 
     TLVReader reader;
     reader.Init(csrElements.data(), static_cast<uint32_t>(csrElements.size()));
@@ -224,37 +255,16 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::Byte
     ReturnErrorOnFailure(chip::Crypto::VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));
 
     NSMutableData * nocBuffer = [[NSMutableData alloc] initWithLength:chip::Controller::kMaxCHIPDERCertLength];
-    uint32_t nocLen = 0;
-    uint8_t * noc = (uint8_t *) [nocBuffer mutableBytes];
-
-    ReturnErrorOnFailure(
-        chip::Credentials::NewNodeOperationalX509Cert(noc_request, chip::Credentials::CertificateIssuerLevel::kIssuerIsRootCA,
-            pubkey, mIssuerKey, noc, chip::Controller::kMaxCHIPDERCertLength, nocLen));
+    MutableByteSpan noc((uint8_t *) [nocBuffer mutableBytes], chip::Controller::kMaxCHIPDERCertLength);
 
     NSMutableData * rcacBuffer = [[NSMutableData alloc] initWithLength:chip::Controller::kMaxCHIPDERCertLength];
-    uint16_t rcacLen = chip::Controller::kMaxCHIPDERCertLength;
-    uint8_t * rcac = (uint8_t *) [rcacBuffer mutableBytes];
+    MutableByteSpan rcac((uint8_t *) [rcacBuffer mutableBytes], chip::Controller::kMaxCHIPDERCertLength);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    PERSISTENT_KEY_OP(
-        mNextFabricId, kOperationalCredentialsRootCertificateStorage, key, err = mStorage->SyncGetKeyValue(key, rcac, rcacLen));
+    MutableByteSpan icac;
 
-    if (err != CHIP_NO_ERROR) {
-        chip::Credentials::X509CertRequestParams rcac_request
-            = { 0, mIssuerId, validityStart, validityEnd, true, mNextFabricId, false, 0 };
-        uint32_t outCertLen = 0;
-        ReturnErrorOnFailure(chip::Credentials::NewRootX509Cert(
-            rcac_request, mIssuerKey, rcac, chip::Controller::kMaxCHIPDERCertLength, outCertLen));
+    ReturnErrorOnFailure(GenerateNOCChainAfterValidation(assignedId, mNextFabricId, pubkey, rcac, icac, noc));
 
-        VerifyOrReturnError(CanCastTo<uint16_t>(outCertLen), CHIP_ERROR_INVALID_ARGUMENT);
-        rcacLen = static_cast<uint16_t>(outCertLen);
-        PERSISTENT_KEY_OP(
-            mNextFabricId, kOperationalCredentialsRootCertificateStorage, key, err = mStorage->SyncSetKeyValue(key, rcac, rcacLen));
-        ReturnErrorOnFailure(err);
-    }
-
-    onCompletion->mCall(
-        onCompletion->mContext, CHIP_NO_ERROR, chip::ByteSpan(noc, nocLen), chip::ByteSpan(), chip::ByteSpan(rcac, rcacLen));
+    onCompletion->mCall(onCompletion->mContext, CHIP_NO_ERROR, noc, icac, rcac);
 
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -76,7 +76,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil];
+    BOOL started = [controller startup:nil vendorId:0];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -94,7 +94,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil];
+    BOOL started = [controller startup:nil vendorId:0];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -32,11 +32,11 @@
 - (void)testControllerLifecycle
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:0]);
     XCTAssertTrue([controller shutdown]);
 
     // now try to restart the controller
-    XCTAssertTrue([controller startup:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:0]);
     XCTAssertTrue([controller shutdown]);
 }
 
@@ -44,7 +44,7 @@
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     for (int i = 0; i < 5; i++) {
-        XCTAssertTrue([controller startup:nil]);
+        XCTAssertTrue([controller startup:nil vendorId:0]);
     }
     XCTAssertTrue([controller shutdown]);
 }
@@ -52,7 +52,7 @@
 - (void)testControllerMultipleShutdown
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil]);
+    XCTAssertTrue([controller startup:nil vendorId:0]);
     for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller shutdown]);
     }


### PR DESCRIPTION
#### Problem
The commissioner operational credentials cannot be created in the same way as a device credentials (since commissioners are implicitly trusted, and there's no mechanism for attestation or CSR). The current controller code is generating a temporary CSR (without DAC, or corresponding key) to generate the certs. This will break once we integrate device attestation checks,

* Fixes #8910

#### Change overview
The commissioner applications will generate the credentials for this scenario, and provide it to Commissioner object at the initialization time.

#### Testing
Tested commissioning flow using CHIPTool iOS app, Python controller app and chip-tool command line app.
CI runs the commissioning tests that exercise the logic that was changed in this PR.
