### PR TITLE
Increase the timeout for EFR32 examples

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -60,23 +60,23 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Build example EFR32 Lock App for BRD4161A
-              timeout-minutes: 5
+              timeout-minutes: 10
               run:
                   scripts/examples/gn_efr32_example.sh examples/lock-app/efr32/
                   out/lock_app_debug BRD4161A
             - name: Build example EFR32 Lighting App for BRD4161A
-              timeout-minutes: 5
+              timeout-minutes: 10
               run:
                   scripts/examples/gn_efr32_example.sh
                   examples/lighting-app/efr32/ out/lighting_app_debug BRD4161A
             - name: Build example EFR32 Lighting App for BRD4161A with RPCs
-              timeout-minutes: 5
+              timeout-minutes: 10
               run:
                   scripts/examples/gn_efr32_example.sh
                   examples/lighting-app/efr32/ out/lighting_app_debug_rpc BRD4161A
                   -args='import("//with_pw_rpc.gni")'
             - name: Build example EFR32 Window Covering for BRD4161A
-              timeout-minutes: 5
+              timeout-minutes: 10
               run:
                   scripts/examples/gn_efr32_example.sh examples/window-app/efr32/
                   out/window_app_debug BRD4161A


### PR DESCRIPTION
#### Problem
Build times for EFR32 examples are very close to the timeout value, which is sometimes causing a failure.

#### Change overview
Increase all example builds for EFR32 from 5 to 10min.

#### Testing
Will be tested with the github CI to ensure completing within the 10min.