### PR TITLE
Check and fix System::Layer shutdown sequencing

### DIFF
--- a/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
+++ b/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
@@ -113,8 +113,10 @@ void ServiceEvents(struct ::timeval & aSleepTime)
     FD_ZERO(&exceptFDs);
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    if (gSystemLayer.State() == System::LayerState::kInitialized)
+    if (gSystemLayer.IsInitialized())
+    {
         gSystemLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, aSleepTime);
+    }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -130,7 +132,7 @@ void ServiceEvents(struct ::timeval & aSleepTime)
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    if (gSystemLayer.State() == System::LayerState::kInitialized)
+    if (gSystemLayer.IsInitialized())
     {
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -58,10 +58,10 @@ exit:
 
 void ShutdownChip(void)
 {
-    chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();
     gSessionManager.Shutdown();
+    chip::DeviceLayer::PlatformMgr().Shutdown();
 }
 
 void TLVPrettyPrinter(const char * aFormat, ...)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -258,6 +258,26 @@ CHIP_ERROR DeviceController::Shutdown()
         mActiveDevices[i].Reset();
     }
 
+    mState = State::NotInitialized;
+
+    // Shut down the interaction model before we try shuttting down the exchange
+    // manager.
+    app::InteractionModelEngine::GetInstance()->Shutdown();
+
+    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
+    // if (mExchangeMgr != nullptr)
+    // {
+    //     mExchangeMgr->Shutdown();
+    // }
+    if (mSessionMgr != nullptr)
+    {
+        mSessionMgr->Shutdown();
+    }
+
+    mStorageDelegate = nullptr;
+
+    ReleaseAllDevices();
+
 #if CONFIG_DEVICE_LAYER
     //
     // We can safely call PlatformMgr().Shutdown(), which like DeviceController::Shutdown(),
@@ -278,26 +298,6 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mSystemLayer = nullptr;
     mInetLayer   = nullptr;
-
-    mState = State::NotInitialized;
-
-    // Shut down the interaction model before we try shuttting down the exchange
-    // manager.
-    app::InteractionModelEngine::GetInstance()->Shutdown();
-
-    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
-    // if (mExchangeMgr != nullptr)
-    // {
-    //     mExchangeMgr->Shutdown();
-    // }
-    if (mSessionMgr != nullptr)
-    {
-        mSessionMgr->Shutdown();
-    }
-
-    mStorageDelegate = nullptr;
-
-    ReleaseAllDevices();
 
     if (mMessageCounterManager != nullptr)
     {

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -96,7 +96,6 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StopEventLoopTask(void
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
 {
-    VerifyOrDieWithMsg(false, DeviceLayer, "Shutdown is not implemented");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -1569,13 +1569,17 @@ CHIP_ERROR TCPEndPoint::DoClose(CHIP_ERROR err, bool suppressCallback)
     else
         State = kState_Closed;
 
-    // Stop the Connect timer in case it is still running.
-
-    StopConnectTimer();
+    if (oldState != kState_Closed)
+    {
+        // Stop the Connect timer in case it is still running.
+        StopConnectTimer();
+    }
 
     // If not making a state transition, return immediately.
     if (State == oldState)
+    {
         return CHIP_NO_ERROR;
+    }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
@@ -2755,7 +2759,9 @@ void TCPEndPoint::HandleIncomingConnection()
     if (conEP != nullptr)
     {
         if (conEP->State == kState_Connected)
+        {
             conEP->Release();
+        }
         conEP->Release();
     }
     if (OnAcceptError != nullptr)

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -471,22 +471,19 @@ void ServiceEvents(uint32_t aSleepTimeMilliseconds)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-    if (gSystemLayer.State() == System::LayerState::kInitialized)
+    if (gSystemLayer.IsInitialized())
     {
         static uint32_t sRemainingSystemLayerEventDelay = 0;
 
-        if (gSystemLayer.State() == System::LayerState::kInitialized)
+        if (sRemainingSystemLayerEventDelay == 0)
         {
-            if (sRemainingSystemLayerEventDelay == 0)
-            {
-                gSystemLayer.WatchableEventsManager().DispatchEvents();
-                sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;
-            }
-            else
-                sRemainingSystemLayerEventDelay--;
-
-            gSystemLayer.WatchableEventsManager().HandlePlatformTimer();
+            gSystemLayer.WatchableEventsManager().DispatchEvents();
+            sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;
         }
+        else
+            sRemainingSystemLayerEventDelay--;
+
+        gSystemLayer.WatchableEventsManager().HandlePlatformTimer();
     }
 #if CHIP_TARGET_STYLE_UNIX
     // TapAddrAutoconf and TapInterface are only needed for LwIP on

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -96,8 +96,11 @@ static void TestInetPre(nlTestSuite * inSuite, void * inContext)
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 
     // Deinit system layer and network
-    ShutdownSystemLayer();
     ShutdownNetwork();
+    if (gSystemLayer.IsInitialized())
+    {
+        ShutdownSystemLayer();
+    }
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
     err = gInet.NewRawEndPoint(kIPVersion_6, kIPProtocol_ICMPv6, &testRawEP);
@@ -589,6 +592,8 @@ static int TestSetup(void * inContext)
  */
 static int TestTeardown(void * inContext)
 {
+    ShutdownNetwork();
+    ShutdownSystemLayer();
     chip::Platform::MemoryShutdown();
     return SUCCESS;
 }

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -80,6 +80,7 @@ static_library("support") {
     "FixedBufferAllocator.h",
     "LifetimePersistedCounter.cpp",
     "LifetimePersistedCounter.h",
+    "ObjectLifeCycle.h",
     "PersistedCounter.cpp",
     "PersistedCounter.h",
     "PersistentStorageMacros.h",

--- a/src/lib/support/ObjectLifeCycle.h
+++ b/src/lib/support/ObjectLifeCycle.h
@@ -1,0 +1,135 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace chip {
+
+/**
+ * Track the life cycle of an object.
+ *
+ * <pre>
+ *                  ┌───────────────┐  Init  ┌─────────────┐  Shutdown  ┌──────────┐  Destroy  ┌───────────┐
+ * Construction ───>│ Uninitialized ├───────>│ Initialized ├───────────>│ Shutdown ├──────────>│ Destroyed │
+ *                  └──────────┬────┘        └─────────────┘            └─────┬────┘           └───────────┘
+ *                      ^      │                               Reset          │
+ *                      └──────┴<─────────────────────────────────────────────┘
+ * </pre>
+ */
+struct ObjectLifeCycle
+{
+    /**
+     * @returns true if and only if the object is in the Initialized state.
+     */
+    bool IsInitialized() const { return mState == State::Initialized; }
+
+    /**
+     * Transition from Uninitialized to Initialized.
+     *
+     * Typical use is `VerifyOrReturnError(state.Init(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
+     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
+     *
+     * @return true     if the state was Uninitialized and is now Initialized.
+     * @return false    otherwise.
+     */
+    bool Init()
+    {
+        if (mState == State::Uninitialized)
+        {
+            mState = State::Initialized;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Transition from Initialized to Shutdown.
+     *
+     * Typical use is `VerifyOrReturnError(state.Shutdown(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
+     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
+     *
+     * @return true     if the state was Initialized and is now Shutdown.
+     * @return false    otherwise.
+     */
+    bool Shutdown()
+    {
+        if (mState == State::Initialized)
+        {
+            mState = State::Shutdown;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Transition from Shutdown back to Uninitialized, or remain Uninitialized.
+     *
+     * Typical use is `VerifyOrReturnError(state.Reset(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
+     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
+     *
+     * @return true     if the state was Uninitialized or Shutdown and is now Uninitialized.
+     * @return false    otherwise.
+     */
+    bool Reset()
+    {
+        if (mState == State::Shutdown)
+        {
+            mState = State::Uninitialized;
+        }
+        return mState == State::Uninitialized;
+    }
+
+    /**
+     * Transition from Uninitialized or Shutdown to Destroyed.
+     *
+     * Typical use is `VerifyOrReturnError(state.Destroy(), CHIP_ERROR_INCORRECT_STATE)`; this function returns `bool` rather than
+     * a `CHIP_ERROR` so that error source tracking will record the call point rather than this function itself.
+     *
+     * @return true     if the state was Uninitialized or Shutdown and is now Destroyed.
+     * @return false    otherwise.
+     */
+    bool Destroy()
+    {
+        if (mState == State::Uninitialized || mState == State::Shutdown)
+        {
+            mState = State::Destroyed;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return the current state as an integer. This is intended for troubleshooting or logging, since there is no code access to
+     * the meaning of the integer value.
+     */
+    explicit operator int() const { return static_cast<int>(mState); }
+
+private:
+    enum class State : uint8_t
+    {
+        Uninitialized = 0, /**< Pre-initialized state; */
+        Initialized   = 1, /**< Initialized state. */
+        Shutdown      = 2, /**< Post-Shutdown state. */
+        Destroyed     = 3, /**< Post-destructor state. */
+    };
+    State mState = State::Uninitialized;
+};
+
+} // namespace chip

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -58,8 +58,8 @@ exit:
 
 void ShutdownChip(void)
 {
-    chip::DeviceLayer::PlatformMgr().Shutdown();
     gMessageCounterManager.Shutdown();
     gExchangeManager.Shutdown();
     gSessionManager.Shutdown();
+    chip::DeviceLayer::PlatformMgr().Shutdown();
 }

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -486,6 +486,7 @@ int TestConfigurationMgr_Setup(void * inContext)
  */
 int TestConfigurationMgr_Teardown(void * inContext)
 {
+    PlatformMgr().Shutdown();
     chip::Platform::MemoryShutdown();
     return SUCCESS;
 }

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -30,40 +30,43 @@
 namespace chip {
 namespace System {
 
-Layer::Layer() : mLayerState(LayerState::kUninitialized) {}
+Layer::~Layer()
+{
+    VerifyOrReturn(mLayerState.Destroy());
+}
 
 CHIP_ERROR Layer::Init()
 {
-    VerifyOrReturnError(State() == LayerState::kUninitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Init(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mWatchableEventsManager.Init(*this));
-    this->mLayerState = LayerState::kInitialized;
+    mLayerState.Init();
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Layer::Shutdown()
 {
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.Shutdown(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mWatchableEventsManager.Shutdown());
-    this->mLayerState = LayerState::kUninitialized;
+    mLayerState.Reset(); // Return to uninitialized state to permit re-initialization.
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Layer::StartTimer(uint32_t aDelayMilliseconds, TimerCompleteCallback aComplete, void * aAppState)
 {
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.StartTimer(aDelayMilliseconds, aComplete, aAppState);
 }
 
 void Layer::CancelTimer(TimerCompleteCallback aOnComplete, void * aAppState)
 {
-    VerifyOrReturn(this->State() == LayerState::kInitialized);
+    VerifyOrReturn(mLayerState.IsInitialized());
     return mWatchableEventsManager.CancelTimer(aOnComplete, aAppState);
 }
 
 CHIP_ERROR Layer::ScheduleWork(TimerCompleteCallback aComplete, void * aAppState)
 {
     assertChipStackLockedByCurrentThread();
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.ScheduleWork(aComplete, aAppState);
 }
 
@@ -91,19 +94,16 @@ CHIP_ERROR Layer::RequestCallbackOnPendingWrite(SocketWatchToken token)
 
 CHIP_ERROR Layer::ClearCallbackOnPendingRead(SocketWatchToken token)
 {
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.ClearCallbackOnPendingRead(token);
 }
 
 CHIP_ERROR Layer::ClearCallbackOnPendingWrite(SocketWatchToken token)
 {
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.ClearCallbackOnPendingWrite(token);
 }
 
 CHIP_ERROR Layer::StopWatchingSocket(SocketWatchToken * tokenInOut)
 {
-    VerifyOrReturnError(State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.StopWatchingSocket(tokenInOut);
 }
 
@@ -116,11 +116,13 @@ SocketWatchToken Layer::InvalidSocketWatchToken()
 
 void Layer::SetDispatchQueue(dispatch_queue_t dispatchQueue)
 {
+    VerifyOrReturn(mLayerState.IsInitialized());
     mWatchableEventsManager.SetDispatchQueue(dispatchQueue);
 }
 
 dispatch_queue_t Layer::GetDispatchQueue()
 {
+    VerifyOrReturnError(mLayerState.IsInitialized(), nullptr);
     return mWatchableEventsManager.GetDispatchQueue();
 }
 
@@ -132,13 +134,13 @@ dispatch_queue_t Layer::GetDispatchQueue()
 
 CHIP_ERROR Layer::AddEventHandlerDelegate(LwIPEventHandlerDelegate & aDelegate)
 {
-    VerifyOrReturnError(mLayerState == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.AddEventHandlerDelegate(aDelegate);
 }
 
 CHIP_ERROR Layer::PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
 {
-    VerifyOrReturnError(mLayerState == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mLayerState.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return mWatchableEventsManager.PostEvent(aTarget, aEventType, aArgument);
 }
 

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -30,7 +30,9 @@
 
 #include <core/CHIPCallback.h>
 
+#include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
+#include <support/ObjectLifeCycle.h>
 #include <system/SystemClock.h>
 #include <system/SystemError.h>
 #include <system/SystemEvent.h>
@@ -52,23 +54,13 @@ namespace System {
 using TimerCompleteCallback = void (*)(Layer * aLayer, void * appState);
 
 /**
- *  @enum LayerState
- *
- *  The state of a Layer object.
- */
-enum class LayerState
-{
-    kUninitialized = 0, /**< Not initialized state. */
-    kInitialized   = 1  /**< Initialized state. */
-};
-
-/**
  * This provides access to timers according to the configured event handling model.
  */
 class DLL_EXPORT Layer
 {
 public:
-    Layer();
+    Layer() = default;
+    ~Layer();
 
     CHIP_ERROR Init();
 
@@ -76,7 +68,7 @@ public:
     // to ensure that they are not used after calling Shutdown().
     CHIP_ERROR Shutdown();
 
-    LayerState State() const { return mLayerState; }
+    bool IsInitialized() const { return mLayerState.IsInitialized(); }
 
     /**
      * @brief
@@ -230,7 +222,7 @@ public:
     Clock & GetClock() { return mClock; }
 
 private:
-    LayerState mLayerState;
+    ObjectLifeCycle mLayerState;
     WatchableEventManager mWatchableEventsManager;
     Clock mClock;
 

--- a/src/system/WatchableEventManagerLwIP.cpp
+++ b/src/system/WatchableEventManagerLwIP.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR WatchableEventManager::AddEventHandlerDelegate(LwIPEventHandlerDelega
 
 CHIP_ERROR WatchableEventManager::PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
     // Sanity check that this instance and the target layer haven't been "crossed".
     VerifyOrDieWithMsg(aTarget.IsRetained(*mSystemLayer), chipSystemLayer, "wrong poster! [target %p != this %p]",
@@ -165,7 +165,7 @@ CHIP_ERROR WatchableEventManager::PostEvent(Object & aTarget, EventType aEventTy
  */
 CHIP_ERROR WatchableEventManager::DispatchEvents()
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return PlatformEventing::DispatchEvents(*mSystemLayer);
 }
 
@@ -181,7 +181,7 @@ CHIP_ERROR WatchableEventManager::DispatchEvents()
  */
 CHIP_ERROR WatchableEventManager::DispatchEvent(Event aEvent)
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return PlatformEventing::DispatchEvent(*mSystemLayer, aEvent);
 }
 
@@ -198,7 +198,7 @@ CHIP_ERROR WatchableEventManager::DispatchEvent(Event aEvent)
  */
 CHIP_ERROR WatchableEventManager::HandleEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
     // Sanity check that this instance and the target layer haven't been "crossed".
     VerifyOrDieWithMsg(aTarget.IsRetained(*mSystemLayer), chipSystemLayer, "wrong handler! [target %p != this %p]",
@@ -244,7 +244,7 @@ CHIP_ERROR WatchableEventManager::HandleEvent(Object & aTarget, EventType aEvent
  */
 CHIP_ERROR WatchableEventManager::StartPlatformTimer(uint32_t aDelayMilliseconds)
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
     return PlatformEventing::StartTimer(*mSystemLayer, aDelayMilliseconds);
 }
 
@@ -265,7 +265,7 @@ CHIP_ERROR WatchableEventManager::StartPlatformTimer(uint32_t aDelayMilliseconds
  */
 CHIP_ERROR WatchableEventManager::HandlePlatformTimer()
 {
-    VerifyOrReturnError(mSystemLayer->State() == LayerState::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
     // Expire each timer in turn until an unexpired timer is reached or the timerlist is emptied.  We set the current expiration
     // time outside the loop; that way timers set after the current tick will not be executed within this expiration window

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -58,7 +58,7 @@ static void ServiceEvents(Layer & aLayer)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-    if (aLayer.State() == LayerState::kInitialized)
+    if (aLayer.IsInitialized())
     {
         aLayer.WatchableEventsManager().HandlePlatformTimer();
     }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -66,10 +66,7 @@ uint32_t EncryptedPacketBufferHandle::GetMsgId() const
 
 SecureSessionMgr::SecureSessionMgr() : mState(State::kNotReady) {}
 
-SecureSessionMgr::~SecureSessionMgr()
-{
-    CancelExpiryTimer();
-}
+SecureSessionMgr::~SecureSessionMgr() {}
 
 CHIP_ERROR SecureSessionMgr::Init(System::Layer * systemLayer, TransportMgrBase * transportMgr, Transport::FabricTable * fabrics,
                                   Transport::MessageCounterManagerInterface * messageCounterManager)


### PR DESCRIPTION
#### Problem

There have been multiple instances of code using a `System::Layer`
object after it has been shut down or destroyed, some previously
fixed in #8865. (In the ancestral code, `System::Layer` was fully
static.)

#### Change overview

- More thoroughly track and check `System::Layer` object state.
- Spin out state tracking into `lib/support/ObjectLifeCycle.h`
- Fix several sequencing issues.

#### Testing

CI; no change to visible functionality intended.
