### PR TITLE
Add ChipMdnsShutdown()

### DIFF
--- a/src/controller/java/MdnsImpl.cpp
+++ b/src/controller/java/MdnsImpl.cpp
@@ -47,6 +47,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -107,7 +107,7 @@ using MdnsBrowseCallback = void (*)(void * context, MdnsService * services, size
 using MdnsAsyncReturnCallback = void (*)(void * context, CHIP_ERROR error);
 
 /**
- * This function intializes the mdns module
+ * This function initializes the mdns module
  *
  * @param[in] initCallback    The callback for notifying the initialization result.
  * @param[in] errorCallback   The callback for notifying internal errors.
@@ -118,6 +118,15 @@ using MdnsAsyncReturnCallback = void (*)(void * context, CHIP_ERROR error);
  *
  */
 CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context);
+
+/**
+ * This function shuts down the mdns module
+ *
+ * @retval CHIP_NO_ERROR  The shutdown succeeds.
+ * @retval Error code     The shutdown fails
+ *
+ */
+CHIP_ERROR ChipMdnsShutdown();
 
 /**
  * This function publishes an service via mDNS.

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -485,6 +485,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback successCallback, MdnsAsyncReturn
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -55,6 +55,11 @@ exit:
     return error;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 static const char * GetProtocolString(MdnsServiceProtocol protocol)
 {
     return protocol == MdnsServiceProtocol::kMdnsProtocolTcp ? "_tcp" : "_udp";

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -338,7 +338,6 @@ exit:
     return error;
 }
 
-
 CHIP_ERROR MdnsAvahi::Shutdown()
 {
     if (mGroup)

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -338,6 +338,22 @@ exit:
     return error;
 }
 
+
+CHIP_ERROR MdnsAvahi::Shutdown()
+{
+    if (mGroup)
+    {
+        avahi_entry_group_free(mGroup);
+        mGroup = nullptr;
+    }
+    if (mClient)
+    {
+        avahi_client_free(mClient);
+        mClient = nullptr;
+    }
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR MdnsAvahi::SetHostname(const char * hostname)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -733,18 +749,6 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
     chip::Platform::Delete(context);
 }
 
-MdnsAvahi::~MdnsAvahi()
-{
-    if (mGroup)
-    {
-        avahi_entry_group_free(mGroup);
-    }
-    if (mClient)
-    {
-        avahi_client_free(mClient);
-    }
-}
-
 void GetMdnsTimeout(timeval & timeout)
 {
     MdnsAvahi::GetInstance().GetPoller().GetTimeout(timeout);
@@ -758,6 +762,11 @@ void HandleMdnsTimeout()
 CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
 {
     return MdnsAvahi::GetInstance().Init(initCallback, errorCallback, context);
+}
+
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return MdnsAvahi::GetInstance().Shutdown();
 }
 
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -100,6 +100,7 @@ public:
     MdnsAvahi & operator=(const MdnsAvahi &) = delete;
 
     CHIP_ERROR Init(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context);
+    CHIP_ERROR Shutdown();
     CHIP_ERROR SetHostname(const char * hostname);
     CHIP_ERROR PublishService(const MdnsService & service);
     CHIP_ERROR StopPublish();
@@ -111,8 +112,6 @@ public:
     Poller & GetPoller() { return mPoller; }
 
     static MdnsAvahi & GetInstance() { return sInstance; }
-
-    ~MdnsAvahi();
 
 private:
     struct BrowseContext

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -32,6 +32,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 const char * GetProtocolString(MdnsServiceProtocol protocol)
 {
     return protocol == MdnsServiceProtocol::kMdnsProtocolUdp ? "_udp" : "_tcp";

--- a/src/platform/tests/TestMdns.cpp
+++ b/src/platform/tests/TestMdns.cpp
@@ -105,7 +105,7 @@ int TestMdns()
     bool ready = false;
 
     std::condition_variable doneCondition;
-    bool done = false;
+    bool done     = false;
     bool shutdown = false;
 
     int retVal = EXIT_FAILURE;


### PR DESCRIPTION
#### Problem

Issue #8001 _MdnsAvahi destructor segfault; require separate shutdown_:
MdnsAvahi can cause a crash on exit due to a static instance running
code in its destructor after dependent components have shut down.

#### Change overview

- Add `ChipMdnsShutdown()`. This is a narrow fix, which does not attempt
  to address other potential problems with singleton mDNS state.
- Fix `TestMdns` to shut down cleanly.

#### Testing

- `TestMdns` and CI.
