### PR TITLE
Fix Bluetooth advertising based on build arguments

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -108,13 +108,11 @@ int ChipLinuxAppInit(int argc, char ** argv)
 
     chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(EventHandler, 0);
 
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
-
 #if CONFIG_NETWORK_LAYER_BLE
+    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
-#endif
-
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     if (LinuxDeviceOptions::GetInstance().mWiFi)

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -50,7 +50,10 @@ enum
 
 constexpr unsigned kAppUsageLength = 64;
 
-OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
+OptionDef sDeviceOptionDefs[] = {
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+                                  { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
                                   { "wifi", kNoArgument, kDeviceOption_WiFi },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -70,8 +73,10 @@ OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOpti
                                   {} };
 
 const char * sDeviceOptionHelp =
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     "  --ble-device <number>\n"
     "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     "\n"
     "  --wifi\n"

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -52,25 +52,26 @@ constexpr unsigned kAppUsageLength = 64;
 
 OptionDef sDeviceOptionDefs[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-                                  { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
+    { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-                                  { "wifi", kNoArgument, kDeviceOption_WiFi },
+    { "wifi", kNoArgument, kDeviceOption_WiFi },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_ENABLE_OPENTHREAD
-                                  { "thread", kNoArgument, kDeviceOption_Thread },
+    { "thread", kNoArgument, kDeviceOption_Thread },
 #endif // CHIP_ENABLE_OPENTHREAD
-                                  { "version", kArgumentRequired, kDeviceOption_Version },
-                                  { "vendor-id", kArgumentRequired, kDeviceOption_VendorID },
-                                  { "product-id", kArgumentRequired, kDeviceOption_ProductID },
-                                  { "custom-flow", kArgumentRequired, kDeviceOption_CustomFlow },
-                                  { "capabilities", kArgumentRequired, kDeviceOption_Capabilities },
-                                  { "discriminator", kArgumentRequired, kDeviceOption_Discriminator },
-                                  { "passcode", kArgumentRequired, kDeviceOption_Passcode },
-                                  { "secured-device-port", kArgumentRequired, kDeviceOption_SecuredDevicePort },
-                                  { "secured-commissioner-port", kArgumentRequired, kDeviceOption_SecuredCommissionerPort },
-                                  { "unsecured-commissioner-port", kArgumentRequired, kDeviceOption_UnsecuredCommissionerPort },
-                                  {} };
+    { "version", kArgumentRequired, kDeviceOption_Version },
+    { "vendor-id", kArgumentRequired, kDeviceOption_VendorID },
+    { "product-id", kArgumentRequired, kDeviceOption_ProductID },
+    { "custom-flow", kArgumentRequired, kDeviceOption_CustomFlow },
+    { "capabilities", kArgumentRequired, kDeviceOption_Capabilities },
+    { "discriminator", kArgumentRequired, kDeviceOption_Discriminator },
+    { "passcode", kArgumentRequired, kDeviceOption_Passcode },
+    { "secured-device-port", kArgumentRequired, kDeviceOption_SecuredDevicePort },
+    { "secured-commissioner-port", kArgumentRequired, kDeviceOption_SecuredCommissionerPort },
+    { "unsecured-commissioner-port", kArgumentRequired, kDeviceOption_UnsecuredCommissionerPort },
+    {}
+};
 
 const char * sDeviceOptionHelp =
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE


### PR DESCRIPTION
#### Problem
Blueototh Low Energy advertising is not being managed properly, gn build arguments 'chip_config_network_layer_ble' is not being handled.

#### Change overview
Enable/Disable Bluetooth advertising based on build arguments

#### Testing
* disabled scenarios
$ gn gen out/host --args='chip_config_network_layer_ble=false'
btmon (bluetooth monitor) should not list advertising commands 

*enabled scenarios
$ gn gen out/host --args='chip_config_network_layer_ble=true'
btmon (bluetooth monitor) should list advertising commands setting advertising data and enabling advertising

$ gn gen out/host
btmon (bluetooth monitor) should list advertising commands setting advertising data and enabling advertising
