### PR TITLE
[CI]: Fix random segmentation fault during event handling

### DIFF
--- a/src/system/WatchableEventManagerSelect.cpp
+++ b/src/system/WatchableEventManagerSelect.cpp
@@ -357,15 +357,15 @@ void WatchableEventManager::HandleEvents()
             SocketEventsFromFDs(watchable->GetFD(), mSelected.mReadSet, mSelected.mWriteSet, mSelected.mErrorSet));
     }
 
-    WatchableSocket * watchableSocket = mAttachedSockets;
-    while (watchableSocket != nullptr)
+    WatchableSocket * nextWatchableSocket = mAttachedSockets;
+    while (nextWatchableSocket != nullptr)
     {
-        WatchableSocket * watchable = watchableSocket;
-        watchableSocket             = watchableSocket->mAttachedNext;
+        WatchableSocket * currentWatchable = nextWatchableSocket;
+        nextWatchableSocket                = nextWatchableSocket->mAttachedNext;
 
-        if (watchable->mPendingIO.HasAny())
+        if (currentWatchable->mPendingIO.HasAny())
         {
-            watchable->InvokeCallback();
+            currentWatchable->InvokeCallback();
         }
     }
 

--- a/src/system/WatchableEventManagerSelect.cpp
+++ b/src/system/WatchableEventManagerSelect.cpp
@@ -356,8 +356,13 @@ void WatchableEventManager::HandleEvents()
         watchable->SetPendingIO(
             SocketEventsFromFDs(watchable->GetFD(), mSelected.mReadSet, mSelected.mWriteSet, mSelected.mErrorSet));
     }
-    for (WatchableSocket * watchable = mAttachedSockets; watchable != nullptr; watchable = watchable->mAttachedNext)
+
+    WatchableSocket * watchableSocket = mAttachedSockets;
+    while (watchableSocket != nullptr)
     {
+        WatchableSocket * watchable = watchableSocket;
+        watchableSocket             = watchableSocket->mAttachedNext;
+
         if (watchable->mPendingIO.HasAny())
         {
             watchable->InvokeCallback();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We have refactored system event handling mechanism recently,  and observed the following seg fault in CI check.

```
python3 ../../third_party/pigweed/repo/pw_build/py/pw_build/python_runner.py --gn-root ../../ --current-path ../../src/transport/raw/tests --default-toolchain=//build/toolchain/host:linux_x64_gcc --current-toolchain=//build/toolchain/host:linux_x64_gcc --touch gen/src/transport/raw/tests/TestTCP_run.pw_pystamp --capture-output -- ../../third_party/pigweed/repo/pw_unit_test/py/pw_unit_test/test_runner.py --runner ../../third_party/pigweed/repo/targets/host/run_test --test tests/TestTCP
INF Test 1/1: [ RUN] TestTCP
ERR ../../third_party/pigweed/repo/targets/host/run_test exited with status 139
OUT [11339]
'#0:','Test-CHIP-Tcp'
'#2:','Setup                     ','PASSED'
'#3:','Simple Init Test IPV4     ','PASSED'
[1628696150.253394][11341:11341] CHIP:IN: TransportMgr initialized
CHIP node ready to service events
[1628696150.254463][11341:11341] CHIP:IN: Freeing connection: connection closed by peer
Segmentation fault (core dumped)
INF Test 1/1: [FAIL] TestTCP
```
The root cause is the WatchableSocket could be changed by InvokeCallback() which might close the socket and disassociate its file descriptor. 

```
    for (WatchableSocket * watchable = mAttachedSockets; watchable != nullptr; watchable = watchable->mAttachedNext)
    {
        if (watchable->mPendingIO.HasAny())
        {
            watchable->InvokeCallback();
        }
    }
```
Log should the watchable->mAttachedNext contain garbage value after InvokeCallback. We should not use its value to access the next element in the watchableSocket list.

[1628957118.857855][12770:12770] CHIP:IN: HandleEvents:watchable:140447941584200:364
[1628957118.857858][12770:12770] CHIP:IN: HandleEvents:watchable->mAttachedNext:140447941585480:364
[1628957118.857862][12770:12770] CHIP:IN: InvokeCallback
[1628957118.858559][12770:12770] CHIP:IN: Freeing connection: connection closed by peer
[1628957118.858569][12770:12770] CHIP:IN: ActiveConnectionState:free
[1628957118.858596][12770:12770] CHIP:IN: WatchableSocket::OnRelease
[1628957118.858807][12770:12770] CHIP:IN: HandleEvents:watchable:140447941584200:365
[1628957118.858814][12770:12770] CHIP:IN: HandleEvents:watchable->mAttachedNext:-2314885530818453537:365

#### Change overview
Move to next watchable before we do InvokeCallback() in case InvokeCallback() close watchable object. 

#### Testing
How was this tested? (at least one bullet point required)
* Verified by CI
