### PR TITLE
Add infineon P6 lock app workflow

### DIFF
--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build example - Infineon P6
+
+on:
+    push:
+    pull_request:
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true    
+
+jobs:
+    infineon:
+        name: Infineon examples building
+        timeout-minutes: 30
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: connectedhomeip/chip-build-infineon:latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  submodules: true
+            - name: Bootstrap
+              timeout-minutes: 25
+              run: scripts/build/gn_bootstrap.sh
+            - name: Uploading bootstrap logs
+              uses: actions/upload-artifact@v2
+              if: ${{ always() }}
+              with:
+                  name: bootstrap-logs
+                  path: |
+                   .environment/gn_out/.ninja_log
+                   .environment/pigweed-venv/*.log
+            - name: Build lock-app example
+              timeout-minutes: 10
+              run: |
+                scripts/run_in_build_env.sh \
+                  "scripts/build/build_examples.py --platform infineon --app lock build"
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -275,7 +275,8 @@
                 "esp32",
                 "host",
                 "nrf",
-                "qpg"
+                "qpg",
+                "infineon"
             ],
             "default": "build"
         },
@@ -309,7 +310,8 @@
                 "nrf52840",
                 "nrf5340",
                 "qpg6100",
-                "x64"
+                "x64",
+                "p6board"
             ],
             "default": "build"
         }

--- a/examples/lock-app/p6/README.md
+++ b/examples/lock-app/p6/README.md
@@ -54,7 +54,7 @@ will then join the network.
 
     Or Using P6 build script
 
-          $ ./scripts/examples/gn_p6_example.sh examples/lock-app/p6
+          $ ./scripts/examples/gn_p6_example.sh examples/lock-app/p6 out/lock_app_p6
 
 -   To delete generated executable, libraries and object files use:
 

--- a/scripts/build/BUILD.gn
+++ b/scripts/build/BUILD.gn
@@ -35,6 +35,7 @@ pw_python_package("build_examples") {
     "builders/efr32.py",
     "builders/esp32.py",
     "builders/host.py",
+    "builders/infineon.py",
     "builders/qpg.py",
     "runner/__init__.py",
     "runner/printonly.py",

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -24,6 +24,7 @@ from builders.esp32 import Esp32Builder, Esp32Board, Esp32App
 from builders.host import HostBuilder, HostApp
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 from builders.qpg import QpgBuilder
+from builders.infineon import InfineonBuilder, InfineonApp, InfineonBoard
 
 from .targets import Application, Board, Platform
 
@@ -87,6 +88,7 @@ _MATCHERS = {
     Platform.EFR32: Matcher(Efr32Builder),
     Platform.NRF: Matcher(NrfConnectBuilder),
     Platform.ANDROID: Matcher(AndroidBuilder),
+    Platform.INFINEON: Matcher(InfineonBuilder),
 }
 
 # Matrix of what can be compiled and what build options are required
@@ -132,6 +134,11 @@ _MATCHERS[Platform.ANDROID].AcceptBoard(Board.ARM, board=AndroidBoard.ARM)
 _MATCHERS[Platform.ANDROID].AcceptBoard(Board.ARM64, board=AndroidBoard.ARM64)
 _MATCHERS[Platform.ANDROID].AcceptBoard(Board.X64, board=AndroidBoard.X64)
 _MATCHERS[Platform.ANDROID].AcceptApplication(Application.CHIP_TOOL)
+
+_MATCHERS[Platform.INFINEON].AcceptApplication(
+    Application.LOCK, app=InfineonApp.LOCK)
+_MATCHERS[Platform.INFINEON].AcceptBoard(
+    Board.P6BOARD, board=InfineonBoard.P6BOARD)
 
 
 class BuilderFactory:

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -27,6 +27,7 @@ class Platform(IntEnum):
     EFR32 = auto()
     NRF = auto()
     ANDROID = auto()
+    INFINEON = auto()
 
     @property
     def ArgName(self):
@@ -64,6 +65,9 @@ class Board(IntEnum):
     ARM = auto()
     ARM64 = auto()
     X64 = auto()
+
+    # Infineon board
+    P6BOARD = auto()
 
     @property
     def ArgName(self):

--- a/scripts/build/builders/infineon.py
+++ b/scripts/build/builders/infineon.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from enum import Enum, auto
+
+from .gn import GnBuilder
+
+
+class InfineonApp(Enum):
+    LOCK = auto()
+
+    def ExampleName(self):
+        if self == InfineonApp.LOCK:
+            return 'lock-app'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+    def AppNamePrefix(self):
+        if self == InfineonApp.LOCK:
+            return 'chip-p6-lock-example'
+        else:
+            raise Exception('Unknown app type: %r' % self)
+
+
+class InfineonBoard(Enum):
+    P6BOARD = 1
+
+    def GnArgName(self):
+        if self == InfineonBoard.P6BOARD:
+            return 'CY8CKIT-062S2-43012'
+
+
+class InfineonBuilder(GnBuilder):
+
+    def __init__(self,
+                 root,
+                 runner,
+                 output_prefix: str,
+                 app: InfineonApp = InfineonApp.LOCK,
+                 board: InfineonBoard = InfineonBoard.P6BOARD):
+        super(InfineonBuilder, self).__init__(
+            root=os.path.join(root, 'examples', app.ExampleName(), 'p6'),
+            runner=runner,
+            output_prefix=output_prefix)
+
+        self.app = app
+        self.gn_build_args = ['p6_board="%s"' % board.GnArgName()]
+
+    def build_outputs(self):
+        items = {
+            '%s.out' % self.app.AppNamePrefix():
+                os.path.join(self.output_dir, '%s.out' %
+                             self.app.AppNamePrefix()),
+            '%s.out.map' % self.app.AppNamePrefix():
+                os.path.join(self.output_dir,
+                             '%s.out.map' % self.app.AppNamePrefix()),
+        }
+
+        return items

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -94,6 +94,9 @@ gn gen --check --fail-on-unused-args {out}/android-x64-chip_tool '--args=target_
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
+# Generating infineon-p6board-lock
+gn gen --check --fail-on-unused-args --root=/TEST/BUILD/ROOT/examples/lock-app/p6 '--args=p6_board="CY8CKIT-062S2-43012"' /OUTPUT/DIR/infineon-p6board-lock
+
 # Building {real_platform}-native-all_clusters
 ninja -C {out}/{real_platform}-native-all_clusters
 
@@ -192,5 +195,8 @@ cp {out}/android-x64-chip_tool/lib/jni/x86_64/libc++_shared.so {root}/src/androi
 
 # Building APP android-x64-chip_tool
 {root}/src/android/CHIPTool/gradlew -p {root}/src/android/CHIPTool -PchipSdkJarDir={out}/android-x64-chip_tool/lib -PbuildDir={out}/android-x64-chip_tool build
+
+# Building infineon-p6board-lock
+ninja -C /OUTPUT/DIR/infineon-p6board-lock
 
 

--- a/scripts/examples/gn_p6_example.sh
+++ b/scripts/examples/gn_p6_example.sh
@@ -41,8 +41,12 @@ env
 
 # Build steps
 EXAMPLE_DIR=$1
-OUTPUT_DIR=out/lock_app_p6
+OUTPUT_DIR=out/example_app
 P6_BOARD=CY8CKIT-062S2-43012
+
+if [[ ! -z "$2" ]]; then
+    OUTPUT_DIR=$2
+fi
 
 gn gen --check --fail-on-unused-args "$OUTPUT_DIR" --root="$EXAMPLE_DIR" --args="p6_board=\"$P6_BOARD\""
 ninja -C "$OUTPUT_DIR"


### PR DESCRIPTION
#### Problem
Infineon P6 lock app build is not present in Matter Workflow

#### Change overview
Add Infineon P6 lock app build to Matter CI workflow
Updated P6 script to support output_directory for GN build in-order to support new apps.

#### Testing
How was this tested? 
* If manually tested, what platforms controller and device platforms were manually tested, and how?
CY8CKIT-062S2-43012 + Raspberry Pi4 (chip-device-ctrl)

@andreilitvin @bzbarsky-apple 