### PR TITLE
Fix discovery issues with minimal mDNS

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -397,8 +397,8 @@ CHIP_ERROR PairingCommand::UpdateNetworkAddress()
 
 void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)
 {
-    ChipLogProgress(chipTool, "OnAddressUpdateComplete: %s", ErrorStr(err));
-    if (err != CHIP_NO_ERROR)
+    ChipLogProgress(chipTool, "OnAddressUpdateComplete: %" PRIx64 ": %s", nodeId, ErrorStr(err));
+    if (err != CHIP_NO_ERROR && nodeId == mRemoteId)
     {
         // Set exit status only if the address update failed.
         // Otherwise wait for OnCommissioningComplete() callback.

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -219,24 +219,18 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
         else if (mDiscoveryType == DiscoveryType::kOperational)
         {
             // Ensure this is our record.
+            // TODO: Fix this comparison which is too loose.
             if (HasQNamePart(data.GetName(), kOperationalServiceName))
             {
                 OnOperationalSrvRecord(data.GetName(), srv);
             }
-            else
-            {
-                mValid = false;
-            }
         }
         else if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
         {
+            // TODO: Fix this comparison which is too loose.
             if (HasQNamePart(data.GetName(), kCommissionableServiceName) || HasQNamePart(data.GetName(), kCommissionerServiceName))
             {
                 OnCommissionableNodeSrvRecord(data.GetName(), srv);
-            }
-            else
-            {
-                mValid = false;
             }
         }
         break;


### PR DESCRIPTION
#### Problem

Discovering the operational service during commissioning fails with minimal
mDNS in certain environments (e.g. otbr + mdnsresponder).

#### Change overview

- Don't skip the rest of the packet if it contains an irrelevant
  resource record. DNS packets can contain records other than
  those directly requested.

- Don't terminate chip-tool commissioning if a device other than
  the commissionee is discovered. There is nothing preventing
  receiving OnAddressUpdateComplete for stale records and this
  will generally happen when doing tests in quick succession
  because stale records accumulate in the SRP server.

#### Testing

`chip-tool pairing ble-thread ex:<dataset-in-base64> 112233 20202021 3840` with Pi + otbr-posix + mdnsresponder

fixes #9099