### PR TITLE
[Darwin] Allow clients to pass in the NOC Signer Keypair

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -312,7 +312,29 @@ struct alignas(size_t) P256KeypairContext
 
 typedef CapacityBoundBuffer<kP256_PublicKey_Length + kP256_PrivateKey_Length> P256SerializedKeypair;
 
-class P256Keypair : public ECPKeypair<P256PublicKey, P256ECDHDerivedSecret, P256ECDSASignature>
+class P256KeypairBase : public ECPKeypair<P256PublicKey, P256ECDHDerivedSecret, P256ECDSASignature>
+{
+public:
+    /**
+     * @brief Initialize the keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    virtual CHIP_ERROR Initialize() = 0;
+
+    /**
+     * @brief Serialize the keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const = 0;
+
+    /**
+     * @brief Deserialize the keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    virtual CHIP_ERROR Deserialize(P256SerializedKeypair & input) = 0;
+};
+
+class P256Keypair : public P256KeypairBase
 {
 public:
     P256Keypair() {}
@@ -322,19 +344,19 @@ public:
      * @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Initialize();
+    virtual CHIP_ERROR Initialize() override;
 
     /**
      * @brief Serialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const;
+    virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
 
     /**
      * @brief Deserialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Deserialize(P256SerializedKeypair & input);
+    virtual CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;
 
     /**
      * @brief Generate a new Certificate Signing Request (CSR).

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -344,19 +344,19 @@ public:
      * @brief Initialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Initialize() override;
+    CHIP_ERROR Initialize() override;
 
     /**
      * @brief Serialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
+    CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
 
     /**
      * @brief Deserialize the keypair.
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;
+    CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;
 
     /**
      * @brief Generate a new Certificate Signing Request (CSR).

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -70,7 +70,7 @@ CHIPDeviceController * InitializeCHIP(void)
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
         storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        [controller startup:storage vendorId:0];
+        [controller startup:storage vendorId:0 nocSigner:nil];
     });
 
     return controller;

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		997DED162695343400975E97 /* CHIPThreadOperationalDataset.mm in Sources */ = {isa = PBXBuildFile; fileRef = 997DED152695343400975E97 /* CHIPThreadOperationalDataset.mm */; };
 		997DED182695344800975E97 /* CHIPThreadOperationalDataset.h in Headers */ = {isa = PBXBuildFile; fileRef = 997DED172695344800975E97 /* CHIPThreadOperationalDataset.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		997DED1A26955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 997DED1926955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm */; };
+		998F286D26D55E10001846C6 /* CHIPKeypair.h in Headers */ = {isa = PBXBuildFile; fileRef = 998F286C26D55E10001846C6 /* CHIPKeypair.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */; };
+		998F287126D56940001846C6 /* CHIPP256KeypairBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */; };
 		99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 99C65E0F267282F1003402F6 /* CHIPControllerTests.m */; };
 		B20252972459E34F00F97062 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* CHIP.framework */; };
 		B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -85,11 +88,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1E857305265519720050A4D9 /* CHIPClientCallbacks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHIPClientCallbacks.cpp; path = ../../../controller/data_model/zap-generated/CHIPClientCallbacks.cpp; sourceTree = "<group>"; };
+		1E857305265519720050A4D9 /* CHIPClientCallbacks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHIPClientCallbacks.cpp; path = "../../../controller/data_model/zap-generated/CHIPClientCallbacks.cpp"; sourceTree = "<group>"; };
 		1E857307265519AE0050A4D9 /* callback-stub.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "callback-stub.cpp"; path = "../../../controller/data_model/zap-generated/callback-stub.cpp"; sourceTree = "<group>"; };
-		1E857309265519AE0050A4D9 /* CHIPClusters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHIPClusters.cpp; path = ../../../controller/data_model/zap-generated/CHIPClusters.cpp; sourceTree = "<group>"; };
+		1E857309265519AE0050A4D9 /* CHIPClusters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHIPClusters.cpp; path = "../../../controller/data_model/zap-generated/CHIPClusters.cpp"; sourceTree = "<group>"; };
 		1E85730A265519AE0050A4D9 /* attribute-size.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-size.cpp"; path = "../../../controller/data_model/zap-generated/attribute-size.cpp"; sourceTree = "<group>"; };
-		1E85730B265519AE0050A4D9 /* IMClusterCommandHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IMClusterCommandHandler.cpp; path = ../../../controller/data_model/zap-generated/IMClusterCommandHandler.cpp; sourceTree = "<group>"; };
+		1E85730B265519AE0050A4D9 /* IMClusterCommandHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IMClusterCommandHandler.cpp; path = "../../../controller/data_model/zap-generated/IMClusterCommandHandler.cpp"; sourceTree = "<group>"; };
 		1E85731226551A490050A4D9 /* binding-table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "binding-table.cpp"; path = "../../../app/util/binding-table.cpp"; sourceTree = "<group>"; };
 		1E85731326551A490050A4D9 /* process-global-message.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "process-global-message.cpp"; path = "../../../app/util/process-global-message.cpp"; sourceTree = "<group>"; };
 		1E85731426551A490050A4D9 /* attribute-list-byte-span.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "attribute-list-byte-span.cpp"; path = "../../../app/util/attribute-list-byte-span.cpp"; sourceTree = "<group>"; };
@@ -109,8 +112,8 @@
 		1E85733226551A700050A4D9 /* reporting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = reporting.cpp; path = ../../../app/reporting/reporting.cpp; sourceTree = "<group>"; };
 		1E85733326551A700050A4D9 /* reporting-default-configuration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "reporting-default-configuration.cpp"; path = "../../../app/reporting/reporting-default-configuration.cpp"; sourceTree = "<group>"; };
 		1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPClustersTests.m; sourceTree = "<group>"; };
-		1EC4CE5925CC26E900D7304F /* CHIPClustersObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPClustersObjc.mm; path = zap-generated/CHIPClustersObjc.mm; sourceTree = "<group>"; };
-		1EC4CE6325CC276600D7304F /* CHIPClustersObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPClustersObjc.h; path = zap-generated/CHIPClustersObjc.h; sourceTree = "<group>"; };
+		1EC4CE5925CC26E900D7304F /* CHIPClustersObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPClustersObjc.mm; path = "zap-generated/CHIPClustersObjc.mm"; sourceTree = "<group>"; };
+		1EC4CE6325CC276600D7304F /* CHIPClustersObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPClustersObjc.h; path = "zap-generated/CHIPClustersObjc.h"; sourceTree = "<group>"; };
 		2C1B02782641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPOperationalCredentialsDelegate.mm; sourceTree = "<group>"; };
 		2C1B02792641DB4E00780EF1 /* CHIPOperationalCredentialsDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPOperationalCredentialsDelegate.h; sourceTree = "<group>"; };
 		2C222ACE255C620600E446B9 /* CHIPDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDevice.h; sourceTree = "<group>"; };
@@ -135,6 +138,9 @@
 		997DED152695343400975E97 /* CHIPThreadOperationalDataset.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPThreadOperationalDataset.mm; sourceTree = "<group>"; };
 		997DED172695344800975E97 /* CHIPThreadOperationalDataset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPThreadOperationalDataset.h; sourceTree = "<group>"; };
 		997DED1926955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPThreadOperationalDatasetTests.mm; sourceTree = "<group>"; };
+		998F286C26D55E10001846C6 /* CHIPKeypair.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPKeypair.h; sourceTree = "<group>"; };
+		998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPP256KeypairBridge.h; sourceTree = "<group>"; };
+		998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPP256KeypairBridge.mm; sourceTree = "<group>"; };
 		99C65E0F267282F1003402F6 /* CHIPControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPControllerTests.m; sourceTree = "<group>"; };
 		B202528D2459E34F00F97062 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20252912459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -275,6 +281,9 @@
 				991DC0822475F45400C13860 /* CHIPDeviceController.h */,
 				991DC0872475F47D00C13860 /* CHIPDeviceController.mm */,
 				B20252912459E34F00F97062 /* Info.plist */,
+				998F286C26D55E10001846C6 /* CHIPKeypair.h */,
+				998F286E26D55EC5001846C6 /* CHIPP256KeypairBridge.h */,
+				998F287026D56940001846C6 /* CHIPP256KeypairBridge.mm */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -318,12 +327,14 @@
 				B2E0D7B8245B0B5C003C5B48 /* CHIPSetupPayload.h in Headers */,
 				997DED182695344800975E97 /* CHIPThreadOperationalDataset.h in Headers */,
 				9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */,
+				998F286D26D55E10001846C6 /* CHIPKeypair.h in Headers */,
 				5129BCFD26A9EE3300122DDF /* CHIPError.h in Headers */,
 				2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
 				1EC4CE6425CC276600D7304F /* CHIPClustersObjc.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* CHIPDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* CHIPPersistentStorageDelegateBridge.h in Headers */,
+				998F286F26D55EC5001846C6 /* CHIPP256KeypairBridge.h in Headers */,
 				2C222ADF255C811800E446B9 /* CHIPDevice_Internal.h in Headers */,
 				991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* CHIPError_Internal.h in Headers */,
@@ -454,6 +465,7 @@
 				2CB7163C252E8A7C0026E2BB /* CHIPDevicePairingDelegateBridge.mm in Sources */,
 				997DED162695343400975E97 /* CHIPThreadOperationalDataset.mm in Sources */,
 				1E85732426551A490050A4D9 /* attribute-list-byte-span.cpp in Sources */,
+				998F287126D56940001846C6 /* CHIPP256KeypairBridge.mm in Sources */,
 				1E85730E265519AE0050A4D9 /* CHIPClusters.cpp in Sources */,
 				1E85732326551A490050A4D9 /* process-global-message.cpp in Sources */,
 				1E85732E26551A490050A4D9 /* ember-print.cpp in Sources */,

--- a/src/darwin/Framework/CHIP/CHIP.h
+++ b/src/darwin/Framework/CHIP/CHIP.h
@@ -21,6 +21,7 @@
 #import <CHIP/CHIPDeviceController.h>
 #import <CHIP/CHIPDevicePairingDelegate.h>
 #import <CHIP/CHIPError.h>
+#import <CHIP/CHIPKeypair.h>
 #import <CHIP/CHIPManualSetupPayloadParser.h>
 #import <CHIP/CHIPPersistentStorageDelegate.h>
 #import <CHIP/CHIPQRCodeSetupPayloadParser.h>

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -100,7 +100,9 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  * @param[in] vendorId The vendor ID of the commissioner application
  * @param[in] nocSigner The CHIPKeypair that is used to to generate and sign Node Operational Credentials
  */
-- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate vendorId:(uint16_t)vendorId nocSigner:(nullable id<CHIPKeypair>)nocSigner;
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
+       vendorId:(uint16_t)vendorId
+      nocSigner:(nullable id<CHIPKeypair>)nocSigner;
 
 /**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -30,6 +30,7 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 
 @protocol CHIPDevicePairingDelegate;
 @protocol CHIPPersistentStorageDelegate;
+@protocol CHIPKeypair;
 
 @interface CHIPDeviceController : NSObject
 
@@ -97,8 +98,9 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  *
  * @param[in] storageDelegate The delegate for persistent storage
  * @param[in] vendorId The vendor ID of the commissioner application
+ * @param[in] nocSigner The CHIPKeypair that is used to to generate and sign Node Operational Credentials
  */
-- (BOOL)startup:(nullable id<CHIPPersistentStorageDelegate>)storageDelegate vendorId:(uint16_t)vendorId;
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate vendorId:(uint16_t)vendorId nocSigner:(nullable id<CHIPKeypair>)nocSigner;
 
 /**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -98,7 +98,7 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
  *
  * @param[in] storageDelegate The delegate for persistent storage
  * @param[in] vendorId The vendor ID of the commissioner application
- * @param[in] nocSigner The CHIPKeypair that is used to to generate and sign Node Operational Credentials
+ * @param[in] nocSigner The CHIPKeypair that is used to generate and sign Node Operational Credentials
  */
 - (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
        vendorId:(uint16_t)vendorId

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -151,7 +151,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         _persistentStorageDelegateBridge->setFrameworkDelegate(storageDelegate);
 
         // create a CHIPP256KeypairBridge here and pass it to the operationalCredentialsDelegate
-        std::unique_ptr<chip::Crypto::CHIPP256KeypairNativeBridge> nativeBridge = nullptr;
+        std::unique_ptr<chip::Crypto::CHIPP256KeypairNativeBridge> nativeBridge;
         if (nocSigner != nil) {
             _keypairBridge.Init(nocSigner);
             nativeBridge.reset(new chip::Crypto::CHIPP256KeypairNativeBridge(_keypairBridge));

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -128,7 +128,9 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     return YES;
 }
 
-- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate vendorId:(uint16_t)vendorId nocSigner:(id<CHIPKeypair>)nocSigner
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
+       vendorId:(uint16_t)vendorId
+      nocSigner:(id<CHIPKeypair>)nocSigner
 {
     chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
 
@@ -150,8 +152,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 
         // create a CHIPP256KeypairBridge here and pass it to the operationalCredentialsDelegate
         std::unique_ptr<chip::Crypto::CHIPP256KeypairNativeBridge> nativeBridge = nullptr;
-        if (nocSigner != nil)
-        {
+        if (nocSigner != nil) {
             _keypairBridge.Init(nocSigner);
             nativeBridge.reset(new chip::Crypto::CHIPP256KeypairNativeBridge(_keypairBridge));
         }

--- a/src/darwin/Framework/CHIP/CHIPKeypair.h
+++ b/src/darwin/Framework/CHIP/CHIPKeypair.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief A function to sign a hash using ECDSA
  * @param hash Hash that needs to be signed
  *
- * @return Returns a the signature. The signature consists of: 2 EC elements (r and s), in raw <r,s> point form (see SEC1).
+ * @return Returns A signature that consists of: 2 EC elements (r and s), in raw <r,s> point form (see SEC1).
  **/
 - (NSData *)ECDSA_sign_hash:(NSData *)hash;
 

--- a/src/darwin/Framework/CHIP/CHIPKeypair.h
+++ b/src/darwin/Framework/CHIP/CHIPKeypair.h
@@ -1,0 +1,46 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol CHIPKeypair <NSObject>
+@required
+
+/**
+ * @brief Initialize the keypair.
+ * @return Should return whether or not the keypair was successfully initialized
+ **/
+- (BOOL)initialize;
+
+/**
+ * @brief A function to sign a hash using ECDSA
+ * @param hash Hash that needs to be signed
+ *
+ * @return Returns a the signature. The signature consists of: 2 EC elements (r and s), in raw <r,s> point form (see SEC1).
+ **/
+- (NSData *)ECDSA_sign_hash:(NSData *)hash;
+
+/** @brief Return public key for the keypair.
+ **/
+- (SecKeyRef)pubkey;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -19,19 +19,21 @@
 #import <Security/Security.h>
 
 #import "CHIPError_Internal.h"
+#import "CHIPP256KeypairBridge.h"
 #import "CHIPPersistentStorageDelegateBridge.h"
 
 #include <controller/OperationalCredentialsDelegate.h>
+#include <platform/Darwin/CHIPP256KeypairNativeBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 class CHIPOperationalCredentialsDelegate : public chip::Controller::OperationalCredentialsDelegate {
 public:
-    CHIPOperationalCredentialsDelegate() {}
+    using ChipP256KeypairPtr = std::unique_ptr<chip::Crypto::P256Keypair>;
 
     ~CHIPOperationalCredentialsDelegate() {}
 
-    CHIP_ERROR init(CHIPPersistentStorageDelegateBridge * storage);
+    CHIP_ERROR init(CHIPPersistentStorageDelegateBridge * storage, ChipP256KeypairPtr nocSigner);
 
     CHIP_ERROR GenerateNOCChain(const chip::ByteSpan & csrElements, const chip::ByteSpan & attestationSignature,
         const chip::ByteSpan & DAC, const chip::ByteSpan & PAI, const chip::ByteSpan & PAA,
@@ -61,7 +63,7 @@ private:
 
     bool ToChipEpochTime(uint32_t offset, uint32_t & epoch);
 
-    chip::Crypto::P256Keypair mIssuerKey;
+    ChipP256KeypairPtr mIssuerKey;
     uint32_t mIssuerId = 1234;
 
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -43,19 +43,28 @@ static BOOL isRunningTests(void)
     return (environment[@"XCTestConfigurationFilePath"] != nil);
 }
 
-CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegateBridge * storage)
+CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegateBridge * storage, ChipP256KeypairPtr nocSigner)
 {
     if (storage == nil) {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+    CHIP_ERROR err = CHIP_NO_ERROR;
     mStorage = storage;
 
-    CHIP_ERROR err = LoadKeysFromKeyChain();
+    if (!nocSigner || nocSigner->Initialize() != CHIP_NO_ERROR)
+    {
+        CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate: No NOC Signer provided, using self managed keys");
+        err = LoadKeysFromKeyChain();
 
-    if (err != CHIP_NO_ERROR) {
-        // Generate keys if keys could not be loaded
-        err = GenerateKeys();
+        if (err != CHIP_NO_ERROR) {
+            // Generate keys if keys could not be loaded
+            err = GenerateKeys();
+        }
+    }
+    else
+    {
+        mIssuerKey = std::move(nocSigner);
     }
 
     if (err == CHIP_NO_ERROR) {
@@ -101,11 +110,11 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
     CFDataRef keyDataRef;
     OSStatus status = SecItemCopyMatching((CFDictionaryRef) query, (CFTypeRef *) &keyDataRef);
     if (status == errSecItemNotFound || keyDataRef == nil) {
-        CHIP_LOG_ERROR("Did not find an existing key in the keychain");
+        CHIP_LOG_ERROR("Did not find self managed keys in the keychain");
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
 
-    CHIP_LOG_ERROR("Found an existing keypair in the keychain");
+    CHIP_LOG_ERROR("Found an existing self managed keypair in the keychain");
     NSData * keyData = CFBridgingRelease(keyDataRef);
 
     NSData * keypairData = [[NSData alloc] initWithBase64EncodedData:keyData options:0];
@@ -120,19 +129,20 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
     serialized.SetLength([keypairData length]);
 
     CHIP_LOG_ERROR("Deserializing the key");
-    return mIssuerKey.Deserialize(serialized);
+    mIssuerKey.reset(new chip::Crypto::P256Keypair());
+    return mIssuerKey->Deserialize(serialized);
 }
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
 {
-    CHIP_LOG_ERROR("Generating keys for the CA");
-    CHIP_ERROR errorCode = mIssuerKey.Initialize();
-    if (errorCode != CHIP_NO_ERROR) {
+    CHIP_LOG_ERROR("Generating self managed keys for the CA");
+    mIssuerKey.reset(new chip::Crypto::P256Keypair());
+    CHIP_ERROR errorCode = mIssuerKey->Initialize();    if (errorCode != CHIP_NO_ERROR) {
         return errorCode;
     }
 
     chip::Crypto::P256SerializedKeypair serializedKey;
-    errorCode = mIssuerKey.Serialize(serializedKey);
+    errorCode = mIssuerKey->Serialize(serializedKey);
 
     NSData * keypairData = [NSData dataWithBytes:serializedKey.Bytes() length:serializedKey.Length()];
 
@@ -157,7 +167,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()
 {
-    CHIP_LOG_ERROR("Deleting current CA keys");
+    CHIP_LOG_ERROR("Deleting self managed CA keys");
     OSStatus status = noErr;
 
     const NSDictionary * deleteParams = @{
@@ -192,7 +202,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     }
 
     X509CertRequestParams noc_request = { 1, mIssuerId, validityStart, validityEnd, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuerKey, noc));
+    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, *mIssuerKey, noc));
     icac.reduce_size(0);
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));
@@ -208,7 +218,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     }
 
     X509CertRequestParams rcac_request = { 0, mIssuerId, validityStart, validityEnd, true, fabricId, false, 0 };
-    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuerKey, rcac));
+    ReturnErrorOnFailure(NewRootX509Cert(rcac_request, *mIssuerKey, rcac));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
     PERSISTENT_KEY_OP(fabricId, kOperationalCredentialsRootCertificateStorage, key,

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -52,7 +52,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
     CHIP_ERROR err = CHIP_NO_ERROR;
     mStorage = storage;
 
-    if (!nocSigner || nocSigner->Initialize() != CHIP_NO_ERROR) {
+    if (!nocSigner) {
         CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate: No NOC Signer provided, using self managed keys");
         err = LoadKeysFromKeyChain();
 

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -54,6 +54,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
 
     if (!nocSigner) {
         CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate: No NOC Signer provided, using self managed keys");
+
+        mIssuerKey.reset(new chip::Crypto::P256Keypair());
         err = LoadKeysFromKeyChain();
 
         if (err != CHIP_NO_ERROR) {
@@ -126,14 +128,12 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
     serialized.SetLength([keypairData length]);
 
     CHIP_LOG_ERROR("Deserializing the key");
-    mIssuerKey.reset(new chip::Crypto::P256Keypair());
     return mIssuerKey->Deserialize(serialized);
 }
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
 {
     CHIP_LOG_ERROR("Generating self managed keys for the CA");
-    mIssuerKey.reset(new chip::Crypto::P256Keypair());
     CHIP_ERROR errorCode = mIssuerKey->Initialize();
     if (errorCode != CHIP_NO_ERROR) {
         return errorCode;

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -52,8 +52,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
     CHIP_ERROR err = CHIP_NO_ERROR;
     mStorage = storage;
 
-    if (!nocSigner || nocSigner->Initialize() != CHIP_NO_ERROR)
-    {
+    if (!nocSigner || nocSigner->Initialize() != CHIP_NO_ERROR) {
         CHIP_LOG_ERROR("CHIPOperationalCredentialsDelegate: No NOC Signer provided, using self managed keys");
         err = LoadKeysFromKeyChain();
 
@@ -61,9 +60,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::init(CHIPPersistentStorageDelegat
             // Generate keys if keys could not be loaded
             err = GenerateKeys();
         }
-    }
-    else
-    {
+    } else {
         mIssuerKey = std::move(nocSigner);
     }
 
@@ -137,7 +134,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
 {
     CHIP_LOG_ERROR("Generating self managed keys for the CA");
     mIssuerKey.reset(new chip::Crypto::P256Keypair());
-    CHIP_ERROR errorCode = mIssuerKey->Initialize();    if (errorCode != CHIP_NO_ERROR) {
+    CHIP_ERROR errorCode = mIssuerKey->Initialize();
+    if (errorCode != CHIP_NO_ERROR) {
         return errorCode;
     }
 
@@ -202,7 +200,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChainAfterValidation(N
     }
 
     X509CertRequestParams noc_request = { 1, mIssuerId, validityStart, validityEnd, true, fabricId, true, nodeId };
-    ReturnErrorOnFailure(NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, *mIssuerKey, noc));
+    ReturnErrorOnFailure(
+        NewNodeOperationalX509Cert(noc_request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, *mIssuerKey, noc));
     icac.reduce_size(0);
 
     uint16_t rcacBufLen = static_cast<uint16_t>(std::min(rcac.size(), static_cast<size_t>(UINT16_MAX)));

--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.h
@@ -1,0 +1,57 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPKeypair.h"
+
+#import "CHIPError_Internal.h"
+#include <crypto/CHIPCryptoPAL.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+class CHIPP256KeypairBridge : public chip::Crypto::P256KeypairBase
+{
+public:
+    ~CHIPP256KeypairBridge() {};
+
+    CHIP_ERROR Init(id<CHIPKeypair>keypair);
+
+    bool HasKeypair() const { return mKeypair != nil; };
+
+    CHIP_ERROR Initialize() override;
+
+    CHIP_ERROR Serialize(chip::Crypto::P256SerializedKeypair & output) const override;
+
+    CHIP_ERROR Deserialize(chip::Crypto::P256SerializedKeypair & input) override;
+
+    CHIP_ERROR NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) override;
+
+    CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, chip::Crypto::P256ECDSASignature & out_signature) override;
+
+    CHIP_ERROR ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, chip::Crypto::P256ECDSASignature & out_signature) override;
+
+    CHIP_ERROR ECDH_derive_secret(const chip::Crypto::P256PublicKey & remote_public_key, chip::Crypto::P256ECDHDerivedSecret & out_secret) const override;
+
+    const chip::Crypto::P256PublicKey & Pubkey() const override { return mPubkey; };
+
+private:
+    id<CHIPKeypair> mKeypair;
+    chip::Crypto::P256PublicKey mPubkey;
+
+    CHIP_ERROR setPubkey();
+};
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.h
@@ -25,9 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 class CHIPP256KeypairBridge : public chip::Crypto::P256KeypairBase
 {
 public:
-    ~CHIPP256KeypairBridge() {};
+    ~CHIPP256KeypairBridge(){};
 
-    CHIP_ERROR Init(id<CHIPKeypair>keypair);
+    CHIP_ERROR Init(id<CHIPKeypair> keypair);
 
     bool HasKeypair() const { return mKeypair != nil; };
 
@@ -43,7 +43,8 @@ public:
 
     CHIP_ERROR ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, chip::Crypto::P256ECDSASignature & out_signature) override;
 
-    CHIP_ERROR ECDH_derive_secret(const chip::Crypto::P256PublicKey & remote_public_key, chip::Crypto::P256ECDHDerivedSecret & out_secret) const override;
+    CHIP_ERROR ECDH_derive_secret(const chip::Crypto::P256PublicKey & remote_public_key,
+                                  chip::Crypto::P256ECDHDerivedSecret & out_secret) const override;
 
     const chip::Crypto::P256PublicKey & Pubkey() const override { return mPubkey; };
 

--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
@@ -34,8 +34,7 @@ CHIP_ERROR CHIPP256KeypairBridge::Init(id<CHIPKeypair> keypair)
 
 CHIP_ERROR CHIPP256KeypairBridge::Initialize()
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -44,8 +43,7 @@ CHIP_ERROR CHIPP256KeypairBridge::Initialize()
 
 CHIP_ERROR CHIPP256KeypairBridge::Serialize(P256SerializedKeypair & output) const
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -54,8 +52,7 @@ CHIP_ERROR CHIPP256KeypairBridge::Serialize(P256SerializedKeypair & output) cons
 
 CHIP_ERROR CHIPP256KeypairBridge::Deserialize(P256SerializedKeypair & input)
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -64,8 +61,7 @@ CHIP_ERROR CHIPP256KeypairBridge::Deserialize(P256SerializedKeypair & input)
 
 CHIP_ERROR CHIPP256KeypairBridge::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length)
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -74,23 +70,20 @@ CHIP_ERROR CHIPP256KeypairBridge::NewCertificateSigningRequest(uint8_t * csr, si
 
 CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature)
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         CHIP_LOG_ERROR("ECDSA sign msg failure: no keypair to sign with.");
         return CHIP_ERROR_INCORRECT_STATE;
     }
     NSData * msgData = [NSData dataWithBytes:msg length:msg_length];
-    NSMutableData *hashedData = [NSMutableData dataWithLength:CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(msgData.bytes, (CC_LONG) msgData.length, (unsigned char *)hashedData.mutableBytes);
+    NSMutableData * hashedData = [NSMutableData dataWithLength:CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(msgData.bytes, (CC_LONG) msgData.length, (unsigned char *) hashedData.mutableBytes);
     CHIP_LOG_DEBUG("Generated Msg hash, signing hash now");
     NSData * signature = [mKeypair ECDSA_sign_hash:hashedData];
-    if (!signature)
-    {
+    if (!signature) {
         CHIP_LOG_ERROR("ECDSA sign msg failure: no signature returned");
         return CHIP_ERROR_INTERNAL;
     }
-    if (signature.length > out_signature.Capacity())
-    {
+    if (signature.length > out_signature.Capacity()) {
         CHIP_LOG_ERROR("ECDSA sign msg failure: unexpected signature size %tu vs %tu ", signature.length, out_signature.Capacity());
         return CHIP_ERROR_NO_MEMORY;
     }
@@ -100,30 +93,28 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg
 
 CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, P256ECDSASignature & out_signature)
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
     NSData * hashData = [NSData dataWithBytes:hash length:hash_length];
     NSData * signature = [mKeypair ECDSA_sign_hash:hashData];
-    if (!signature)
-    {
+    if (!signature) {
         CHIP_LOG_ERROR("ECDSA sign hash failure: no signature returned");
         return CHIP_ERROR_INTERNAL;
     }
-    if (signature.length > out_signature.Capacity())
-    {
-        CHIP_LOG_ERROR("ECDSA sign hash failure: unexpected signature size %tu vs %tu ", signature.length, out_signature.Capacity());
+    if (signature.length > out_signature.Capacity()) {
+        CHIP_LOG_ERROR(
+            "ECDSA sign hash failure: unexpected signature size %tu vs %tu ", signature.length, out_signature.Capacity());
         return CHIP_ERROR_NO_MEMORY;
     }
     std::memmove(out_signature, signature.bytes, signature.length);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
+CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(
+    const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
 {
-    if (!HasKeypair())
-    {
+    if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -133,15 +124,13 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(const P256PublicKey & remot
 CHIP_ERROR CHIPP256KeypairBridge::setPubkey()
 {
     SecKeyRef pubkeyRef = [mKeypair pubkey];
-    if (!pubkeyRef)
-    {
+    if (!pubkeyRef) {
         CHIP_LOG_ERROR("Unable to initialize Pubkey");
         return CHIP_ERROR_INTERNAL;
     }
 
     NSData * pubkeyData = (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation(pubkeyRef, nil);
-    if (!pubkeyData)
-    {
+    if (!pubkeyData) {
         CHIP_LOG_ERROR("Unable to copy external representation for pubkey ref, returning empty Pubkey");
         return CHIP_ERROR_INTERNAL;
     }

--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
@@ -1,0 +1,154 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPP256KeypairBridge.h"
+
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/SecKey.h>
+#include <string>
+
+#import "CHIPKeypair.h"
+#import "CHIPLogging.h"
+
+using namespace chip::Crypto;
+
+CHIP_ERROR CHIPP256KeypairBridge::Init(id<CHIPKeypair> keypair)
+{
+    mKeypair = keypair;
+    return setPubkey();
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Initialize()
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return ([mKeypair initialize]) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Serialize(P256SerializedKeypair & output) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Deserialize(P256SerializedKeypair & input)
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length)
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature)
+{
+    if (!HasKeypair())
+    {
+        CHIP_LOG_ERROR("ECDSA sign msg failure: no keypair to sign with.");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    NSData * msgData = [NSData dataWithBytes:msg length:msg_length];
+    NSMutableData *hashedData = [NSMutableData dataWithLength:CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(msgData.bytes, (CC_LONG) msgData.length, (unsigned char *)hashedData.mutableBytes);
+    CHIP_LOG_DEBUG("Generated Msg hash, signing hash now");
+    NSData * signature = [mKeypair ECDSA_sign_hash:hashedData];
+    if (!signature)
+    {
+        CHIP_LOG_ERROR("ECDSA sign msg failure: no signature returned");
+        return CHIP_ERROR_INTERNAL;
+    }
+    if (signature.length > out_signature.Capacity())
+    {
+        CHIP_LOG_ERROR("ECDSA sign msg failure: unexpected signature size %tu vs %tu ", signature.length, out_signature.Capacity());
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    std::memmove(out_signature, signature.bytes, signature.length);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, P256ECDSASignature & out_signature)
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    NSData * hashData = [NSData dataWithBytes:hash length:hash_length];
+    NSData * signature = [mKeypair ECDSA_sign_hash:hashData];
+    if (!signature)
+    {
+        CHIP_LOG_ERROR("ECDSA sign hash failure: no signature returned");
+        return CHIP_ERROR_INTERNAL;
+    }
+    if (signature.length > out_signature.Capacity())
+    {
+        CHIP_LOG_ERROR("ECDSA sign hash failure: unexpected signature size %tu vs %tu ", signature.length, out_signature.Capacity());
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    std::memmove(out_signature, signature.bytes, signature.length);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::setPubkey()
+{
+    SecKeyRef pubkeyRef = [mKeypair pubkey];
+    if (!pubkeyRef)
+    {
+        CHIP_LOG_ERROR("Unable to initialize Pubkey");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    NSData * pubkeyData = (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation(pubkeyRef, nil);
+    if (!pubkeyData)
+    {
+        CHIP_LOG_ERROR("Unable to copy external representation for pubkey ref, returning empty Pubkey");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    uint8_t pubkeyBytes[kP256_PublicKey_Length];
+    std::memmove(&pubkeyBytes, pubkeyData.bytes, pubkeyData.length);
+    mPubkey = P256PublicKey(pubkeyBytes);
+
+    return CHIP_NO_ERROR;
+}

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -76,7 +76,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0];
+    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -94,7 +94,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil vendorId:0];
+    BOOL started = [controller startup:nil vendorId:0 nocSigner:nil];
     XCTAssertTrue(started);
 
     NSError * error;

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -32,11 +32,11 @@
 - (void)testControllerLifecycle
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0]);
+    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 
     // now try to restart the controller
-    XCTAssertTrue([controller startup:nil vendorId:0]);
+    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
     XCTAssertTrue([controller shutdown]);
 }
 
@@ -44,7 +44,7 @@
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     for (int i = 0; i < 5; i++) {
-        XCTAssertTrue([controller startup:nil vendorId:0]);
+        XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
     }
     XCTAssertTrue([controller shutdown]);
 }
@@ -52,7 +52,7 @@
 - (void)testControllerMultipleShutdown
 {
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
-    XCTAssertTrue([controller startup:nil vendorId:0]);
+    XCTAssertTrue([controller startup:nil vendorId:0 nocSigner:nil]);
     for (int i = 0; i < 5; i++) {
         XCTAssertTrue([controller shutdown]);
     }

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -39,6 +39,8 @@ static_library("Darwin") {
     "BlePlatformConfig.h",
     "CHIPDevicePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",
+    "CHIPP256KeypairNativeBridge.cpp",
+    "CHIPP256KeypairNativeBridge.h",
     "CHIPPlatformConfig.h",
     "ConfigurationManagerImpl.cpp",
     "ConfigurationManagerImpl.h",
@@ -57,8 +59,6 @@ static_library("Darwin") {
     "PosixConfig.cpp",
     "PosixConfig.h",
     "SystemPlatformConfig.h",
-    "CHIPP256KeypairNativeBridge.h",
-    "CHIPP256KeypairNativeBridge.cpp",
   ]
 
   deps = [

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -57,6 +57,8 @@ static_library("Darwin") {
     "PosixConfig.cpp",
     "PosixConfig.h",
     "SystemPlatformConfig.h",
+    "CHIPP256KeypairNativeBridge.h",
+    "CHIPP256KeypairNativeBridge.cpp",
   ]
 
   deps = [

--- a/src/platform/Darwin/CHIPP256KeypairNativeBridge.cpp
+++ b/src/platform/Darwin/CHIPP256KeypairNativeBridge.cpp
@@ -1,0 +1,59 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/Darwin/CHIPP256KeypairNativeBridge.h>
+
+using namespace chip::Crypto;
+
+CHIPP256KeypairNativeBridge::~CHIPP256KeypairNativeBridge() {}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::Initialize()
+{
+    return mKeypairBase.Initialize();
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::Serialize(P256SerializedKeypair & output) const
+{
+    return mKeypairBase.Serialize(output);
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::Deserialize(P256SerializedKeypair & input)
+{
+    return mKeypairBase.Deserialize(input);
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature)
+{
+    return mKeypairBase.ECDSA_sign_msg(msg, msg_length, out_signature);
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::ECDSA_sign_hash(const uint8_t * hash, size_t hash_length,
+                                                        P256ECDSASignature & out_signature)
+{
+    return mKeypairBase.ECDSA_sign_hash(hash, hash_length, out_signature);
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::ECDH_derive_secret(const P256PublicKey & remote_public_key,
+                                                           P256ECDHDerivedSecret & out_secret) const
+{
+    return mKeypairBase.ECDH_derive_secret(remote_public_key, out_secret);
+}
+
+CHIP_ERROR CHIPP256KeypairNativeBridge::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length)
+{
+    return mKeypairBase.NewCertificateSigningRequest(csr, csr_length);
+}

--- a/src/platform/Darwin/CHIPP256KeypairNativeBridge.h
+++ b/src/platform/Darwin/CHIPP256KeypairNativeBridge.h
@@ -21,7 +21,7 @@
 namespace chip {
 namespace Crypto {
 
-// This class allows briding a Darwin P256KeypairBase implementation to
+// This class allows bridging a Darwin P256KeypairBase implementation to
 // the expected P256Keypair implementation in libChip.
 //
 // TODO: The Darwin layer is not able to directly extend P256Keypair for some reason.

--- a/src/platform/Darwin/CHIPP256KeypairNativeBridge.h
+++ b/src/platform/Darwin/CHIPP256KeypairNativeBridge.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <crypto/CHIPCryptoPAL.h>
+
+namespace chip {
+namespace Crypto {
+
+// This class allows briding a Darwin P256KeypairBase implementation to
+// the expected P256Keypair implementation in libChip.
+//
+// TODO: The Darwin layer is not able to directly extend P256Keypair for some reason.
+// Remove this wrapper when that is figured out.
+class CHIPP256KeypairNativeBridge : public P256Keypair
+{
+public:
+    CHIPP256KeypairNativeBridge(P256KeypairBase & baseKeypair) : mKeypairBase(baseKeypair) {}
+
+    ~CHIPP256KeypairNativeBridge();
+
+    CHIP_ERROR Initialize() override;
+
+    CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
+
+    CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;
+
+    CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) override;
+
+    CHIP_ERROR ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, P256ECDSASignature & out_signature) override;
+
+    CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const override;
+
+    CHIP_ERROR NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) override;
+
+    const P256PublicKey & Pubkey() const override { return mKeypairBase.Pubkey(); }
+
+private:
+    P256KeypairBase & mKeypairBase;
+};
+
+} // namespace Crypto
+} // namespace chip


### PR DESCRIPTION
#### Problem
The Darwin SDK manages the keypair used to generate NOC internally. 
Instead we should allow the client to manage this keypair themselves and pass it in when the controller is started up.

#### Change overview
- Exposes a CHIPKeypair interface that clients can pass in to override which keypair is used by the SDK to generate the NOC.
- Adds bridge classes to allow overriding the default P256Keypair implementation. 
(Note - For some reason the Darwin SDK cannot directly extend P256Keypair, it can only extend pure virtual classes and so I had to split off P256Keypair into a Base class and implement that in Darwin)

#### Testing
How was this tested? (at least one bullet point required)
* If  new unit tests are not added, why not?
The "self-managed" keypair behavior should remain unchanged and so all the cluster tests should be exercising it. I also tested this manually with the iOS CHIPTool App.
The new functionality is not currently used by anything in the tree, we need to update the iOS CHIPTool App to manage its own keypair and that would start exercising this. 
