### PR TITLE
[controller] Add InteractionPeer interface for cluster control

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -30,6 +30,8 @@ static_library("controller") {
     "EmptyDataModelHandler.cpp",
     "ExampleOperationalCredentialsIssuer.cpp",
     "ExampleOperationalCredentialsIssuer.h",
+    "InteractionPeer.cpp",
+    "InteractionPeer.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -24,6 +24,7 @@
  *    the CHIP device.
  */
 
+#include "InteractionPeer.h"
 #include <app/InteractionModelEngine.h>
 #include <controller/CHIPCluster.h>
 #include <protocols/temp_zcl/TempZCL.h>
@@ -32,7 +33,7 @@
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR ClusterBase::Associate(Device * device, EndpointId endpoint)
+CHIP_ERROR ClusterBase::Associate(InteractionPeer * device, EndpointId endpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // TODO: Check if the device supports mCluster at the requested endpoint

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <controller/CHIPDevice.h>
+#include <controller/InteractionPeer.h>
 
 namespace chip {
 namespace Controller {
@@ -36,7 +37,9 @@ class DLL_EXPORT ClusterBase
 public:
     virtual ~ClusterBase() {}
 
-    CHIP_ERROR Associate(Device * device, EndpointId endpoint);
+    CHIP_ERROR Associate(Device * device, EndpointId endpoint) { return Associate(device->GetInteractionPeer(), endpoint); }
+
+    CHIP_ERROR Associate(InteractionPeer * device, EndpointId endpoint);
 
     void Dissociate();
 
@@ -72,7 +75,7 @@ protected:
     CHIP_ERROR RequestAttributeReporting(AttributeId attributeId, Callback::Cancelable * reportHandler);
 
     const ClusterId mClusterId;
-    Device * mDevice;
+    InteractionPeer * mDevice;
     EndpointId mEndpoint;
 };
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -30,6 +30,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/util/CHIPDeviceCallbacksMgr.h>
 #include <app/util/basic-types.h>
+#include <controller/InteractionPeer.h>
 #include <controller/data_model/zap-generated/CHIPClientCallbacks.h>
 #include <core/CHIPCallback.h>
 #include <core/CHIPCore.h>
@@ -95,13 +96,13 @@ class Device;
 typedef void (*OnDeviceConnected)(void * context, Device * device);
 typedef void (*OnDeviceConnectionFailure)(void * context, NodeId deviceId, CHIP_ERROR error);
 
-class DLL_EXPORT Device : public Messaging::ExchangeDelegate, public SessionEstablishmentDelegate
+class DLL_EXPORT Device : public Messaging::ExchangeDelegate, public SessionEstablishmentDelegate, public InteractionPeerDelegate
 {
 public:
     ~Device();
     Device() :
         mOpenPairingSuccessCallback(OnOpenPairingWindowSuccessResponse, this),
-        mOpenPairingFailureCallback(OnOpenPairingWindowFailureResponse, this)
+        mOpenPairingFailureCallback(OnOpenPairingWindowFailureResponse, this), mInteractionPeer(this)
     {}
     Device(const Device &) = delete;
 
@@ -123,41 +124,6 @@ public:
     void SetDelegate(DeviceStatusDelegate * delegate) { mStatusDelegate = delegate; }
 
     // ----- Messaging -----
-    /**
-     * @brief
-     *   Send the provided message to the device
-     *
-     * @param[in] protocolId  The protocol identifier of the CHIP message to be sent.
-     * @param[in] msgType     The message type of the message to be sent.  Must be a valid message type for protocolId.
-     * @param [in] sendFlags  SendMessageFlags::kExpectResponse or SendMessageFlags::kNone
-     * @param[in] message     The message payload to be sent.
-     *
-     * @return CHIP_ERROR   CHIP_NO_ERROR on success, or corresponding error
-     */
-    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
-                           System::PacketBufferHandle && message);
-
-    /**
-     * A strongly-message-typed version of SendMessage.
-     */
-    template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
-    CHIP_ERROR SendMessage(MessageType msgType, Messaging::SendFlags sendFlags, System::PacketBufferHandle && message)
-    {
-        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), sendFlags,
-                           std::move(message));
-    }
-
-    CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
-                                        Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter);
-
-    CHIP_ERROR SendWriteAttributeRequest(app::WriteClientHandle aHandle, Callback::Cancelable * onSuccessCallback,
-                                         Callback::Cancelable * onFailureCallback);
-
-    /**
-     * @brief
-     *   Send the command in internal command sender.
-     */
-    CHIP_ERROR SendCommands(app::CommandSender * commandObj);
 
     /**
      * @brief Get the IP address and port assigned to the device.
@@ -341,8 +307,6 @@ public:
 
     void Reset();
 
-    NodeId GetDeviceId() const { return mDeviceId; }
-
     bool MatchesSession(SessionHandle session) const { return mSecureSession == session; }
 
     SessionHandle GetSecureSession() const { return mSecureSession; }
@@ -350,20 +314,6 @@ public:
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
 
     PASESessionSerializable & GetPairing() { return mPairing; }
-
-    uint8_t GetNextSequenceNumber() { return mSequenceNumber++; };
-    void AddResponseHandler(uint8_t seqNum, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                            app::TLVDataFilter tlvDataFilter = nullptr);
-    void CancelResponseHandler(uint8_t seqNum);
-    void AddReportHandler(EndpointId endpoint, ClusterId cluster, AttributeId attribute, Callback::Cancelable * onReportCallback);
-
-    // This two functions are pretty tricky, it is used to bridge the response, we need to implement interaction model delegate on
-    // the app side instead of register callbacks here. The IM delegate can provide more infomation then callback and it is
-    // type-safe.
-    // TODO: Implement interaction model delegate in the application.
-    void AddIMResponseHandler(app::CommandSender * commandObj, Callback::Cancelable * onSuccessCallback,
-                              Callback::Cancelable * onFailureCallback);
-    void CancelIMResponseHandler(app::CommandSender * commandObj);
 
     void OperationalCertProvisioned();
     bool IsOperationalCertProvisioned() const { return mDeviceOperationalCertProvisioned; }
@@ -373,6 +323,27 @@ public:
         bool loadedSecureSession = false;
         return LoadSecureSessionParametersIfNeeded(loadedSecureSession);
     };
+
+    InteractionPeer * GetInteractionPeer() { return &mInteractionPeer; }
+
+    //////////// InteractionPeerDelegate Implementation ///////////////
+
+    /*
+     * Sends a message. Note that:
+     *  - This function will implicitly setup the session to the peer device if the sessoin is not established.
+     *  - If the first send fails, the function will try disconnect and re-estatlish the session to send again.
+     *  - The protocolId and msgType shall be a vlid combination.
+     */
+    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
+                           System::PacketBufferHandle && message) override;
+
+    NodeId GetDeviceId() const override { return mDeviceId; }
+
+    FabricIndex GetFabricIndex() const override { return mFabricIndex; }
+
+    SessionHandle * GetSessionHandle() override { return &mSecureSession; }
+
+    CHIP_ERROR PreparePeer() override;
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -453,8 +424,6 @@ private:
 
     SessionHandle mSecureSession = {};
 
-    uint8_t mSequenceNumber = 0;
-
     uint32_t mLocalMessageCounter = 0;
     uint32_t mPeerMessageCounter  = 0;
 
@@ -516,6 +485,8 @@ private:
 
     Callback::Callback<DefaultSuccessCallback> mOpenPairingSuccessCallback;
     Callback::Callback<DefaultFailureCallback> mOpenPairingFailureCallback;
+
+    InteractionPeer mInteractionPeer;
 };
 
 /**

--- a/src/controller/InteractionPeer.cpp
+++ b/src/controller/InteractionPeer.cpp
@@ -1,0 +1,114 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <controller/InteractionPeer.h>
+
+namespace chip {
+namespace Controller {
+
+CHIP_ERROR InteractionPeer::SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
+                                                     Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter)
+{
+
+    uint8_t seqNum = GetNextSequenceNumber();
+    aPath.mNodeId  = mDelegate->GetDeviceId();
+
+    ReturnErrorOnFailure(mDelegate->PreparePeer());
+
+    if (onSuccessCallback != nullptr || onFailureCallback != nullptr)
+    {
+        AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback, aTlvDataFilter);
+    }
+    // The application context is used to identify different requests from client application the type of it is intptr_t, here we
+    // use the seqNum.
+    CHIP_ERROR err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(
+        mDelegate->GetDeviceId(), 0, mDelegate->GetSessionHandle(), nullptr /*event path params list*/, 0, &aPath, 1,
+        0 /* event number */, seqNum /* application context */);
+    if (err != CHIP_NO_ERROR)
+    {
+        CancelResponseHandler(seqNum);
+    }
+    return err;
+}
+
+CHIP_ERROR InteractionPeer::SendWriteAttributeRequest(app::WriteClientHandle aHandle, Callback::Cancelable * onSuccessCallback,
+                                                      Callback::Cancelable * onFailureCallback)
+{
+    uint8_t seqNum = GetNextSequenceNumber();
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    aHandle->SetAppIdentifier(seqNum);
+    ReturnErrorOnFailure(mDelegate->PreparePeer());
+
+    AddResponseHandler(seqNum, onSuccessCallback, onFailureCallback);
+    if ((err = aHandle.SendWriteRequest(mDelegate->GetDeviceId(), 0, mDelegate->GetSessionHandle())) != CHIP_NO_ERROR)
+    {
+        CancelResponseHandler(seqNum);
+    }
+    return err;
+}
+
+void InteractionPeer::AddResponseHandler(uint8_t seqNum, Callback::Cancelable * onSuccessCallback,
+                                         Callback::Cancelable * onFailureCallback, app::TLVDataFilter tlvDataFilter)
+{
+    app::CHIPDeviceCallbacksMgr::GetInstance().AddResponseCallback(mDelegate->GetDeviceId(), seqNum, onSuccessCallback,
+                                                                   onFailureCallback, tlvDataFilter);
+}
+
+void InteractionPeer::CancelResponseHandler(uint8_t seqNum)
+{
+    app::CHIPDeviceCallbacksMgr::GetInstance().CancelResponseCallback(mDelegate->GetDeviceId(), seqNum);
+}
+
+void InteractionPeer::AddIMResponseHandler(app::CommandSender * commandObj, Callback::Cancelable * onSuccessCallback,
+                                           Callback::Cancelable * onFailureCallback)
+{
+    // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
+    // there are only one active command transaction on one command sender object. This is a bit tricky, we try to assume that
+    // chip::NodeId is uint64_t so the pointer can be used as a NodeId for CallbackMgr.
+    static_assert(std::is_same<chip::NodeId, uint64_t>::value, "chip::NodeId is not uint64_t");
+    chip::NodeId transactionId = reinterpret_cast<chip::NodeId>(commandObj);
+    app::CHIPDeviceCallbacksMgr::GetInstance().AddResponseCallback(transactionId, 0 /* seqNum, always 0 for IM before #6559 */,
+                                                                   onSuccessCallback, onFailureCallback);
+}
+
+void InteractionPeer::CancelIMResponseHandler(app::CommandSender * commandObj)
+{
+    // We are using the pointer to command sender object as the identifier of command transactions. This makes sense as long as
+    // there are only one active command transaction on one command sender object. This is a bit tricky, we try to assume that
+    // chip::NodeId is uint64_t so the pointer can be used as a NodeId for CallbackMgr.
+    static_assert(std::is_same<chip::NodeId, uint64_t>::value, "chip::NodeId is not uint64_t");
+    chip::NodeId transactionId = reinterpret_cast<chip::NodeId>(commandObj);
+    app::CHIPDeviceCallbacksMgr::GetInstance().CancelResponseCallback(transactionId, 0 /* seqNum, always 0 for IM before #6559 */);
+}
+
+void InteractionPeer::AddReportHandler(EndpointId endpoint, ClusterId cluster, AttributeId attribute,
+                                       Callback::Cancelable * onReportCallback)
+{
+    app::CHIPDeviceCallbacksMgr::GetInstance().AddReportCallback(mDelegate->GetDeviceId(), endpoint, cluster, attribute,
+                                                                 onReportCallback);
+}
+
+CHIP_ERROR InteractionPeer::SendCommands(app::CommandSender * commandObj)
+{
+    ReturnErrorOnFailure(mDelegate->PreparePeer());
+    VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    return commandObj->SendCommandRequest(mDelegate->GetDeviceId(), mDelegate->GetFabricIndex(), mDelegate->GetSessionHandle());
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/InteractionPeer.h
+++ b/src/controller/InteractionPeer.h
@@ -1,0 +1,117 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/CommandSender.h>
+#include <app/InteractionModelEngine.h>
+#include <app/util/CHIPDeviceCallbacksMgr.h>
+#include <app/util/basic-types.h>
+#include <controller/data_model/zap-generated/CHIPClientCallbacks.h>
+
+namespace chip {
+namespace Controller {
+
+// The interface for the underlying connection of Interaction Peer
+class InteractionPeerDelegate
+{
+public:
+    // Setup the peer connection if needed.
+    virtual CHIP_ERROR PreparePeer() = 0;
+
+    virtual NodeId GetDeviceId() const = 0;
+
+    virtual FabricIndex GetFabricIndex() const = 0;
+
+    // Acquires the underlying session handle used to create the exchange context.
+    virtual SessionHandle * GetSessionHandle() = 0;
+
+    // Sends a raw message to the peer.
+    virtual CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
+                                   System::PacketBufferHandle && message) = 0;
+
+    virtual ~InteractionPeerDelegate() {}
+};
+
+// The interface for generated cluster control client to interact with a remote peer
+class InteractionPeer
+{
+public:
+    InteractionPeer(InteractionPeerDelegate * delegate) : mDelegate(delegate) {}
+
+    // Sends a raw message to the peer.
+    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, Messaging::SendFlags sendFlags,
+                           System::PacketBufferHandle && message)
+    {
+        return mDelegate->SendMessage(protocolId, msgType, sendFlags, std::move(message));
+    }
+
+    // The type-safe version of SendMessage
+    template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
+    CHIP_ERROR SendMessage(MessageType msgType, Messaging::SendFlags sendFlags, System::PacketBufferHandle && message)
+    {
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), to_underlying(msgType), sendFlags,
+                           std::move(message));
+    }
+
+    CHIP_ERROR SendReadAttributeRequest(app::AttributePathParams aPath, Callback::Cancelable * onSuccessCallback,
+                                        Callback::Cancelable * onFailureCallback, app::TLVDataFilter aTlvDataFilter);
+
+    /**
+     * @brief Sends write attribute request to peer.
+     *
+     */
+    CHIP_ERROR SendWriteAttributeRequest(app::WriteClientHandle aHandle, Callback::Cancelable * onSuccessCallback,
+                                         Callback::Cancelable * onFailureCallback);
+
+    /**
+     * @brief Returns a new sequence number for interaction.
+     *
+     */
+    uint8_t GetNextSequenceNumber() { return mSequenceNumber++; };
+
+    void AddResponseHandler(uint8_t seqNum, Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
+                            app::TLVDataFilter tlvDataFilter = nullptr);
+
+    void CancelResponseHandler(uint8_t seqNum);
+
+    void AddReportHandler(EndpointId endpoint, ClusterId cluster, AttributeId attribute, Callback::Cancelable * onReportCallback);
+
+    // This two functions are pretty tricky, it is used to bridge the response, we need to implement interaction model delegate on
+    // the app side instead of register callbacks here. The IM delegate can provide more infomation then callback and it is
+    // type-safe.
+    // TODO: Implement interaction model delegate in the application.
+    // TODO: Add docstring @erjiaqing
+    void AddIMResponseHandler(app::CommandSender * commandObj, Callback::Cancelable * onSuccessCallback,
+                              Callback::Cancelable * onFailureCallback);
+
+    // TODO: Add docstring @erjiaqing
+    void CancelIMResponseHandler(app::CommandSender * commandObj);
+
+    // Send the command in internal command sender.
+    CHIP_ERROR SendCommands(app::CommandSender * commandObj);
+
+    NodeId GetDeviceId() { return mDelegate->GetDeviceId(); }
+
+private:
+    InteractionPeerDelegate * mDelegate;
+    uint8_t mSequenceNumber                     = 0;
+    app::CHIPDeviceCallbacksMgr & mCallbacksMgr = app::CHIPDeviceCallbacksMgr::GetInstance();
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -470,8 +470,8 @@ JNI_METHOD(void, sendMessage)(JNIEnv * env, jobject self, jlong handle, jlong de
         else
         {
             // We don't install a response handler, so aren't waiting for a response
-            err = chipDevice->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest, Messaging::SendMessageFlags::kNone,
-                                          std::move(buffer));
+            err = chipDevice->GetInteractionPeer()->SendMessage(Protocols::TempZCL::MsgType::TempZCLRequest,
+                                                                Messaging::SendMessageFlags::kNone, std::move(buffer));
         }
     }
 


### PR DESCRIPTION
#### Problem

The `controller::Device` class is currently tightly bond with `controller::DeviceController` and cannot be used for device-to-device interaction.

#### Change overview

* Split all cluster interaction functions to `InteractionPeer` to decouple them from commission and storage.

#### Testing

Manually build and run. The chip-tool pairing and control is working.