### PR TITLE
Improve build mbed example workflow:

### DIFF
--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
     mbedos:
         name: Mbed OS examples building
-        timeout-minutes: 30
+        timeout-minutes: 60
         
         env:
             BUILD_TYPE: mbedos
@@ -46,6 +46,19 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
+
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
 
             - name: Build lock-app example
               timeout-minutes: 10


### PR DESCRIPTION

#### Problem
There is a timeout on the mbed building lock-app because it took more than 10 minutes to bootstrap and then build.
Issue #8959

#### Change overview
 Increasing job timeout to 60min
 Adding bootstrap and uploading bootstrap logs job's steps

#### Testing
Execute Github actions with these changes on the ARMmbed fork.