### PR TITLE
Fix unknown type name 'u_int16_t' (clang arm-linux-musleabi)

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1532,7 +1532,7 @@ static void startColorLoop(EndpointId endpoint, uint8_t startFromStartHue)
     uint16_t currentHue = 0;
     Attributes::GetEnhancedCurrentHue(endpoint, &currentHue);
 
-    u_int16_t startHue = 0x2300;
+    uint16_t startHue = 0x2300;
     if (startFromStartHue)
     {
         Attributes::GetColorLoopStartEnhancedHue(endpoint, &startHue);


### PR DESCRIPTION
This patch fixes color-control-server when cross compiling with clang
for arm-linux-musleabi: "color-control-server.cpp:1535:5: error:
unknown type name 'u_int16_t'; did you mean 'uint16_t'?
     u_int16_t startHue = 0x2300;"

#### Problem
*Fix build error
* Issue: https://github.com/project-chip/connectedhomeip/issues/9092

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* build using yocto hardknott for rpi0w 
