### PR TITLE
[Android] Close BLE connection after network commissioning

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -81,6 +81,7 @@ class CHIPToolActivity :
   }
 
   override fun onCommissioningComplete(code: Int) {
+    ChipClient.getDeviceController(this).close()
     if (code == 0) {
       showFragment(OnOffClientFragment.newInstance(), false)
     } else {


### PR DESCRIPTION
#### Problem
For each commissioning flow in the Android CHIPTool, the BLE connection is kept alive indefinitely, even after network commissioning / CASE establishment.

#### Change overview
Close the BLE connection after `EnableNetwork` (`DeviceProvisioningFragment.Callback#onCommissioningComplete`).

#### Testing
Commissioned and controlled all-clusters-app on m5stack
