### PR TITLE
dns-sd: Add platform impl tests.

### DIFF
--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -16,26 +16,165 @@
  *    limitations under the License.
  */
 
+#include <lib/core/PeerId.h>
 #include <mdns/Discovery_ImplPlatform.h>
+#include <platform/fake/MdnsImpl.h>
 #include <support/UnitTestRegistration.h>
+#include <support/logging/CHIPLogging.h>
 
 #include <nlunit-test.h>
 
-namespace {
+#if !defined(CHIP_DEVICE_LAYER_TARGET_FAKE) || CHIP_DEVICE_LAYER_TARGET_FAKE != 1
+#error "This test is designed for use only with the fake platform"
+#endif
 
+namespace {
+using namespace chip;
 using namespace chip::Mdns;
 
+const uint8_t kMac[kMaxMacSize] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+const char host[]               = "0102030405060708";
+
+const PeerId kPeerId1                               = PeerId().SetFabricId(0xBEEFBEEFF00DF00D).SetNodeId(0x1111222233334444);
+const PeerId kPeerId2                               = PeerId().SetFabricId(0x5555666677778888).SetNodeId(0x1212343456567878);
+OperationalAdvertisingParameters operationalParams1 = OperationalAdvertisingParameters()
+                                                          .SetPeerId(kPeerId1)
+                                                          .SetMac(ByteSpan(kMac))
+                                                          .SetPort(CHIP_PORT)
+                                                          .EnableIpV4(true)
+                                                          .SetMRPRetryIntervals(32, 33);
+test::ExpectedCall operationalCall1 = test::ExpectedCall()
+                                          .SetProtocol(MdnsServiceProtocol::kMdnsProtocolTcp)
+                                          .SetServiceName("_matter")
+                                          .SetInstanceName("BEEFBEEFF00DF00D-1111222233334444")
+                                          .SetHostName(host)
+                                          .AddTxt("CRI", "32")
+                                          .AddTxt("CRA", "33");
+OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingParameters()
+                                                          .SetPeerId(kPeerId2)
+                                                          .SetMac(ByteSpan(kMac))
+                                                          .SetPort(CHIP_PORT)
+                                                          .EnableIpV4(true)
+                                                          .SetMRPRetryIntervals(32, 33);
+test::ExpectedCall operationalCall2 = test::ExpectedCall()
+                                          .SetProtocol(MdnsServiceProtocol::kMdnsProtocolTcp)
+                                          .SetServiceName("_matter")
+                                          .SetInstanceName("5555666677778888-1212343456567878")
+                                          .SetHostName(host)
+                                          .AddTxt("CRI", "32")
+                                          .AddTxt("CRA", "33");
+
+CommissionAdvertisingParameters commissionableNodeParamsSmall =
+    CommissionAdvertisingParameters()
+        .SetCommissionAdvertiseMode(CommssionAdvertiseMode::kCommissionableNode)
+        .SetMac(ByteSpan(kMac))
+        .SetLongDiscriminator(0xFFE)
+        .SetShortDiscriminator(0xF)
+        .SetCommissioningMode(false, false);
+// Instance names need to be obtained from the advertiser, so they are not set here.
+test::ExpectedCall commissionableSmall = test::ExpectedCall()
+                                             .SetProtocol(MdnsServiceProtocol::kMdnsProtocolUdp)
+                                             .SetServiceName("_matterc")
+                                             .SetHostName(host)
+                                             .AddTxt("CM", "0")
+                                             .AddTxt("D", "4094")
+                                             .AddSubtype("_S15")
+                                             .AddSubtype("_L4094")
+                                             .AddSubtype("_C0");
+CommissionAdvertisingParameters commissionableNodeParamsLarge =
+    CommissionAdvertisingParameters()
+        .SetCommissionAdvertiseMode(CommssionAdvertiseMode::kCommissionableNode)
+        .SetMac(ByteSpan(kMac, sizeof(kMac)))
+        .SetLongDiscriminator(22)
+        .SetShortDiscriminator(2)
+        .SetVendorId(chip::Optional<uint16_t>(555))
+        .SetDeviceType(chip::Optional<uint16_t>(25))
+        .SetCommissioningMode(true, true)
+        .SetDeviceName(chip::Optional<const char *>("testy-test"))
+        .SetPairingHint(chip::Optional<uint16_t>(3))
+        .SetPairingInstr(chip::Optional<const char *>("Pair me"))
+        .SetProductId(chip::Optional<uint16_t>(897))
+        .SetRotatingId(chip::Optional<const char *>("id_that_spins"));
+
+test::ExpectedCall commissionableLarge = test::ExpectedCall()
+                                             .SetProtocol(MdnsServiceProtocol::kMdnsProtocolUdp)
+                                             .SetServiceName("_matterc")
+                                             .SetHostName(host)
+                                             .AddTxt("D", "22")
+                                             .AddTxt("VP", "555+897")
+                                             .AddTxt("AP", "1")
+                                             .AddTxt("CM", "1")
+                                             .AddTxt("DT", "25")
+                                             .AddTxt("DN", "testy-test")
+                                             .AddTxt("RI", "id_that_spins")
+                                             .AddTxt("PI", "Pair me")
+                                             .AddTxt("PH", "3")
+                                             .AddSubtype("_S2")
+                                             .AddSubtype("_L22")
+                                             .AddSubtype("_V555")
+                                             .AddSubtype("_T25")
+                                             .AddSubtype("_C1")
+                                             .AddSubtype("_A1");
 void TestStub(nlTestSuite * inSuite, void * inContext)
 {
+    // This is a test of the fake platform impl. We want
+    // We want the platform to return unexpected event if it gets a start
+    // without an expected event.
+    ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_NOT_IMPLEMENTED);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_UNEXPECTED_EVENT);
+}
+
+void TestOperational(nlTestSuite * inSuite, void * inContext)
+{
+    ChipLogError(Discovery, "Test operational");
+    test::Reset();
+    DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+
+    operationalCall1.callType = test::CallType::kStart;
+    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall1) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams1) == CHIP_NO_ERROR);
+
+    // Next call to advertise should call start again with just the new data.
+    test::Reset();
+    operationalCall2.callType = test::CallType::kStart;
+    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall2) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams2) == CHIP_NO_ERROR);
+}
+
+void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
+{
+    ChipLogError(Discovery, "Test commissionable");
+    test::Reset();
+    DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init() == CHIP_NO_ERROR);
+
+    commissionableSmall.callType = test::CallType::kStart;
+    NL_TEST_ASSERT(inSuite,
+                   mdnsPlatform.GetCommissionableInstanceName(commissionableSmall.instanceName,
+                                                              sizeof(commissionableSmall.instanceName)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableSmall) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsSmall) == CHIP_NO_ERROR);
+
+    // TODO: Right now, platform impl doesn't stop commissionable node before starting a new one. Add stop call here once that is
+    // fixed.
+    test::Reset();
+    commissionableLarge.callType = test::CallType::kStart;
+    NL_TEST_ASSERT(inSuite,
+                   mdnsPlatform.GetCommissionableInstanceName(commissionableLarge.instanceName,
+                                                              sizeof(commissionableLarge.instanceName)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableLarge) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLarge) == CHIP_NO_ERROR);
 }
 
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestStub", TestStub), //
-    NL_TEST_SENTINEL()                 //
+    NL_TEST_DEF("TestStub", TestStub),                             //
+    NL_TEST_DEF("TestOperational", TestOperational),               //
+    NL_TEST_DEF("TestCommissionableNode", TestCommissionableNode), //
+    NL_TEST_SENTINEL()                                             //
 };
 
 } // namespace

--- a/src/platform/fake/MdnsImpl.h
+++ b/src/platform/fake/MdnsImpl.h
@@ -1,0 +1,172 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "lib/mdns/platform/Mdns.h"
+#include <support/CHIPMemString.h>
+
+namespace chip {
+namespace Mdns {
+
+namespace test {
+enum class CallType
+{
+    kUnknown,
+    kStart,
+    kStop,
+};
+
+struct ExpectedTxt
+{
+    static constexpr size_t kMaxExpectedKeySize = 3;
+    static constexpr size_t kMaxExpectedValSize = 128;
+    char key[kMaxExpectedKeySize + 1]           = "";
+    char value[kMaxExpectedValSize + 1]         = "";
+    bool operator==(const TextEntry & txt) const
+    {
+        if (strlen(txt.mKey) > kMaxExpectedKeySize || strcmp(txt.mKey, key) != 0)
+        {
+            return false;
+        }
+        if (strlen(value) != txt.mDataSize || memcmp(value, txt.mData, txt.mDataSize) != 0)
+        {
+            return false;
+        }
+        return true;
+    }
+};
+
+struct ExpectedSubtype
+{
+    char name[kMaxSubtypeDescSize] = "";
+    bool operator==(const char * subtype) const { return strcmp(name, subtype) == 0; }
+};
+struct ExpectedCall
+{
+    ExpectedCall & AddTxt(const char * key, const char * val)
+    {
+        if (numTxt < kMaxTxtRecords)
+        {
+            Platform::CopyString(txt[numTxt].key, key);
+            Platform::CopyString(txt[numTxt].value, val);
+            numTxt++;
+        }
+        return *this;
+    }
+    ExpectedCall & AddSubtype(const char * sub)
+    {
+        if (numSubtypes < kMaxSubtypes)
+        {
+
+            Platform::CopyString(subtype[numSubtypes++].name, sub);
+        }
+        return *this;
+    }
+    ExpectedCall & SetServiceName(const char * name)
+    {
+        Platform::CopyString(serviceName, name);
+        return *this;
+    }
+    ExpectedCall & SetInstanceName(const char * name)
+    {
+        Platform::CopyString(instanceName, name);
+        return *this;
+    }
+    ExpectedCall & SetHostName(const char * name)
+    {
+        Platform::CopyString(hostName, name);
+        return *this;
+    }
+    ExpectedCall & SetProtocol(MdnsServiceProtocol prot)
+    {
+        protocol = prot;
+        return *this;
+    }
+    bool TxtIsExpected(const TextEntry & entry) const
+    {
+        for (size_t i = 0; i < numTxt; ++i)
+        {
+            if (txt[i] == entry)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    bool SubtypeIsExpected(const char * sub) const
+    {
+        for (size_t i = 0; i < numSubtypes; ++i)
+        {
+            if (subtype[i] == sub)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool CheckMatch(CallType call, const MdnsService * service) const
+    {
+        bool callOk       = call == callType;
+        bool instanceOk   = strcmp(instanceName, service->mName) == 0;
+        bool hostOk       = strcmp(hostName, service->mHostName) == 0;
+        bool serviceOk    = strcmp(serviceName, service->mType) == 0;
+        bool subtypeNumOk = numSubtypes == service->mSubTypeSize;
+        bool txtNumOk     = numTxt == service->mTextEntrySize;
+        if (!callOk || !instanceOk || !hostOk || !serviceOk || !subtypeNumOk || !txtNumOk)
+        {
+            return false;
+        }
+        // There aren't a lot of these, so just double loop for now.
+        // The orders of the txt and subtypes don't necessarily match.
+        for (size_t i = 0; i < service->mSubTypeSize; ++i)
+        {
+            if (!SubtypeIsExpected(service->mSubTypes[i]))
+            {
+                return false;
+            }
+        }
+        for (size_t i = 0; i < service->mTextEntrySize; ++i)
+        {
+            if (!TxtIsExpected(service->mTextEntries[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static constexpr size_t kMaxTxtRecords          = 10;
+    static constexpr size_t kMaxSubtypes            = 10;
+    CallType callType                               = CallType::kUnknown;
+    MdnsServiceProtocol protocol                    = MdnsServiceProtocol::kMdnsProtocolUnknown;
+    char instanceName[kMdnsInstanceNameMaxSize + 1] = "";
+    char hostName[kMdnsHostNameMaxSize + 1]         = "";
+    char serviceName[kMdnsTypeMaxSize + 1]          = "";
+    ExpectedSubtype subtype[kMaxSubtypes];
+    size_t numSubtypes = 0;
+    ExpectedTxt txt[kMaxTxtRecords];
+    size_t numTxt = 0;
+
+    bool IsValid() const { return callType != CallType::kUnknown && protocol != MdnsServiceProtocol::kMdnsProtocolUnknown; }
+};
+
+CHIP_ERROR AddExpectedCall(const ExpectedCall & call);
+void Reset();
+
+} // namespace test
+
+} // namespace Mdns
+} // namespace chip


### PR DESCRIPTION
#### Problem
We currently do not have any tests that the information being send to the mdns platform impl is correct, or that the correct functions are being called.

#### Change overview
Adds basic tests for platform mdns. More to come as more functionality is added.

#### Testing
- only tests - they pass.
