### PR TITLE
Updated CHIPCert APIs to Use ByteSpans

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -130,28 +130,23 @@ void ChipCertificateSet::Clear()
     mCertCount = 0;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCert(const ByteSpan chipCert, BitFlags<CertDecodeFlags> decodeFlags)
 {
-    CHIP_ERROR err;
     TLVReader reader;
     TLVType type;
     uint64_t tag;
 
-    reader.Init(chipCert, chipCertLen);
+    reader.Init(chipCert);
 
-    err = reader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next());
 
     type = reader.GetType();
     tag  = reader.GetTag();
 
-    VerifyOrExit((type == kTLVType_Structure || type == kTLVType_Array) && (tag == AnonymousTag),
-                 err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError((type == kTLVType_Structure || type == kTLVType_Array) && (tag == AnonymousTag),
+                        CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
-    err = LoadCert(reader, decodeFlags, ByteSpan(chipCert, chipCertLen));
-
-exit:
-    return err;
+    return LoadCert(reader, decodeFlags, chipCert);
 }
 
 CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags, ByteSpan chipCert)
@@ -238,28 +233,23 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCerts(const ByteSpan chipCert, BitFlags<CertDecodeFlags> decodeFlags)
 {
-    CHIP_ERROR err;
     TLVReader reader;
     TLVType type;
     uint64_t tag;
 
-    reader.Init(chipCerts, chipCertsLen);
+    reader.Init(chipCert);
 
-    err = reader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next());
 
     type = reader.GetType();
     tag  = reader.GetTag();
 
-    VerifyOrExit((type == kTLVType_Structure || type == kTLVType_Array) && (tag == AnonymousTag),
-                 err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrReturnError((type == kTLVType_Structure || type == kTLVType_Array) && (tag == AnonymousTag),
+                        CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
-    err = LoadCerts(reader, decodeFlags);
-
-exit:
-    return err;
+    return LoadCerts(reader, decodeFlags);
 }
 
 CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags)
@@ -957,7 +947,7 @@ CHIP_ERROR ExtractPeerIdFromOpCert(const ByteSpan & opcert, PeerId * peerId)
 
     ReturnErrorOnFailure(certSet.Init(1));
 
-    ReturnErrorOnFailure(certSet.LoadCert(opcert.data(), static_cast<uint32_t>(opcert.size()), BitFlags<CertDecodeFlags>()));
+    ReturnErrorOnFailure(certSet.LoadCert(opcert, BitFlags<CertDecodeFlags>()));
 
     return ExtractPeerIdFromOpCert(certSet.GetCertSet()[0], peerId);
 }

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -423,12 +423,11 @@ public:
      *        In case of an error the certificate set is left in the same state as prior to this call.
      *
      * @param chipCert     Buffer containing certificate encoded in CHIP format.
-     * @param chipCertLen  The length of the certificate buffer.
      * @param decodeFlags  Certificate decoding option flags.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCert(const ByteSpan chipCert, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificate into set.
@@ -452,12 +451,11 @@ public:
      *        In case of an error the certificate set is left in the same state as prior to this call.
      *
      * @param chipCerts     Buffer containing array of certificates or a single certificate encoded in CHIP TLV form.
-     * @param chipCertsLen  The length of the certificates buffer.
      * @param decodeFlags   Certificate decoding option flags.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCerts(const ByteSpan chipCerts, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificates into set.
@@ -589,12 +587,11 @@ private:
  *        the certData is used.
  *
  * @param chipCert     Buffer containing CHIP certificate.
- * @param chipCertLen  The length of the CHIP certificate.
  * @param certData     Structure containing data extracted from the CHIP certificate.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR DecodeChipCert(const uint8_t * chipCert, uint32_t chipCertLen, ChipCertificateData & certData);
+CHIP_ERROR DecodeChipCert(const ByteSpan chipCert, ChipCertificateData & certData);
 
 /**
  * @brief Decode CHIP certificate.
@@ -624,14 +621,11 @@ CHIP_ERROR DecodeChipDN(chip::TLV::TLVReader & reader, ChipDN & dn);
  * @brief Convert standard X.509 certificate to CHIP certificate.
  *
  * @param x509Cert        CHIP X.509 DER encoded certificate.
- * @param chipCertBuf     Buffer to store converted certificate in CHIP format.
- * @param chipCertBufSize The size of the buffer to store converted certificate.
- * @param chipCertLen     The length of the converted certificate.
+ * @param chipCert        Buffer to store converted certificate in CHIP format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, uint8_t * chipCertBuf, uint32_t chipCertBufSize,
-                                     uint32_t & chipCertLen);
+CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, MutableByteSpan & chipCert);
 
 /**
  * @brief Convert standard X.509 certificates to CHIP certificate array.
@@ -671,29 +665,11 @@ CHIP_ERROR ExtractCertsFromCertArray(const ByteSpan & opCertArray, ByteSpan & no
  * @brief Convert CHIP certificate to the standard X.509 DER encoded certificate.
  *
  * @param chipCert        CHIP certificate in CHIP TLV encoding.
- * @param x509CertBuf     Buffer to store converted certificate in X.509 DER format.
- * @param x509CertBufSize The size of the buffer to store converted certificate.
- * @param x509CertLen     The length of the converted certificate.
+ * @param x509Cet         Buffer to store converted certificate in X.509 DER format.
  *
  * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
  **/
-CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, uint8_t * x509CertBuf, uint32_t x509CertBufSize,
-                                     uint32_t & x509CertLen);
-
-/**
- * @brief Generate a standard X.509 DER encoded certificate using provided CHIP certificate and signing key
- *
- * @param chipCert        Buffer containing CHIP certificate.
- * @param chipCertLen     The length of the CHIP certificate.
- * @param keypair         The certificate signing key
- * @param x509CertBuf     Buffer to store signed certificate in X.509 DER format.
- * @param x509CertBufSize The size of the buffer to store converted certificate.
- * @param x509CertLen     The length of the converted certificate.
- *
- * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
- **/
-CHIP_ERROR GenerateSignedX509CertFromChipCert(const uint8_t * chipCert, uint32_t chipCertLen, Crypto::P256Keypair & keypair,
-                                              uint8_t * x509CertBuf, uint32_t x509CertBufSize, uint32_t & x509CertLen);
+CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, MutableByteSpan & x509Cert);
 
 // TODO: Add support for Authentication Tag Attribute
 struct X509CertRequestParams

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -700,8 +700,7 @@ exit:
     return err;
 }
 
-DLL_EXPORT CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, uint8_t * chipCertBuf, uint32_t chipCertBufSize,
-                                                uint32_t & chipCertLen)
+CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, MutableByteSpan & chipCert)
 {
     ASN1Reader reader;
     TLVWriter writer;
@@ -714,13 +713,13 @@ DLL_EXPORT CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, uint8_t
 
     reader.Init(x509Cert.data(), static_cast<uint32_t>(x509Cert.size()));
 
-    writer.Init(chipCertBuf, chipCertBufSize);
+    writer.Init(chipCert);
 
     ReturnErrorOnFailure(ConvertCertificate(reader, writer, AnonymousTag, issuer, subject, fabric));
 
     ReturnErrorOnFailure(writer.Finalize());
 
-    chipCertLen = writer.GetLengthWritten();
+    chipCert.reduce_size(writer.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -834,33 +834,30 @@ exit:
     return err;
 }
 
-DLL_EXPORT CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, uint8_t * x509CertBuf, uint32_t x509CertBufSize,
-                                                uint32_t & x509CertLen)
+DLL_EXPORT CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, MutableByteSpan & x509Cert)
 {
     TLVReader reader;
     ASN1Writer writer;
     ChipCertificateData certData;
 
-    VerifyOrReturnError(!chipCert.empty(), CHIP_ERROR_INVALID_ARGUMENT);
-
     reader.Init(chipCert);
 
-    writer.Init(x509CertBuf, x509CertBufSize);
+    writer.Init(x509Cert.data(), static_cast<uint32_t>(x509Cert.size()));
 
     certData.Clear();
 
     ReturnErrorOnFailure(DecodeConvertCert(reader, writer, certData));
 
-    x509CertLen = writer.GetLengthWritten();
+    x509Cert.reduce_size(writer.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DecodeChipCert(const uint8_t * chipCert, uint32_t chipCertLen, ChipCertificateData & certData)
+CHIP_ERROR DecodeChipCert(const ByteSpan chipCert, ChipCertificateData & certData)
 {
     TLVReader reader;
 
-    reader.Init(chipCert, chipCertLen);
+    reader.Init(chipCert);
 
     return DecodeChipCert(reader, certData);
 }

--- a/src/credentials/CHIPOperationalCredentials.cpp
+++ b/src/credentials/CHIPOperationalCredentials.cpp
@@ -307,7 +307,7 @@ CHIP_ERROR OperationalCredentialSet::FromSerializable(const OperationalCredentia
 
     SuccessOrExit(err = certificateSet.Init(kOperationalCertificatesMax));
 
-    err = certificateSet.LoadCert(serializable.mRootCertificate, serializable.mRootCertificateLen,
+    err = certificateSet.LoadCert(ByteSpan(serializable.mRootCertificate, serializable.mRootCertificateLen),
                                   BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor));
     SuccessOrExit(err);
 
@@ -315,7 +315,7 @@ CHIP_ERROR OperationalCredentialSet::FromSerializable(const OperationalCredentia
 
     if (serializable.mCACertificateLen != 0)
     {
-        err = certificateSet.LoadCert(serializable.mCACertificate, serializable.mCACertificateLen,
+        err = certificateSet.LoadCert(ByteSpan(serializable.mCACertificate, serializable.mCACertificateLen),
                                       BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash));
         SuccessOrExit(err);
     }

--- a/src/credentials/tests/CHIPCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPCert_test_vectors.cpp
@@ -54,7 +54,7 @@ extern const uint8_t gTestCerts[] = {
 };
 // clang-format on
 
-extern const size_t gNumTestCerts = sizeof(gTestCerts) / sizeof(gTestCerts[0]);
+extern const size_t gNumTestCerts = ArraySize(gTestCerts);
 
 CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, ByteSpan & cert)
 {
@@ -181,7 +181,7 @@ CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags
     SuccessOrExit(err);
 
     // Load it into the certificate set.
-    err = certSet.LoadCert(cert.data(), static_cast<uint32_t>(cert.size()), decodeFlags);
+    err = certSet.LoadCert(cert, decodeFlags);
     SuccessOrExit(err);
 
     // Get loaded certificate data.

--- a/src/credentials/tests/TestChipOperationalCredentials.cpp
+++ b/src/credentials/tests/TestChipOperationalCredentials.cpp
@@ -114,7 +114,7 @@ static void TestChipOperationalCredentials_CertValidation(nlTestSuite * inSuite,
                                                                          { TestCerts::kNode01_01, sGenTBSHashFlag,  sNullLoadFlag       } } },
     };
     // clang-format on
-    static const size_t sNumValidationTestCases = sizeof(sValidationTestCases) / sizeof(sValidationTestCases[0]);
+    static const size_t sNumValidationTestCases = ArraySize(sValidationTestCases);
 
     for (unsigned i = 0; i < sNumValidationTestCases; i++)
     {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -344,8 +344,9 @@ CHIP_ERROR CASESession::SendSigmaR1()
         FabricId fabricId;
         MutableByteSpan destinationIdSpan(destinationIdentifier);
 
-        ReturnErrorOnFailure(DecodeChipCert(mOpCredSet->GetDevOpCred(mTrustedRootId), mOpCredSet->GetDevOpCredLen(mTrustedRootId),
-                                            nodeOperationalCertificate));
+        ReturnErrorOnFailure(
+            DecodeChipCert(ByteSpan(mOpCredSet->GetDevOpCred(mTrustedRootId), mOpCredSet->GetDevOpCredLen(mTrustedRootId)),
+                           nodeOperationalCertificate));
         ReturnErrorOnFailure(nodeOperationalCertificate.mSubjectDN.GetCertFabricId(fabricId));
         // retrieve Fabric IPK
         MutableByteSpan ipkSpan(mIPK);
@@ -1036,8 +1037,9 @@ CHIP_ERROR CASESession::FindDestinationIdCandidate(const ByteSpan & destinationI
 
         trustedRootId = mOpCredSet->GetTrustedRootId(static_cast<uint16_t>(certChainIdx));
 
-        ReturnErrorOnFailure(DecodeChipCert(mOpCredSet->GetDevOpCred(trustedRootId), mOpCredSet->GetDevOpCredLen(trustedRootId),
-                                            nodeOperationalCertificate));
+        ReturnErrorOnFailure(
+            DecodeChipCert(ByteSpan(mOpCredSet->GetDevOpCred(trustedRootId), mOpCredSet->GetDevOpCredLen(trustedRootId)),
+                           nodeOperationalCertificate));
 
         ReturnErrorOnFailure(nodeOperationalCertificate.mSubjectDN.GetCertChipId(nodeId));
         ReturnErrorOnFailure(nodeOperationalCertificate.mSubjectDN.GetCertFabricId(fabricId));
@@ -1116,8 +1118,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const ByteSpan & respon
     ReturnErrorOnFailure(certSet.Init(3));
 
     Encoding::LittleEndian::BufferWriter bbuf(responderID, responderID.Length());
-    ReturnErrorOnFailure(certSet.LoadCert(responderOpCert.data(), static_cast<uint32_t>(responderOpCert.size()),
-                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
+    ReturnErrorOnFailure(certSet.LoadCert(responderOpCert, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
 
     bbuf.Put(certSet.GetCertSet()[0].mPublicKey.data(), certSet.GetCertSet()[0].mPublicKey.size());
 
@@ -1125,8 +1126,7 @@ CHIP_ERROR CASESession::Validate_and_RetrieveResponderID(const ByteSpan & respon
 
     // Validate responder identity located in msg_r2_encrypted
     ReturnErrorOnFailure(mOpCredSet->FindCertSet(mTrustedRootId)
-                             ->LoadCert(responderOpCert.data(), static_cast<uint32_t>(responderOpCert.size()),
-                                        BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
+                             ->LoadCert(responderOpCert, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
 
     ReturnErrorOnFailure(SetEffectiveTime());
     // Locate the subject DN and key id that will be used as input the FindValidCert() method.

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -156,16 +156,16 @@ static CHIP_ERROR InitCredentialSets()
     ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount));
 
     // Add the trusted root certificate to the certificate set.
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len),
                                                              BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len,
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len),
                                                           BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len),
                                                              BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len,
+    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len),
                                                           BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
     ReturnErrorOnFailure(commissionerDevOpCred.Init(&commissionerCertificateSet, 1));

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -397,11 +397,8 @@ bool ReadCert(const char * fileName, X509 * cert)
 
 bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
 {
-    bool res          = true;
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    const uint8_t * p = nullptr;
-    uint32_t certLen  = 0;
-    std::unique_ptr<uint8_t[]> x509CertBuf(new uint8_t[kMaxDERCertLength]);
+    bool res         = true;
+    uint32_t certLen = 0;
     std::unique_ptr<uint8_t[]> certBuf;
 
     res = ReadFileIntoMem(fileName, nullptr, certLen);
@@ -419,6 +416,18 @@ bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
         res = ReadCertPEM(fileName, cert);
         VerifyTrueOrExit(res);
     }
+    else if (certFmt == kCertFormat_X509_DER)
+    {
+        const uint8_t * outCert = certBuf.get();
+
+        VerifyOrReturnError(chip::CanCastTo<int>(certLen), false);
+
+        if (d2i_X509(&cert, &outCert, static_cast<int>(certLen)) == nullptr)
+        {
+            ReportOpenSSLErrorAndExit("d2i_X509", res = false);
+        }
+    }
+    // Otherwise, it is either CHIP TLV or CHIP TLV Base64 encoded.
     else
     {
         if (certFmt == kCertFormat_Chip_Base64)
@@ -427,23 +436,21 @@ bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
             VerifyTrueOrExit(res);
         }
 
-        if (certFmt == kCertFormat_Chip_Base64 || certFmt == kCertFormat_Chip_Raw)
-        {
-            err = ConvertChipCertToX509Cert(ByteSpan(certBuf.get(), certLen), x509CertBuf.get(), kMaxDERCertLength, certLen);
-            if (err != CHIP_NO_ERROR)
-            {
-                fprintf(stderr, "Error converting certificate: %s\n", chip::ErrorStr(err));
-                ExitNow(res = false);
-            }
+        std::unique_ptr<uint8_t[]> x509CertBuf(new uint8_t[kMaxDERCertLength]);
+        MutableByteSpan x509Cert(x509CertBuf.get(), kMaxDERCertLength);
 
-            p = x509CertBuf.get();
-        }
-        else
+        CHIP_ERROR err = ConvertChipCertToX509Cert(ByteSpan(certBuf.get(), certLen), x509Cert);
+        if (err != CHIP_NO_ERROR)
         {
-            p = certBuf.get();
+            fprintf(stderr, "Error converting certificate: %s\n", chip::ErrorStr(err));
+            ExitNow(res = false);
         }
 
-        if (d2i_X509(&cert, &p, certLen) == nullptr)
+        const uint8_t * outCert = x509Cert.data();
+
+        VerifyOrReturnError(chip::CanCastTo<int>(x509Cert.size()), false);
+
+        if (d2i_X509(&cert, &outCert, static_cast<int>(x509Cert.size())) == nullptr)
         {
             ReportOpenSSLErrorAndExit("d2i_X509", res = false);
         }
@@ -453,12 +460,12 @@ exit:
     return res;
 }
 
-bool X509ToChipCert(X509 * cert, uint8_t * certBuf, uint32_t certBufSize, uint32_t & certLen)
+bool X509ToChipCert(X509 * cert, MutableByteSpan & chipCert)
 {
     bool res = true;
     CHIP_ERROR err;
     uint8_t * derCert = nullptr;
-    int32_t derCertLen;
+    int derCertLen;
 
     derCertLen = i2d_X509(cert, &derCert);
     if (derCertLen < 0)
@@ -466,9 +473,9 @@ bool X509ToChipCert(X509 * cert, uint8_t * certBuf, uint32_t certBufSize, uint32
         ReportOpenSSLErrorAndExit("i2d_X509", res = false);
     }
 
-    VerifyOrReturnError(chip::CanCastTo<uint32_t>(derCertLen), false);
+    VerifyOrReturnError(chip::CanCastTo<size_t>(derCertLen), false);
 
-    err = ConvertX509CertToChipCert(ByteSpan(derCert, static_cast<uint32_t>(derCertLen)), certBuf, certBufSize, certLen);
+    err = ConvertX509CertToChipCert(ByteSpan(derCert, static_cast<size_t>(derCertLen)), chipCert);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "ConvertX509CertToChipCert() failed\n%s\n", chip::ErrorStr(err));
@@ -479,18 +486,17 @@ exit:
     return res;
 }
 
-bool LoadChipCert(const char * fileName, bool isTrused, ChipCertificateSet & certSet, uint8_t * certBuf, uint32_t certBufSize)
+bool LoadChipCert(const char * fileName, bool isTrused, ChipCertificateSet & certSet, MutableByteSpan & chipCert)
 {
     bool res = true;
     CHIP_ERROR err;
-    uint32_t certLen;
     BitFlags<CertDecodeFlags> decodeFlags;
     std::unique_ptr<X509, void (*)(X509 *)> cert(X509_new(), &X509_free);
 
     res = ReadCert(fileName, cert.get());
     VerifyTrueOrExit(res);
 
-    res = X509ToChipCert(cert.get(), certBuf, certBufSize, certLen);
+    res = X509ToChipCert(cert.get(), chipCert);
     VerifyTrueOrExit(res);
 
     if (isTrused)
@@ -502,7 +508,7 @@ bool LoadChipCert(const char * fileName, bool isTrused, ChipCertificateSet & cer
         decodeFlags.Set(CertDecodeFlags::kGenerateTBSHash);
     }
 
-    err = certSet.LoadCert(certBuf, certLen, decodeFlags);
+    err = certSet.LoadCert(chipCert, decodeFlags);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Error reading %s\n%s\n", fileName, chip::ErrorStr(err));
@@ -540,18 +546,19 @@ bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
     else if (certFmt == kCertFormat_Chip_Raw || certFmt == kCertFormat_Chip_Base64)
     {
         uint8_t * certToWrite      = nullptr;
-        uint32_t certToWriteLen    = 0;
-        uint32_t chipCertLen       = kMaxCHIPCertLength;
-        uint32_t chipCertBase64Len = BASE64_ENCODED_LEN(chipCertLen);
-        std::unique_ptr<uint8_t[]> chipCert(new uint8_t[chipCertLen]);
+        size_t certToWriteLen      = 0;
+        uint32_t chipCertBase64Len = BASE64_ENCODED_LEN(kMaxCHIPCertLength);
         std::unique_ptr<uint8_t[]> chipCertBase64(new uint8_t[chipCertBase64Len]);
+        uint8_t chipCertBuf[kMaxCHIPCertLength];
+        MutableByteSpan chipCert(chipCertBuf);
 
-        res = X509ToChipCert(cert, chipCert.get(), chipCertLen, chipCertLen);
+        res = X509ToChipCert(cert, chipCert);
         VerifyTrueOrExit(res);
 
         if (certFmt == kCertFormat_Chip_Base64)
         {
-            res = Base64Encode(chipCert.get(), chipCertLen, chipCertBase64.get(), chipCertBase64Len, chipCertBase64Len);
+            res = Base64Encode(chipCert.data(), static_cast<uint32_t>(chipCert.size()), chipCertBase64.get(), chipCertBase64Len,
+                               chipCertBase64Len);
             VerifyTrueOrExit(res);
 
             certToWrite    = chipCertBase64.get();
@@ -559,8 +566,8 @@ bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
         }
         else
         {
-            certToWrite    = chipCert.get();
-            certToWriteLen = chipCertLen;
+            certToWrite    = chipCert.data();
+            certToWriteLen = chipCert.size();
         }
 
         if (fwrite(certToWrite, 1, certToWriteLen, file) != certToWriteLen)

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -28,6 +28,7 @@
 
 namespace {
 
+using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Credentials;
 using namespace chip::ASN1;
@@ -209,8 +210,8 @@ bool PrintCert(const char * fileName, X509 * cert)
     ChipCertificateSet certSet;
     const ChipCertificateData * certData;
     chip::BitFlags<CertDecodeFlags> decodeFlags;
-    std::unique_ptr<uint8_t[]> certBuf(new uint8_t[kMaxCHIPCertLength]);
-    uint32_t certLen;
+    uint8_t chipCertBuf[kMaxCHIPCertLength];
+    MutableByteSpan chipCert(chipCertBuf);
     int indent = 4;
 
     VerifyOrExit(cert != nullptr, res = false);
@@ -218,7 +219,7 @@ bool PrintCert(const char * fileName, X509 * cert)
     res = OpenFile(fileName, file, true);
     VerifyTrueOrExit(res);
 
-    res = X509ToChipCert(cert, certBuf.get(), kMaxCHIPCertLength, certLen);
+    res = X509ToChipCert(cert, chipCert);
     VerifyTrueOrExit(res);
 
     err = certSet.Init(1);
@@ -228,7 +229,7 @@ bool PrintCert(const char * fileName, X509 * cert)
         ExitNow(res = false);
     }
 
-    err = certSet.LoadCert(certBuf.get(), certLen, decodeFlags);
+    err = certSet.LoadCert(chipCert, decodeFlags);
     if (err != CHIP_NO_ERROR)
     {
         fprintf(stderr, "Error reading %s: %s\n", fileName, chip::ErrorStr(err));

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -30,6 +30,7 @@
 
 namespace {
 
+using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Credentials;
 using namespace chip::ASN1;
@@ -147,6 +148,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     const ChipCertificateData * validatedCert     = nullptr;
     ValidationContext context;
     uint8_t certsBuf[kMaxCerts * kMaxCHIPCertLength];
+    MutableByteSpan chipCert[kMaxCerts];
 
     context.Reset();
 
@@ -168,12 +170,13 @@ bool Cmd_ValidateCert(int argc, char * argv[])
 
     for (size_t i = 0; i < gNumCertFileNames; i++)
     {
-        res =
-            LoadChipCert(gCACertFileNames[i], gCACertIsTrusted[i], certSet, &certsBuf[i * kMaxCHIPCertLength], kMaxCHIPCertLength);
+        chipCert[i] = MutableByteSpan(&certsBuf[i * kMaxCHIPCertLength], kMaxCHIPCertLength);
+        res         = LoadChipCert(gCACertFileNames[i], gCACertIsTrusted[i], certSet, chipCert[i]);
         VerifyTrueOrExit(res);
     }
 
-    res = LoadChipCert(gTargetCertFileName, false, certSet, &certsBuf[gNumCertFileNames * kMaxCHIPCertLength], kMaxCHIPCertLength);
+    chipCert[gNumCertFileNames] = MutableByteSpan(&certsBuf[gNumCertFileNames * kMaxCHIPCertLength], kMaxCHIPCertLength);
+    res                         = LoadChipCert(gTargetCertFileName, false, certSet, chipCert[gNumCertFileNames]);
     VerifyTrueOrExit(res);
 
     certToBeValidated = certSet.GetLastCert();

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -128,8 +128,9 @@ extern bool Cmd_GenAttCert(int argc, char * argv[]);
 
 extern bool ReadCert(const char * fileName, X509 * cert);
 extern bool ReadCert(const char * fileName, X509 * cert, CertFormat & origCertFmt);
-extern bool LoadChipCert(const char * fileName, bool isTrused, chip::Credentials::ChipCertificateSet & certSet, uint8_t * certBuf,
-                         uint32_t certBufSize);
+extern bool LoadChipCert(const char * fileName, bool isTrused, chip::Credentials::ChipCertificateSet & certSet,
+                         chip::MutableByteSpan & chipCert);
+
 extern bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt);
 
 extern bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
@@ -144,7 +145,7 @@ extern bool GenerateKeyPair(EVP_PKEY * key);
 extern bool ReadKey(const char * fileName, EVP_PKEY * key);
 extern bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
 
-extern bool X509ToChipCert(X509 * cert, uint8_t * certBuf, uint32_t certBufSize, uint32_t & certLen);
+extern bool X509ToChipCert(X509 * cert, chip::MutableByteSpan & chipCert);
 
 extern bool InitOpenSSL();
 extern bool Base64Encode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -365,13 +365,12 @@ CHIP_ERROR FabricInfo::GetCredentials(OperationalCredentialSet & credentials, Ch
     ReturnErrorOnFailure(certificates.Init(kMaxNumCertsInOpCreds));
 
     ReturnErrorOnFailure(
-        certificates.LoadCert(mRootCert, mRootCertLen,
-                              BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor).Set(CertDecodeFlags::kGenerateTBSHash)));
+        certificates.LoadCert(ByteSpan(mRootCert, mRootCertLen), BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
 
     if (mICACert != nullptr && mICACertLen > 0)
     {
         ReturnErrorOnFailure(
-            certificates.LoadCert(mICACert, mICACertLen, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
+            certificates.LoadCert(ByteSpan(mICACert, mICACertLen), BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
     }
 
     credentials.Release();


### PR DESCRIPTION
#### Problem
CHIPCert APIs: not all of them use ByteSpan for input/output params and they don't integrate well with the rest of the code.  

#### Change overview
  -- Updated CHIPCert APIs to Use ByteSpans
  -- added new method TLVReader::Init() that initializes reader with ByteSpan.
  -- using ArraySize() where appropriate
  -- Other minor cleanups

#### Testing
unit testing