### PR TITLE
ESP32: Increase main stack size

### DIFF
--- a/examples/all-clusters-app/esp32/sdkconfig.defaults
+++ b/examples/all-clusters-app/esp32/sdkconfig.defaults
@@ -43,8 +43,8 @@ CONFIG_DEVICE_VENDOR_ID=0x235A
 CONFIG_DEVICE_PRODUCT_ID=0x4541
 
 # Main task needs a bit more stack than the default
-# default is 3584, bump this up to 4k.
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096
+# default is 3584, bump this up to 5k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
 
 #enable debug shell
 CONFIG_ENABLE_CHIP_SHELL=y

--- a/examples/bridge-app/esp32/sdkconfig.defaults
+++ b/examples/bridge-app/esp32/sdkconfig.defaults
@@ -36,3 +36,7 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 4k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096

--- a/examples/lock-app/esp32/sdkconfig.defaults
+++ b/examples/lock-app/esp32/sdkconfig.defaults
@@ -36,3 +36,7 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 4k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096

--- a/examples/temperature-measurement-app/esp32/sdkconfig.defaults
+++ b/examples/temperature-measurement-app/esp32/sdkconfig.defaults
@@ -72,3 +72,7 @@ CONFIG_TCP_SYNMAXRTX=6
 # Product id
 CONFIG_DEVICE_VENDOR_ID=0x235A
 CONFIG_DEVICE_PRODUCT_ID=0x4554
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 4k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096


### PR DESCRIPTION
#### Problem
* Compiling examples with esp32 goes into stack overflow issue.
* This PR #8888 is responsible for this issue.
* Logs
```
I (2055) chip[DIS]: Advertise commission parameter vendorID=9050 productID=65279 discriminator=3840/00
I (2065) chip[DIS]: 
***ERROR*** A stack overflow in task main has been detected.

Backtrace:0x4008f6c2:0x3ffbb3d0 0x4008fdf1:0x3ffbb3f0 0x4009311e:0x3ffbb410 0x400919bc:0x3ffbb490 0x4008fee8:0x3ffbb4b0 0x4008fe9a:0x00000000 |<-CORRUPTED
0x4008f6c2: panic_abort at /home/sweety/Espressif/esp-idf/components/esp_system/panic.c:367

0x4008fdf1: esp_system_abort at /home/sweety/Espressif/esp-idf/components/esp_system/system_api.c:112

0x4009311e: vApplicationStackOverflowHook at /home/sweety/Espressif/esp-idf/components/freertos/port/xtensa/port.c:489

0x400919bc: vTaskSwitchContext at /home/sweety/Espressif/esp-idf/components/freertos/tasks.c:3289

0x4008fee8: _frxt_dispatch at /home/sweety/Espressif/esp-idf/components/freertos/port/xtensa/portasm.S:432

0x4008fe9a: _frxt_int_exit at /home/sweety/Espressif/esp-idf/components/freertos/port/xtensa/portasm.S:231

```

#### Change overview
* Increase stack size.

#### Testing
* Successfully compiled all examples
