### PR TITLE
Update our .gitattributes to properly list our generated files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
 # Mark all files in the "gen" folders as auto-generated to hide them in diffs
 **/gen/** linguist-generated
+# Same for files in zap-generated folders
+**/zap-generated/** linguist-generated
+# And some specific generated files
+examples/chip-tool/commands/clusters/Commands.h  linguist-generated
+examples/chip-tool/commands/reporting/Commands.h linguist-generated
+examples/chip-tool/commands/tests/Commands.h linguist-generated
+src/controller/python/chip/clusters/CHIPClusters.cpp linguist-generated
+src/controller/python/chip/clusters/CHIPClusters.py linguist-generated
+src/darwin/Framework/CHIPTests/CHIPClustersTests.m linguist-generated


### PR DESCRIPTION
There were two issues:

1) Some generated files were never in "gen" directories to start with.

2) When we moved a bunch of files from "gen" to "zap-generated"
   directories, we didn't update .gitattributes.

#### Problem
Things that should be marked generated in PRs are not.

#### Change overview
Add our generated files to `.gitattributes`

#### Testing
Not sure how best to test this apart from seeing what PRs look like afterward.