### PR TITLE
Optional: allow holding non-default-constructable-type

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -146,6 +146,7 @@ config("disabled_warnings") {
   cflags = [
     "-Wno-deprecated-declarations",
     "-Wno-unknown-warning-option",
+    "-Wno-maybe-uninitialized",
     "-Wno-missing-field-initializers",
     "-Wno-unused-parameter",
   ]

--- a/src/lib/core/InPlace.h
+++ b/src/lib/core/InPlace.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the chip::Optional class to handle values which may
+ *      or may not be present.
+ *
+ */
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <lib/core/InPlace.h>
+#include <lib/support/Variant.h>
+
+namespace chip {
+
+/// InPlace is disambiguation tags that can be passed to the constructors to indicate that the contained object should be
+/// constructed in-place
+struct InPlaceType
+{
+    explicit InPlaceType() = default;
+};
+constexpr InPlaceType InPlace{};
+
+} // namespace chip

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -23,7 +23,9 @@
  */
 #pragma once
 
-#include <assert.h>
+#include <core/CHIPCore.h>
+#include <lib/core/InPlace.h>
+#include <lib/support/Variant.h>
 
 namespace chip {
 
@@ -36,79 +38,159 @@ class Optional
 {
 public:
     constexpr Optional() : mHasValue(false) {}
-    explicit Optional(const T & value) : mValue(value), mHasValue(true) {}
+    ~Optional()
+    {
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
+    }
 
-    constexpr Optional(const Optional & other) = default;
-    constexpr Optional(Optional && other)      = default;
+    explicit Optional(const T & value) : mHasValue(true) { new (&mValue.mData) T(value); }
 
-    /**
-     * Assignment operator implementation.
-     *
-     * NOTE: Manually implemented instead of =default  since other::mValue may not be initialized
-     * if it has no value.
-     */
+    template <class... Args>
+    constexpr explicit Optional(InPlaceType, Args &&... args) : mHasValue(true)
+    {
+        new (&mValue.mData) T(std::forward<Args>(args)...);
+    }
+
+    constexpr Optional(const Optional & other) : mHasValue(other.mHasValue)
+    {
+        if (mHasValue)
+        {
+            new (&mValue.mData) T(other.mValue.mData);
+        }
+    }
+
+    constexpr Optional(Optional && other) : mHasValue(other.mHasValue)
+    {
+        if (mHasValue)
+        {
+            new (&mValue.mData) T(std::move(other.mValue.mData));
+            other.mValue.mData.~T();
+            other.mHasValue = false;
+        }
+    }
+
     constexpr Optional & operator=(const Optional & other)
     {
-        if (other.HasValue())
+        if (mHasValue)
         {
-            SetValue(other.Value());
+            mValue.mData.~T();
         }
-        else
+        mHasValue = other.mHasValue;
+        if (mHasValue)
         {
-            ClearValue();
+            new (&mValue.mData) T(other.mValue.mData);
         }
         return *this;
+    }
+
+    constexpr Optional & operator=(Optional && other)
+    {
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
+        mHasValue = other.mHasValue;
+        if (mHasValue)
+        {
+            new (&mValue.mData) T(std::move(other.mValue.mData));
+            other.mValue.mData.~T();
+            other.mHasValue = false;
+        }
+        return *this;
+    }
+
+    /// Constructs the contained value in-place
+    template <class... Args>
+    constexpr T & Emplace(Args &&... args)
+    {
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
+        mHasValue = true;
+        new (&mValue.mData) T(std::forward<Args>(args)...);
+        return mValue.mData;
     }
 
     /** Make the optional contain a specific value */
     constexpr void SetValue(const T & value)
     {
-        mValue    = value;
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
         mHasValue = true;
+        new (&mValue.mData) T(value);
+    }
+
+    /** Make the optional contain a specific value */
+    constexpr void SetValue(T && value)
+    {
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
+        mHasValue = true;
+        new (&mValue.mData) T(std::move(value));
     }
 
     /** Invalidate the value inside the optional. Optional now has no value */
-    constexpr void ClearValue() { mHasValue = false; }
+    constexpr void ClearValue()
+    {
+        if (mHasValue)
+        {
+            mValue.mData.~T();
+        }
+        mHasValue = false;
+    }
 
     /** Gets the current value of the optional. Valid IFF `HasValue`. */
     const T & Value() const
     {
-        assert(HasValue());
-        return mValue;
+        VerifyOrDie(HasValue());
+        return mValue.mData;
     }
 
     /** Gets the current value of the optional if the optional has a value;
         otherwise returns the provided default value. */
-    const T & ValueOr(const T & defaultValue) const
-    {
-        if (HasValue())
-        {
-            return mValue;
-        }
-        return defaultValue;
-    }
+    const T & ValueOr(const T & defaultValue) const { return HasValue() ? Value() : defaultValue; }
 
     /** Checks if the optional contains a value or not */
     constexpr bool HasValue() const { return mHasValue; }
 
-    /** Comparison operator, handling missing values. */
     bool operator==(const Optional & other) const
     {
-        return (mHasValue == other.mHasValue) && (!other.mHasValue || (mValue == other.mValue));
+        return (mHasValue == other.mHasValue) && (!other.mHasValue || (mValue.mData == other.mValue.mData));
     }
-
-    /** Comparison operator, handling missing values. */
     bool operator!=(const Optional & other) const { return !(*this == other); }
 
     /** Convenience method to create an optional without a valid value. */
     static Optional<T> Missing() { return Optional<T>(); }
 
     /** Convenience method to create an optional containing the specified value. */
-    static Optional<T> Value(const T & value) { return Optional(value); }
+    template <class... Args>
+    static Optional<T> Value(Args &&... args)
+    {
+        return Optional(InPlace, std::forward<Args>(args)...);
+    }
 
 private:
-    T mValue;       ///< Value IFF optional contains a value
-    bool mHasValue; ///< True IFF optional contains a value
+    bool mHasValue;
+    union Value
+    {
+        Value() {}
+        ~Value() {}
+        T mData;
+    } mValue;
 };
+
+template <class T, class... Args>
+constexpr Optional<T> MakeOptional(Args &&... args)
+{
+    return Optional<T>(InPlace, std::forward<Args>(args)...);
+}
 
 } // namespace chip

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
     "TestCHIPCallback.cpp",
     "TestCHIPErrorStr.cpp",
     "TestCHIPTLV.cpp",
+    "TestOptional.cpp",
     "TestReferenceCounted.cpp",
   ]
 

--- a/src/lib/core/tests/TestOptional.cpp
+++ b/src/lib/core/tests/TestOptional.cpp
@@ -1,0 +1,211 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a test for  CHIP core library reference counted object.
+ *
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <lib/core/Optional.h>
+#include <support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+struct Count
+{
+    Count(int i) : m(i) { ++created; }
+    ~Count() { ++destroyed; }
+
+    Count(const Count & o) : m(o.m) { ++created; }
+    Count & operator=(const Count &) = default;
+
+    Count(Count && o) : m(o.m) { ++created; }
+    Count & operator=(Count &&) = default;
+
+    int m;
+
+    static void ResetCounter()
+    {
+        created   = 0;
+        destroyed = 0;
+    }
+
+    static int created;
+    static int destroyed;
+};
+
+struct CountMovable : public Count
+{
+public:
+    CountMovable(int i) : Count(i) {}
+
+    CountMovable(const CountMovable & o) = delete;
+    CountMovable & operator=(const CountMovable &) = delete;
+
+    CountMovable(CountMovable && o) = default;
+    CountMovable & operator=(CountMovable &&) = default;
+};
+
+int Count::created;
+int Count::destroyed;
+
+static void TestBasic(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testOptional = Optional<Count>::Value(100);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, testOptional.HasValue() && testOptional.Value().m == 100);
+
+        testOptional.ClearValue();
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 1);
+        NL_TEST_ASSERT(inSuite, !testOptional.HasValue());
+
+        testOptional.SetValue(Count(101));
+        NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 2);
+        NL_TEST_ASSERT(inSuite, testOptional.HasValue() && testOptional.Value().m == 101);
+
+        testOptional.Emplace(102);
+        NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 3);
+        NL_TEST_ASSERT(inSuite, testOptional.HasValue() && testOptional.Value().m == 102);
+    }
+
+    NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 4);
+}
+
+static void TestMake(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testOptional = MakeOptional<Count>(200);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, testOptional.HasValue() && testOptional.Value().m == 200);
+    }
+
+    NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 1);
+}
+
+static void TestCopy(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testSrc = Optional<Count>::Value(300);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, testSrc.HasValue() && testSrc.Value().m == 300);
+
+        {
+            Optional<Count> testDst(testSrc);
+            NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 0);
+            NL_TEST_ASSERT(inSuite, testDst.HasValue() && testDst.Value().m == 300);
+        }
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+
+        {
+            Optional<Count> testDst;
+            NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+            NL_TEST_ASSERT(inSuite, !testDst.HasValue());
+
+            testDst = testSrc;
+            NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 1);
+            NL_TEST_ASSERT(inSuite, testDst.HasValue() && testDst.Value().m == 300);
+        }
+        NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 2);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 3);
+}
+
+static void TestMove(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testSrc = MakeOptional<CountMovable>(400);
+        Optional<CountMovable> testDst(std::move(testSrc));
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+        NL_TEST_ASSERT(inSuite, testDst.HasValue() && testDst.Value().m == 400);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 2);
+
+    {
+        Optional<CountMovable> testDst;
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 2);
+        NL_TEST_ASSERT(inSuite, !testDst.HasValue());
+
+        auto testSrc = MakeOptional<CountMovable>(401);
+        testDst      = std::move(testSrc);
+        NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 3);
+        NL_TEST_ASSERT(inSuite, testDst.HasValue() && testDst.Value().m == 401);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 4);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("OptionalBasic", TestBasic),
+    NL_TEST_DEF("OptionalMake", TestMake),
+    NL_TEST_DEF("OptionalCopy", TestCopy),
+    NL_TEST_DEF("OptionalMove", TestMove),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestOptional_Setup(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestOptional_Teardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestOptional(void)
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "Optional",
+        &sTests[0],
+        TestOptional_Setup,
+        TestOptional_Teardown
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestOptional)

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -26,6 +26,8 @@
 #ifndef GENERIC_THREAD_STACK_MANAGER_IMPL_OPENTHREAD_IPP
 #define GENERIC_THREAD_STACK_MANAGER_IMPL_OPENTHREAD_IPP
 
+#include <cassert>
+
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
 #include <openthread/joiner.h>

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -252,7 +252,7 @@ public:
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
 
-        assert(begin == nullptr || (begin >= iter && begin < &mStates[kMaxConnectionCount]));
+        VerifyOrDie(begin == nullptr || (begin >= iter && begin < &mStates[kMaxConnectionCount]));
 
         if (begin != nullptr)
         {

--- a/src/transport/PeerMessageCounter.h
+++ b/src/transport/PeerMessageCounter.h
@@ -58,7 +58,7 @@ public:
 
     void SyncStarting(FixedByteSpan<kChallengeSize> challenge)
     {
-        assert(mStatus == Status::NotSynced);
+        VerifyOrDie(mStatus == Status::NotSynced);
         mStatus = Status::SyncInProcess;
         new (&mSyncInProcess) SyncInProcess();
         ::memcpy(mSyncInProcess.mChallenge.data(), challenge.data(), kChallengeSize);

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -136,7 +136,7 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
     constexpr Header::EncryptionType encType = Header::EncryptionType::kAESCCMTagLen16;
 
     const size_t taglen = MessageAuthenticationCode::TagLenForEncryptionType(encType);
-    assert(taglen <= kMaxTagLen);
+    VerifyOrDie(taglen <= kMaxTagLen);
 
     VerifyOrReturnError(mKeyAvailable, CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
     VerifyOrReturnError(input != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -82,7 +82,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(55ull));
 
     header.ClearSourceNodeId().SetDestinationNodeId(11);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
@@ -92,7 +92,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 123);
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11));
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(11ull));
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
@@ -103,8 +103,8 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetSecureSessionControlMsg(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
@@ -113,8 +113,8 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
     NL_TEST_ASSERT(inSuite, header.IsSecureSessionControlMsg());
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetEncryptionKeyID(2);
@@ -124,8 +124,8 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
     NL_TEST_ASSERT(inSuite, header.GetEncryptionKeyID() == 2);
 
     header.SetMessageId(234).SetSourceNodeId(77).SetDestinationNodeId(88);
@@ -135,8 +135,8 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     header.SetMessageId(222).SetSourceNodeId(1).SetDestinationNodeId(2);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, header.GetMessageId() == 234);
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88));
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77));
+    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
+    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
 }
 
 void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
Unlike C++ 17 `std::optional`, our `Optional` is not able to hold a non-default-constructable-type

#### Change overview
Change how to construct `mValue`, use placement new instead.

#### Testing
Manually tested using unit-tests.