### PR TITLE
Don't output an unused PrepareListFromTLV function.

### DIFF
--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -330,6 +330,7 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
     return true;
 }
 
+{{#if (chip_has_client_cluster_with_server_list_attribute)}}
 static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t *& message, uint16_t & messageLen)
 {
     CHIP_ERROR tlvError = CHIP_NO_ERROR;
@@ -354,6 +355,7 @@ static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t 
     reader.ExitContainer(type);
     return EMBER_ZCL_STATUS_SUCCESS;
 }
+{{/if}}
 
 {{#chip_client_clusters}}
 {{#if (chip_server_has_list_attributes)}}

--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -316,21 +316,35 @@ function chip_available_cluster_commands(options)
   return promise;
 }
 
+/**
+ * Check if there are any client clusters whose server sides have list attributes.
+ *
+ */
+function chip_has_client_cluster_with_server_list_attribute(options)
+{
+  let clientClusters = Clusters.getClientClusters();
+  let attributeLists
+      = clientClusters.then(clusters => Promise.all(clusters.map(cluster => Clusters.getServerAttributes(cluster.name))));
+  let haveServerAttribute = attributeLists.then(attrLists => attrLists.some(attrList => attrList.some(attr => attr.isList)));
+  return asPromise.call(this, haveServerAttribute);
+}
+
 //
 // Module exports
 //
-exports.chip_clusters                   = chip_clusters;
-exports.chip_has_clusters               = chip_has_clusters;
-exports.chip_client_clusters            = chip_client_clusters;
-exports.chip_has_client_clusters        = chip_has_client_clusters;
-exports.chip_server_clusters            = chip_server_clusters;
-exports.chip_has_server_clusters        = chip_has_server_clusters;
-exports.chip_cluster_commands           = chip_cluster_commands;
-exports.chip_cluster_command_arguments  = chip_cluster_command_arguments;
-exports.chip_server_global_responses    = chip_server_global_responses;
-exports.chip_cluster_responses          = chip_cluster_responses;
-exports.chip_cluster_response_arguments = chip_cluster_response_arguments
-exports.chip_attribute_list_entryTypes  = chip_attribute_list_entryTypes;
-exports.chip_server_cluster_attributes  = chip_server_cluster_attributes;
-exports.chip_server_has_list_attributes = chip_server_has_list_attributes;
-exports.chip_available_cluster_commands = chip_available_cluster_commands;
+exports.chip_clusters                                      = chip_clusters;
+exports.chip_has_clusters                                  = chip_has_clusters;
+exports.chip_client_clusters                               = chip_client_clusters;
+exports.chip_has_client_clusters                           = chip_has_client_clusters;
+exports.chip_server_clusters                               = chip_server_clusters;
+exports.chip_has_server_clusters                           = chip_has_server_clusters;
+exports.chip_cluster_commands                              = chip_cluster_commands;
+exports.chip_cluster_command_arguments                     = chip_cluster_command_arguments;
+exports.chip_server_global_responses                       = chip_server_global_responses;
+exports.chip_cluster_responses                             = chip_cluster_responses;
+exports.chip_cluster_response_arguments                    = chip_cluster_response_arguments
+exports.chip_attribute_list_entryTypes                     = chip_attribute_list_entryTypes;
+exports.chip_server_cluster_attributes                     = chip_server_cluster_attributes;
+exports.chip_server_has_list_attributes                    = chip_server_has_list_attributes;
+exports.chip_available_cluster_commands                    = chip_available_cluster_commands;
+exports.chip_has_client_cluster_with_server_list_attribute = chip_has_client_cluster_with_server_list_attribute

--- a/zzz_generated/lighting-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/lighting-app/zap-generated/CHIPClientCallbacks.cpp
@@ -348,31 +348,6 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
     return true;
 }
 
-static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t *& message, uint16_t & messageLen)
-{
-    CHIP_ERROR tlvError = CHIP_NO_ERROR;
-    TLV::TLVReader reader;
-    TLV::TLVType type;
-    reader.Init(*tlvData);
-    reader.EnterContainer(type);
-    tlvError = reader.Next();
-    if (tlvError != CHIP_NO_ERROR && tlvError != CHIP_END_OF_TLV && CanCastTo<uint16_t>(reader.GetLength()))
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    if (tlvError == CHIP_NO_ERROR)
-    {
-        tlvError   = reader.GetDataPtr(message);
-        messageLen = static_cast<uint16_t>(reader.GetLength());
-    }
-    if (tlvError != CHIP_NO_ERROR)
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    reader.ExitContainer(type);
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");

--- a/zzz_generated/pump-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/pump-app/zap-generated/CHIPClientCallbacks.cpp
@@ -348,31 +348,6 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
     return true;
 }
 
-static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t *& message, uint16_t & messageLen)
-{
-    CHIP_ERROR tlvError = CHIP_NO_ERROR;
-    TLV::TLVReader reader;
-    TLV::TLVType type;
-    reader.Init(*tlvData);
-    reader.EnterContainer(type);
-    tlvError = reader.Next();
-    if (tlvError != CHIP_NO_ERROR && tlvError != CHIP_END_OF_TLV && CanCastTo<uint16_t>(reader.GetLength()))
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    if (tlvError == CHIP_NO_ERROR)
-    {
-        tlvError   = reader.GetDataPtr(message);
-        messageLen = static_cast<uint16_t>(reader.GetLength());
-    }
-    if (tlvError != CHIP_NO_ERROR)
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    reader.ExitContainer(type);
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClientCallbacks.cpp
@@ -348,31 +348,6 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
     return true;
 }
 
-static EmberAfStatus PrepareListFromTLV(TLV::TLVReader * tlvData, const uint8_t *& message, uint16_t & messageLen)
-{
-    CHIP_ERROR tlvError = CHIP_NO_ERROR;
-    TLV::TLVReader reader;
-    TLV::TLVType type;
-    reader.Init(*tlvData);
-    reader.EnterContainer(type);
-    tlvError = reader.Next();
-    if (tlvError != CHIP_NO_ERROR && tlvError != CHIP_END_OF_TLV && CanCastTo<uint16_t>(reader.GetLength()))
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    if (tlvError == CHIP_NO_ERROR)
-    {
-        tlvError   = reader.GetDataPtr(message);
-        messageLen = static_cast<uint16_t>(reader.GetLength());
-    }
-    if (tlvError != CHIP_NO_ERROR)
-    {
-        return EMBER_ZCL_STATUS_INVALID_VALUE;
-    }
-    reader.ExitContainer(type);
-    return EMBER_ZCL_STATUS_SUCCESS;
-}
-
 bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * message, uint16_t messageLen)
 {
     ChipLogProgress(Zcl, "emberAfReportAttributeCallback:");


### PR DESCRIPTION
Only output it if it's needed.

#### Problem
We are outputting a function that is not used in some cases, and that fails to compile.

#### Change overview
Output the function conditionally.

#### Testing
@holbrookt says this fixes the compilation issues he was seeing.