### PR TITLE
Increase timeout for build and test runs - this runs 3 separate build…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,7 +136,7 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Setup Build, Run Build and Run Tests
-              timeout-minutes: 20
+              timeout-minutes: 50
               run: |
                   for BUILD_TYPE  in gcc_release clang mbedtls; do
                       case $BUILD_TYPE in


### PR DESCRIPTION
… and tests

#### Problem
CI timeout in the build (20 minutes insufficient to run and test all 3 builds)

#### Change overview
Increase timeout from 20 minutes to 50. Hoping this will be enough.

#### Testing
CI change - no local test (testing  locally would have different hw anyway)