### PR TITLE
[python] Add return value to `ZCLWriteAttribute`

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -784,8 +784,9 @@ class DeviceMgrCmd(Cmd):
                     raise exceptions.UnknownCluster(args[0])
                 attribute_type = all_attrs.get(args[0], {}).get(
                     args[1], {}).get("type", None)
-                self.devCtrl.ZCLWriteAttribute(args[0], args[1], int(
+                res = self.devCtrl.ZCLWriteAttribute(args[0], args[1], int(
                     args[2]), int(args[3]), int(args[4]), ParseValueWithType(args[5], attribute_type))
+                print(repr(res))
             else:
                 self.do_help("zclwrite")
         except exceptions.ChipStackException as ex:

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -333,6 +333,8 @@ class ChipDeviceController(object):
         # We are not using IM for Attributes.
         res = self._Cluster.WriteAttribute(
             device, cluster, attribute, endpoint, groupid, value, False)
+        if blocking:
+            return im.GetAttributeWriteResponse(im.DEFAULT_ATTRIBUTEWRITE_APPID)
 
     def ZCLConfigureAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, change, blocking=True):
         device = c_void_p(None)

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -4342,12 +4342,12 @@ class ChipClusters:
     def ClusterBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid)
     def ClusterBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterBasic_ReadAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid)
     def ClusterBasic_WriteAttributeLocation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_Basic_Location(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Basic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
@@ -4402,7 +4402,7 @@ class ChipClusters:
     def ClusterBridgedDeviceBasic_ReadAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid)
     def ClusterBridgedDeviceBasic_WriteAttributeUserLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_BridgedDeviceBasic_UserLabel(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterBridgedDeviceBasic_ReadAttributeHardwareVersion(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_HardwareVersion(device, ZCLendpoint, ZCLgroupid)
@@ -4899,12 +4899,12 @@ class ChipClusters:
     def ClusterTestCluster_ReadAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid)
     def ClusterTestCluster_WriteAttributeCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_CharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterTestCluster_ReadAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid)
     def ClusterTestCluster_WriteAttributeLongCharString(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bytes):
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
         return self._chipLib.chip_ime_WriteAttribute_TestCluster_LongCharString(device, ZCLendpoint, ZCLgroupid, value, len(value))
     def ClusterTestCluster_ReadAttributeUnsupported(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_Unsupported(device, ZCLendpoint, ZCLgroupid)

--- a/src/controller/python/chip/interaction_model/Delegate.cpp
+++ b/src/controller/python/chip/interaction_model/Delegate.cpp
@@ -80,6 +80,28 @@ CHIP_ERROR PythonInteractionModelDelegate::CommandResponseProcessed(const app::C
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR PythonInteractionModelDelegate::WriteResponseStatus(const app::WriteClient * apWriteClient,
+                                                               const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
+                                                               const uint32_t aProtocolId, const uint16_t aProtocolCode,
+                                                               app::AttributePathParams & aAttributePathParams,
+                                                               uint8_t aCommandIndex)
+{
+    if (onWriteResponseFunct != nullptr)
+    {
+        AttributeWriteStatus status{ apWriteClient->GetSourceNodeId(),
+                                     apWriteClient->GetAppIdentifier(),
+                                     aProtocolId,
+                                     aProtocolCode,
+                                     aAttributePathParams.mEndpointId,
+                                     aAttributePathParams.mClusterId,
+                                     aAttributePathParams.mFieldId };
+        onWriteResponseFunct(&status, sizeof(status));
+    }
+    DeviceControllerInteractionModelDelegate::WriteResponseStatus(apWriteClient, aGeneralCode, aProtocolId, aProtocolCode,
+                                                                  aAttributePathParams, aCommandIndex);
+    return CHIP_NO_ERROR;
+}
+
 void PythonInteractionModelDelegate::OnReportData(const app::ReadClient * apReadClient, const app::ClusterInfo & aPath,
                                                   TLV::TLVReader * apData, Protocols::InteractionModel::ProtocolCode status)
 {
@@ -137,6 +159,11 @@ void pychip_InteractionModelDelegate_SetCommandResponseErrorCallback(PythonInter
 void pychip_InteractionModelDelegate_SetOnReportDataCallback(PythonInteractionModelDelegate_OnReportDataFunct f)
 {
     gPythonInteractionModelDelegate.SetOnReportDataCallback(f);
+}
+
+void pychip_InteractionModelDelegate_SetOnWriteResponseStatusCallback(PythonInteractionModelDelegate_OnWriteResponseStatusFunct f)
+{
+    gPythonInteractionModelDelegate.SetOnWriteResponseStatusCallback(f);
 }
 
 PythonInteractionModelDelegate & PythonInteractionModelDelegate::Instance()

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -14,7 +14,7 @@
    limitations under the License.
 '''
 
-from construct import Struct, Int32ul, Int16ul, Int8ul
+from construct import Struct, Int64ul, Int32ul, Int16ul, Int8ul
 from ctypes import CFUNCTYPE, c_void_p, c_size_t, c_uint32, c_uint64, c_uint8, c_uint16, c_ssize_t
 import ctypes
 import chip.native
@@ -33,6 +33,16 @@ IMCommandStatus = Struct(
     "ClusterId" / Int32ul,
     "CommandId" / Int32ul,
     "CommandIndex" / Int8ul,
+)
+
+IMWriteStatus = Struct(
+    "NodeId" / Int64ul,
+    "AppIdentifier" / Int64ul,
+    "ProtocolId" / Int32ul,
+    "ProtocolCode" / Int16ul,
+    "EndpointId" / Int16ul,
+    "ClusterId" / Int32ul,
+    "AttributeId" / Int32ul,
 )
 
 # AttributePath should not contain padding
@@ -58,6 +68,12 @@ class AttributeReadResult:
     value: 'typing.Any'
 
 
+@dataclass
+class AttributeWriteResult:
+    path: AttributePath
+    status: int
+
+
 # typedef void (*PythonInteractionModelDelegate_OnCommandResponseStatusCodeReceivedFunct)(uint64_t commandSenderPtr,
 #                                                                                         void * commandStatusBuf);
 # typedef void (*PythonInteractionModelDelegate_OnCommandResponseProtocolErrorFunct)(uint64_t commandSenderPtr, uint8_t commandIndex);
@@ -71,6 +87,7 @@ _OnCommandResponseProtocolErrorFunct = CFUNCTYPE(None, c_uint64, c_uint8)
 _OnCommandResponseFunct = CFUNCTYPE(None, c_uint64, c_uint32)
 _OnReportDataFunct = CFUNCTYPE(
     None, c_uint64, c_ssize_t, c_void_p, c_uint32, c_void_p, c_uint32, c_uint16)
+_OnWriteResponseStatusFunct = CFUNCTYPE(None, c_void_p, c_uint32)
 
 _commandStatusDict = dict()
 _commandIndexStatusDict = dict()
@@ -80,9 +97,13 @@ _commandStatusCV = threading.Condition(_commandStatusLock)
 _attributeDict = dict()
 _attributeDictLock = threading.RLock()
 
+_writeStatusDict = dict()
+_writeStatusDictLock = threading.RLock()
+
 # A placeholder commandHandle, will be removed once we decouple CommandSender with CHIPClusters
 PLACEHOLDER_COMMAND_HANDLE = 1
 DEFAULT_ATTRIBUTEREAD_APPID = 0
+DEFAULT_ATTRIBUTEWRITE_APPID = 0
 
 
 def _GetCommandStatus(commandHandle: int):
@@ -111,7 +132,7 @@ def _SetCommandIndexStatus(commandHandle: int, commandIndex: int, status):
         _commandIndexStatusDict[commandHandle] = indexDict
 
 
-@_OnCommandResponseStatusCodeReceivedFunct
+@ _OnCommandResponseStatusCodeReceivedFunct
 def _OnCommandResponseStatusCodeReceived(commandHandle: int, IMCommandStatusBuf, IMCommandStatusBufLen):
     status = IMCommandStatus.parse(ctypes.string_at(
         IMCommandStatusBuf, IMCommandStatusBufLen))
@@ -119,17 +140,17 @@ def _OnCommandResponseStatusCodeReceived(commandHandle: int, IMCommandStatusBuf,
                            status["CommandIndex"], status)
 
 
-@_OnCommandResponseProtocolErrorFunct
+@ _OnCommandResponseProtocolErrorFunct
 def _OnCommandResponseProtocolError(commandHandle: int, errorcode: int):
     pass
 
 
-@_OnCommandResponseFunct
+@ _OnCommandResponseFunct
 def _OnCommandResponse(commandHandle: int, errorcode: int):
     _SetCommandStatus(PLACEHOLDER_COMMAND_HANDLE, errorcode)
 
 
-@_OnReportDataFunct
+@ _OnReportDataFunct
 def _OnReportData(nodeId: int, appId: int, attrPathBuf, attrPathBufLen: int, tlvDataBuf, tlvDataBufLen: int, statusCode: int):
     attrPath = AttributePathStruct.parse(
         ctypes.string_at(attrPathBuf, attrPathBufLen))
@@ -150,6 +171,21 @@ def _OnReportData(nodeId: int, appId: int, attrPathBuf, attrPathBufLen: int, tlv
             path, statusCode, tlvData)
 
 
+@_OnWriteResponseStatusFunct
+def _OnWriteResponseStatus(IMAttributeWriteResult, IMAttributeWriteResultLen):
+    status = IMWriteStatus.parse(ctypes.string_at(
+        IMAttributeWriteResult, IMAttributeWriteResultLen))
+
+    appId = status["AppIdentifier"]
+    if appId < 256:
+        # For all attribute write requests using CHIPCluster API, appId is filled by CHIPDevice, and should be smaller than 256 (UINT8_MAX).
+        appId = DEFAULT_ATTRIBUTEWRITE_APPID
+
+    with _writeStatusDictLock:
+        _writeStatusDict[appId] = AttributeWriteResult(AttributePath(
+            status["NodeId"], status["EndpointId"], status["ClusterId"], status["AttributeId"]), status["ProtocolCode"])
+
+
 def InitIMDelegate():
     handle = chip.native.GetLibraryHandle()
     if not handle.pychip_InteractionModelDelegate_SetCommandResponseStatusCallback.argtypes:
@@ -164,6 +200,8 @@ def InitIMDelegate():
                    c_uint32, [ctypes.POINTER(c_uint64)])
         setter.Set("pychip_InteractionModelDelegate_SetOnReportDataCallback", None, [
                    _OnReportDataFunct])
+        setter.Set("pychip_InteractionModelDelegate_SetOnWriteResponseStatusCallback", None, [
+                   _OnWriteResponseStatusFunct])
 
         handle.pychip_InteractionModelDelegate_SetCommandResponseStatusCallback(
             _OnCommandResponseStatusCodeReceived)
@@ -173,6 +211,8 @@ def InitIMDelegate():
             _OnCommandResponse)
         handle.pychip_InteractionModelDelegate_SetOnReportDataCallback(
             _OnReportData)
+        handle.pychip_InteractionModelDelegate_SetOnWriteResponseStatusCallback(
+            _OnWriteResponseStatus)
 
 
 def ClearCommandStatus(commandHandle: int):
@@ -231,3 +271,8 @@ def GetCommandSenderHandle() -> int:
 def GetAttributeReadResponse(appId: int) -> AttributeReadResult:
     with _attributeDictLock:
         return _attributeDict.get(appId, None)
+
+
+def GetAttributeWriteResponse(appId: int) -> AttributeWriteResult:
+    with _writeStatusDictLock:
+        return _writeStatusDict.get(appId, None)

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -142,7 +142,7 @@ class ChipClusters:
 {{#if isWritableAttribute}}
     def Cluster{{asUpperCamelCase parent.name}}_WriteAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: {{ asPythonType chipType }}):
 {{#if (isCharString type)}}
-        value = value.encode("utf-8") + b'\x00'
+        value = value.encode("utf-8")
 {{/if}}
         return self._chipLib.chip_ime_WriteAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLgroupid, value{{#if (isString type)}}, len(value){{/if}})
 {{/if}}

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -15,6 +15,8 @@
 #    limitations under the License.
 #
 
+from dataclasses import dataclass
+from typing import Any
 from chip import ChipDeviceCtrl
 import threading
 import os
@@ -179,21 +181,44 @@ class BaseTestHelper:
         return True
 
     def TestWriteBasicAttributes(self, nodeid: int, endpoint: int, group: int):
-        basic_cluster_attrs = [
-            ("UserLabel", "Test"),
+        @dataclass
+        class AttributeWriteRequest:
+            cluster: str
+            attribute: str
+            value: Any
+
+        requests = [
+            AttributeWriteRequest("Basic", "UserLabel", "Test"),
         ]
         failed_zcl = []
-        for basic_attr in basic_cluster_attrs:
+        for req in requests:
             try:
-                self.devCtrl.ZCLWriteAttribute(cluster="Basic",
-                                               attribute=basic_attr[0],
-                                               nodeid=nodeid,
-                                               endpoint=endpoint,
-                                               groupid=group,
-                                               value=basic_attr[1])
+                res = self.devCtrl.ZCLWriteAttribute(cluster=req.cluster,
+                                                     attribute=req.attribute,
+                                                     nodeid=nodeid,
+                                                     endpoint=endpoint,
+                                                     groupid=group,
+                                                     value=req.value)
+                if res is None:
+                    raise Exception(
+                        f"Write {req.cluster}.{req.attribute} attribute: no value get")
+                elif res.status != 0:
+                    raise Exception(
+                        f"Write {req.cluster}.{req.attribute} attribute: non-zero status code {res.status}")
                 time.sleep(2)
+                res = self.devCtrl.ZCLReadAttribute(
+                    cluster=req.cluster, attribute=req.attribute, nodeid=nodeid, endpoint=endpoint, groupid=group)
+                if res is None:
+                    raise Exception(
+                        f"Read written {req.cluster}.{req.attribute} attribute: failed to read attribute")
+                elif res.status != 0:
+                    raise Exception(
+                        f"Read written {req.cluster}.{req.attribute} attribute: non-zero status code {res.status}")
+                elif res.value != req.value:
+                    raise Exception(
+                        f"Read written {req.cluster}.{req.attribute} attribute: expected {req.value} got {res.value}")
             except Exception:
-                failed_zcl.append(basic_attr)
+                failed_zcl.append(req)
         if failed_zcl:
             self.logger.exception(f"Following attributes failed: {failed_zcl}")
             return False


### PR DESCRIPTION
#### Problem

ZCLWriteAttribute does not have a structured return value for python script api.

#### Change overview

- Implement related functions
- Attribute writes won't append \0 to end of char string (size of string will be indicated by length field in tlv).

#### Testing
- `src/controller/python/test/test_scripts/base.py` updated
