### PR TITLE
[Echo]: Fix OnResponseTimeout is not fired when SendMessage fails

### DIFF
--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -29,6 +29,9 @@ namespace chip {
 namespace Protocols {
 namespace Echo {
 
+// The Echo message timeout value in milliseconds.
+constexpr uint32_t kEchoMessageTimeoutMsec = 800;
+
 CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session)
 {
     // Error if already initialized.
@@ -74,6 +77,8 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, Me
         return CHIP_ERROR_NO_MEMORY;
     }
 
+    mExchangeCtx->SetResponseTimeout(kEchoMessageTimeoutMsec);
+
     // Send an Echo Request message.  Discard the exchange context if the send fails.
     err = mExchangeCtx->SendMessage(MsgType::EchoRequest, std::move(payload),
                                     sendFlags.Set(Messaging::SendMessageFlags::kExpectResponse));
@@ -114,6 +119,7 @@ CHIP_ERROR EchoClient::OnMessageReceived(Messaging::ExchangeContext * ec, const 
 
 void EchoClient::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
+    mExchangeCtx = nullptr;
     ChipLogProgress(Echo, "Time out! failed to receive echo response from Exchange: %p", ec);
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We found OnResponseTimeout was not triggered if SendMessage failed during test, this is regression from previous releases.
  This regression is caused by recent ExchangeContext API change, just setting send flag kExpectResponse is not enough, 
  client also needs to explicitly set response timeout value (> 0) to enable response timeout handler.  
 
* Fixes #9093

#### Change overview
Set response timeout value during echo SendMessage

#### Testing
How was this tested? (at least one bullet point required)
* ./chip-echo-requester 192.168.86.171 and drop response message
* ./chip-echo-responder <ip> and confirm OnResponseTimeout is triggered.
```
Send echo request message to Node: 12344321
[1629240235.226394][1957785:1957785] CHIP:IN: Secure message was encrypted: Msg ID 1
[1629240235.226399][1957785:1957785] CHIP:IN: Encrypted message 0x562346ec9b18 to 0x0000000000BC5C01 of type 1 and protocolId 1 on exchange 39017.
[1629240235.226406][1957785:1957785] CHIP:IN: Sending msg 0x562346ec9b18 to 0x0000000000BC5C01 at utc time: 1120292203 msec
[1629240235.226410][1957785:1957785] CHIP:IN: Sending secure msg on generic transport
[1629240235.226464][1957785:1957785] CHIP:IN: Secure msg send status ../../src/inet/IPEndPointBasis.cpp:915: Success
[1629240235.226717][1957785:1957785] CHIP:EM: Received message of type 0x10 with vendorId 0x0000 and protocolId 0x0000 on exchange 39017
[1629240235.226731][1957785:1957785] CHIP:EM: Rxd Ack; Removing MsgId:00000001 from Retrans Table
[1629240235.226735][1957785:1957785] CHIP:EM: Removed CHIP MsgId:00000001 from RetransTable
[1629240236.027884][1957785:1957785] CHIP:ECH: Time out! failed to receive echo response from Exchange: 0x562346ec9c20
No response received
```
