### PR TITLE
[Android] Replace static service resolve callback with Java abstraction

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -26,21 +26,18 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import chip.devicecontroller.ChipDeviceController
-import chip.devicecontroller.NsdManagerServiceResolver
+import chip.setuppayload.SetupPayload
+import chip.setuppayload.SetupPayloadParser
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
 import com.google.chip.chiptool.attestation.AttestationTestFragment
+import com.google.chip.chiptool.clusterclient.OnOffClientFragment
+import com.google.chip.chiptool.clusterclient.SensorClientFragment
 import com.google.chip.chiptool.echoclient.EchoClientFragment
 import com.google.chip.chiptool.provisioning.DeviceProvisioningFragment
 import com.google.chip.chiptool.provisioning.ProvisionNetworkType
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceDetailsFragment
 import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
-import chip.devicecontroller.PreferencesKeyValueStoreManager
-import chip.setuppayload.SetupPayload
-import chip.setuppayload.SetupPayloadParser
-import com.google.chip.chiptool.clusterclient.OnOffClientFragment
-import com.google.chip.chiptool.clusterclient.SensorClientFragment
 
 class CHIPToolActivity :
     AppCompatActivity(),

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
@@ -21,9 +21,9 @@ import android.content.Context
 import android.util.Log
 import chip.devicecontroller.ChipDeviceController
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback
-import chip.devicecontroller.NsdManagerServiceResolver
 import chip.devicecontroller.PreferencesKeyValueStoreManager
-import java.lang.IllegalStateException
+import chip.devicecontroller.mdns.ChipMdnsCallbackImpl
+import chip.devicecontroller.mdns.NsdManagerServiceResolver
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -37,7 +37,8 @@ object ChipClient {
     if (!this::chipDeviceController.isInitialized) {
       chipDeviceController = ChipDeviceController(
         PreferencesKeyValueStoreManager(context),
-        NsdManagerServiceResolver(context)
+        NsdManagerServiceResolver(context),
+        ChipMdnsCallbackImpl()
       )
     }
     return chipDeviceController

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -37,6 +37,7 @@ shared_library("jni") {
     "AndroidKeyValueStoreManagerImpl.h",
     "CHIPDeviceController-JNI.cpp",
     "CHIPJNIError.h",
+    "CHIPMdnsCallbackImpl-JNI.cpp",
     "JniReferences.cpp",
     "JniReferences.h",
     "JniTypeWrappers.h",
@@ -73,9 +74,11 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java",
     "src/chip/devicecontroller/KeyValueStoreManager.java",
-    "src/chip/devicecontroller/NsdManagerServiceResolver.java",
     "src/chip/devicecontroller/PreferencesKeyValueStoreManager.java",
-    "src/chip/devicecontroller/ServiceResolver.java",
+    "src/chip/devicecontroller/mdns/ChipMdnsCallback.java",
+    "src/chip/devicecontroller/mdns/ChipMdnsCallbackImpl.java",
+    "src/chip/devicecontroller/mdns/NsdManagerServiceResolver.java",
+    "src/chip/devicecontroller/mdns/ServiceResolver.java",
   ]
 
   javac_flags = [ "-Xlint:deprecation" ]

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -225,7 +225,8 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     chip::Platform::MemoryShutdown();
 }
 
-JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject keyValueStoreManager, jobject serviceResolver)
+JNI_METHOD(jlong, newDeviceController)
+(JNIEnv * env, jobject self, jobject keyValueStoreManager, jobject serviceResolver, jobject chipMdnsCallback)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -235,8 +236,8 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject keyVa
     ChipLogProgress(Controller, "newDeviceController() called");
 
     DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeWithObject(keyValueStoreManager);
-    using ::chip::Mdns::InitializeWithObject;
-    InitializeWithObject(serviceResolver);
+    using ::chip::Mdns::InitializeWithObjects;
+    InitializeWithObjects(serviceResolver, chipMdnsCallback);
 
     wrapper = AndroidDeviceControllerWrapper::AllocateNew(sJVM, self, JniReferences::GetInstance().GetStackLock(), kLocalDeviceId,
                                                           &sSystemLayer, &sInetLayer, &err);
@@ -259,15 +260,6 @@ exit:
     }
 
     return result;
-}
-
-JNI_METHOD(void, handleServiceResolve)
-(JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callbackHandle,
- jlong contextHandle)
-{
-    using namespace chip::Mdns;
-    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
-    HandleResolve(instanceName, serviceType, address, port, callbackHandle, contextHandle);
 }
 
 JNI_METHOD(void, pairDevice)

--- a/src/controller/java/CHIPMdnsCallbackImpl-JNI.cpp
+++ b/src/controller/java/CHIPMdnsCallbackImpl-JNI.cpp
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2020-2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#include "JniReferences.h"
+#include "MdnsImpl.h"
+#include "StackLock.h"
+
+#include <jni.h>
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_mdns_ChipMdnsCallbackImpl_##METHOD_NAME
+
+JNI_METHOD(void, handleServiceResolve)
+(JNIEnv * env, jclass self, jstring instanceName, jstring serviceType, jstring address, jint port, jlong callbackHandle,
+ jlong contextHandle)
+{
+    StackLockGuard lock(chip::Controller::JniReferences::GetInstance().GetStackLock());
+    using ::chip::Mdns::HandleResolve;
+    HandleResolve(instanceName, serviceType, address, port, callbackHandle, contextHandle);
+}

--- a/src/controller/java/MdnsImpl.h
+++ b/src/controller/java/MdnsImpl.h
@@ -24,9 +24,10 @@ namespace Mdns {
 
 /**
  * Initialize DNS-SD implementation for Android with an object of a class
- * that implements chip.devicecontroller.ServiceResolver interface.
+ * that implements chip.devicecontroller.mdns.ServiceResolver interface, and an object of a class that implements
+ * chip.devicecontroller.mdns.ChipMdnsCallback interface.
  */
-void InitializeWithObject(jobject resolverObject);
+void InitializeWithObjects(jobject resolverObject, jobject chipMdnsCallbackObject);
 
 /**
  * Pass results of the service resolution to the CHIP stack.

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -21,6 +21,8 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.util.Log;
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback;
+import chip.devicecontroller.mdns.ChipMdnsCallback;
+import chip.devicecontroller.mdns.ServiceResolver;
 
 /** Controller to interact with the CHIP device. */
 public class ChipDeviceController {
@@ -31,8 +33,9 @@ public class ChipDeviceController {
   private BluetoothGatt bleGatt;
   private CompletionListener completionListener;
 
-  public ChipDeviceController(KeyValueStoreManager manager, ServiceResolver resolver) {
-    deviceControllerPtr = newDeviceController(manager, resolver);
+  public ChipDeviceController(
+      KeyValueStoreManager manager, ServiceResolver resolver, ChipMdnsCallback chipMdnsCallback) {
+    deviceControllerPtr = newDeviceController(manager, resolver, chipMdnsCallback);
   }
 
   public void setCompletionListener(CompletionListener listener) {
@@ -228,7 +231,8 @@ public class ChipDeviceController {
     return isActive(deviceControllerPtr, deviceId);
   }
 
-  private native long newDeviceController(KeyValueStoreManager manager, ServiceResolver resolver);
+  private native long newDeviceController(
+      KeyValueStoreManager manager, ServiceResolver resolver, ChipMdnsCallback chipMdnsCallback);
 
   private native void pairDevice(
       long deviceControllerPtr, long deviceId, int connectionId, long pinCode, byte[] csrNonce);
@@ -261,14 +265,6 @@ public class ChipDeviceController {
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 
   private native boolean isActive(long deviceControllerPtr, long deviceId);
-
-  public static native void handleServiceResolve(
-      String instanceName,
-      String serviceType,
-      String address,
-      int port,
-      long callbackHandle,
-      long contextHandle);
 
   static {
     System.loadLibrary("CHIPController");

--- a/src/controller/java/src/chip/devicecontroller/mdns/ChipMdnsCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/mdns/ChipMdnsCallback.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller.mdns;
+
+/** Interface for communicating with the CHIP mDNS stack. */
+public interface ChipMdnsCallback {
+  void handleServiceResolve(
+      String instanceName,
+      String serviceType,
+      String address,
+      int port,
+      long callbackHandle,
+      long contextHandle);
+}

--- a/src/controller/java/src/chip/devicecontroller/mdns/ChipMdnsCallbackImpl.java
+++ b/src/controller/java/src/chip/devicecontroller/mdns/ChipMdnsCallbackImpl.java
@@ -15,8 +15,14 @@
  *   limitations under the License.
  *
  */
-package chip.devicecontroller;
+package chip.devicecontroller.mdns;
 
-public interface ServiceResolver {
-  void resolve(String instanceName, String serviceType, long callbackHandle, long contextHandle);
+public class ChipMdnsCallbackImpl implements ChipMdnsCallback {
+  public native void handleServiceResolve(
+      String instanceName,
+      String serviceType,
+      String address,
+      int port,
+      long callbackHandle,
+      long contextHandle);
 }

--- a/src/controller/java/src/chip/devicecontroller/mdns/NsdManagerServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/mdns/NsdManagerServiceResolver.java
@@ -15,7 +15,7 @@
  *   limitations under the License.
  *
  */
-package chip.devicecontroller;
+package chip.devicecontroller.mdns;
 
 import android.content.Context;
 import android.net.nsd.NsdManager;
@@ -48,7 +48,8 @@ public class NsdManagerServiceResolver implements ServiceResolver {
       final String instanceName,
       final String serviceType,
       final long callbackHandle,
-      final long contextHandle) {
+      final long contextHandle,
+      final ChipMdnsCallback chipMdnsCallback) {
     multicastLock.acquire();
 
     NsdServiceInfo serviceInfo = new NsdServiceInfo();
@@ -77,7 +78,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
             Log.w(
                 TAG,
                 "Failed to resolve service '" + serviceInfo.getServiceName() + "': " + errorCode);
-            ChipDeviceController.handleServiceResolve(
+            chipMdnsCallback.handleServiceResolve(
                 instanceName, serviceType, null, 0, callbackHandle, contextHandle);
 
             if (multicastLock.isHeld()) {
@@ -95,7 +96,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
                     + "' to "
                     + serviceInfo.getHost());
             // TODO: Find out if DNS-SD results for Android should contain interface ID
-            ChipDeviceController.handleServiceResolve(
+            chipMdnsCallback.handleServiceResolve(
                 instanceName,
                 serviceType,
                 serviceInfo.getHost().getHostAddress(),

--- a/src/controller/java/src/chip/devicecontroller/mdns/ServiceResolver.java
+++ b/src/controller/java/src/chip/devicecontroller/mdns/ServiceResolver.java
@@ -1,0 +1,33 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller.mdns;
+
+/** Interface for resolving network services. */
+public interface ServiceResolver {
+  /**
+   * Resolve an address for the given instance name and service type. The implementation of this
+   * function should call {@link ChipMdnsCallback#handleServiceResolve} on chipMdnsCallback, passing
+   * through the callbackHandle and contextHandle.
+   */
+  void resolve(
+      String instanceName,
+      String serviceType,
+      long callbackHandle,
+      long contextHandle,
+      ChipMdnsCallback chipMdnsCallback);
+}


### PR DESCRIPTION
#### Problem
When Android resolves a service, we call the static `handleServiceResolve` on `ChipDeviceController.java`. 
* Static methods like this are hard to test
* chip mDNS stack has no dependency on ChipDeviceController, so it doesn't make sense to have this method in `ChipDeviceController.java` 

#### Change overview
* Move mDNS related classes to `chip.devicecontroller.mdns` package
* Move `ChipDeviceController.handleServiceResolve` to `ChipMdnsCallback` / `ChipMdnsCallbackImpl`, with its own `-JNI.cpp` file
* Require `ChipMdnsCallback` instance in `ChipDeviceController` constructor
* Have`ServiceResolver` provide `ChipMdnsCallback` as a parameter in `resolve()`. This removes the need for a static accessor.

#### Testing
* Verify that updating device address still works
