### PR TITLE
Remove unused python imports

### DIFF
--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -22,7 +22,6 @@
 import json
 import os
 import argparse
-import re
 
 # Parse the build's compile_commands.json to generate
 # final args file for CHIP build.

--- a/scripts/build/build/factory.py
+++ b/scripts/build/build/factory.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from typing import Set
-
-from builders.builder import Builder
 
 from builders.android import AndroidBoard, AndroidBuilder
 from builders.efr32 import Efr32Builder, Efr32App, Efr32Board

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import os
-import shutil
-
 from enum import IntEnum, auto
 
 

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 import shlex
 

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from enum import Enum, auto
 

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 
 from .builder import Builder

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from platform import uname, release
 from enum import Enum, auto

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 
 from .gn import GnBuilder

--- a/scripts/flashing/nrfconnect_firmware_utils.py
+++ b/scripts/flashing/nrfconnect_firmware_utils.py
@@ -47,7 +47,6 @@ operations:
                         Do not reset device after flashing
 """
 
-import errno
 import os
 import sys
 

--- a/scripts/tools/memory/report_summary.py
+++ b/scripts/tools/memory/report_summary.py
@@ -34,7 +34,7 @@ import memdf.collect
 import memdf.report
 import memdf.select
 
-from memdf import Config, DFs, SectionDF, SymbolDF
+from memdf import Config, DFs, SymbolDF
 
 
 def main(argv):

--- a/scripts/tools/zap/convert.py
+++ b/scripts/tools/zap/convert.py
@@ -16,12 +16,9 @@
 #
 
 import argparse
-import json
 import os
-from pathlib import Path
 import subprocess
 import sys
-import urllib.request
 
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../../..'))

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -40,10 +40,8 @@ import base64
 import textwrap
 import time
 import string
-import re
 import traceback
 from cmd import Cmd
-from chip.ChipBleUtility import FAKE_CONN_OBJ_VALUE
 from chip.setup_payload import SetupPayload
 
 # Extend sys.path with one or more directories, relative to the location of the

--- a/src/controller/python/chip/ChipBluezMgr.py
+++ b/src/controller/python/chip/ChipBluezMgr.py
@@ -27,9 +27,7 @@ from __future__ import print_function
 import dbus
 import dbus.service
 import dbus.mainloop.glib
-import gc
 import logging
-import pprint
 import sys
 import threading
 import time
@@ -45,22 +43,9 @@ except Exception as ex:
     logging.exception("Unable to find GObject from gi.repository")
     from pgi.repository import GObject
 
-from .ChipUtility import ChipUtility
-
 from .ChipBleUtility import (
-    BLE_SUBSCRIBE_OPERATION_SUBSCRIBE,
-    BLE_SUBSCRIBE_OPERATION_UNSUBSCRIBE,
     BLE_ERROR_REMOTE_DEVICE_DISCONNECTED,
-    VoidPtrToUUIDString,
-    BleTxEvent,
     BleDisconnectEvent,
-    BleRxEvent,
-    BleSubscribeEvent,
-    BleTxEventStruct,
-    BleDisconnectEventStruct,
-    BleRxEventStruct,
-    BleSubscribeEventStruct,
-    BleDeviceIdentificationInfo,
     ParseServiceData,
 )
 

--- a/src/controller/python/chip/ChipCommissionableNodeCtrl.py
+++ b/src/controller/python/chip/ChipCommissionableNodeCtrl.py
@@ -25,8 +25,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-import time
-from threading import Thread
 from ctypes import *
 from .ChipStack import *
 from .exceptions import *

--- a/src/controller/python/chip/ChipCoreBluetoothMgr.py
+++ b/src/controller/python/chip/ChipCoreBluetoothMgr.py
@@ -44,7 +44,6 @@ from .ChipBleUtility import (
     BleDisconnectEventStruct,
     BleRxEventStruct,
     BleSubscribeEventStruct,
-    BleDeviceIdentificationInfo,
     ParseServiceData,
 )
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -27,8 +27,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-import time
-from threading import Thread
 from ctypes import *
 from .ChipStack import *
 from .clusters.CHIPClusters import *

--- a/src/controller/python/chip/discovery/library_handle.py
+++ b/src/controller/python/chip/discovery/library_handle.py
@@ -16,7 +16,7 @@
 
 import chip.native
 import ctypes
-from ctypes import c_void_p, c_int32, c_uint32, c_uint64
+from ctypes import c_uint32, c_uint64
 from chip.discovery.types import DiscoverSuccessCallback_t, DiscoverFailureCallback_t
 
 

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -15,7 +15,7 @@
 '''
 
 from construct import Struct, Int64ul, Int32ul, Int16ul, Int8ul
-from ctypes import CFUNCTYPE, c_void_p, c_size_t, c_uint32, c_uint64, c_uint8, c_uint16, c_ssize_t
+from ctypes import CFUNCTYPE, c_void_p, c_uint32, c_uint64, c_uint8, c_uint16, c_ssize_t
 import ctypes
 import chip.native
 import threading

--- a/src/controller/python/chip/internal/commissioner.py
+++ b/src/controller/python/chip/internal/commissioner.py
@@ -15,7 +15,7 @@
 #
 from chip.configuration import GetLocalNodeId
 from chip.native import NativeLibraryHandleMethodArguments, GetLibraryHandle
-from ctypes import c_uint64, c_uint32, c_uint16, c_char_p
+from ctypes import c_uint64, c_uint32, c_uint16
 from enum import Enum
 from typing import Optional
 from chip.internal.types import NetworkCredentialsRequested, OperationalCredentialsRequested, PairingComplete

--- a/src/controller/python/chip/internal/thread.py
+++ b/src/controller/python/chip/internal/thread.py
@@ -18,7 +18,7 @@
 # Generally thread credentials are assumed to be binary objects, however for
 # testing purposes, we expose the internal structure here.
 
-from construct import BitStruct, Byte, Bytes, Enum, Flag, Int16ul, Int32ul, Int64ul, PaddedString, Padding, Struct
+from construct import Byte, Bytes, Int16ul, Int64ul, PaddedString, Struct
 
 ThreadNetworkInfo = Struct(
     "ActiveTimestamp" / Int64ul,

--- a/src/controller/python/chip/logging/types.py
+++ b/src/controller/python/chip/logging/types.py
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-from ctypes import CFUNCTYPE, py_object, c_char_p, c_uint8
+from ctypes import CFUNCTYPE, c_char_p, c_uint8
 
 # Log callback: void(category, module, message)
 LogRedirectCallback_t = CFUNCTYPE(None, c_uint8, c_char_p, c_char_p)


### PR DESCRIPTION
#### Problem
Having unused modules in python scripts can impact the startup time and hamper application's performance. It can also pollute the namespace with names that could interfere with your variables and occupy some memory.

#### Change overview
This change removes unused python import modules.

#### Testing
Manually tested verifying the uniqueness on the script.

