### PR TITLE
[IM]: Fix OnResponseTimeout is never fired when SendMessage fails

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, FabricIndex aFabric
         mpExchangeCtx = mpExchangeMgr->NewContext(*secureSession, this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(timeout > 0 ? timeout : kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(timeout);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(commandPacket),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -109,7 +109,7 @@ exit:
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
-    ChipLogProgress(DataManagement, "CommandSender:Time out! failed to receive invoke command response from Exchange: %d",
+    ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Exchange: %d",
                     apExchangeContext->GetExchangeId());
 
     if (mpDelegate != nullptr)

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -50,9 +50,12 @@ public:
     // handle calling Shutdown on itself once it decides it's done with waiting
     // for a response (i.e. times out or gets a response).
     //
+    // Client can specify the maximum time to wait for response (in milliseconds) via timeout parameter.
+    // Default timeout value will be used otherwise.
+    //
     // If SendCommandRequest is never called, or the call fails, the API
     // consumer is responsible for calling Shutdown on the CommandSender.
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession = nullptr);
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession, uint32_t timeout = 0);
 
 private:
     // ExchangeDelegate interface implementation.  Private so people won't

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -55,7 +55,8 @@ public:
     //
     // If SendCommandRequest is never called, or the call fails, the API
     // consumer is responsible for calling Shutdown on the CommandSender.
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession, uint32_t timeout = 0);
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * secureSession,
+                                  uint32_t timeout = kImMessageTimeoutMsec);
 
 private:
     // ExchangeDelegate interface implementation.  Private so people won't

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -34,6 +34,9 @@
 
 namespace chip {
 namespace app {
+
+static constexpr uint32_t kImMessageTimeoutMsec = 12000;
+
 class ReadClient;
 class WriteClient;
 class CommandSender;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -183,7 +183,7 @@ CHIP_ERROR InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext *
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogDetail(DataManagement, "Msg type %d not supported", aPayloadHeader.GetMessageType());
+    ChipLogDetail(InteractionModel, "Msg type %d not supported", aPayloadHeader.GetMessageType());
 
     // Todo: Add status report
     // err = SendStatusReport(ec, kChipProfile_Common, kStatus_UnsupportedMessage);
@@ -234,7 +234,7 @@ CHIP_ERROR InteractionModelEngine::OnReadRequest(Messaging::ExchangeContext * ap
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogDetail(DataManagement, "Receive Read request");
+    ChipLogDetail(InteractionModel, "Receive Read request");
 
     for (auto & readHandler : mReadHandlers)
     {
@@ -264,7 +264,7 @@ CHIP_ERROR InteractionModelEngine::OnWriteRequest(Messaging::ExchangeContext * a
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    ChipLogDetail(DataManagement, "Receive Write request");
+    ChipLogDetail(InteractionModel, "Receive Write request");
 
     for (auto & writeHandler : mWriteHandlers)
     {
@@ -314,8 +314,7 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
 
 void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
-    ChipLogProgress(DataManagement, "InteractionModelEngine:Time out! failed to receive echo response from Exchange: %d",
-                    ec->GetExchangeId());
+    ChipLogProgress(InteractionModel, "Time out! failed to receive echo response from Exchange: %d", ec->GetExchangeId());
 }
 
 CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -314,7 +314,8 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
 
 void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 {
-    ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Exchange: %d", ec->GetExchangeId());
+    ChipLogProgress(DataManagement, "InteractionModelEngine:Time out! failed to receive echo response from Exchange: %d",
+                    ec->GetExchangeId());
 }
 
 CHIP_ERROR InteractionModelEngine::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -52,10 +52,8 @@
 namespace chip {
 namespace app {
 
-constexpr size_t kMaxSecureSduLengthBytes = 1024;
-/* TODO: https://github.com/project-chip/connectedhomeip/issues/7489 */
-constexpr uint32_t kImMessageTimeoutMsec = 12000;
-constexpr FieldId kRootFieldId           = 0;
+static constexpr size_t kMaxSecureSduLengthBytes = 1024;
+static constexpr FieldId kRootFieldId            = 0;
 
 /**
  * @class InteractionModelEngine

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex,
         mpExchangeCtx = mpExchangeMgr->NewContext(SessionHandle(aNodeId, 0, 0, aFabricIndex), this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(timeout > 0 ? timeout : kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(timeout);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -89,7 +89,7 @@ void ReadClient::MoveToState(const ClientState aTargetState)
 CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
                                        EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                        AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
-                                       EventNumber aEventNumber)
+                                       EventNumber aEventNumber, uint32_t timeout)
 {
     // TODO: SendRequest parameter is too long, need to have the structure to represent it
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -143,7 +143,7 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex,
         mpExchangeCtx = mpExchangeMgr->NewContext(SessionHandle(aNodeId, 0, 0, aFabricIndex), this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(timeout > 0 ? timeout : kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
@@ -348,7 +348,7 @@ exit:
 
 void ReadClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
-    ChipLogProgress(DataManagement, "Time out! failed to receive report data from Exchange: %d",
+    ChipLogProgress(DataManagement, "ReadClient:Time out! failed to receive report data from Exchange: %d",
                     apExchangeContext->GetExchangeId());
     if (nullptr != mpDelegate)
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -348,7 +348,7 @@ exit:
 
 void ReadClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
-    ChipLogProgress(DataManagement, "ReadClient:Time out! failed to receive report data from Exchange: %d",
+    ChipLogProgress(DataManagement, "Time out! failed to receive report data from Exchange: %d",
                     apExchangeContext->GetExchangeId());
     if (nullptr != mpDelegate)
     {

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -69,13 +69,16 @@ public:
      *  until the corresponding InteractionModelDelegate::ReportProcessed or InteractionModelDelegate::ReportError
      *  call happens with guarantee.
      *
+     *  Client can specify the maximum time to wait for response (in milliseconds) via timeout parameter.
+     *  Default timeout value will be used otherwise.
+     *
      *  @retval #others fail to send read request
      *  @retval #CHIP_NO_ERROR On success.
      */
     CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * aSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
-                               EventNumber aEventNumber);
+                               EventNumber aEventNumber, uint32_t timeout = 0);
 
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -78,7 +78,7 @@ public:
     CHIP_ERROR SendReadRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * aSecureSession,
                                EventPathParams * apEventPathParamsList, size_t aEventPathParamsListSize,
                                AttributePathParams * apAttributePathParamsList, size_t aAttributePathParamsListSize,
-                               EventNumber aEventNumber, uint32_t timeout = 0);
+                               EventNumber aEventNumber, uint32_t timeout = kImMessageTimeoutMsec);
 
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -272,7 +272,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricInde
         mpExchangeCtx = mpExchangeMgr->NewContext(*apSecureSession, this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(timeout > 0 ? timeout : kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(timeout);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::WriteRequest, std::move(packet),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -247,7 +247,8 @@ void WriteClient::ClearState()
     MoveToState(State::Uninitialized);
 }
 
-CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession)
+CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
+                                         uint32_t timeout)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle packet;
@@ -271,7 +272,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricInde
         mpExchangeCtx = mpExchangeMgr->NewContext(*apSecureSession, this);
     }
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+    mpExchangeCtx->SetResponseTimeout(timeout > 0 ? timeout : kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::WriteRequest, std::move(packet),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
@@ -326,7 +327,7 @@ exit:
 
 void WriteClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
-    ChipLogProgress(DataManagement, "Time out! failed to receive write response from Exchange: %d",
+    ChipLogProgress(DataManagement, "WriteClient:Time out! failed to receive write response from Exchange: %d",
                     apExchangeContext->GetExchangeId());
 
     if (mpDelegate != nullptr)
@@ -396,9 +397,10 @@ exit:
     return err;
 }
 
-CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession)
+CHIP_ERROR WriteClientHandle::SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
+                                               uint32_t timeout)
 {
-    CHIP_ERROR err = mpWriteClient->SendWriteRequest(aNodeId, aFabricIndex, apSecureSession);
+    CHIP_ERROR err = mpWriteClient->SendWriteRequest(aNodeId, aFabricIndex, apSecureSession, timeout);
 
     if (err == CHIP_NO_ERROR)
     {

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -327,7 +327,7 @@ exit:
 
 void WriteClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
-    ChipLogProgress(DataManagement, "WriteClient:Time out! failed to receive write response from Exchange: %d",
+    ChipLogProgress(DataManagement, "Time out! failed to receive write response from Exchange: %d",
                     apExchangeContext->GetExchangeId());
 
     if (mpDelegate != nullptr)

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -88,11 +88,13 @@ private:
     /**
      *  Once SendWriteRequest returns successfully, the WriteClient will
      *  handle calling Shutdown on itself once it decides it's done with waiting
-     *  for a response (i.e. times out or gets a response).
+     *  for a response (i.e. times out or gets a response). Client can specify
+     *  the maximum time to wait for response (in milliseconds) via timeout parameter.
+     *  Default timeout value will be used otherwise.
      *  If SendWriteRequest is never called, or the call fails, the API
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession, uint32_t timeout);
 
     /**
      *  Initialize the client object. Within the lifetime
@@ -173,7 +175,7 @@ public:
      *  Finalize the message and send it to the desired node. The underlying write object will always be released, and the user
      * should not use this object after calling this function.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession, uint32_t timeout = 0);
 
     /**
      *  Encode an attribute value that can be directly encoded using TLVWriter::Put

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -175,7 +175,8 @@ public:
      *  Finalize the message and send it to the desired node. The underlying write object will always be released, and the user
      * should not use this object after calling this function.
      */
-    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession, uint32_t timeout = 0);
+    CHIP_ERROR SendWriteRequest(NodeId aNodeId, FabricIndex aFabricIndex, SessionHandle * apSecureSession,
+                                uint32_t timeout = kImMessageTimeoutMsec);
 
     /**
      *  Encode an attribute value that can be directly encoded using TLVWriter::Put

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -239,7 +239,7 @@ void TestCommandInteraction::TestCommandSenderWithWrongState(nlTestSuite * apSui
     err                            = commandSender.Init(&gExchangeManager, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex);
+    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
 }
 
@@ -278,7 +278,7 @@ void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSu
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     AddCommandDataElement(apSuite, apContext, &commandSender, false);
-    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex);
+    err = commandSender.SendCommandRequest(kTestDeviceNodeId, gFabricIndex, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);
 
     GenerateReceivedCommand(apSuite, apContext, buf, true /*aNeedCommandData*/);

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -91,6 +91,7 @@ static const char ModuleNames[] = "-\0\0" // None
                                   "SPL"   // SetupPayload
                                   "SVR"   // AppServer
                                   "DIS"   // Discovery
+                                  "IM"    // InteractionModel
     ;
 
 #define ModuleNamesCount ((sizeof(ModuleNames) - 1) / chip::Logging::kMaxModuleNameLen)

--- a/src/lib/support/logging/Constants.h
+++ b/src/lib/support/logging/Constants.h
@@ -54,6 +54,7 @@ enum LogModule
     kLogModule_SetupPayload,
     kLogModule_AppServer,
     kLogModule_Discovery,
+    kLogModule_InteractionModel,
 
     kLogModule_Max
 };


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We found OnResponseTimeout was not triggered if SendMessage failed during IM read/write tests.
The reason is the current IM timeout value is set to 12 seconds, but the IM test interval is set to 1 second, the response timeout handler never has an chance to fire in case of SendMessage fails, since the timeout timer is cleared by the next iteration of test.

* Fixes #9093, #7489

#### Change overview
* Allow IM client to set the command timeout value. The IM client can use the current value (kImMessageTimeoutMsec) as the default timeout, in case this value is not overridden.

* Adjust the IM timeout value to a number less than IM test interval.

#### Testing
How was this tested? (at least one bullet point required)
* Do not start ./chip-im-responder on the server side
* ./chip-im-initiator 192.168.86.171 and confirm the response timeout handler are triggered.
```
[1629389848.711849][2051823:2051823] CHIP:DMG: CommandSender:Time out! failed to receive invoke command response from Exchange: 39017

[1629389849.713490][2051823:2051823] CHIP:DMG: CommandSender:Time out! failed to receive invoke command response from Exchange: 39018

[1629389850.713965][2051823:2051823] CHIP:DMG: CommandSender:Time out! failed to receive invoke command response from Exchange: 39019

[1629389852.717663][2051823:2051823] CHIP:DMG: CommandSender:Time out! failed to receive invoke command response from Exchange: 39020

[1629389853.717126][2051823:2051823] CHIP:DMG: ReadClient:Time out! failed to receive report data from Exchange: 39021

[1629389854.718814][2051823:2051823] CHIP:DMG: ReadClient:Time out! failed to receive report data from Exchange: 39022

[1629389855.719741][2051823:2051823] CHIP:DMG: ReadClient:Time out! failed to receive report data from Exchange: 39023

[1629389857.721055][2051823:2051823] CHIP:DMG: WriteClient:Time out! failed to receive write response from Exchange: 39024

[1629389858.721158][2051823:2051823] CHIP:DMG: WriteClient:Time out! failed to receive write response from Exchange: 39025

[1629389859.721473][2051823:2051823] CHIP:DMG: WriteClient:Time out! failed to receive write response from Exchange: 39026
```



