### PR TITLE
[Darwin] Fix Watchable Event Manager Select crash on shutdown

### DIFF
--- a/src/system/WatchableEventManagerSelect.cpp
+++ b/src/system/WatchableEventManagerSelect.cpp
@@ -77,6 +77,15 @@ CHIP_ERROR WatchableEventManager::Shutdown()
     while ((timer = mTimerList.PopEarliest()) != nullptr)
     {
         timer->Clear();
+
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+        if (timer->mTimerSource != nullptr)
+        {
+            dispatch_source_cancel(timer->mTimerSource);
+            dispatch_release(timer->mTimerSource);
+        }
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+
         timer->Release();
     }
     mWakeEvent.Close();


### PR DESCRIPTION
#### Problem
#8800 split out some functionality into their own implementations. In the new code that was added, timers are not properly cancelled during shutdown. 
This leads to a crash when shutdown is called while a timer is queued. The timer will run after everything has shutdown and will crash on an assert.

```
Thread 9 Queue : com.zigbee.chip.framework.controller.workqueue (serial)
#0	0x00000001b985f9bc in __pthread_kill ()
#1	0x00000001f3484398 in pthread_kill ()
#2	0x000000018d85acf0 in abort ()
#3	0x0000000101b21290 in chip::System::Timer::List::Remove(chip::System::Timer*) at connectedhomeip/src/system/SystemTimer.cpp:168
#4	0x0000000101b23520 in chip::System::Timer::MutexedList::Remove(chip::System::Timer*) at connectedhomeip/src/system/SystemTimer.h:104
#5	0x0000000101b2257c in chip::System::WatchableEventManager::HandleTimerComplete(chip::System::Timer*) at connectedhomeip/src/system/WatchableEventManagerSelect.cpp:370
#6	0x0000000101b22548 in invocation function for block in chip::System::WatchableEventManager::StartTimer(unsigned int, void (*)(chip::System::Layer*, void*), void*) at connectedhomeip/src/system/WatchableEventManagerSelect.cpp:139
```

#### Change overview
Cancel all pending timers while shutting down The WatchableEventManager. 

#### Testing
How was this tested? (at least one bullet point required)
We need more testing for all this code. I don't see any unit tests here. I'm unsure how to go about adding tests here. 
* If manually tested, what platforms controller and device platforms were manually tested, and how?
I tested this manually with the iOS controller which restarts the Darwin CHIP stack before pairing. The controller no longer crashes when calling shutdown before subsequent pairings.
