### PR TITLE
Fix: POSIX PlatformManagerImpl bug with RunEventLoop twice

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -55,8 +55,6 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     ReturnErrorOnFailure(GenericPlatformManagerImpl<ImplClass>::_InitChipStack());
 
-    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
-
     int ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
     VerifyOrReturnError(ret == 0, System::MapErrorPOSIX(ret));
 
@@ -141,6 +139,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::ProcessDeviceEvents()
 template <class ImplClass>
 void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
 {
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
     pthread_mutex_lock(&mStateLock);
 
     //
@@ -203,6 +202,8 @@ void * GenericPlatformManagerImpl_POSIX<ImplClass>::EventLoopTaskMain(void * arg
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
 {
+    mShouldRunEventLoop.store(true, std::memory_order_relaxed);
+
     int err;
     err = pthread_attr_init(&mChipTaskAttr);
     VerifyOrReturnError(err == 0, System::MapErrorPOSIX(err));

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -122,6 +122,37 @@ static void TestPlatformMgr_RunEventLoopTwoTasks(nlTestSuite * inSuite, void * i
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+static void TestPlatformMgr_RunEventLoopTwice(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err = PlatformMgr().InitChipStack();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // first time
+    stopRan  = false;
+    sleepRan = false;
+
+    PlatformMgr().ScheduleWork(SleepSome);
+    PlatformMgr().ScheduleWork(StopTheLoop);
+
+    PlatformMgr().RunEventLoop();
+    NL_TEST_ASSERT(inSuite, stopRan);
+    NL_TEST_ASSERT(inSuite, sleepRan);
+
+    // second time
+    stopRan  = false;
+    sleepRan = false;
+
+    PlatformMgr().ScheduleWork(SleepSome);
+    PlatformMgr().ScheduleWork(StopTheLoop);
+
+    PlatformMgr().RunEventLoop();
+    NL_TEST_ASSERT(inSuite, stopRan);
+    NL_TEST_ASSERT(inSuite, sleepRan);
+
+    err = PlatformMgr().Shutdown();
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
 void StopAndSleep(intptr_t arg)
 {
     // Ensure that we don't proceed after stopping until the sleep is done too.
@@ -187,6 +218,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Test basic PlatformMgr::StartEventLoopTask", TestPlatformMgr_BasicEventLoopTask),
     NL_TEST_DEF("Test basic PlatformMgr::RunEventLoop", TestPlatformMgr_BasicRunEventLoop),
     NL_TEST_DEF("Test PlatformMgr::RunEventLoop with two tasks", TestPlatformMgr_RunEventLoopTwoTasks),
+    NL_TEST_DEF("Test PlatformMgr::RunEventLoop twice", TestPlatformMgr_RunEventLoopTwice),
     NL_TEST_DEF("Test PlatformMgr::RunEventLoop with stop before sleep", TestPlatformMgr_RunEventLoopStopBeforeSleep),
     NL_TEST_DEF("Test PlatformMgr::TryLockChipStack", TestPlatformMgr_TryLockChipStack),
     NL_TEST_DEF("Test PlatformMgr::AddEventHandler", TestPlatformMgr_AddEventHandler),


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp was not running the event loop when RunEventLoop was called more than once. To illustrate, consider the following client side logic:

```
1. Schedule StopEventLoopTask after 1 sec
2. RunEventLoop
3. Schedule StopEventLoopTask after 1 sec 
4. RunEventLoop
```

Without this fix, the program would exit before the scheduled 1 sec delay and call to StopEventLoopTask in **step#3** above.

#### Change overview
Changes to GenericPlatformManagerImpl_POSIX and added a unit test in src/platform/tests/TestPlatformMgr.cpp

#### Testing
How was this tested? (at least one bullet point required)
* The added unit test checks that sleep and stop happened after calling RunEventLoop. The test runs this cycle twice to ensure mShouldRunEventLoop's state is set correctly.