### PR TITLE
Variant: Remove requriment of VariantId

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -1297,50 +1297,42 @@ public:
 private:
     struct VariantViaBinding
     {
-        static constexpr const std::size_t VariantId = 1;
         explicit VariantViaBinding(uint8_t bindingIndex) : mBindingIndex(bindingIndex) {}
         uint8_t mBindingIndex;
     };
 
     struct VariantViaAddressTable
     {
-        static constexpr const std::size_t VariantId = 2;
     };
 
     struct VariantDirect
     {
-        static constexpr const std::size_t VariantId = 3;
         explicit VariantDirect(NodeId nodeId) : mNodeId(nodeId) {}
         NodeId mNodeId;
     };
 
     struct VariantMulticast
     {
-        static constexpr const std::size_t VariantId = 4;
         explicit VariantMulticast(GroupId groupId) : mGroupId(groupId) {}
         GroupId mGroupId;
     };
 
     struct VariantMulticastWithAlias
     {
-        static constexpr const std::size_t VariantId = 5;
         explicit VariantMulticastWithAlias(GroupId groupId) : mGroupId(groupId) {}
         GroupId mGroupId;
     };
 
     struct VariantBroadcast
     {
-        static constexpr const std::size_t VariantId = 6;
     };
 
     struct VariantBroadcastWithAlias
     {
-        static constexpr const std::size_t VariantId = 7;
     };
 
     struct VariantViaExchange
     {
-        static constexpr const std::size_t VariantId = 8;
         explicit VariantViaExchange(Messaging::ExchangeContext * exchangeContext) : mExchangeContext(exchangeContext) {}
         Messaging::ExchangeContext * mExchangeContext;
     };

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -136,7 +136,6 @@ private:
     // mPreparing is pretty big, consider move it outside
     struct PrepareVars
     {
-        static constexpr const size_t VariantId = 1;
         PrepareState mState;
         Inet::IPAddressType mAddressType;
         Inet::IPAddress mAddress;
@@ -146,7 +145,6 @@ private:
 
     struct ReadyVars
     {
-        static constexpr const size_t VariantId = 2;
         ReadyVars(SessionHandle session) : mSession(session) {}
         const SessionHandle mSession;
     };

--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -30,55 +30,55 @@ namespace chip {
 
 namespace VariantInternal {
 
-template <typename... Ts>
+template <std::size_t Index, typename... Ts>
 struct VariantCurry;
 
-template <typename T, typename... Ts>
-struct VariantCurry<T, Ts...>
+template <std::size_t Index, typename T, typename... Ts>
+struct VariantCurry<Index, T, Ts...>
 {
     inline static void Destroy(std::size_t id, void * data)
     {
-        if (id == T::VariantId)
+        if (id == Index)
             reinterpret_cast<T *>(data)->~T();
         else
-            VariantCurry<Ts...>::Destroy(id, data);
+            VariantCurry<Index + 1, Ts...>::Destroy(id, data);
     }
 
     inline static void Move(std::size_t that_t, void * that_v, void * this_v)
     {
-        if (that_t == T::VariantId)
+        if (that_t == Index)
             new (this_v) T(std::move(*reinterpret_cast<T *>(that_v)));
         else
-            VariantCurry<Ts...>::Move(that_t, that_v, this_v);
+            VariantCurry<Index + 1, Ts...>::Move(that_t, that_v, this_v);
     }
 
     inline static void Copy(std::size_t that_t, const void * that_v, void * this_v)
     {
-        if (that_t == T::VariantId)
+        if (that_t == Index)
         {
             new (this_v) T(*reinterpret_cast<const T *>(that_v));
         }
         else
         {
-            VariantCurry<Ts...>::Copy(that_t, that_v, this_v);
+            VariantCurry<Index + 1, Ts...>::Copy(that_t, that_v, this_v);
         }
     }
 
     inline static bool Equal(std::size_t type_t, const void * that_v, const void * this_v)
     {
-        if (type_t == T::VariantId)
+        if (type_t == Index)
         {
             return *reinterpret_cast<const T *>(this_v) == *reinterpret_cast<const T *>(that_v);
         }
         else
         {
-            return VariantCurry<Ts...>::Equal(type_t, that_v, this_v);
+            return VariantCurry<Index + 1, Ts...>::Equal(type_t, that_v, this_v);
         }
     }
 };
 
-template <>
-struct VariantCurry<>
+template <std::size_t Index>
+struct VariantCurry<Index>
 {
     inline static void Destroy(std::size_t id, void * data) {}
     inline static void Move(std::size_t that_t, void * that_v, void * this_v) {}
@@ -90,23 +90,41 @@ struct VariantCurry<>
     }
 };
 
+template <typename T, typename TupleType>
+class TupleIndexOfType
+{
+private:
+    template <std::size_t Index>
+    static constexpr
+        typename std::enable_if<std::is_same<T, typename std::tuple_element<Index, TupleType>::type>::value, std::size_t>::type
+        calculate()
+    {
+        return Index;
+    }
+
+    template <std::size_t Index>
+    static constexpr
+        typename std::enable_if<!std::is_same<T, typename std::tuple_element<Index, TupleType>::type>::value, std::size_t>::type
+        calculate()
+    {
+        return calculate<Index + 1>();
+    }
+
+public:
+    static constexpr std::size_t value = calculate<0>();
+};
+
 } // namespace VariantInternal
 
 /**
  * @brief
  *   Represents a type-safe union. An instance of Variant at any given time either holds a value of one of its
- *   alternative types, or no value. Each type must define a unique value of a static field named VariantId.
+ *   alternative types, or no value.
  *
  *   Example:
- *     struct Type1
- *     {
- *         static constexpr const std::size_t VariantId = 1;
- *     };
+ *     struct Type1 {};
  *
- *     struct Type2
- *     {
- *         static constexpr const std::size_t VariantId = 2;
- *     };
+ *     struct Type2 {};
  *
  *     Variant<Type1, Type2> v;
  *     v.Set<Type1>(); // v contains Type1
@@ -121,7 +139,7 @@ private:
     static constexpr std::size_t kInvalidType = SIZE_MAX;
 
     using Data  = typename std::aligned_storage<kDataSize, kDataAlign>::type;
-    using Curry = VariantInternal::VariantCurry<Ts...>;
+    using Curry = VariantInternal::VariantCurry<0, Ts...>;
 
     std::size_t mTypeId;
     Data mData;
@@ -158,13 +176,13 @@ public:
 
     bool operator==(const Variant & other) const
     {
-        return GetType() == other.GetType() && Curry::Equal(mTypeId, &other.mData, &mData);
+        return GetType() == other.GetType() && (!Valid() || Curry::Equal(mTypeId, &other.mData, &mData));
     }
 
     template <typename T>
     bool Is() const
     {
-        return (mTypeId == T::VariantId);
+        return (mTypeId == VariantInternal::TupleIndexOfType<T, std::tuple<Ts...>>::value);
     }
 
     std::size_t GetType() const { return mTypeId; }
@@ -176,20 +194,20 @@ public:
     {
         Curry::Destroy(mTypeId, &mData);
         new (&mData) T(std::forward<Args>(args)...);
-        mTypeId = T::VariantId;
+        mTypeId = VariantInternal::TupleIndexOfType<T, std::tuple<Ts...>>::value;
     }
 
     template <typename T>
     T & Get()
     {
-        VerifyOrDie(mTypeId == T::VariantId);
+        VerifyOrDie((mTypeId == VariantInternal::TupleIndexOfType<T, std::tuple<Ts...>>::value));
         return *reinterpret_cast<T *>(&mData);
     }
 
     template <typename T>
     const T & Get() const
     {
-        VerifyOrDie(mTypeId == T::VariantId);
+        VerifyOrDie((mTypeId == VariantInternal::TupleIndexOfType<T, std::tuple<Ts...>>::value));
         return *reinterpret_cast<const T *>(&mData);
     }
 

--- a/src/lib/support/tests/TestVariant.cpp
+++ b/src/lib/support/tests/TestVariant.cpp
@@ -25,14 +25,13 @@ namespace {
 
 struct Simple
 {
-    static constexpr const std::size_t VariantId = 1;
+    bool operator==(const Simple &) const { return true; }
 };
 
 struct Pod
 {
-    static constexpr const std::size_t VariantId = 2;
-
     Pod(int v1, int v2) : m1(v1), m2(v2) {}
+    bool operator==(const Pod & other) const { return m1 == other.m1 && m2 == other.m2; }
 
     int m1;
     int m2;
@@ -40,8 +39,6 @@ struct Pod
 
 struct Movable
 {
-    static constexpr const std::size_t VariantId = 3;
-
     Movable(int v1, int v2) : m1(v1), m2(v2) {}
 
     Movable(Movable &) = delete;
@@ -56,8 +53,6 @@ struct Movable
 
 struct Count
 {
-    static constexpr const std::size_t VariantId = 4;
-
     Count() { ++created; }
     ~Count() { ++destroyed; }
 
@@ -213,6 +208,50 @@ void TestVariantMoveAssign(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, v2.Get<Pod>().m2 == 10);
 }
 
+void TestVariantCompare(nlTestSuite * inSuite, void * inContext)
+{
+    Variant<Simple, Pod> v0;
+    Variant<Simple, Pod> v1;
+    Variant<Simple, Pod> v2;
+    Variant<Simple, Pod> v3;
+    Variant<Simple, Pod> v4;
+
+    v1.Set<Simple>();
+    v2.Set<Pod>(5, 10);
+    v3.Set<Pod>(5, 10);
+    v4.Set<Pod>(5, 11);
+
+    NL_TEST_ASSERT(inSuite, (v0 == v0));
+    NL_TEST_ASSERT(inSuite, !(v0 == v1));
+    NL_TEST_ASSERT(inSuite, !(v0 == v2));
+    NL_TEST_ASSERT(inSuite, !(v0 == v3));
+    NL_TEST_ASSERT(inSuite, !(v0 == v4));
+
+    NL_TEST_ASSERT(inSuite, !(v1 == v0));
+    NL_TEST_ASSERT(inSuite, (v1 == v1));
+    NL_TEST_ASSERT(inSuite, !(v1 == v2));
+    NL_TEST_ASSERT(inSuite, !(v1 == v3));
+    NL_TEST_ASSERT(inSuite, !(v1 == v4));
+
+    NL_TEST_ASSERT(inSuite, !(v2 == v0));
+    NL_TEST_ASSERT(inSuite, !(v2 == v1));
+    NL_TEST_ASSERT(inSuite, (v2 == v2));
+    NL_TEST_ASSERT(inSuite, (v2 == v3));
+    NL_TEST_ASSERT(inSuite, !(v2 == v4));
+
+    NL_TEST_ASSERT(inSuite, !(v3 == v0));
+    NL_TEST_ASSERT(inSuite, !(v3 == v1));
+    NL_TEST_ASSERT(inSuite, (v3 == v2));
+    NL_TEST_ASSERT(inSuite, (v3 == v3));
+    NL_TEST_ASSERT(inSuite, !(v3 == v4));
+
+    NL_TEST_ASSERT(inSuite, !(v4 == v0));
+    NL_TEST_ASSERT(inSuite, !(v4 == v1));
+    NL_TEST_ASSERT(inSuite, !(v4 == v2));
+    NL_TEST_ASSERT(inSuite, !(v4 == v3));
+    NL_TEST_ASSERT(inSuite, (v4 == v4));
+}
+
 int Setup(void * inContext)
 {
     return SUCCESS;
@@ -229,10 +268,11 @@ int Teardown(void * inContext)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestVariantSimple),     NL_TEST_DEF_FN(TestVariantMovable),
-                                 NL_TEST_DEF_FN(TestVariantCtorDtor),   NL_TEST_DEF_FN(TestVariantCopy),
-                                 NL_TEST_DEF_FN(TestVariantMove),       NL_TEST_DEF_FN(TestVariantCopyAssign),
-                                 NL_TEST_DEF_FN(TestVariantMoveAssign), NL_TEST_SENTINEL() };
+static const nlTest sTests[] = {
+    NL_TEST_DEF_FN(TestVariantSimple),     NL_TEST_DEF_FN(TestVariantMovable), NL_TEST_DEF_FN(TestVariantCtorDtor),
+    NL_TEST_DEF_FN(TestVariantCopy),       NL_TEST_DEF_FN(TestVariantMove),    NL_TEST_DEF_FN(TestVariantCopyAssign),
+    NL_TEST_DEF_FN(TestVariantMoveAssign), NL_TEST_DEF_FN(TestVariantCompare), NL_TEST_SENTINEL()
+};
 
 int TestVariant()
 {


### PR DESCRIPTION
#### Problem
Variant type should not require a VariantId field in the member types.

#### Change overview
Instead of using VariantId, calculate index of the type in the tuple at compile time.

#### Testing
Manually verified by unit-tests