### PR TITLE
[zephyr] Added random module seed initialization.

### DIFF
--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -26,6 +26,8 @@
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_Zephyr.cpp>
 
+#include <drivers/entropy.h>
+
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -38,10 +40,16 @@ PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
+    const struct device * entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+    unsigned int seed;
 
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
+
+    // Get entropy to initialize seed for pseudorandom operations.
+    SuccessOrExit(entropy_get_entropy(entropy, reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
+    srand(seed);
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();


### PR DESCRIPTION
#### Problem
It seems that currently random module seed for Zephyr platform is not properly initialized, as on every boot rand methods return
the same values.

#### Change overview
Added getting entropy source and initializing srand seed with it.

#### Testing
Small change, verified manually that `GetRandU64()` method used for generating commissionable advertising service instance name returns pseudo-random value on every attempt.

Fixes: https://github.com/project-chip/connectedhomeip/issues/8931
