### PR TITLE
[nfc] fix Matter URI scheme

### DIFF
--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="ch" /><!-- Process CHIP URIs -->
+                <data android:scheme="mt" /><!-- Process Matter URIs -->
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
#### Problem
Matter NFC Tag is not recognized by Android CHIP Tool after migrating from `ch` to `mt` URI scheme.

#### Change overview
Changed URI scheme from `ch` to `mt`.

#### Testing
Built Android CHIP Tool, installed it on Android device, and manually brought the phone to NFC Tag (nRF52840 build from master).

Fixes: #9179 