### PR TITLE
Implement DisarmFailSafe function in DeviceControlServer.

### DIFF
--- a/src/include/platform/internal/DeviceControlServer.h
+++ b/src/include/platform/internal/DeviceControlServer.h
@@ -45,7 +45,7 @@ public:
 private:
     // ===== Members for internal use by the following friends.
     static DeviceControlServer sInstance;
-    friend void CommissioningTimerFunction(System::Layer * layer, void * aAppState);
+    friend void HandleArmFailSafe(System::Layer * layer, void * aAppState);
     void CommissioningFailedTimerComplete();
 
     // ===== Private members reserved for use by this class only.

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -28,7 +28,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-void CommissioningTimerFunction(System::Layer * layer, void * aAppState)
+void HandleArmFailSafe(System::Layer * layer, void * aAppState)
 {
     DeviceControlServer * server = reinterpret_cast<DeviceControlServer *>(aAppState);
     server->CommissioningFailedTimerComplete();
@@ -52,19 +52,19 @@ void DeviceControlServer::CommissioningFailedTimerComplete()
 CHIP_ERROR DeviceControlServer::ArmFailSafe(uint16_t expiryLengthSeconds)
 {
     uint32_t timerMs = expiryLengthSeconds * 1000;
-    SystemLayer.StartTimer(timerMs, CommissioningTimerFunction, this);
+    SystemLayer.StartTimer(timerMs, HandleArmFailSafe, this);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceControlServer::DisarmFailSafe()
 {
-    // TODO
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    SystemLayer.CancelTimer(HandleArmFailSafe, this);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceControlServer::CommissioningComplete()
 {
-    SystemLayer.CancelTimer(CommissioningTimerFunction, this);
+    VerifyOrReturnError(CHIP_NO_ERROR == DisarmFailSafe(), CHIP_ERROR_INTERNAL);
     ChipDeviceEvent event;
     event.Type                         = DeviceEventType::kCommissioningComplete;
     event.CommissioningComplete.status = CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* DisarmFailSafe function is not implemented and used in DeviceControlServer
* Fixes #9110 

#### Change overview
Implement DisarmFailSafe function in DeviceControlServer

#### Testing
How was this tested? (at least one bullet point required)
* Arm arm-fail-safe timer from chip-tool: "./chip-tool generalcommissioning arm-fail-safe"
* Send command commissioning-complete "./chip-tool generalcommissioning commissioning-complete"
* Confirm HandleArmFailSafe is disarmed. 
