### PR TITLE
Load fabric info at FabricTable init

### DIFF
--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -584,6 +584,17 @@ CHIP_ERROR FabricTable::Init(PersistentStorageDelegate * storage)
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mStorage = storage;
     ChipLogDetail(Discovery, "Init fabric pairing table with server storage");
+
+    // Load the current fabrics from the storage. This is done here, since ConstFabricIterator
+    // iterator doesn't have mechanism to load fabric info from storage on demand.
+    // TODO - Update ConstFabricIterator to load fabric info from storage
+    static_assert(kMaxValidFabricIndex <= UINT8_MAX, "Cannot create more fabrics than UINT8_MAX");
+    for (FabricIndex i = kMinValidFabricIndex; i <= kMaxValidFabricIndex; i++)
+    {
+        FabricInfo * fabric = &mStates[i - kMinValidFabricIndex];
+        LoadFromStorage(fabric);
+    }
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
The device does not advertise on mDNS as operational device after reboot.

#### Change overview
The `ConstFabricIterator` doesn't load the fabric info from the storage if it is not already initialized. mDNS advertisement uses this iterator.

The current PR loads the fabric info at the initialization. This is currently not ideal, as our current FabricInfo data structure is carrying a lot more information than needed. There's an open issue to optimize the FabricInfo RAM usage and data storage. 

The change in this PR is still useful for longer term. I have also added a TODO to refactor `ConstFabricIterator` for it to be able to load FabricInfo from storage on demand.

#### Testing
The current CI tests exercise the updated code to ensure that original functionality is intact.
Also, tested that mDNS advertisements pick up the fabric info by configuring multiple fabrics on m5stack and rebooting it.
