### PR TITLE
Add thermostat app for host builds in build_example.py

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -290,6 +290,7 @@
                 "light",
                 "lock",
                 "shell",
+                "thermostat",
                 "window-covering"
             ],
             "default": "build"

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -96,6 +96,8 @@ _MATCHERS[Platform.HOST].AcceptApplication(
     Application.ALL_CLUSTERS, app=HostApp.ALL_CLUSTERS)
 _MATCHERS[Platform.HOST].AcceptApplication(
     Application.CHIP_TOOL, app=HostApp.CHIP_TOOL)
+_MATCHERS[Platform.HOST].AcceptApplication(
+    Application.THERMOSTAT, app=HostApp.THERMOSTAT)
 
 _MATCHERS[Platform.ESP32].AcceptBoard(Board.DEVKITC, board=Esp32Board.DevKitC)
 _MATCHERS[Platform.ESP32].AcceptBoard(Board.M5STACK, board=Esp32Board.M5Stack)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -86,6 +86,7 @@ class Application(IntEnum):
     SHELL = auto()
     CHIP_TOOL = auto()
     BRIDGE = auto()
+    THERMOSTAT = auto()
 
     @property
     def ArgName(self):

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -115,6 +115,7 @@ class Builder(ABC):
                 os.makedirs(target_dir_full_name)
 
             shutil.copyfile(source_name, target_full_name)
+            shutil.copymode(source_name, target_full_name)
 
     def SetIdentifier(self, platform: str, board: str, app: str):
         self.identifier = '-'.join([platform, board, app])

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -23,12 +23,15 @@ from .gn import GnBuilder
 class HostApp(Enum):
     ALL_CLUSTERS = auto()
     CHIP_TOOL = auto()
+    THERMOSTAT = auto()
 
     def ExamplePath(self):
         if self == HostApp.ALL_CLUSTERS:
             return 'all-clusters-app/linux'
         elif self == HostApp.CHIP_TOOL:
             return 'chip-tool'
+        elif self == HostApp.THERMOSTAT:
+            return 'thermostat/linux'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -37,6 +40,8 @@ class HostApp(Enum):
             return 'chip-all-clusters-app'
         elif self == HostApp.CHIP_TOOL:
             return 'chip-tool'
+        elif self == HostApp.THERMOSTAT:
+            return 'thermostat-app'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -4,6 +4,9 @@ gn gen --check --fail-on-unused-args --root={root}/examples/all-clusters-app/lin
 # Generating {real_platform}-native-chip_tool
 gn gen --check --fail-on-unused-args --root={root}/examples/chip-tool {out}/{real_platform}-native-chip_tool
 
+# Generating {real_platform}-native-thermostat
+gn gen --check --fail-on-unused-args --root={root}/examples/thermostat/linux {out}/{real_platform}-native-thermostat
+
 # Generating qpg-qpg6100-lock
 gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/qpg {out}/qpg-qpg6100-lock
 
@@ -99,6 +102,9 @@ ninja -C {out}/{real_platform}-native-all_clusters
 
 # Building {real_platform}-native-chip_tool
 ninja -C {out}/{real_platform}-native-chip_tool
+
+# Building {real_platform}-native-thermostat
+ninja -C {out}/{real_platform}-native-thermostat
 
 # Building qpg-qpg6100-lock
 ninja -C {out}/qpg-qpg6100-lock


### PR DESCRIPTION
#### Problem
build_example.py should have as broad support as possible for building things

#### Change overview
Added thermostat to the host builds

#### Testing
Manual build and unit tests pass and commands look ok.
