### PR TITLE
[Android] Initialize opcreds issuer keypair when controller is initialized

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -110,9 +110,6 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GenerateNOCChain(const ByteSpan & csr
         return err;
     }
 
-    // Initializing the KeyPair.
-    Initialize();
-
     NodeId assignedId;
     if (mNodeIdRequested)
     {
@@ -216,11 +213,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     initParams.inetLayer                      = inetLayer;
     initParams.bleLayer                       = GetJNIBleLayer();
 
-    *errInfoOnFailure = wrapper->OpCredsIssuer().Initialize(*initParams.storageDelegate);
-    if (*errInfoOnFailure != CHIP_NO_ERROR)
-    {
-        return nullptr;
-    }
+    wrapper->InitializeOperationalCredentialsIssuer();
 
     Platform::ScopedMemoryBuffer<uint8_t> noc;
     if (!noc.Alloc(kMaxCHIPDERCertLength))
@@ -297,7 +290,7 @@ void AndroidDeviceControllerWrapper::OnCommissioningComplete(NodeId deviceId, CH
     env->CallVoidMethod(mJavaObjectRef, onCommissioningCompleteMethod, static_cast<jlong>(deviceId), error.AsInteger());
 }
 
-CHIP_ERROR AndroidDeviceControllerWrapper::Initialize()
+CHIP_ERROR AndroidDeviceControllerWrapper::InitializeOperationalCredentialsIssuer()
 {
     chip::Crypto::P256SerializedKeypair serializedKey;
     uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -43,13 +43,12 @@ public:
     ~AndroidDeviceControllerWrapper();
 
     chip::Controller::DeviceCommissioner * Controller() { return mController.get(); }
-    chip::Controller::ExampleOperationalCredentialsIssuer & OpCredsIssuer() { return mOpCredsIssuer; }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
     jobject JavaObjectRef() { return mJavaObjectRef; }
     jlong ToJNIHandle();
 
     void CallJavaMethod(const char * methodName, jint argument);
-    CHIP_ERROR Initialize();
+    CHIP_ERROR InitializeOperationalCredentialsIssuer();
 
     // DevicePairingDelegate implementation
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;


### PR DESCRIPTION
#### Problem
* After #8966, `GenerateNOCChainAfterValidation` is called before the opcreds issuer keypair is initialized, resulting in an error.

#### Change overview
* Move keypair initialization to `AndroidDeviceControllerWrapper::AllocateNew`
* Remove ExampleOperationalCredentialsIssuer from Android code as it's not used anymore

#### Testing
* Commissioned and controlled esp32
