### PR TITLE
Get peer's node ID from session instead of packet header for response handling

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -476,11 +476,9 @@ CHIP_ERROR DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, 
     uint16_t index;
 
     VerifyOrExit(mState == State::Initialized, ChipLogError(Controller, "OnMessageReceived was called in incorrect state"));
+    VerifyOrExit(ec != nullptr, ChipLogError(Controller, "OnMessageReceived was called with null exchange"));
 
-    VerifyOrExit(packetHeader.GetSourceNodeId().HasValue(),
-                 ChipLogError(Controller, "OnMessageReceived was called for unknown source node"));
-
-    index = FindDeviceIndex(packetHeader.GetSourceNodeId().Value());
+    index = FindDeviceIndex(ec->GetSecureSession().GetPeerNodeId());
     VerifyOrExit(index < kNumMaxActiveDevices, ChipLogError(Controller, "OnMessageReceived was called for unknown device object"));
 
     mActiveDevices[index].OnMessageReceived(ec, packetHeader, payloadHeader, std::move(msgBuf));

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -155,7 +155,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
 - (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff configured"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff configured"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -191,7 +191,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
 - (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff cancelled"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff cancelled"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -134,6 +134,79 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterTestCluster_Reporting_0000_BindOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Binding to OnOff Cluster complete"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPBinding * bindingCluster = [[CHIPBinding alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(bindingCluster);
+    [bindingCluster bind:kDeviceId groupId:0
+              endpointId:1
+               clusterId:6
+         responseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Reporting Test Binding status : %@", err);
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff configured"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster configureAttributeOnOffWithMinInterval:0
+                                             maxInterval:1
+                                         responseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Reporting Test Configure status: %@", err);
+
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0002_ReportOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"First report received"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster reportAttributeOnOffWithResponseHandler:^(NSError * err, NSDictionary * values)
+    {
+        NSLog(@"Reporting Test Report first report: %@", err);
+        [expectation fulfill];
+        XCTAssertEqual(err.code, 0);
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff cancelled"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster configureAttributeOnOffWithMinInterval:0
+                                             maxInterval:0xffff
+                                         responseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Reporting Test Cancel Reports status: %@", err);
+
+        XCTAssertEqual(err.code, 0);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 {{>test_cluster tests="TestCluster, Test_TC_OO_1_1, Test_TC_OO_2_1, Test_TC_OO_2_2, Test_TC_DM_1_1, Test_TC_DM_3_1, Test_TC_CC_3_4, Test_TC_CC_5, Test_TC_CC_6, Test_TC_CC_7, Test_TC_CC_8, Test_TC_WNCV_1_1, Test_TC_WNCV_2_1, Test_TC_BI_1_1, Test_TC_FLW_1_1, Test_TC_TM_1_1, Test_TC_OCC_1_1"}}
 
 {{#chip_client_clusters}}

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -174,7 +174,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
 - (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff configured"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff configured"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -209,7 +209,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 
 - (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff cancelled"];
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff cancelled"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -152,6 +152,79 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterTestCluster_Reporting_0000_BindOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Binding to OnOff Cluster complete"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPBinding * bindingCluster = [[CHIPBinding alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(bindingCluster);
+    [bindingCluster bind:kDeviceId
+                 groupId:0
+              endpointId:1
+               clusterId:6
+         responseHandler:^(NSError * err, NSDictionary * values) {
+             NSLog(@"Reporting Test Binding status : %@", err);
+             XCTAssertEqual(err.code, 0);
+             [expectation fulfill];
+         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff configured"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster configureAttributeOnOffWithMinInterval:0
+                                             maxInterval:1
+                                         responseHandler:^(NSError * err, NSDictionary * values) {
+                                             NSLog(@"Reporting Test Configure status: %@", err);
+
+                                             XCTAssertEqual(err.code, 0);
+                                             [expectation fulfill];
+                                         }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0002_ReportOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"First report received"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster reportAttributeOnOffWithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Reporting Test Report first report: %@", err);
+        [expectation fulfill];
+        XCTAssertEqual(err.code, 0);
+    }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
+{
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Reportin OnOff cancelled"];
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPOnOff * onOffCluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(onOffCluster);
+    [onOffCluster configureAttributeOnOffWithMinInterval:0
+                                             maxInterval:0xffff
+                                         responseHandler:^(NSError * err, NSDictionary * values) {
+                                             NSLog(@"Reporting Test Cancel Reports status: %@", err);
+
+                                             XCTAssertEqual(err.code, 0);
+                                             [expectation fulfill];
+                                         }];
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 - (void)testSendClusterTestCluster_000000_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command"];


### PR DESCRIPTION
#### Problem
The reports from peer node are getting dropped when received on the controller.
```
CHIP: [CTL] OnMessageReceived was called for unknown source node
```

#### Change overview
The unicast encrypted messages do not carry node IDs in packet headers. The controller code was using the source node ID to identify which device sent the message. This PR updates it to use session information to identify the device object.

#### Testing
A new test (`testSendClusterTestCluster_Reporting_0002_ReportOnOff_Test`) has been added to ensure that reports are received and processed on the controller.
