### PR TITLE
Remove APIs which on longer make sense in heap based ObjectPool

### DIFF
--- a/src/system/WatchableEventManagerLwIP.cpp
+++ b/src/system/WatchableEventManagerLwIP.cpp
@@ -278,7 +278,7 @@ CHIP_ERROR WatchableEventManager::HandlePlatformTimer()
     // The platform timer API has MSEC resolution so expire any timer with less than 1 msec remaining.
     size_t timersHandled = 0;
     Timer * timer        = nullptr;
-    while ((timersHandled < Timer::sPool.Size()) && ((timer = mTimerList.PopIfEarlier(currentTime + 1)) != nullptr))
+    while ((timersHandled < CHIP_SYSTEM_CONFIG_NUM_TIMERS) && ((timer = mTimerList.PopIfEarlier(currentTime + 1)) != nullptr))
     {
         mHandlingTimerComplete = true;
         timer->HandleComplete();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The size of ObjectPool is not fixed under configuration flag CHIP_SYSTEM_CONFIG_POOL_USE_HEAP, therefore, some legacy index based APIs are no longer make sense. Currently, those APIs are only used by unit test. 

#### Change overview
Remove APIs which do not make sense in heap based ObjectPool.

#### Testing
How was this tested? (at least one bullet point required)
* Checked with ./TestSystemObject since the removed APIs are only used in unit test.


