### PR TITLE
Make build example able to skip timestamps in logs

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -57,4 +57,4 @@ jobs:
             - name: Build android examples
               run: |
                 ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --platform android build"
+                  "./scripts/build/build_examples.py --no-log-timestamps --platform android build"

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -54,5 +54,5 @@ jobs:
               timeout-minutes: 10
               run: |
                 scripts/run_in_build_env.sh \
-                  "scripts/build/build_examples.py --platform infineon --app lock build"
+                  "scripts/build/build_examples.py --no-log-timestamps --platform infineon --app lock build"
 

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -117,9 +117,9 @@ def ValidateRepoPath(context, parameter, value):
 def main(context, log_level, platform, board, app, repo, out_prefix, clean,
          dry_run, dry_run_output, enable_flashbundle, no_log_timestamps):
     # Ensures somewhat pretty logging of what is going on
-    log_fmt='%(asctime)s %(levelname)-7s %(message)s'
+    log_fmt = '%(asctime)s %(levelname)-7s %(message)s'
     if no_log_timestamps:
-      log_fmt='%(levelname)-7s %(message)s'
+        log_fmt = '%(levelname)-7s %(message)s'
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
     if not 'PW_PROJECT_ROOT' in os.environ:

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -117,9 +117,9 @@ def ValidateRepoPath(context, parameter, value):
 def main(context, log_level, platform, board, app, repo, out_prefix, clean,
          dry_run, dry_run_output, enable_flashbundle, no_log_timestamps):
     # Ensures somewhat pretty logging of what is going on
-    log_fmt='%(asctime)s %(levelname)-7s %(message)s')
+    log_fmt='%(asctime)s %(levelname)-7s %(message)s'
     if no_log_timestamps:
-      log_fmt='%(levelname)-7s %(message)s')
+      log_fmt='%(levelname)-7s %(message)s'
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
     if not 'PW_PROJECT_ROOT' in os.environ:

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -108,13 +108,19 @@ def ValidateRepoPath(context, parameter, value):
     default="-",
     type=click.File("wt"),
     help='Where to write the dry run output')
+@click.option(
+    '--no-log-timestamps',
+    default=False,
+    is_flag=True,
+    help='Skip timestaps in log output')
 @click.pass_context
 def main(context, log_level, platform, board, app, repo, out_prefix, clean,
-         dry_run, dry_run_output, enable_flashbundle):
+         dry_run, dry_run_output, enable_flashbundle, no_log_timestamps):
     # Ensures somewhat pretty logging of what is going on
-    coloredlogs.install(
-        level=__LOG_LEVELS__[log_level],
-        fmt='%(asctime)s %(name)s %(levelname)-7s %(message)s')
+    log_fmt='%(asctime)s %(levelname)-7s %(message)s')
+    if no_log_timestamps:
+      log_fmt='%(levelname)-7s %(message)s')
+    coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
     if not 'PW_PROJECT_ROOT' in os.environ:
         raise click.UsageError("""


### PR DESCRIPTION
#### Problem
Github CI already supports timestamps as an option. This means that adding timestamps to build logs pollutes the output - cannot remove them and with a default of 'show timestamps' the time is duplicated which wastes horizontal space

#### Change overview
Adds a flag of 'skip timestamps' in the build_examples.py script.
Do not include 'name' in the log of build_examples.py (does not seem useful to show 'ROOT' and we do not use extensive log separatation)
For workflows, disable timestamps.

#### Testing
Build change - CI checks the build (in particular infineon and android)