### PR TITLE
Set commissioner credentials instead of adding new entry

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -232,11 +232,12 @@ CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParam
     ReturnErrorOnFailure(ConvertX509CertsToChipCertArray(params.controllerNOC, params.controllerICAC, chipCertSpan));
     ReturnErrorOnFailure(newFabric.SetOperationalCertsFromCertArray(chipCertSpan));
     newFabric.SetVendorId(params.controllerVendorId);
-    ReturnErrorOnFailure(mFabrics.AddNewFabric(newFabric, &mFabricIndex));
-    ChipLogProgress(Controller, "Joined new fabric at index %d", mFabricIndex);
 
     Transport::FabricInfo * fabric = mFabrics.FindFabricWithIndex(mFabricIndex);
     ReturnErrorCodeIf(fabric == nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    ReturnErrorOnFailure(fabric->SetFabricInfo(newFabric));
+    ChipLogProgress(Controller, "Joined the fabric at index %d", mFabricIndex);
 
     mLocalDeviceId = fabric->GetNodeId();
     mVendorId      = fabric->GetVendorId();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -356,7 +356,7 @@ protected:
 
     void PersistNextKeyId();
 
-    FabricIndex mFabricIndex = 1;
+    FabricIndex mFabricIndex = Transport::kMinValidFabricIndex;
     Transport::FabricTable mFabrics;
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -196,6 +196,8 @@ public:
         ReleaseOperationalCerts();
     }
 
+    CHIP_ERROR SetFabricInfo(FabricInfo & fabric);
+
     friend class FabricTable;
 
 private:
@@ -234,8 +236,6 @@ private:
     static CHIP_ERROR DeleteFromKVS(PersistentStorageDelegate * kvs, FabricIndex id);
 
     void SetOperationalId(PeerId id) { mOperationalId = id; }
-
-    CHIP_ERROR SetFabricInfo(FabricInfo & fabric);
 
     void ReleaseOperationalCerts();
     void ReleaseRootCert();


### PR DESCRIPTION
#### Problem
The commissioner app is adding new fabric on every run, even though the same fabric is being used.

#### Change overview
The commissioner class had been calling `FabricTable::AddNewFabric()` API  to create the fabric info at init time. This resulted in creating a new fabric on every run, specially since we started saving and loading fabric table whenever it's updated.

This PR changes the init to assign the credentials to fabric info for the assigned index, instead of adding a new fabric.

#### Testing
This problem was more visible with chip-tool, as we run a new instance of it for every command.
Tested this PR with chip-tool to ensure that the same fabric is being used for every run, and the chip-tool is still able to pair and control the devices.