### PR TITLE
nrfconnect: Fixed bug with not handling CHIPoBLE disconnect

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -113,7 +113,7 @@ int AppTask::Init()
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
-#if defined(CONFIG_CHIP_NFC_COMMISSIONING) || defined(CONFIG_MCUMGR_SMP_BT)
+#if defined(CONFIG_CHIP_NFC_COMMISSIONING)
     PlatformMgr().AddEventHandler(ChipEventHandler, 0);
 #endif
 
@@ -392,25 +392,13 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     }
 }
 
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
 void AppTask::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */)
 {
     if (event->Type != DeviceEventType::kCHIPoBLEAdvertisingChange)
         return;
 
-    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
-    {
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-        NFCMgr().StopTagEmulation();
-#endif
-#ifdef CONFIG_MCUMGR_SMP_BT
-        // After CHIPoBLE advertising stop, start advertising SMP in case Thread is enabled or there are no active CHIPoBLE
-        // connections (exclude the case when CHIPoBLE advertising is stopped on the connection time)
-        if (GetDFUOverSMP().IsEnabled() && (ConnectivityMgr().IsThreadProvisioned() || ConnectivityMgr().NumBLEConnections() == 0))
-            sAppTask.RequestSMPAdvertisingStart();
-#endif
-    }
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
+    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
     {
         if (NFCMgr().IsTagEmulationStarted())
         {
@@ -421,8 +409,12 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */
             ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
         }
     }
-#endif
+    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
+    {
+        NFCMgr().StopTagEmulation();
+    }
 }
+#endif
 
 void AppTask::CancelTimer()
 {

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -104,7 +104,7 @@ int AppTask::Init()
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
 
-#if defined(CONFIG_CHIP_NFC_COMMISSIONING) || defined(CONFIG_MCUMGR_SMP_BT)
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
     PlatformMgr().AddEventHandler(ChipEventHandler, 0);
 #endif
     return 0;
@@ -392,25 +392,13 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     }
 }
 
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
 void AppTask::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */)
 {
     if (event->Type != DeviceEventType::kCHIPoBLEAdvertisingChange)
         return;
 
-    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
-    {
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-        NFCMgr().StopTagEmulation();
-#endif
-#ifdef CONFIG_MCUMGR_SMP_BT
-        // After CHIPoBLE advertising stop, start advertising SMP in case Thread is enabled or there are no active CHIPoBLE
-        // connections (exclude the case when CHIPoBLE advertising is stopped on the connection time)
-        if (GetDFUOverSMP().IsEnabled() && (ConnectivityMgr().IsThreadProvisioned() || ConnectivityMgr().NumBLEConnections() == 0))
-            sAppTask.RequestSMPAdvertisingStart();
-#endif
-    }
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
+    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
     {
         if (NFCMgr().IsTagEmulationStarted())
         {
@@ -421,8 +409,12 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */
             ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
         }
     }
-#endif
+    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
+    {
+        NFCMgr().StopTagEmulation();
+    }
 }
+#endif
 
 void AppTask::CancelTimer()
 {

--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -30,6 +30,8 @@
 
 #include <support/logging/CHIPLogging.h>
 
+using namespace ::chip::DeviceLayer;
+
 DFUOverSMP DFUOverSMP::sDFUOverSMP;
 
 void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
@@ -44,6 +46,8 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
     bt_conn_cb_register(&mBleConnCallbacks);
 
     restartAdvertisingCallback = startAdvertisingCb;
+
+    PlatformMgr().AddEventHandler(ChipEventHandler, 0);
 }
 
 void DFUOverSMP::ConfirmNewImage()
@@ -81,7 +85,7 @@ void DFUOverSMP::StartServer()
         ChipLogProgress(DeviceLayer, "Enabled software update");
 
         // Start SMP advertising only in case CHIPoBLE advertising is not working.
-        if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled())
+        if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
             StartBLEAdvertising();
     }
     else
@@ -92,7 +96,7 @@ void DFUOverSMP::StartServer()
 
 void DFUOverSMP::StartBLEAdvertising()
 {
-    if (!mIsEnabled)
+    if (!mIsEnabled && !mIsAdvertisingEnabled)
         return;
 
     const char * deviceName = bt_get_name();
@@ -119,20 +123,47 @@ void DFUOverSMP::StartBLEAdvertising()
     else
     {
         ChipLogProgress(DeviceLayer, "Started SMP service BLE advertising");
+        mIsAdvertisingEnabled = true;
     }
 }
 
 void DFUOverSMP::OnBleDisconnect(struct bt_conn * conId, uint8_t reason)
 {
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    PlatformMgr().LockChipStack();
 
     // After BLE disconnect SMP advertising needs to be restarted. Before making it ensure that BLE disconnect was not triggered
     // by closing CHIPoBLE service connection (in that case CHIPoBLE advertising needs to be restarted).
-    if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled() &&
-        chip::DeviceLayer::ConnectivityMgr().NumBLEConnections() == 0)
+    if (!ConnectivityMgr().IsBLEAdvertisingEnabled() && (ConnectivityMgr().NumBLEConnections() == 0))
     {
         sDFUOverSMP.restartAdvertisingCallback();
     }
 
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+    PlatformMgr().UnlockChipStack();
+}
+
+void DFUOverSMP::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg */)
+{
+    if (!GetDFUOverSMP().IsEnabled())
+        return;
+
+    switch (event->Type)
+    {
+    case DeviceEventType::kCHIPoBLEAdvertisingChange:
+        if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
+        {
+            // Check if CHIPoBLE advertising was stopped permanently or it just a matter of opened BLE connection.
+            if (ConnectivityMgr().NumBLEConnections() == 0)
+                sDFUOverSMP.restartAdvertisingCallback();
+        }
+        break;
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
+        // Check if after closing CHIPoBLE connection advertising is working, if no start SMP advertising.
+        if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
+        {
+            sDFUOverSMP.restartAdvertisingCallback();
+        }
+        break;
+    default:
+        break;
+    }
 }

--- a/examples/platform/nrfconnect/util/include/DFUOverSMP.h
+++ b/examples/platform/nrfconnect/util/include/DFUOverSMP.h
@@ -43,8 +43,10 @@ private:
 
     static int UploadConfirmHandler(uint32_t offset, uint32_t size, void * arg);
     static void OnBleDisconnect(bt_conn * conn, uint8_t reason);
+    static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 
     bool mIsEnabled;
+    bool mIsAdvertisingEnabled;
     bt_conn_cb mBleConnCallbacks;
     DFUOverSMPRestartAdvertisingHandler restartAdvertisingCallback;
 

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -173,6 +173,13 @@ enum PublicEventTypes
     kCHIPoBLEConnectionEstablished,
 
     /**
+     * CHIPoBLE Connection Closed
+     *
+     * Signals that an external entity has closed existing CHIPoBLE connection with the device.
+     */
+    kCHIPoBLEConnectionClosed,
+
+    /**
      * Thread State Change
      *
      * Signals that a state change has occurred in the Thread stack.


### PR DESCRIPTION
#### Problem
Current implementation of Zephyr BLEMgr introduced in: https://github.com/project-chip/connectedhomeip/pull/8857 has a bug that BLEMgr handles BLE disconnect event only if CHIPoBLE advertising is enabled to determine whether this disconnect event is related to CHIPoBLE or some other service. That condition is wrong as advertising is not working when connection with commissioner is being closed.

#### Change overview
* Changed condition checking if advertising is enabled to check if CHIPoBLE GATT service is registered (that one persists during
connection).
* Refactored DFUoverSMP module to implement ChipEventHandler and not force handling advertisments restart in the AppTask.cpp.
* Aligned lock-app and lighting-app examples to those changes.
* Created new platform event kCHIPoBLEConnectionClosed to inform about closing CHIPoBLE connection and let perform some actions related to this in the application (e.g. turn on some other advertising).

#### Testing
Verified on nrfconnect platform that CHIPoBLE and SMP advertising behavior is as described in https://github.com/project-chip/connectedhomeip/pull/8857. Checked also that commissioning using Python CHIP controller and DFU over BLE still work properly.
