### PR TITLE
Fix efr32 unit tests

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,10 +55,6 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
     ]
 
-    if (chip_device_platform != "fake") {
-      deps += [ "${chip_root}/src/protocols/secure_channel/tests" ]
-    }
-
     if (current_os != "zephyr") {
       deps += [ "${chip_root}/src/lib/mdns/minimal/records/tests" ]
     }


### PR DESCRIPTION
#### Problem
A recent change added the secure_channel test to efr32 unit test build, which currently doesn't work.

#### Change overview
It appears a rebase mix-up meant that this line actually wasn't doing anything for the fake platform as that test is still included in the !efr block (line 77). Good news is that the fake platform is currently passing this test and so it doesn't actually need to be removed for fake platform anymore.

#### Testing
- gn_build.sh on linux to verify fake platform passes
- built and ran efr32 unit tests
