### PR TITLE
Use fabric specifc credentials for CASE session setup

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -421,14 +421,14 @@ bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(EndpointId endpoin
 
     VerifyOrExit(csr.Alloc(Crypto::kMAX_CSR_Length), err = CHIP_ERROR_NO_MEMORY);
 
-    if (gFabricBeingCommissioned.GetEphemeralKey() == nullptr)
+    if (gFabricBeingCommissioned.GetOperationalKey() == nullptr)
     {
         Crypto::P256Keypair keypair;
         keypair.Initialize();
         SuccessOrExit(err = gFabricBeingCommissioned.SetEphemeralKey(&keypair));
     }
 
-    err = gFabricBeingCommissioned.GetEphemeralKey()->NewCertificateSigningRequest(csr.Get(), csrLength);
+    err = gFabricBeingCommissioned.GetOperationalKey()->NewCertificateSigningRequest(csr.Get(), csrLength);
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: NewCertificateSigningRequest returned %d", err);
     SuccessOrExit(err);
     VerifyOrExit(csrLength < UINT8_MAX, err = CHIP_ERROR_INTERNAL);

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -264,8 +264,10 @@ void ChannelContext::EnterCasePairingState()
     // TODO: currently only supports IP/UDP paring
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(prepare.mAddress);
-    CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(
-        addr, mFabricsTable, mFabricIndex, prepare.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
+    Transport::FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
+    VerifyOrReturn(fabric != nullptr);
+    CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(addr, fabric, prepare.mBuilder.GetPeerNodeId(),
+                                                                   mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -265,8 +265,7 @@ void ChannelContext::EnterCasePairingState()
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(prepare.mAddress);
     CHIP_ERROR err = prepare.mCasePairingSession->EstablishSession(
-        addr, &prepare.mBuilder.GetOperationalCredentialSet(), prepare.mBuilder.GetOperationalCredentialSetIndex(),
-        prepare.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
+        addr, mFabricsTable, mFabricIndex, prepare.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -79,7 +79,8 @@ class ChannelContext : public ReferenceCounted<ChannelContext, ChannelContextDel
 {
 public:
     ChannelContext(ExchangeManager * exchangeManager, ChannelManager * channelManager) :
-        mState(ChannelState::kNone), mExchangeManager(exchangeManager), mChannelManager(channelManager)
+        mState(ChannelState::kNone), mExchangeManager(exchangeManager), mChannelManager(channelManager), mFabricsTable(nullptr),
+        mFabricIndex(Transport::kUndefinedFabricIndex)
     {}
 
     void Start(const ChannelBuilder & builder);
@@ -122,6 +123,8 @@ private:
     ChannelState mState;
     ExchangeManager * mExchangeManager;
     ChannelManager * mChannelManager;
+    Transport::FabricTable * mFabricsTable;
+    FabricIndex mFabricIndex;
 
     enum class PrepareState
     {

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -552,8 +552,10 @@ CHIP_ERROR Device::WarmupCASESession()
     mLocalMessageCounter = 0;
     mPeerMessageCounter  = 0;
 
-    ReturnErrorOnFailure(
-        mCASESession.EstablishSession(mDeviceAddress, mFabricsTable, mFabricIndex, mDeviceId, keyID, exchange, this));
+    Transport::FabricInfo * fabric = mFabricsTable->FindFabricWithIndex(mFabricIndex);
+    ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    ReturnErrorOnFailure(mCASESession.EstablishSession(mDeviceAddress, fabric, mDeviceId, keyID, exchange, this));
 
     mState = ConnectionState::Connecting;
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -553,7 +553,7 @@ CHIP_ERROR Device::WarmupCASESession()
     mPeerMessageCounter  = 0;
 
     ReturnErrorOnFailure(
-        mCASESession.EstablishSession(mDeviceAddress, mCredentials, mCredentialsIndex, mDeviceId, keyID, exchange, this));
+        mCASESession.EstablishSession(mDeviceAddress, mFabricsTable, mFabricIndex, mDeviceId, keyID, exchange, this));
 
     mState = ConnectionState::Connecting;
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -78,17 +78,16 @@ using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
 
 struct ControllerDeviceInitParams
 {
-    DeviceTransportMgr * transportMgr                   = nullptr;
-    SecureSessionMgr * sessionMgr                       = nullptr;
-    Messaging::ExchangeManager * exchangeMgr            = nullptr;
-    Inet::InetLayer * inetLayer                         = nullptr;
-    PersistentStorageDelegate * storageDelegate         = nullptr;
-    Credentials::OperationalCredentialSet * credentials = nullptr;
-    uint8_t credentialsIndex                            = 0;
-    SessionIDAllocator * idAllocator                    = nullptr;
+    DeviceTransportMgr * transportMgr           = nullptr;
+    SecureSessionMgr * sessionMgr               = nullptr;
+    Messaging::ExchangeManager * exchangeMgr    = nullptr;
+    Inet::InetLayer * inetLayer                 = nullptr;
+    PersistentStorageDelegate * storageDelegate = nullptr;
+    SessionIDAllocator * idAllocator            = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * bleLayer = nullptr;
 #endif
+    Transport::FabricTable * fabricsTable = nullptr;
 };
 
 class Device;
@@ -188,19 +187,18 @@ public:
      */
     void Init(ControllerDeviceInitParams params, uint16_t listenPort, FabricIndex fabric)
     {
-        mTransportMgr     = params.transportMgr;
-        mSessionManager   = params.sessionMgr;
-        mExchangeMgr      = params.exchangeMgr;
-        mInetLayer        = params.inetLayer;
-        mListenPort       = listenPort;
-        mFabricIndex      = fabric;
-        mStorageDelegate  = params.storageDelegate;
-        mCredentials      = params.credentials;
-        mCredentialsIndex = params.credentialsIndex;
-        mIDAllocator      = params.idAllocator;
+        mTransportMgr    = params.transportMgr;
+        mSessionManager  = params.sessionMgr;
+        mExchangeMgr     = params.exchangeMgr;
+        mInetLayer       = params.inetLayer;
+        mListenPort      = listenPort;
+        mFabricIndex     = fabric;
+        mStorageDelegate = params.storageDelegate;
+        mIDAllocator     = params.idAllocator;
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
+        mFabricsTable = params.fabricsTable;
     }
 
     /**
@@ -496,14 +494,11 @@ private:
 
     FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
 
+    Transport::FabricTable * mFabricsTable = nullptr;
+
     bool mDeviceOperationalCertProvisioned = false;
 
     CASESession mCASESession;
-
-    Credentials::OperationalCredentialSet * mCredentials = nullptr;
-    // TODO: Switch to size_t whenever OperationalCredentialSet Class is updated to support more then 255 credentials per controller
-    uint8_t mCredentialsIndex = 0;
-
     PersistentStorageDelegate * mStorageDelegate = nullptr;
 
     uint8_t mCSRNonce[kOpCSRNonceLength];

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -195,10 +195,10 @@ public:
         mFabricIndex     = fabric;
         mStorageDelegate = params.storageDelegate;
         mIDAllocator     = params.idAllocator;
+        mFabricsTable    = params.fabricsTable;
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
-        mFabricsTable = params.fabricsTable;
     }
 
     /**

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -237,7 +237,6 @@ CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParam
 
     Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
-    ReturnErrorOnFailure(fabric->GetCredentials(mCredentials, mCertificates, mRootKeyId, mCredentialsIndex));
 
     mLocalDeviceId = fabric->GetNodeId();
     mVendorId      = fabric->GetVendorId();
@@ -725,14 +724,13 @@ void DeviceController::OnNodeIdResolutionFailed(const chip::PeerId & peer, CHIP_
 ControllerDeviceInitParams DeviceController::GetControllerDeviceInitParams()
 {
     return ControllerDeviceInitParams{
-        .transportMgr     = mTransportMgr,
-        .sessionMgr       = mSessionMgr,
-        .exchangeMgr      = mExchangeMgr,
-        .inetLayer        = mInetLayer,
-        .storageDelegate  = mStorageDelegate,
-        .credentials      = &mCredentials,
-        .credentialsIndex = mCredentialsIndex,
-        .idAllocator      = &mIDAllocator,
+        .transportMgr    = mTransportMgr,
+        .sessionMgr      = mSessionMgr,
+        .exchangeMgr     = mExchangeMgr,
+        .inetLayer       = mInetLayer,
+        .storageDelegate = mStorageDelegate,
+        .idAllocator     = &mIDAllocator,
+        .fabricsTable    = &mFabrics,
     };
 }
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -361,11 +361,6 @@ protected:
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 
-    Credentials::ChipCertificateSet mCertificates;
-    Credentials::OperationalCredentialSet mCredentials;
-    Credentials::CertificateKeyId mRootKeyId;
-    uint8_t mCredentialsIndex;
-
     SessionIDAllocator mIDAllocator;
 
     uint16_t mVendorId;

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -941,6 +941,22 @@ CHIP_ERROR ExtractPeerIdFromOpCert(const ChipCertificateData & opcert, PeerId * 
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * fabricId)
+{
+    const ChipDN & subjectDN = cert.mSubjectDN;
+    for (uint8_t i = 0; i < subjectDN.RDNCount(); ++i)
+    {
+        const auto & rdn = subjectDN.rdn[i];
+        if (rdn.mAttrOID == ASN1::kOID_AttributeType_ChipFabricId)
+        {
+            *fabricId = rdn.mChipVal;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
 CHIP_ERROR ExtractPeerIdFromOpCert(const ByteSpan & opcert, PeerId * peerId)
 {
     ChipCertificateSet certSet;

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -833,6 +833,20 @@ CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, ASN1::AS
 CHIP_ERROR ConvertECDSASignatureDERToRaw(ASN1::ASN1Reader & reader, chip::TLV::TLVWriter & writer, uint64_t tag);
 
 /**
+ * Extract the FabricID from a CHIP certificate in ByteSpan TLV-encoded
+ * form.  This does not perform any sort of validation on the certificate
+ * structure other than parsing it.
+ *
+ * This function can be used to extract Fabric ID from an ICA certificate.
+ * These certificates may not contain a NodeID, so ExtractPeerIdFromOpCert()
+ * cannot be used for such certificates.
+ *
+ * @return CHIP_ERROR_INVALID_ARGUMENT if the passed-in cert does not have RDN
+ * corresponding to FabricID.
+ */
+CHIP_ERROR ExtractFabricIdFromCert(const ChipCertificateData & cert, FabricId * fabricId);
+
+/**
  * Extract a PeerId from an operational certificate that has already been
  * parsed.
  *

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -50,6 +50,9 @@ static constexpr uint16_t kX509NoWellDefinedExpirationDateYear = 9999;
 static constexpr uint32_t kMaxCHIPCertLength = 400;
 static constexpr uint32_t kMaxDERCertLength  = 600;
 
+// The certificate array has additional overhead due to array encoding
+static constexpr uint32_t kMaxCHIPOpCertArrayLength = (2 * kMaxCHIPCertLength + 32);
+
 // The decode buffer is used to reconstruct TBS section of X.509 certificate, which doesn't include signature.
 static constexpr uint32_t kMaxCHIPCertDecodeBufLength = kMaxDERCertLength - Crypto::kMax_ECDSA_Signature_Length_Der;
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -229,6 +229,13 @@ public:
         memcpy(&bytes[0], &raw_value[0], N);
     }
 
+    template <size_t N>
+    constexpr P256PublicKey(const FixedByteSpan<N> & value)
+    {
+        static_assert(N == kP256_PublicKey_Length, "Can only initialize from proper sized byte span");
+        memcpy(&bytes[0], value.data(), N);
+    }
+
     SupportedECPKeyTypes Type() const override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() const override { return kP256_PublicKey_Length; }
     operator uint8_t *() override { return bytes; }

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -74,6 +74,7 @@ private:
     chip::NodeId mNextRequestedNodeId = 1;
     chip::FabricId mNextFabricId = 0;
     bool mNodeIdRequested = false;
+    bool mGenerateRootCert = false;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -34,8 +34,6 @@ public:
         {
             mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1);
         }
-
-        mCredentials.Release();
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
@@ -68,9 +66,6 @@ private:
     FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
 
     Transport::FabricTable * mFabrics = nullptr;
-    Credentials::ChipCertificateSet mCertificates;
-    Credentials::OperationalCredentialSet mCredentials;
-    Credentials::CertificateKeyId mRootKeyId;
 
     CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -623,7 +623,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle & msg)
 
     uint8_t responderRandom[kSigmaParamRandomNumberSize];
     // Responder opCert must fit up to 2x TLV certificates in an array
-    uint8_t responderOpCert[EstimateTLVStructOverhead((kMaxCHIPOpCertArrayLength), 2)];
+    uint8_t responderOpCert[EstimateTLVStructOverhead(kMaxCHIPOpCertArrayLength, 2)];
     size_t responderOpCertLen;
 
     uint16_t responderSessionId = 0;
@@ -914,7 +914,7 @@ CHIP_ERROR CASESession::HandleSigmaR3(System::PacketBufferHandle & msg)
     P256PublicKey remoteCredential;
 
     // Initiator opCert must fit up to 2x TLV certificates in an array
-    uint8_t initiatorOpCert[EstimateTLVStructOverhead((kMaxCHIPOpCertArrayLength), 2)];
+    uint8_t initiatorOpCert[EstimateTLVStructOverhead(kMaxCHIPOpCertArrayLength, 2)];
     size_t initiatorOpCertLen;
 
     uint8_t msg_salt[kIPKSize + kSHA256_Hash_Length];

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -88,11 +88,10 @@ public:
 
     /**
      * @brief
-     *   Initialize using operational credentials code and wait for session establishment requests.
+     *   Initialize using configured fabrics and wait for session establishment requests.
      *
-     * @param operationalCredentialSet      CHIP Certificate Set used to store the chain root of trust an validate peer node
-     *                                      certificates
      * @param myKeyId                       Key ID to be assigned to the secure session on the peer node
+     * @param fabrics                       Table of fabrics that are currently configured on the device
      * @param delegate                      Callback object
      *
      * @return CHIP_ERROR     The result of initialization
@@ -105,11 +104,7 @@ public:
      *   Create and send session establishment request using device's operational credentials.
      *
      * @param peerAddress                   Address of peer with which to establish a session.
-     * @param operationalCredentialSet      CHIP Certificate Set used to store the chain root of trust an validate peer node
-     *                                      certificates
-     * @param opCredSetIndex                Index value used to choose the chain root of trust for establishing a session. Retrieve
-     *                                      this index value from an operationalCredentialSet's entry that matches the device's
-     *                                      operational credentials
+     * @param fabric                        The fabric that should be used for connecting with the peer
      * @param peerNodeId                    Node id of the peer node
      * @param myKeyId                       Key ID to be assigned to the secure session on the peer node
      * @param exchangeCtxt                  The exchange context to send and receive messages with the peer
@@ -117,8 +112,8 @@ public:
      *
      * @return CHIP_ERROR      The result of initialization
      */
-    CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, Transport::FabricTable * fabrics, FabricIndex fabricIndex,
-                                NodeId peerNodeId, uint16_t myKeyId, Messaging::ExchangeContext * exchangeCtxt,
+    CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, Transport::FabricInfo * fabric, NodeId peerNodeId,
+                                uint16_t myKeyId, Messaging::ExchangeContext * exchangeCtxt,
                                 SessionEstablishmentDelegate * delegate);
 
     /**
@@ -183,7 +178,7 @@ private:
         kUnexpected           = 0xff,
     };
 
-    CHIP_ERROR Init(uint16_t myKeyId, Transport::FabricTable * fabrics, SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR Init(uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
 
     CHIP_ERROR SendSigmaR1();
     CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(System::PacketBufferHandle & msg);
@@ -245,7 +240,7 @@ private:
     SessionEstablishmentExchangeDispatch mMessageDispatch;
 
     Transport::FabricTable * mFabricsTable = nullptr;
-    FabricIndex mFabricIndex;
+    Transport::FabricInfo * mFabricInfo    = nullptr;
 
     struct SigmaErrorMsg
     {

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -57,20 +57,10 @@ TransportMgrBase gTransportMgr;
 Test::LoopbackTransport gLoopback;
 chip::Test::IOContext gIOContext;
 
-OperationalCredentialSet commissionerDevOpCred;
-OperationalCredentialSet accessoryDevOpCred;
-
-ChipCertificateSet commissionerCertificateSet;
-ChipCertificateSet accessoryCertificateSet;
-
-P256SerializedKeypair commissionerOpKeysSerialized;
-P256SerializedKeypair accessoryOpKeysSerialized;
-
-P256Keypair commissionerOpKeys;
-P256Keypair accessoryOpKeys;
-
-CertificateKeyId trustedRootId = CertificateKeyId(sTestCert_Root01_SubjectKeyId);
-uint8_t commissionerCredentialsIndex;
+FabricTable gCommissionerFabrics;
+FabricIndex gCommissionerFabricIndex;
+FabricTable gDeviceFabrics;
+FabricIndex gDeviceFabricIndex;
 
 NodeId Node01_01 = 0xDEDEDEDE00010001;
 } // namespace
@@ -89,16 +79,6 @@ public:
 
     uint32_t mNumPairingErrors   = 0;
     uint32_t mNumPairingComplete = 0;
-};
-
-class TestCASESessionDestinationId : public CASESession
-{
-public:
-    CHIP_ERROR GenerateDestinationID(const ByteSpan & random, const Credentials::P256PublicKeySpan & rootPubkey, NodeId nodeId,
-                                     FabricId fabricId, const ByteSpan & ipk, MutableByteSpan & destinationId)
-    {
-        return CASESession::GenerateDestinationID(random, rootPubkey, nodeId, fabricId, ipk, destinationId);
-    }
 };
 
 class TestCASESessionIPK : public CASESession
@@ -128,60 +108,48 @@ private:
 
 static CHIP_ERROR InitCredentialSets()
 {
-    commissionerDevOpCred.Release();
-    accessoryDevOpCred.Release();
-    commissionerCertificateSet.Release();
-    accessoryCertificateSet.Release();
+    FabricInfo commissionerFabric;
 
-    ReturnErrorOnFailure(
-        commissionerOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
-
-    memcpy((uint8_t *) (commissionerOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (commissionerOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+    P256SerializedKeypair opKeysSerialized;
+    memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+    memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
            sTestCert_Node01_01_PrivateKey_Len);
 
-    ReturnErrorOnFailure(commissionerOpKeys.Deserialize(commissionerOpKeysSerialized));
+    ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
-    ReturnErrorOnFailure(
-        accessoryOpKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
+    P256Keypair opKey;
+    ReturnErrorOnFailure(opKey.Deserialize(opKeysSerialized));
+    ReturnErrorOnFailure(commissionerFabric.SetEphemeralKey(&opKey));
 
-    memcpy((uint8_t *) (accessoryOpKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (accessoryOpKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+    ReturnErrorOnFailure(commissionerFabric.SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)));
+
+    uint8_t certChainBuf[kMaxCHIPCertLength * 2];
+    MutableByteSpan certChain(certChainBuf);
+
+    ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(ByteSpan(sTestCert_Node01_01_DER, sTestCert_Node01_01_DER_Len),
+                                                         ByteSpan(sTestCert_ICA01_DER, sTestCert_ICA01_DER_Len), certChain));
+    ReturnErrorOnFailure(commissionerFabric.SetOperationalCertsFromCertArray(certChain));
+
+    ReturnErrorOnFailure(gCommissionerFabrics.AddNewFabric(commissionerFabric, &gCommissionerFabricIndex));
+
+    FabricInfo deviceFabric;
+
+    memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+    memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
            sTestCert_Node01_01_PrivateKey_Len);
 
-    ReturnErrorOnFailure(accessoryOpKeys.Deserialize(accessoryOpKeysSerialized));
+    ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
-    ReturnErrorOnFailure(commissionerCertificateSet.Init(kStandardCertsCount));
+    ReturnErrorOnFailure(opKey.Deserialize(opKeysSerialized));
+    ReturnErrorOnFailure(deviceFabric.SetEphemeralKey(&opKey));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.Init(kStandardCertsCount));
+    ReturnErrorOnFailure(deviceFabric.SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)));
 
-    // Add the trusted root certificate to the certificate set.
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len),
-                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+    ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(ByteSpan(sTestCert_Node01_01_DER, sTestCert_Node01_01_DER_Len),
+                                                         ByteSpan(sTestCert_ICA01_DER, sTestCert_ICA01_DER_Len), certChain));
+    ReturnErrorOnFailure(deviceFabric.SetOperationalCertsFromCertArray(certChain));
 
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len),
-                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(commissionerCertificateSet.LoadCert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len),
-                                                             BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(accessoryCertificateSet.LoadCert(ByteSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len),
-                                                          BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-
-    ReturnErrorOnFailure(commissionerDevOpCred.Init(&commissionerCertificateSet, 1));
-    commissionerCredentialsIndex = static_cast<uint8_t>(commissionerDevOpCred.GetCertCount() - 1U);
-
-    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                                            static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
-
-    ReturnErrorOnFailure(commissionerDevOpCred.SetDevOpCredKeypair(trustedRootId, &commissionerOpKeys));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.Init(&accessoryCertificateSet, 1));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCred(trustedRootId, sTestCert_Node01_01_Chip,
-                                                         static_cast<uint16_t>(sTestCert_Node01_01_Chip_Len)));
-
-    ReturnErrorOnFailure(accessoryDevOpCred.SetDevOpCredKeypair(trustedRootId, &accessoryOpKeys));
+    ReturnErrorOnFailure(gDeviceFabrics.AddNewFabric(deviceFabric, &gDeviceFabricIndex));
 
     return CHIP_NO_ERROR;
 }
@@ -191,9 +159,11 @@ void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     // Test all combinations of invalid parameters
     TestCASESecurePairingDelegate delegate;
     TestCASESessionIPK pairing;
+    FabricTable fabrics;
 
-    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(&accessoryDevOpCred, 0, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(&accessoryDevOpCred, 0, &delegate) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(0, nullptr, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(0, nullptr, &delegate) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(0, &fabrics, &delegate) == CHIP_NO_ERROR);
 }
 
 void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
@@ -203,16 +173,20 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     // Test all combinations of invalid parameters
     TestCASESecurePairingDelegate delegate;
     CASESession pairing;
+    FabricTable fabrics;
 
     NL_TEST_ASSERT(inSuite, pairing.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
     ExchangeContext * context = ctx.NewExchangeToLocal(&pairing);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                            commissionerCredentialsIndex, Node01_01, 0, nullptr, nullptr) != CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), nullptr, 0, Node01_01, 0, nullptr,
+                                            nullptr) != CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                            commissionerCredentialsIndex, Node01_01, 0, context, &delegate) == CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                            gCommissionerFabricIndex, Node01_01, 0, nullptr, nullptr) != CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                            gCommissionerFabricIndex, Node01_01, 0, context, &delegate) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
@@ -226,8 +200,8 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context1  = ctx.NewExchangeToLocal(&pairing1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                             commissionerCredentialsIndex, Node01_01, 0, context1,
+                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                             gCommissionerFabricIndex, Node01_01, 0, context1,
                                              &delegate) == CHIP_ERROR_BAD_REQUEST);
     gLoopback.mMessageSendError = CHIP_NO_ERROR;
 }
@@ -254,10 +228,10 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(&pairingCommissioner);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.ListenForSessionEstablishment(&accessoryDevOpCred, 0, &delegateAccessory) == CHIP_NO_ERROR);
+                   pairingAccessory.ListenForSessionEstablishment(0, &gDeviceFabrics, &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                                        commissionerCredentialsIndex, Node01_01, 0, contextCommissioner,
+                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                                        gCommissionerFabricIndex, Node01_01, 0, contextCommissioner,
                                                         &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
@@ -274,7 +248,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
 void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
 {
     TestCASESecurePairingDelegate delegateCommissioner;
-    CASESession pairingCommissioner;
+    TestCASESessionIPK pairingCommissioner;
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
@@ -355,9 +329,8 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
 {
     TestCASESecurePairingDelegate delegateCommissioner;
 
-    auto * pairingCommissioner = chip::Platform::New<CASESession>();
+    auto * pairingCommissioner = chip::Platform::New<TestCASESessionIPK>();
 
-    FabricTable fabricTable;
     TestPersistentStorageDelegate storageDelegate;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
@@ -367,57 +340,30 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
 
     SessionIDAllocator idAllocator;
 
-    fabricTable.Init(&storageDelegate);
-
-    FabricInfo fabric;
-
-    NL_TEST_ASSERT(inSuite, fabric.SetEphemeralKey(&accessoryOpKeys) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, fabric.SetRootCert(ByteSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len)) == CHIP_NO_ERROR);
-
-    uint8_t chipCert[kMaxCHIPCertLength * 2];
-    MutableByteSpan chipCertSpan(chipCert, sizeof(chipCert));
-    NL_TEST_ASSERT(inSuite,
-                   ConvertX509CertsToChipCertArray(ByteSpan(sTestCert_Node01_01_DER, sTestCert_Node01_01_DER_Len),
-                                                   ByteSpan(sTestCert_ICA01_DER, sTestCert_ICA01_DER_Len),
-                                                   chipCertSpan) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, fabric.SetOperationalCertsFromCertArray(chipCertSpan) == CHIP_NO_ERROR);
-
-    FabricIndex index;
-    fabricTable.AddNewFabric(fabric, &index);
-    fabricTable.Store(index);
-    fabricTable.ReleaseFabricIndex(index);
-
-    fabricTable.LoadFromStorage(index);
-    FabricInfo * loaded_fabric = fabricTable.FindFabricWithIndex(index);
-
-    ChipCertificateSet certificates;
-    OperationalCredentialSet credentials;
-    CertificateKeyId rootKeyId;
-    uint8_t credentialsIndex;
-    NL_TEST_ASSERT(inSuite, loaded_fabric->GetCredentials(credentials, certificates, rootKeyId, credentialsIndex) == CHIP_NO_ERROR);
+    gDeviceFabrics.Init(&storageDelegate);
 
     NL_TEST_ASSERT(inSuite,
                    gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &gTransportMgr,
-                                                                &ctx.GetSecureSessionManager(), &fabricTable,
+                                                                &ctx.GetSecureSessionManager(), &gDeviceFabrics,
                                                                 &idAllocator) == CHIP_NO_ERROR);
 
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(pairingCommissioner);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &credentials,
-                                                         credentialsIndex, Node01_01, 0, contextCommissioner,
+                   pairingCommissioner->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                                         gCommissionerFabricIndex, Node01_01, 0, contextCommissioner,
                                                          &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 
-    auto * pairingCommissioner1 = chip::Platform::New<CASESession>();
+    auto * pairingCommissioner1 = chip::Platform::New<TestCASESessionIPK>();
     NL_TEST_ASSERT(inSuite, pairingCommissioner1->MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
     ExchangeContext * contextCommissioner1 = ctx.NewExchangeToLocal(pairingCommissioner1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner1->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &credentials,
-                                                          credentialsIndex, Node01_01, 0, contextCommissioner1,
+                   pairingCommissioner1->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
+                                                          gCommissionerFabricIndex, Node01_01, 0, contextCommissioner1,
                                                           &delegateCommissioner) == CHIP_NO_ERROR);
 
     chip::Platform::Delete(pairingCommissioner);
@@ -444,8 +390,8 @@ void CASE_SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     TestCASESecurePairingDelegate delegateCommissioner;
 
     // Allocate on the heap to avoid stack overflow in some restricted test scenarios (e.g. QEMU)
-    auto * testPairingSession1 = chip::Platform::New<CASESession>();
-    auto * testPairingSession2 = chip::Platform::New<CASESession>();
+    auto * testPairingSession1 = chip::Platform::New<TestCASESessionIPK>();
+    auto * testPairingSession2 = chip::Platform::New<TestCASESessionIPK>();
 
     CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, *testPairingSession1, delegateCommissioner);
     CASE_SecurePairingDeserialize(inSuite, inContext, *testPairingSession1, *testPairingSession2);
@@ -479,39 +425,6 @@ void CASE_SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     chip::Platform::Delete(testPairingSession2);
 }
 
-void CASE_DestinationIDGenerationTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestCASESessionDestinationId pairingCommissioner;
-
-    uint8_t random[kSigmaParamRandomNumberSize]        = { 0x7e, 0x17, 0x12, 0x31, 0x56, 0x8d, 0xfa, 0x17, 0x20, 0x6b, 0x3a,
-                                                    0xcc, 0xf8, 0xfa, 0xec, 0x2f, 0x4d, 0x21, 0xb5, 0x80, 0x11, 0x31,
-                                                    0x96, 0xf4, 0x7c, 0x7c, 0x4d, 0xeb, 0x81, 0x0a, 0x73, 0xdc };
-    uint8_t destinationIdentifier[kSHA256_Hash_Length] = { 0 };
-    NodeId nodeId                                      = 0xCD5544AA7B13EF14;
-    FabricId fabricId                                  = 0x2906C908D115D362;
-    uint8_t rootPubkey[kP256_PublicKey_Length] = { 0x04, 0x4a, 0x9f, 0x42, 0xb1, 0xca, 0x48, 0x40, 0xd3, 0x72, 0x92, 0xbb, 0xc7,
-                                                   0xf6, 0xa7, 0xe1, 0x1e, 0x22, 0x20, 0x0c, 0x97, 0x6f, 0xc9, 0x00, 0xdb, 0xc9,
-                                                   0x8a, 0x7a, 0x38, 0x3a, 0x64, 0x1c, 0xb8, 0x25, 0x4a, 0x2e, 0x56, 0xd4, 0xe2,
-                                                   0x95, 0xa8, 0x47, 0x94, 0x3b, 0x4e, 0x38, 0x97, 0xc4, 0xa7, 0x73, 0xe9, 0x30,
-                                                   0x27, 0x7b, 0x4d, 0x9f, 0xbe, 0xde, 0x8a, 0x05, 0x26, 0x86, 0xbf, 0xac, 0xfa };
-    P256PublicKeySpan rootPubkeySpan(rootPubkey);
-    uint8_t destinationIdentifierTestVector[kSHA256_Hash_Length] = { 0xc8, 0xe1, 0x70, 0x0d, 0x12, 0x5a, 0xff, 0xbc,
-                                                                     0xea, 0xda, 0x34, 0x2a, 0x0d, 0x00, 0xdb, 0x7c,
-                                                                     0xa0, 0x65, 0x05, 0xae, 0x5d, 0x0b, 0x29, 0x87,
-                                                                     0xf3, 0xaf, 0x4b, 0x77, 0xe3, 0x94, 0x05, 0x1d };
-
-    uint8_t ipk[] = { 0x4a, 0x71, 0xcd, 0xd7, 0xb2, 0xa3, 0xca, 0x90, 0x24, 0xf9, 0x6f, 0x3c, 0x96, 0xa1, 0x9d, 0xee };
-
-    {
-        MutableByteSpan destinationIdSpan(destinationIdentifier, sizeof(destinationIdentifier));
-        NL_TEST_ASSERT(inSuite,
-                       pairingCommissioner.GenerateDestinationID(ByteSpan(random, sizeof(random)), rootPubkeySpan, nodeId, fabricId,
-                                                                 ByteSpan(ipk, sizeof(ipk)), destinationIdSpan) == CHIP_NO_ERROR);
-    }
-
-    NL_TEST_ASSERT(inSuite, memcmp(destinationIdentifier, destinationIdentifierTestVector, sizeof(destinationIdentifier)) == 0);
-}
-
 // Test Suite
 
 /**
@@ -525,7 +438,6 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Handshake",   CASE_SecurePairingHandshakeTest),
     NL_TEST_DEF("ServerHandshake", CASE_SecurePairingHandshakeServerTest),
     NL_TEST_DEF("Serialize",   CASE_SecurePairingSerializeTest),
-    NL_TEST_DEF("DestinationID Generation", CASE_DestinationIDGenerationTest),
 
     NL_TEST_SENTINEL()
 };
@@ -588,10 +500,8 @@ int CASE_TestSecurePairing_Teardown(void * inContext)
 {
     reinterpret_cast<TestContext *>(inContext)->Shutdown();
     gIOContext.Shutdown();
-    commissionerDevOpCred.Release();
-    accessoryDevOpCred.Release();
-    commissionerCertificateSet.Release();
-    accessoryCertificateSet.Release();
+    gCommissionerFabrics.Reset();
+    gDeviceFabrics.Reset();
     chip::Platform::MemoryShutdown();
     return SUCCESS;
 }

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -173,20 +173,21 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     // Test all combinations of invalid parameters
     TestCASESecurePairingDelegate delegate;
     CASESession pairing;
-    FabricTable fabrics;
+    FabricInfo * fabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
 
     NL_TEST_ASSERT(inSuite, pairing.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
     ExchangeContext * context = ctx.NewExchangeToLocal(&pairing);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), nullptr, 0, Node01_01, 0, nullptr,
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), nullptr, Node01_01, 0, nullptr,
                                             nullptr) != CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                            gCommissionerFabricIndex, Node01_01, 0, nullptr, nullptr) != CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0, nullptr,
+                                            nullptr) != CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                            gCommissionerFabricIndex, Node01_01, 0, context, &delegate) == CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0, context,
+                                            &delegate) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
@@ -200,8 +201,7 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context1  = ctx.NewExchangeToLocal(&pairing1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                             gCommissionerFabricIndex, Node01_01, 0, context1,
+                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0, context1,
                                              &delegate) == CHIP_ERROR_BAD_REQUEST);
     gLoopback.mMessageSendError = CHIP_NO_ERROR;
 }
@@ -227,12 +227,14 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
 
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(&pairingCommissioner);
 
+    FabricInfo * fabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
+
     NL_TEST_ASSERT(inSuite,
                    pairingAccessory.ListenForSessionEstablishment(0, &gDeviceFabrics, &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                                        gCommissionerFabricIndex, Node01_01, 0, contextCommissioner,
-                                                        &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0,
+                                                        contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
@@ -353,10 +355,12 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
 
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(pairingCommissioner);
 
+    FabricInfo * fabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
+    NL_TEST_ASSERT(inSuite, fabric != nullptr);
+
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                                         gCommissionerFabricIndex, Node01_01, 0, contextCommissioner,
-                                                         &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0,
+                                                         contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
@@ -366,9 +370,8 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     ExchangeContext * contextCommissioner1 = ctx.NewExchangeToLocal(pairingCommissioner1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner1->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &gCommissionerFabrics,
-                                                          gCommissionerFabricIndex, Node01_01, 0, contextCommissioner1,
-                                                          &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner1->EstablishSession(Transport::PeerAddress(Transport::Type::kBle), fabric, Node01_01, 0,
+                                                          contextCommissioner1, &delegateCommissioner) == CHIP_NO_ERROR);
 
     chip::Platform::Delete(pairingCommissioner);
     chip::Platform::Delete(pairingCommissioner1);

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -153,6 +153,9 @@ CHIP_ERROR FabricInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
     SuccessOrExit(err = SetRootCert(ByteSpan(info->mRootCert, rootCertLen)));
 
     {
+        // The compressed fabric ID doesn't change for a fabric over time.
+        // Computing it here will save computational overhead when it's accessed by other
+        // parts of the code.
         MutableByteSpan compressedId(reinterpret_cast<uint8_t *>(&mCompressedFabricId), sizeof(mCompressedFabricId));
         SuccessOrExit(err = GenerateCompressedFabricId(mRootPubkey, mOperationalId.GetFabricId(), compressedId));
     }

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -422,14 +422,14 @@ CHIP_ERROR FabricInfo::GenerateDestinationID(const ByteSpan & ipk, const ByteSpa
 {
     constexpr uint16_t kSigmaParamRandomNumberSize = 32;
     constexpr size_t kDestinationMessageLen =
-        kSigmaParamRandomNumberSize + kKeyIdentifierLength + sizeof(FabricId) + sizeof(NodeId);
+        kSigmaParamRandomNumberSize + kP256_PublicKey_Length + sizeof(FabricId) + sizeof(NodeId);
     HMAC_sha hmac;
     uint8_t destinationMessage[kDestinationMessageLen];
 
     Encoding::LittleEndian::BufferWriter bbuf(destinationMessage, sizeof(destinationMessage));
 
     bbuf.Put(random.data(), random.size());
-    bbuf.Put(mRootKeyId, mRootKeyIdLen);
+    bbuf.Put(mRootPubkey.ConstBytes(), mRootPubkey.Length());
     bbuf.Put64(GetFabricId());
     bbuf.Put64(destNodeId);
 

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -263,9 +263,7 @@ CHIP_ERROR FabricInfo::SetRootCert(const ByteSpan & cert)
     mRootCertAllocatedLen = (mRootCertLen > mRootCertAllocatedLen) ? mRootCertLen : mRootCertAllocatedLen;
     memcpy(mRootCert, cert.data(), mRootCertLen);
 
-    Encoding::LittleEndian::BufferWriter bbuf(mRootPubkey, mRootPubkey.Length());
-    bbuf.Put(certData.mPublicKey.data(), certData.mPublicKey.size());
-    VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    mRootPubkey = P256PublicKey(certData.mPublicKey);
 
     return CHIP_NO_ERROR;
 }
@@ -412,9 +410,7 @@ CHIP_ERROR FabricInfo::VerifyCredentials(const ByteSpan & noc, ValidationContext
         }
     }
 
-    Encoding::LittleEndian::BufferWriter bbuf(nocPubkey, nocPubkey.Length());
-    bbuf.Put(certificates.GetCertSet()[nocCertIndex].mPublicKey.data(), certificates.GetCertSet()[nocCertIndex].mPublicKey.size());
-    VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    nocPubkey = P256PublicKey(certificates.GetCertSet()[nocCertIndex].mPublicKey);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem
CASE session is always using operational certificates from the first fabric. This will break when multiple fabrics are provisioned on the device.

#### Change overview

- CASESession to use fabrics table to generate the destination ID.
- The peer uses its fabrics table to match the destination ID with the configured fabrics.
- The operational certificates from the matched fabric are used for CASE session setup.

#### Testing
Updated `TestCASESession` unit tests to use the fabrics table to identify the certificates.
Also, tested the commissioning and CASE session flows using chip-tool, Python controller app, and iOS CHIPTool apps.
