### PR TITLE
ESP32: CI fixes

### DIFF
--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -204,8 +204,12 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
+    Get fabric ID using `get-fabricid` and use the decimal value of compressed
+    fabric id.
 
-         - chip-device-ctrl > resolve 0 135246
+         - chip-device-ctrl > get-fabricid
+
+         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
 
 ### Cluster control
 

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -177,8 +177,12 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
+    Get fabric ID using `get-fabricid` and use the decimal value of compressed
+    fabric id.
 
-         - chip-device-ctrl > resolve 0 135246
+         - chip-device-ctrl > get-fabricid
+
+         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
 
 ### Cluster control
 

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -177,8 +177,12 @@ commissioning and cluster control.
          - chip-device-ctrl > close-ble
 
 -   Resolve DNS-SD name and update address of the node in the device controller.
+    Get fabric ID using `get-fabricid` and use the decimal value of compressed
+    fabric id.
 
-         - chip-device-ctrl > resolve 0 135246
+         - chip-device-ctrl > get-fabricid
+
+         - chip-device-ctrl > resolve <Compressed Fabric ID> 135246
 
 ### Cluster control
 

--- a/scripts/examples/esp_example.sh
+++ b/scripts/examples/esp_example.sh
@@ -21,7 +21,7 @@ env
 
 app="$1"
 sdkconfig_name="$2"
-root=examples/$app/esp32/
+root=examples/$app/esp32
 
 shift 1
 
@@ -43,8 +43,7 @@ fi
 rm -f "$root"/sdkconfig
 (
     cd "$root"
-    idf.py set-target "$idf_target"
-    idf.py -D SDKCONFIG_DEFAULTS="$sdkconfig_name" build
+    idf.py -D SDKCONFIG_DEFAULTS="$sdkconfig_name" set-target "$idf_target" build
 ) || {
     echo "build $sdkconfig_name failed"
     exit 1


### PR DESCRIPTION
#### Problem
* CI was not catching the build for M5Stack.
* All examples were getting compiled with only devkitc, this is because during `idf.py set-target` it generates the sdkconfig file with `sdkconfig.defaults` which is not overwritten later.

#### Change overview
* The care is taken that sdkconfig is generated with the particular device type.

#### Testing
* Locally tested using `./scripts/build/build_examples.py --platform esp32 --board m5stack --app all-clusters build`
* Successful CI