### PR TITLE
Update chip-tool documentation.

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -12,48 +12,68 @@ An example application that uses CHIP to send messages to a CHIP server.
 
 ## Building the Example Application
 
-Building the example application is quite straightforward.
-
-### gn
+Building the example application is quite straightforward. It can either be done
+as part of an overall "build everything" build:
 
 ```
-cd examples/chip-tool
-git submodule update --init
-source third_party/connectedhomeip/scripts/activate.sh
-gn gen out/debug
-ninja -C out/debug
+./gn_build.sh
 ```
 
--   After the application is built, it can be found in the build directory as
-    `out/debug/chip-tool`
+which puts the binary at `out/debug/standalone/chip-tool` or directly via:
 
-## Using the Client to Pair a device
+```
+scripts/examples/gn_build_example.sh examples/chip-tool SOME-PATH/
+```
 
-In order to send commands to a device, it must be paired with the client.
+which puts the binary at `SOME-PATH/chip-tool`.
 
-#### Pair a device
+## Using the Client to commission a device
 
-To initiate a client pairing request to a device, run the built executable and
-choose the pairing mode.
+In order to send commands to a device, it must be commissioned with the client.
+chip-tool currently only supports commissioning and remembering one device at a
+time. The configuration state is stored in `/tmp/chip_tool_config.ini`; deleting
+this and other `.ini` files in `/tmp` can sometimes resolve issues due to stale
+configuration.
 
-##### Pair a device configured to bypass Rendezvous
+#### Commission a device
 
-The command below pair a device with the provided IP address and port of the
-server to talk to.
+To initiate a client commissioning request to a device, run the built executable
+and choose the pairing mode.
+
+##### Commission a device configured to bypass Rendezvous
+
+The command below commissions a device with the provided IP address and port of
+the server to talk to.
 
     $ chip-tool pairing bypass 192.168.0.30 5540
 
-#### Pair a device over BLE
+#### Commission a device over BLE
 
 Run the built executable and pass it the discriminator and pairing code of the
-remote device.
+remote device, as well as the network credentials to use.
 
 The command below uses the default values hard-coded into the debug versions of
-the ESP32 all-clusters-app:
+the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
-    $ chip-tool pairing ble 20202021 3840
+    $ chip-tool pairing ble-wifi ssid password 0 20202021 3840
 
-### Unpair a device
+where:
+
+-   ssid is the Wi-Fi SSID either as a string, or in the form hex:XXXXXXXX where
+    the bytes of the SSID are encoded as two-digit hex numbers.
+-   paswword is the Wi-Fi password, again either as a string or as hex data
+-   The 0 is the fabric id, until more complete support for multiple fabrics is
+    implemented in our commissioning process.
+
+For example:
+
+    $ chip-tool pairing ble-wifi xyz secret 0 20202021 3840
+
+or equivalently:
+
+    $ chip-tool pairing ble-wifi hex:787980 hex:736563726574 0 20202021 3840
+
+### Forget the currently-commissioned device
 
     $ chip-tool pairing unpair
 
@@ -140,7 +160,7 @@ and the `parse-setup-payload` command
 
 #### Manual Setup Code
 
-    $ chip-tool payload parse-setup-payload :#####"
+    $ chip-tool payload parse-setup-payload "#####"
 
 # Using the Client for Additional Data Payload
 


### PR DESCRIPTION
The pairing bits were quite out of date

#### Problem
Docs out of date

#### Change overview
Use the right pairing command format, update the build instructions.

#### Testing
I wish we had automated testing that the docs match reality.