### PR TITLE
Add status report support for IM read

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -115,6 +115,7 @@ static_library("app") {
     ":app_buildconfig",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
+    "${chip_root}/src/protocols/secure_channel",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -195,6 +195,15 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
+    /**
+     * Notification that a read client has completed the read interaction.
+     * @param[in]  apReadClient  A current read client which can identify the read client to the consumer, particularly
+     * during multiple read interactions
+     * @param[in]  aError  notify final error regarding the current read interaction
+     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
+     */
+    virtual CHIP_ERROR ReadDone(const ReadClient * apReadClient, CHIP_ERROR aError) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     virtual ~InteractionModelDelegate() = default;
 };
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -240,9 +240,9 @@ CHIP_ERROR InteractionModelEngine::OnReadRequest(Messaging::ExchangeContext * ap
     {
         if (readHandler.IsFree())
         {
-            err = readHandler.Init(mpDelegate);
+            err = readHandler.Init(mpDelegate, apExchangeContext);
             SuccessOrExit(err);
-            err               = readHandler.OnReadRequest(apExchangeContext, std::move(aPayload));
+            err               = readHandler.OnReadRequest(std::move(aPayload));
             apExchangeContext = nullptr;
             break;
         }

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -25,6 +25,7 @@
 #include <app/AppBuildConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
+#include <protocols/secure_channel/StatusReport.h>
 
 namespace chip {
 namespace app {
@@ -52,14 +53,18 @@ exit:
 void ReadClient::Shutdown()
 {
     AbortExistingExchangeContext();
-    ShutdownInternal();
+    ShutdownInternal(CHIP_NO_ERROR);
 }
 
-void ReadClient::ShutdownInternal()
+void ReadClient::ShutdownInternal(CHIP_ERROR aError)
 {
     mpExchangeMgr = nullptr;
     mpExchangeCtx = nullptr;
-    mpDelegate    = nullptr;
+    if (mpDelegate != nullptr)
+    {
+        mpDelegate->ReadDone(this, aError);
+        mpDelegate = nullptr;
+    }
     MoveToState(ClientState::Uninitialized);
 }
 
@@ -161,6 +166,40 @@ exit:
     return err;
 }
 
+CHIP_ERROR ReadClient::SendStatusReport(CHIP_ERROR aError, bool aExpectResponse)
+{
+    Protocols::SecureChannel::GeneralStatusCode generalCode = Protocols::SecureChannel::GeneralStatusCode::kSuccess;
+    uint32_t protocolId                                     = Protocols::InteractionModel::Id.ToFullyQualifiedSpecForm();
+    uint16_t protocolCode                                   = to_underlying(Protocols::InteractionModel::ProtocolCode::Success);
+    VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    if (aError != CHIP_NO_ERROR)
+    {
+        generalCode  = Protocols::SecureChannel::GeneralStatusCode::kFailure;
+        protocolCode = to_underlying(Protocols::InteractionModel::ProtocolCode::InvalidSubscription);
+    }
+
+    ChipLogProgress(DataManagement, "SendStatusReport with error %s", ErrorStr(aError));
+    Protocols::SecureChannel::StatusReport report(generalCode, protocolId, protocolCode);
+
+    Encoding::LittleEndian::PacketBufferWriter buf(System::PacketBufferHandle::New(kMaxSecureSduLengthBytes));
+    report.WriteToBuffer(buf);
+    System::PacketBufferHandle msgBuf = buf.Finalize();
+    VerifyOrReturnLogError(!msgBuf.IsNull(), CHIP_ERROR_NO_MEMORY);
+
+    if (aExpectResponse)
+    {
+        ReturnLogErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::SecureChannel::MsgType::StatusReport, std::move(msgBuf),
+                                                           Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
+    }
+    else
+    {
+        ReturnLogErrorOnFailure(mpExchangeCtx->SendMessage(Protocols::SecureChannel::MsgType::StatusReport, std::move(msgBuf)));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ReadClient::GenerateEventPathList(ReadRequest::Builder & aRequest, EventPathParams * apEventPathParamsList,
                                              size_t aEventPathParamsListSize, EventNumber & aEventNumber)
 {
@@ -226,31 +265,25 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
                                          const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(!IsFree(), err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReportData),
                  err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
     err = ProcessReportData(std::move(aPayload));
+    SuccessOrExit(err);
+    err = SendStatusReport(err, false);
 
 exit:
-    ChipLogFunctError(err);
-
-    MoveToState(ClientState::Initialized);
-
-    if (mpDelegate != nullptr)
+    if (err != CHIP_NO_ERROR)
     {
-        if (err != CHIP_NO_ERROR)
-        {
-            mpDelegate->ReportError(this, err);
-        }
-        else
-        {
-            mpDelegate->ReportProcessed(this);
-        }
+        mpDelegate->ReportError(this, err);
     }
-
-    // TODO(#7521): Should close it after checking moreChunkedMessages flag is not set.
-    ShutdownInternal();
+    else
+    {
+        mpDelegate->ReportProcessed(this);
+    }
+    ChipLogFunctError(err);
+    ShutdownInternal(err);
 
     return err;
 }
@@ -352,9 +385,12 @@ void ReadClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContex
                     apExchangeContext->GetExchangeId());
     if (nullptr != mpDelegate)
     {
-        mpDelegate->ReportError(this, CHIP_ERROR_TIMEOUT);
+        if (ClientState::AwaitingResponse == mState)
+        {
+            mpDelegate->ReportError(this, CHIP_ERROR_TIMEOUT);
+        }
     }
-    ShutdownInternal();
+    ShutdownInternal(CHIP_ERROR_TIMEOUT);
 }
 
 CHIP_ERROR ReadClient::ProcessAttributeDataList(TLV::TLVReader & aAttributeDataListReader)

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -82,6 +82,7 @@ public:
 
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
+    CHIP_ERROR SendStatusReport(CHIP_ERROR aError, bool aExpectResponse);
 
 private:
     friend class TestReadInteraction;
@@ -136,7 +137,7 @@ private:
      * Internal shutdown method that we use when we know what's going on with
      * our exchange and don't need to manually close it.
      */
-    void ShutdownInternal();
+    void ShutdownInternal(CHIP_ERROR aError);
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -284,14 +284,9 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
     ChipLogDetail(DataManagement, "<RE> ReportsInFlight = %" PRIu32 " with readHandler %" PRIu32 ", RE has %s", mNumReportsInFlight,
                   mCurReadHandlerIdx, mMoreChunkedMessages ? "more messages" : "no more messages");
 
-    if (!mMoreChunkedMessages)
-    {
-        OnReportConfirm();
-    }
-
 exit:
     ChipLogFunctError(err);
-    if (!mMoreChunkedMessages || err != CHIP_NO_ERROR)
+    if (err != CHIP_NO_ERROR)
     {
         apReadHandler->Shutdown();
     }

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -66,6 +66,13 @@ public:
     void Run();
 
     /**
+     * Should be invoked when the device receives a Status report, or when the Report data request times out.
+     * This allows the engine to do some clean-up.
+     *
+     */
+    void OnReportConfirm();
+
+    /**
      * Main work-horse function that executes the run-loop asynchronously on the CHIP thread
      */
     CHIP_ERROR ScheduleRun();
@@ -88,13 +95,6 @@ private:
      *
      */
     CHIP_ERROR SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload);
-
-    /**
-     * Should be invoked when the device receives a Status report, or when the Report data request times out.
-     * This allows the engine to do some clean-up.
-     *
-     */
-    void OnReportConfirm();
 
     /**
      * Generate and send the report data request when there exists subscription or read request

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -152,7 +152,17 @@ public:
         return err;
     }
 
-    bool mGotEventResponse = false;
+    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
+    {
+        if (aError == CHIP_NO_ERROR)
+        {
+            mGotReadStatusResponse = true;
+        }
+        return aError;
+    }
+
+    bool mGotEventResponse      = false;
+    bool mGotReadStatusResponse = false;
 };
 } // namespace
 
@@ -289,8 +299,9 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    readHandler.Init(nullptr);
+    Messaging::ExchangeManager exchangeManager;
+    Messaging::ExchangeContext * exchangeCtx = exchangeManager.NewContext(SessionHandle(), nullptr);
+    readHandler.Init(nullptr, exchangeCtx);
 
     GenerateReportData(apSuite, apContext, reportDatabuf);
     err = readHandler.SendReportData(std::move(reportDatabuf));
@@ -320,7 +331,7 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = readHandler.OnReadRequest(nullptr, std::move(readRequestbuf));
+    err = readHandler.OnReadRequest(std::move(readRequestbuf));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     engine->Shutdown();
@@ -417,7 +428,9 @@ void TestReadInteraction::TestReadHandlerInvalidAttributePath(nlTestSuite * apSu
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    readHandler.Init(nullptr);
+    Messaging::ExchangeManager exchangeManager;
+    Messaging::ExchangeContext * exchangeCtx = exchangeManager.NewContext(SessionHandle(), nullptr);
+    readHandler.Init(nullptr, exchangeCtx);
 
     GenerateReportData(apSuite, apContext, reportDatabuf);
     err = readHandler.SendReportData(std::move(reportDatabuf));
@@ -443,7 +456,7 @@ void TestReadInteraction::TestReadHandlerInvalidAttributePath(nlTestSuite * apSu
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = readHandler.OnReadRequest(nullptr, std::move(readRequestbuf));
+    err = readHandler.OnReadRequest(std::move(readRequestbuf));
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
     engine->Shutdown();
 }
@@ -566,6 +579,7 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+    NL_TEST_ASSERT(apSuite, !delegate.mGotReadStatusResponse);
 
     chip::app::EventPathParams eventPathParams[2];
     eventPathParams[0].mNodeId     = kTestNodeId;
@@ -585,6 +599,7 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
     NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
+    NL_TEST_ASSERT(apSuite, delegate.mGotReadStatusResponse);
 
     // By now we should have closed all exchanges and sent all pending acks, so
     // there should be no queued-up things in the retransmit table.

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -133,10 +133,10 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    readHandler.OnReadRequest(exchangeCtx, std::move(readRequestbuf));
+    readHandler.OnReadRequest(std::move(readRequestbuf));
     reportingEngine.Init();
     err = reportingEngine.BuildAndSendSingleReportData(&readHandler);
-    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
 }
 } // namespace reporting
 } // namespace app

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -437,15 +437,19 @@ public:
     {
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override
-    {
-        HandleReadComplete();
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override { return CHIP_NO_ERROR; }
     CHIP_ERROR ReportError(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
     {
         printf("ReportError with err %" CHIP_ERROR_FORMAT, aError.Format());
         return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
+    {
+        if (aError == CHIP_NO_ERROR)
+        {
+            HandleReadComplete();
+        }
+        return aError;
     }
     CHIP_ERROR CommandResponseStatus(const chip::app::CommandSender * apCommandSender,
                                      const chip::Protocols::SecureChannel::GeneralStatusCode aGeneralCode,


### PR DESCRIPTION
#### Problem
* Fixes #9191
#### Change overview
-- When Read Client receives report data from Read handler, it needs to
send status report to handler per IM spec("Data reports (i.e. non-empty ReportData messages) SHALL always require a response."
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Encoding-Specification.adoc#reportdatamessage)
-- Add status report generation and process.
-- Add corresponding unit test and integration test

#### Testing
How was this tested? (at least one bullet point required)
Update the unit and integration test to check if status report is successfully sent.