### PR TITLE
[Linux]: Fix for Device Configuration info does not match with the generated pairing code

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -88,13 +88,13 @@ int ChipLinuxAppInit(int argc, char ** argv)
     err = chip::Platform::MemoryInit();
     SuccessOrExit(err);
 
+    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+    SuccessOrExit(err);
+
     err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
     SuccessOrExit(err);
 
     err = ParseArguments(argc, argv);
-    SuccessOrExit(err);
-
-    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
     ConfigurationMgr().LogDeviceConfig();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* This issue was reported from TE5, the dumped Device Configuration info does not match with the generated SetupQRCode and Manual pairing code on Linux platform.

```
[1626738927.239620][12299:12299] CHIP:DL: Device Configuration:
[1626738927.239679][12299:12299] CHIP:DL: Serial Number: TEST_SN
[1626738927.239704][12299:12299] CHIP:DL: Vendor Id: 9050 (0x235A)
[1626738927.239723][12299:12299] CHIP:DL: Product Id: 65279 (0xFEFF)
[1626738927.239744][12299:12299] CHIP:DL: Product Revision: 1
[1626738927.239764][12299:12299] CHIP:DL: Setup Pin Code: 20202021
[1626738927.239785][12299:12299] CHIP:DL: Setup Discriminator: 3840 (0xF00)
[1626738927.239805][12299:12299] CHIP:DL: Manufacturing Date: (not set)
[1626738927.239824][12299:12299] CHIP:DL: Device Type: 65535 (0xFFFF)
[1626738927.239877][12299:12299] CHIP:SVR: SetupQRCode: [MT:YNJV75HZ00KA0648G00]
[1626738927.239925][12299:12299] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
[1626738927.239944][12299:12299] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AYNJV75HZ00KA0648G00
[1626738927.239984][12299:12299] CHIP:SVR: Manual pairing code: [34970112332]
```
The root cause is the example app try to populate the SetupCode from ConfigurationMgr before it is initialized.  

* Fixes #8533 

#### Change overview
Init ConfigurationMgr before use on Linux platform. 

#### Testing
How was this tested? (at least one bullet point required)
* yufengw@yufengw-SEi:~/connectedhomeip/examples/lighting-app/linux/out/debug$ ./chip-lighting-app
[1630076942.334151][763167:763167] CHIP:DL: Device Configuration:
[1630076942.334159][763167:763167] CHIP:DL:   Serial Number: 89051
[1630076942.334162][763167:763167] CHIP:DL:   Vendor Id: 9050 (0x235A)
[1630076942.334166][763167:763167] CHIP:DL:   Product Id: 65279 (0xFEFF)
[1630076942.334174][763167:763167] CHIP:DL:   Product Revision: 1234
[1630076942.334202][763167:763167] CHIP:DL:   Setup Pin Code: 34567890
[1630076942.334215][763167:763167] CHIP:DL:   Setup Discriminator: 2976 (0xBA0)
[1630076942.334236][763167:763167] CHIP:DL:   Manufacturing Date: 2008/09/20
[1630076942.334258][763167:763167] CHIP:DL:   Device Type: 257 (0x101)
[1630076942.334281][763167:763167] CHIP:SVR: SetupQRCode: [MT:YNJV7VSC00CMVH7SR00]
[1630076942.334298][763167:763167] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
[1630076942.334302][763167:763167] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AYNJV7VSC00CMVH7SR00
[1630076942.334326][763167:763167] CHIP:SVR: Manual pairing code: [26318621095]

* chip-device-ctrl > setup-payload parse-qr MT:YNJV7VSC00CMVH7SR00
Version: 0
VendorID: 9050
ProductID: 65279
CommissioningFlow: 0
RendezvousInformation: 2 [BLE]
Discriminator: 2976
SetUpPINCode: 34567890
chip-device-ctrl > 
