### PR TITLE
[Android] Move ChipDeviceController dependencies to constructor

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -55,8 +55,6 @@ class CHIPToolActivity :
     setContentView(R.layout.top_activity)
 
     if (savedInstanceState == null) {
-      ChipDeviceController.setKeyValueStoreManager(PreferencesKeyValueStoreManager(this))
-      ChipDeviceController.setServiceResolver(NsdManagerServiceResolver(this))
       val fragment = SelectActionFragment.newInstance()
       supportFragmentManager
           .beginTransaction()

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
@@ -17,9 +17,12 @@
  */
 package com.google.chip.chiptool
 
+import android.content.Context
 import android.util.Log
 import chip.devicecontroller.ChipDeviceController
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback
+import chip.devicecontroller.NsdManagerServiceResolver
+import chip.devicecontroller.PreferencesKeyValueStoreManager
 import java.lang.IllegalStateException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -30,9 +33,12 @@ object ChipClient {
   private const val TAG = "ChipClient"
   private lateinit var chipDeviceController: ChipDeviceController
 
-  fun getDeviceController(): ChipDeviceController {
+  fun getDeviceController(context: Context): ChipDeviceController {
     if (!this::chipDeviceController.isInitialized) {
-      chipDeviceController = ChipDeviceController()
+      chipDeviceController = ChipDeviceController(
+        PreferencesKeyValueStoreManager(context),
+        NsdManagerServiceResolver(context)
+      )
     }
     return chipDeviceController
   }
@@ -40,9 +46,9 @@ object ChipClient {
   /**
    * Wrapper around [ChipDeviceController.getConnectedDevicePointer] to return the value directly.
    */
-  suspend fun getConnectedDevicePointer(nodeId: Long): Long {
+  suspend fun getConnectedDevicePointer(context: Context, nodeId: Long): Long {
     return suspendCoroutine { continuation ->
-      getDeviceController().getConnectedDevicePointer(
+      getDeviceController(context).getConnectedDevicePointer(
         nodeId,
         object : GetConnectedDeviceCallback {
           override fun onDeviceConnected(devicePointer: Long) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -86,7 +86,7 @@ class BluetoothManager {
    */
   suspend fun connect(context: Context, device: BluetoothDevice): BluetoothGatt? {
     return suspendCancellableCoroutine { continuation ->
-      val bluetoothGattCallback = getBluetoothGattCallback(continuation)
+      val bluetoothGattCallback = getBluetoothGattCallback(context, continuation)
 
       Log.i(TAG, "Connecting")
       val gatt = device.connectGatt(context, false, bluetoothGattCallback)
@@ -95,10 +95,11 @@ class BluetoothManager {
   }
 
   private fun getBluetoothGattCallback(
-      continuation: CancellableContinuation<BluetoothGatt?>
+    context: Context,
+    continuation: CancellableContinuation<BluetoothGatt?>
   ): BluetoothGattCallback {
     return object : BluetoothGattCallback() {
-      private val wrappedCallback = ChipClient.getDeviceController().callback
+      private val wrappedCallback = ChipClient.getDeviceController(context).callback
       private val coroutineContinuation = continuation
 
       override fun onConnectionStateChange(

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 
 class OnOffClientFragment : Fragment() {
   private val deviceController: ChipDeviceController
-    get() = ChipClient.getDeviceController()
+    get() = ChipClient.getDeviceController(requireContext())
 
   private val scope = CoroutineScope(Dispatchers.Main + Job())
 
@@ -136,7 +136,7 @@ class OnOffClientFragment : Fragment() {
 
   private suspend fun sendLevelCommandClick() {
     val cluster = ChipClusters.LevelControlCluster(
-      ChipClient.getConnectedDevicePointer(deviceIdEd.text.toString().toLong()), 1
+      ChipClient.getConnectedDevicePointer(requireContext(), deviceIdEd.text.toString().toLong()), 1
     )
     cluster.moveToLevel(object : ChipClusters.DefaultClusterCallback {
       override fun onSuccess() {
@@ -193,7 +193,7 @@ class OnOffClientFragment : Fragment() {
 
   private suspend fun getOnOffClusterForDevice(): OnOffCluster {
     return OnOffCluster(
-      ChipClient.getConnectedDevicePointer(deviceIdEd.text.toString().toLong()), 1
+      ChipClient.getConnectedDevicePointer(requireContext(), deviceIdEd.text.toString().toLong()), 1
     )
   }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -129,7 +129,7 @@ class SensorClientFragment : Fragment() {
     val clusterConfig = CLUSTERS[clusterName]
     val clusterRead = clusterConfig!!["read"] as (Long, Int, ReadCallback) -> Unit
 
-    val device = ChipClient.getConnectedDevicePointer(deviceId)
+    val device = ChipClient.getConnectedDevicePointer(requireContext(), deviceId)
 
     clusterRead(device, endpointId, object : ReadCallback {
       override fun onSuccess(value: Int) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/echoclient/EchoClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/echoclient/EchoClientFragment.kt
@@ -36,7 +36,7 @@ import kotlinx.android.synthetic.main.on_off_client_fragment.deviceIdEd
 class EchoClientFragment : Fragment() {
 
   private val deviceController: ChipDeviceController
-    get() = ChipClient.getDeviceController()
+    get() = ChipClient.getDeviceController(requireContext())
 
   override fun onCreateView(
       inflater: LayoutInflater,

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -79,7 +79,7 @@ class DeviceProvisioningFragment : Fragment() {
     }
 
     scope.launch {
-      val deviceController = ChipClient.getDeviceController()
+      val deviceController = ChipClient.getDeviceController(requireContext())
       val bluetoothManager = BluetoothManager()
 
       showMessage(

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -96,7 +96,7 @@ class EnterNetworkFragment : Fragment() {
     val ssidBytes = ssid.toByteArray()
     val pwdBytes = password.toByteArray()
 
-    val devicePtr = ChipClient.getDeviceController()
+    val devicePtr = ChipClient.getDeviceController(requireContext())
       .getDevicePointer(DeviceIdUtil.getLastDeviceId(requireContext()))
     val cluster = NetworkCommissioningCluster(devicePtr, /* endpointId = */ 0)
 
@@ -188,7 +188,7 @@ class EnterNetworkFragment : Fragment() {
     }
 
     try {
-      ChipClient.getDeviceController().enableThreadNetwork(
+      ChipClient.getDeviceController(requireContext()).enableThreadNetwork(
         DeviceIdUtil.getLastDeviceId(requireContext()),
         MakeThreadOperationalDataset(
           channelStr.toString().toInt(),

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -225,7 +225,7 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     chip::Platform::MemoryShutdown();
 }
 
-JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
+JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject keyValueStoreManager, jobject serviceResolver)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -233,6 +233,10 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self)
     long result                              = 0;
 
     ChipLogProgress(Controller, "newDeviceController() called");
+
+    DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(keyValueStoreManager);
+    using namespace chip::Mdns;
+    InitializeWithObject(serviceResolver);
 
     wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, JniReferences::GetInstance().GetStackLock(), kLocalDeviceId,
                                                           &sSystemLayer, &sInetLayer, &err);
@@ -255,19 +259,6 @@ exit:
     }
 
     return result;
-}
-
-JNI_METHOD(void, setKeyValueStoreManager)(JNIEnv * env, jclass self, jobject manager)
-{
-    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(manager);
-}
-
-JNI_METHOD(void, setServiceResolver)(JNIEnv * env, jclass self, jobject resolver)
-{
-    using namespace chip::Mdns;
-    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    InitializeWithObject(resolver);
 }
 
 JNI_METHOD(void, handleServiceResolve)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -235,7 +235,7 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject keyVa
     ChipLogProgress(Controller, "newDeviceController() called");
 
     DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(keyValueStoreManager);
-    using namespace chip::Mdns;
+    using ::chip::Mdns::InitializeWithObject;
     InitializeWithObject(serviceResolver);
 
     wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, JniReferences::GetInstance().GetStackLock(), kLocalDeviceId,

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -31,8 +31,8 @@ public class ChipDeviceController {
   private BluetoothGatt bleGatt;
   private CompletionListener completionListener;
 
-  public ChipDeviceController() {
-    deviceControllerPtr = newDeviceController();
+  public ChipDeviceController(KeyValueStoreManager manager, ServiceResolver resolver) {
+    deviceControllerPtr = newDeviceController(manager, resolver);
   }
 
   public void setCompletionListener(CompletionListener listener) {
@@ -228,7 +228,7 @@ public class ChipDeviceController {
     return isActive(deviceControllerPtr, deviceId);
   }
 
-  private native long newDeviceController();
+  private native long newDeviceController(KeyValueStoreManager manager, ServiceResolver resolver);
 
   private native void pairDevice(
       long deviceControllerPtr, long deviceId, int connectionId, long pinCode, byte[] csrNonce);
@@ -261,10 +261,6 @@ public class ChipDeviceController {
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 
   private native boolean isActive(long deviceControllerPtr, long deviceId);
-
-  public static native void setKeyValueStoreManager(KeyValueStoreManager manager);
-
-  public static native void setServiceResolver(ServiceResolver resolver);
 
   public static native void handleServiceResolve(
       String instanceName,


### PR DESCRIPTION
#### Problem
* ChipDeviceController.java uses static setters for `ServiceResolver` and `KeyValueStoreManager`. These objects are required, so this approach is error-prone, and not friendly for dependency injection.

#### Change overview
* Replace static setters with constructor params

#### Testing
* Ran through commissioning & control with esp32
