### PR TITLE
Fix typo in README.md

### DIFF
--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -287,7 +287,7 @@ via 2002::2
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
 -   To use the chip-rpc console after it has been installed run:
-    `python3 -m chip-rpc.console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
+    `python3 -m chip_rpc.console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
 -   Then you can simulate a button press or realease using the following command
     where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -141,7 +141,7 @@ details.
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
 -   To use the chip-rpc console after it has been installed run:
-    `python3 -m chip-rpc.console -s localhost:33000 -o /<YourFolder>/pw_log.out`
+    `python3 -m chip_rpc.console -s localhost:33000 -o /<YourFolder>/pw_log.out`
 
 -   Then you can Get and Set the light using the RPCs:
     `rpcs.chip.rpc.Lighting.Get()`


### PR DESCRIPTION
#### Problem
Typo in README.md : Python module name is `chip_rpc` and not `chip-rpc`.

#### Change overview
Fix name in lighting-app linux and efr32 README.md. 
