### PR TITLE
Update Pigweed to 8552c61aaccdd

### DIFF
--- a/examples/common/pigweed/rpc_console/py/BUILD.gn
+++ b/examples/common/pigweed/rpc_console/py/BUILD.gn
@@ -21,9 +21,13 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
 pw_python_package("chip_rpc") {
   generate_setup = {
-    name = "chip_rpc"
-    version = "0.0.1"
-    install_requires = [ "ipython" ]
+    metadata = {
+      name = "chip_rpc"
+      version = "0.0.1"
+    }
+    options = {
+      install_requires = [ "ipython" ]
+    }
   }
   sources = [ "chip_rpc/console.py" ]
   python_deps = [

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -49,8 +49,6 @@ executable("chip-lighting-app") {
 
   include_dirs = [ "include" ]
 
-  cflags = [ "-Wconversion" ]
-
   if (chip_enable_pw_rpc) {
     defines = [ "PW_RPC_ENABLED" ]
 
@@ -76,6 +74,10 @@ executable("chip-lighting-app") {
     ]
 
     deps += pw_build_LINK_DEPS
+  } else {
+    # The system_rpc_server.cc file is in pigweed and doesn't compile with
+    # -Wconversion, remove check for RPC build only.
+    cflags = [ "-Wconversion" ]
   }
 
   output_dir = root_out_dir

--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -135,7 +135,7 @@ portpicker==1.4.0
     #   mobly
 prettytable==0.7.2
     # via -r requirements.mbed.txt
-prompt-toolkit==3.0.18
+prompt-toolkit==3.0.20
     # via ipython
 protobuf==3.17.3
     # via -r requirements.txt

--- a/src/test_driver/efr32/py/BUILD.gn
+++ b/src/test_driver/efr32/py/BUILD.gn
@@ -20,8 +20,10 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
 pw_python_package("nl_test_runner") {
   generate_setup = {
-    name = "nl_test_runner"
-    version = "0.0.1"
+    metadata = {
+      name = "nl_test_runner"
+      version = "0.0.1"
+    }
   }
   sources = [ "nl_test_runner/nl_test_runner.py" ]
   python_deps = [

--- a/src/test_driver/efr32/py/nl_test_runner/nl_test_runner.py
+++ b/src/test_driver/efr32/py/nl_test_runner/nl_test_runner.py
@@ -18,6 +18,7 @@
 import argparse
 import logging
 from pw_hdlc.rpc import HdlcRpcClient, default_channels, write_to_file
+from pw_status import Status
 import serial  # type: ignore
 import subprocess
 import sys
@@ -88,8 +89,11 @@ def get_hdlc_rpc_client(device: str, baudrate: int, output: Any, **kwargs):
 
 def runner(client) -> int:
     """ Run the tests"""
-    result = client.client.channel(
+    status, result = client.client.channel(
         1).rpcs.chip.rpc.NlTest.Run(pw_rpc_timeout_s=120)
+
+    if not status.ok():
+        raise Exception("Error running test RPC: {}".format(status))
 
     total_failed = 0
     total_run = 0


### PR DESCRIPTION
#### Problem
Periodically update Pigweed

#### Change overview
Pigweed updated, main changes:
- Get amd64 protoc on arm64 Macs
- Change to how pw_python_package generate_setup args are passed
- Change to behavior and return types of streaming RPCs

#### Testing
- clean boostrap.sh
- Build lighting app with RPCs for EFR
- Build rpc_console and used it with the above running app
- Built and ran the efr32 unit tests.

