### PR TITLE
Update unit test's titles to match unit tests

### DIFF
--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -170,7 +170,7 @@ static const nlTest sTests[] =
 // clang-format off
 static nlTestSuite sSuite =
 {
-    "Test-CHIP-SecureChannel",
+    "Test-CHIP-SecureSession",
     &sTests[0],
     nullptr,
     nullptr

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -423,7 +423,7 @@ int Finalize(void * aContext);
 // clang-format off
 nlTestSuite sSuite =
 {
-    "Test-CHIP-Connection",
+    "Test-CHIP-SecureSessionMgr",
     &sTests[0],
     Initialize,
     Finalize


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Failed to locate the right unit test during debug, the title and tests are not matched.


#### Change overview
* Update unit test's titles to match unit tests

#### Testing
How was this tested? (at least one bullet point required)
* No logic change, confirm the title and unit tests are matched during unit test.