### PR TITLE
doc: nrfconnect: add advertising timeout info

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -219,7 +219,7 @@ opposite one.
 the test mode using the default configuration.
 
 **Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
-enables Bluetooth LE advertising for the predefined period of time.
+enables Bluetooth LE advertising for the predefined period of time (15 minutes by default).
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -209,7 +209,7 @@ opposite one.
 the test mode using the default configuration.
 
 **Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
-enables Bluetooth LE advertising for the predefined period of time.
+enables Bluetooth LE advertising for the predefined period of time (15 minutes by default).
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the

--- a/examples/pump-app/nrfconnect/README.md
+++ b/examples/pump-app/nrfconnect/README.md
@@ -159,7 +159,7 @@ opposite one.
 the test mode using the default configuration.
 
 **Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
-enables Bluetooth LE advertising for the predefined period of time.
+enables Bluetooth LE advertising for the predefined period of time (15 minutes by default).
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the

--- a/examples/pump-controller-app/nrfconnect/README.md
+++ b/examples/pump-controller-app/nrfconnect/README.md
@@ -159,7 +159,7 @@ opposite one.
 the test mode using the default configuration.
 
 **Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
-enables Bluetooth LE advertising for the predefined period of time.
+enables Bluetooth LE advertising for the predefined period of time (15 minutes by default).
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the


### PR DESCRIPTION
#### Problem
Missing info on the predefined advertising time and discrepancy with the NCS Matter examples.

#### Change overview
Added information to nRF Connect examples about how long advertising predefined time is.

#### Testing
Doc changes only.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>
