### PR TITLE
Fix typo, call  SetAdditionalCommissioning with true instead of false

### DIFF
--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -91,7 +91,7 @@ CommissionAdvertisingParameters commissionableNodeParamsLarge =
         .SetVendorId(chip::Optional<uint16_t>(555))
         .SetDeviceType(chip::Optional<uint16_t>(25))
         .SetCommissioningMode(true)
-        .SetAdditionalCommissioning(false)
+        .SetAdditionalCommissioning(true)
         .SetDeviceName(chip::Optional<const char *>("testy-test"))
         .SetPairingHint(chip::Optional<uint16_t>(3))
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))


### PR DESCRIPTION
Error:
../../src/lib/mdns/platform/tests/TestPlatform.cpp:172: assertion failed: "mdnsPlatform.Advertise(commissionableNodeParamsLarge) == CHIP_NO_ERROR"
'#3:','TestCommissionableNode','FAILED'

Fix:
 call SetAdditionalCommissioning with true instead of false