### PR TITLE
Reduce Network and Github Job usage in Linux Build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,15 +24,75 @@ concurrency:
     cancel-in-progress: true
   
 jobs:
-    build_linux:
-        name: Build on Linux
+    build_linux_gcc_debug:
+        name: Build on Linux (gcc_debug)
         timeout-minutes: 60
 
-        strategy:
-            matrix:
-                type: [gcc_debug, gcc_release, clang, mbedtls]
-        env:
-            BUILD_TYPE: ${{ matrix.type }}
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build:latest
+            volumes:
+                - "/tmp/log_output:/tmp/test_logs"
+            options:
+                --sysctl "net.ipv6.conf.all.disable_ipv6=0
+                net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
+
+        steps:
+            - name: Dump GitHub context
+              env:
+                GITHUB_CONTEXT: ${{ toJSON(github) }}
+              run: echo "$GITHUB_CONTEXT"
+            - name: Dump Concurrency context
+              env:
+                CONCURRENCY_CONTEXT: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+              run: echo "$CONCURRENCY_CONTEXT"
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Setup Build
+              run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true"
+            - name: Run Build
+              timeout-minutes: 20
+              run: scripts/build/gn_build.sh
+            - name: Run Tests
+              timeout-minutes: 2
+              run: scripts/tests/gn_tests.sh
+            # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
+            # TODO https://github.com/project-chip/connectedhomeip/issues/1512
+            # - name: Run Code Coverage
+            #   if: ${{ contains('main', env.BUILD_TYPE) }}
+            #   run: scripts/tools/codecoverage.sh
+            # - name: Upload Code Coverage
+            #   if: ${{ contains('main', env.BUILD_TYPE) }}
+            #   run: bash <(curl -s https://codecov.io/bash)
+            - name: Setup Build Without Detail Logging
+              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
+            - name: Run Build Without Detail Logging
+              timeout-minutes: 20
+              run: scripts/build/gn_build.sh
+            - name: Setup Build Without Progress Logging
+              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
+            - name: Run Build Without Progress Logging
+              timeout-minutes: 20
+              run: scripts/build/gn_build.sh
+    build_linux:
+        name: Build on Linux (gcc_release, clang, mbedtls)
+        timeout-minutes: 60
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -59,7 +119,7 @@ jobs:
               with:
                   submodules: true
             - name: Initialize CodeQL
-              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
+              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
               uses: github/codeql-action/init@v1
               with:
                   languages: "cpp"
@@ -75,23 +135,20 @@ jobs:
                   path: |
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
-            - name: Setup Build
-              run: |
-                  case $BUILD_TYPE in
-                     "gcc_debug") GN_ARGS='chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true';;
-                     "gcc_release") GN_ARGS='is_debug=false';;
-                     "clang") GN_ARGS='is_clang=true';;
-                     "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
-                      *) echo >&2 "Unrecognized build type: ${BUILD_TYPE}"; exit 1;;
-                  esac
-
-                  scripts/build/gn_gen.sh --args="$GN_ARGS"
-            - name: Run Build
+            - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 20
-              run: scripts/build/gn_build.sh
-            - name: Run Tests
-              timeout-minutes: 2
-              run: scripts/tests/gn_tests.sh
+              run: |
+                  for BUILD_TYPE  in gcc_release clang mbedtls; do
+                      case $BUILD_TYPE in
+                          "gcc_release") GN_ARGS='is_debug=false';;
+                          "clang") GN_ARGS='is_clang=true';;
+                          "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
+                      esac
+
+                      scripts/build/gn_gen.sh --args="$GN_ARGS"
+                      scripts/build/gn_build.sh
+                      scripts/tests/gn_tests.sh
+                  done
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
             # - name: Run Code Coverage
@@ -107,22 +164,8 @@ jobs:
             # - name: Remove nrfxlib binaries for CodeQL Analysis
             #   run: find . -type d -name "nrfxlib" -exec rm -rf {} +
             - name: Perform CodeQL Analysis
-              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' && (matrix.type == 'gcc_release' || matrix.type == 'clang' || matrix.type == 'mbedtls') }}
+              if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/master' }}
               uses: github/codeql-action/analyze@v1
-            - name: Setup Build Without Detail Logging
-              if: ${{ matrix.type == 'gcc_debug' }}
-              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
-            - name: Run Build Without Detail Logging
-              if: ${{ matrix.type == 'gcc_debug' }}
-              timeout-minutes: 20
-              run: scripts/build/gn_build.sh
-            - name: Setup Build Without Progress Logging
-              if: ${{ matrix.type == 'gcc_debug' }}
-              run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
-            - name: Run Build Without Progress Logging
-              if: ${{ matrix.type == 'gcc_debug' }}
-              timeout-minutes: 20
-              run: scripts/build/gn_build.sh
     build_darwin:
         name: Build on Darwin
         timeout-minutes: 60


### PR DESCRIPTION
#### Problem
The Linux build workflow creates multiples jobs, they clone and bootstrap the source code independently. Those steps download ~11 GB of packages and sub-modules in four separated jobs (Virtual Machines). As consequence, the quota of concurrent jobs is reduced for other tasks limiting their processing and queuing jobs. 

#### Change overview
This change reuses checkout and bootstrap steps to reduce the building time and network usage. This helps to avoid the queuing of concurrent jobs and quickly respond to changes submitted by developers. 

#### Testing
This change was tested using the public runners provided by GitHub. [This sample](https://github.com/electrocucaracha/connectedhomeip/runs/3326678848), which uses new approach, took 14m 49s to process gcc_release, clang and mbedtls builds compared to [a previous execution](https://github.com/project-chip/connectedhomeip/actions/runs/1082956070) which took 19m 23s