### PR TITLE
Add read attribute positive and negative unit tests

### DIFF
--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -20,9 +20,13 @@
 
 #include <app/AttributePathParams.h>
 #include <app/util/basic-types.h>
+#include <assert.h>
+#include <core/Optional.h>
 
 namespace chip {
 namespace app {
+static constexpr AttributeId kRootAttributeId = 0xFFFFFFFF;
+
 struct ClusterInfo
 {
     enum class Flags : uint8_t
@@ -39,15 +43,51 @@ struct ClusterInfo
             return false;
         }
 
-        if (mFlags.Has(Flags::kFieldIdValid) && (mFieldId == 0xFFFFFFFF))
+        Optional<AttributeId> myFieldId =
+            mFlags.Has(Flags::kFieldIdValid) ? Optional<AttributeId>::Value(mFieldId) : Optional<AttributeId>::Missing();
+
+        Optional<AttributeId> otherFieldId = other.mFlags.Has(Flags::kFieldIdValid) ? Optional<AttributeId>::Value(other.mFieldId)
+                                                                                    : Optional<AttributeId>::Missing();
+
+        Optional<ListIndex> myListIndex =
+            mFlags.Has(Flags::kListIndexValid) ? Optional<ListIndex>::Value(mListIndex) : Optional<ListIndex>::Missing();
+
+        Optional<ListIndex> otherListIndex = other.mFlags.Has(Flags::kListIndexValid) ? Optional<ListIndex>::Value(other.mListIndex)
+                                                                                      : Optional<ListIndex>::Missing();
+
+        // If list index exists, field index must exist
+        // Field 0xFFFFFFF (any) &  listindex set is invalid
+        assert(!(myListIndex.HasValue() && !myFieldId.HasValue()));
+        assert(!(otherListIndex.HasValue() && !otherFieldId.HasValue()));
+        assert(!(myFieldId == Optional<AttributeId>::Value(kRootAttributeId) && myListIndex.HasValue()));
+        assert(!(otherFieldId == Optional<AttributeId>::Value(kRootAttributeId) && otherListIndex.HasValue()));
+
+        if (myFieldId == Optional<AttributeId>::Value(kRootAttributeId))
         {
             return true;
         }
 
-        if (mFlags.Has(Flags::kFieldIdValid) && other.mFlags.Has(Flags::kFieldIdValid) && (mFieldId == other.mFieldId))
+        if (myFieldId != otherFieldId)
         {
+            return false;
+        }
+
+        // We only support top layer for attribute representation, either FieldId or FieldId + ListIndex
+        // Combination: if myFieldId == otherFieldId, ListIndex cannot exist without FieldId
+        // 1. myListIndex and otherListIndex both missing or both exactly the same, then current is superset of other
+        // 2. myListIndex is missing, no matter if otherListIndex is missing or not, then current is superset of other
+        if (myListIndex == otherListIndex)
+        {
+            // either both missing or both exactly the same
             return true;
         }
+
+        if (!myListIndex.HasValue())
+        {
+            // difference is ok only if myListIndex is missing
+            return true;
+        }
+
         return false;
     }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -229,8 +229,9 @@ exit:
     return err;
 }
 
-CHIP_ERROR InteractionModelEngine::OnReadRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
-                                                 const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload)
+CHIP_ERROR InteractionModelEngine::OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext,
+                                                        const PacketHeader & aPacketHeader, const PayloadHeader & aPayloadHeader,
+                                                        System::PacketBufferHandle && aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -240,9 +241,9 @@ CHIP_ERROR InteractionModelEngine::OnReadRequest(Messaging::ExchangeContext * ap
     {
         if (readHandler.IsFree())
         {
-            err = readHandler.Init(mpDelegate, apExchangeContext);
+            err = readHandler.Init(mpExchangeMgr, mpDelegate, apExchangeContext);
             SuccessOrExit(err);
-            err               = readHandler.OnReadRequest(std::move(aPayload));
+            err               = readHandler.OnReadInitialRequest(std::move(aPayload));
             apExchangeContext = nullptr;
             break;
         }
@@ -299,7 +300,7 @@ CHIP_ERROR InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext 
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReadRequest))
     {
-        err = OnReadRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+        err = OnReadInitialRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::WriteRequest))
     {

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -53,7 +53,6 @@ namespace chip {
 namespace app {
 
 static constexpr size_t kMaxSecureSduLengthBytes = 1024;
-static constexpr FieldId kRootFieldId            = 0;
 
 /**
  * @class InteractionModelEngine
@@ -157,8 +156,8 @@ private:
      * Called when Interaction Model receives a Read Request message.  Errors processing
      * the Read Request are handled entirely within this function.
      */
-    CHIP_ERROR OnReadRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
-                             const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
+    CHIP_ERROR OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                                    const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
 
     /**
      * Called when Interaction Model receives a Write Request message.  Errors processing

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -80,7 +80,7 @@ public:
 
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
-    CHIP_ERROR SendStatusReport(CHIP_ERROR aError, bool aExpectResponse);
+    CHIP_ERROR SendStatusReport(CHIP_ERROR aError);
 
 private:
     friend class TestReadInteraction;
@@ -88,9 +88,9 @@ private:
 
     enum class ClientState
     {
-        Uninitialized = 0, ///< The client has not been initialized
-        Initialized,       ///< The client has been initialized and is ready for a SendReadRequest
-        AwaitingResponse,  ///< The client has sent out the read request message
+        Uninitialized = 0,     ///< The client has not been initialized
+        Initialized,           ///< The client has been initialized and is ready for a SendReadRequest
+        AwaitingInitialReport, ///< The client is waiting for initial report
     };
 
     /**
@@ -119,7 +119,7 @@ private:
      *
      */
     bool IsFree() const { return mState == ClientState::Uninitialized; }
-
+    bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
     CHIP_ERROR GenerateEventPathList(EventPathList::Builder & aEventPathListBuilder, EventPathParams * apEventPathParamsList,
                                      size_t aEventPathParamsListSize);
     CHIP_ERROR GenerateAttributePathList(AttributePathList::Builder & aAttributeathListBuilder,
@@ -139,12 +139,14 @@ private:
      * our exchange and don't need to manually close it.
      */
     void ShutdownInternal(CHIP_ERROR aError);
-
+    void ClearInitialReport() { mInitialReport = false; }
+    bool IsInitialReport() { return mInitialReport; }
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
     ClientState mState                         = ClientState::Uninitialized;
     uint64_t mAppIdentifier                    = 0;
+    bool mInitialReport                        = true;
 };
 
 }; // namespace app

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -31,16 +31,19 @@
 
 namespace chip {
 namespace app {
-CHIP_ERROR ReadHandler::Init(InteractionModelDelegate * apDelegate, Messaging::ExchangeContext * apExchangeContext)
+CHIP_ERROR ReadHandler::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                             Messaging::ExchangeContext * apExchangeContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Error if already initialized.
     VerifyOrReturnError(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    mpExchangeMgr              = apExchangeMgr;
     mpExchangeCtx              = apExchangeContext;
     mSuppressResponse          = true;
     mpAttributeClusterInfoList = nullptr;
     mpEventClusterInfoList     = nullptr;
     mCurrentPriority           = PriorityLevel::Invalid;
+    mInitialReport             = true;
     MoveToState(HandlerState::Initialized);
     mpDelegate = apDelegate;
     if (apExchangeContext != nullptr)
@@ -51,8 +54,17 @@ CHIP_ERROR ReadHandler::Init(InteractionModelDelegate * apDelegate, Messaging::E
     return err;
 }
 
-void ReadHandler::Shutdown()
+void ReadHandler::Shutdown(ShutdownOptions aOptions)
 {
+    if (aOptions == ShutdownOptions::AbortCurrentExchange)
+    {
+        if (mpExchangeCtx != nullptr)
+        {
+            mpExchangeCtx->Abort();
+            mpExchangeCtx = nullptr;
+        }
+    }
+
     if (IsReporting())
     {
         InteractionModelEngine::GetInstance()->GetReportingEngine().OnReportConfirm();
@@ -64,10 +76,11 @@ void ReadHandler::Shutdown()
     mpAttributeClusterInfoList = nullptr;
     mpEventClusterInfoList     = nullptr;
     mCurrentPriority           = PriorityLevel::Invalid;
+    mInitialReport             = false;
     mpDelegate                 = nullptr;
 }
 
-CHIP_ERROR ReadHandler::OnReadRequest(System::PacketBufferHandle && aPayload)
+CHIP_ERROR ReadHandler::OnReadInitialRequest(System::PacketBufferHandle && aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferHandle response;
@@ -93,33 +106,38 @@ CHIP_ERROR ReadHandler::OnStatusReport(Messaging::ExchangeContext * apExchangeCo
     VerifyOrExit((statusReport.GetProtocolId() == Protocols::InteractionModel::Id.ToFullyQualifiedSpecForm()) &&
                      (statusReport.GetProtocolCode() == to_underlying(Protocols::InteractionModel::ProtocolCode::Success)),
                  err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(IsReporting(), err = CHIP_ERROR_INCORRECT_STATE);
-
-exit:
-    Shutdown();
-    return err;
-}
-
-CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(IsReportable(), err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-
-    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
-                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
-    if (err == CHIP_NO_ERROR)
+    switch (mState)
     {
-        MoveToState(HandlerState::Reporting);
+    case HandlerState::Reporting:
+        Shutdown();
+        break;
+    case HandlerState::Reportable:
+    case HandlerState::Initialized:
+    case HandlerState::Uninitialized:
+    default:
+        err = CHIP_ERROR_INCORRECT_STATE;
+        break;
     }
-
 exit:
-    ChipLogFunctError(err);
     if (err != CHIP_NO_ERROR)
     {
         Shutdown();
     }
     return err;
+}
+
+CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload)
+{
+    VerifyOrReturnLogError(IsReportable(), CHIP_ERROR_INCORRECT_STATE);
+    if (IsInitialReport())
+    {
+        VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        mSecureHandle = mpExchangeCtx->GetSecureSession();
+    }
+    VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    MoveToState(HandlerState::Reporting);
+    return mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
+                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
 }
 
 CHIP_ERROR ReadHandler::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -50,6 +50,12 @@ namespace app {
 class ReadHandler : public Messaging::ExchangeDelegate
 {
 public:
+    enum class ShutdownOptions
+    {
+        KeepCurrentExchange,
+        AbortCurrentExchange,
+    };
+
     /**
      *  Initialize the ReadHandler. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -61,24 +67,25 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(InteractionModelDelegate * apDelegate, Messaging::ExchangeContext * apExchangeContext);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                    Messaging::ExchangeContext * apExchangeContext);
 
     /**
      *  Shut down the ReadHandler. This terminates this instance
      *  of the object and releases all held resources.
      *
      */
-    void Shutdown();
+    void Shutdown(ShutdownOptions aOptions = ShutdownOptions::KeepCurrentExchange);
     /**
      *  Process a read request.  Parts of the processing may end up being asynchronous, but the ReadHandler
-     *  guarantees that it will call Shutdown on itself when processing is done (including if OnReadRequest
+     *  guarantees that it will call Shutdown on itself when processing is done (including if OnReadInitialRequest
      *  returns an error).
      *
      *  @retval #Others If fails to process read request
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR OnReadRequest(System::PacketBufferHandle && aPayload);
+    CHIP_ERROR OnReadInitialRequest(System::PacketBufferHandle && aPayload);
 
     /**
      *  Send ReportData to initiator
@@ -153,8 +160,10 @@ private:
 
     // The last schedule event number snapshoted in the beginning when preparing to fill new events to reports
     EventNumber mLastScheduledEventNumber[kNumPriorityLevel];
-    InteractionModelDelegate * mpDelegate = nullptr;
-    bool mInitialReport                   = false;
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    InteractionModelDelegate * mpDelegate      = nullptr;
+    bool mInitialReport                        = false;
+    SessionHandle mSecureHandle;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -292,7 +292,7 @@ exit:
     ChipLogFunctError(err);
     if (err != CHIP_NO_ERROR)
     {
-        apReadHandler->Shutdown();
+        apReadHandler->Shutdown(ReadHandler::ShutdownOptions::AbortCurrentExchange);
     }
     return err;
 }

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -42,15 +42,23 @@ void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContex
 {
     ClusterInfo clusterInfo1;
     ClusterInfo clusterInfo2;
+    ClusterInfo clusterInfo3;
     clusterInfo1.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
     clusterInfo2.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+    clusterInfo3.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
     clusterInfo1.mFieldId = 1;
     clusterInfo2.mFieldId = 1;
+    clusterInfo3.mFieldId = 1;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
-
     clusterInfo2.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
     clusterInfo2.mListIndex = 1;
     NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
+    clusterInfo3.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
+    clusterInfo3.mListIndex = 1;
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo3));
 }
 
 void TestAttributePathIncludedDifferentFieldId(nlTestSuite * apSuite, void * apContext)

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -97,14 +97,6 @@ bool ServerClusterCommandExists(chip::ClusterId aClusterId, chip::CommandId aCom
     return (aEndPointId == kTestEndpointId && aClusterId == kTestClusterId && aCommandId == kTestCommandId);
 }
 
-CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * apWriter, bool * apDataExists)
-{
-    // We do not really care about the value, just return a not found status code.
-    VerifyOrReturnError(apWriter != nullptr, CHIP_NO_ERROR);
-    return apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_Status),
-                         static_cast<uint16_t>(Protocols::InteractionModel::ProtocolCode::UnsupportedAttribute));
-}
-
 class TestCommandInteraction
 {
 public:

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -55,13 +55,15 @@ uint8_t gDebugEventBuffer[128];
 uint8_t gInfoEventBuffer[128];
 uint8_t gCritEventBuffer[128];
 chip::app::CircularEventBuffer gCircularEventBuffer[3];
-chip::NodeId kTestNodeId           = 1;
-chip::ClusterId kTestClusterId     = 6;
-chip::EndpointId kTestEndpointId   = 1;
-chip::EventId kTestEventIdDebug    = 1;
-chip::EventId kTestEventIdCritical = 2;
-uint64_t kTestEventTag             = 1;
-using TestContext                  = chip::Test::MessagingContext;
+chip::NodeId kTestNodeId              = 1;
+chip::ClusterId kTestClusterId        = 6;
+chip::ClusterId kInvalidTestClusterId = 7;
+chip::EndpointId kTestEndpointId      = 1;
+chip::EventId kTestEventIdDebug       = 1;
+chip::EventId kTestEventIdCritical    = 2;
+uint8_t kTestFieldValue1              = 1;
+uint64_t kTestEventTag                = 1;
+using TestContext                     = chip::Test::MessagingContext;
 TestContext sContext;
 
 void InitializeEventLogging(chip::Messaging::ExchangeManager & aExchangeManager)
@@ -151,6 +153,18 @@ public:
         return err;
     }
 
+    void OnReportData(const chip::app::ReadClient * apReadClient, const chip::app::ClusterInfo & aPath,
+                      chip::TLV::TLVReader * apData, chip::Protocols::InteractionModel::ProtocolCode status) override
+    {
+        mGotAttributeResponse = true;
+    }
+
+    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override
+    {
+        mGotReport = true;
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
     {
         if (aError == CHIP_NO_ERROR)
@@ -161,12 +175,31 @@ public:
     }
 
     bool mGotEventResponse      = false;
+    bool mGotAttributeResponse  = false;
+    bool mGotReport             = false;
     bool mGotReadStatusResponse = false;
 };
 } // namespace
 
 namespace chip {
 namespace app {
+CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * apWriter, bool * apDataExists)
+{
+    CHIP_ERROR err   = CHIP_NO_ERROR;
+    uint64_t version = 0;
+    VerifyOrExit(aClusterInfo.mClusterId == kTestClusterId && aClusterInfo.mEndpointId == kTestEndpointId,
+                 err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(apWriter != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), kTestFieldValue1);
+    SuccessOrExit(err);
+    err = apWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_DataVersion), version);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
 class TestReadInteraction
 {
 public:
@@ -178,7 +211,8 @@ public:
     static void TestReadClientGenerateTwoEventPathList(nlTestSuite * apSuite, void * apContext);
     static void TestReadClientInvalidReport(nlTestSuite * apSuite, void * apContext);
     static void TestReadHandlerInvalidAttributePath(nlTestSuite * apSuite, void * apContext);
-    static void TestReadEventRoundtrip(nlTestSuite * apSuite, void * apContext);
+    static void TestReadRoundtrip(nlTestSuite * apSuite, void * apContext);
+    static void TestReadInvalidAttributePathRoundtrip(nlTestSuite * apSuite, void * apContext);
 
 private:
     static void GenerateReportData(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload,
@@ -297,7 +331,7 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     Messaging::ExchangeManager exchangeManager;
     Messaging::ExchangeContext * exchangeCtx = exchangeManager.NewContext(SessionHandle(), nullptr);
-    readHandler.Init(nullptr, exchangeCtx);
+    readHandler.Init(&exchangeManager, nullptr, exchangeCtx);
 
     GenerateReportData(apSuite, apContext, reportDatabuf);
     err = readHandler.SendReportData(std::move(reportDatabuf));
@@ -327,7 +361,7 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = readHandler.OnReadRequest(std::move(readRequestbuf));
+    err = readHandler.OnReadInitialRequest(std::move(readRequestbuf));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     engine->Shutdown();
@@ -426,7 +460,7 @@ void TestReadInteraction::TestReadHandlerInvalidAttributePath(nlTestSuite * apSu
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     Messaging::ExchangeManager exchangeManager;
     Messaging::ExchangeContext * exchangeCtx = exchangeManager.NewContext(SessionHandle(), nullptr);
-    readHandler.Init(nullptr, exchangeCtx);
+    readHandler.Init(&exchangeManager, nullptr, exchangeCtx);
 
     GenerateReportData(apSuite, apContext, reportDatabuf);
     err = readHandler.SendReportData(std::move(reportDatabuf));
@@ -452,7 +486,7 @@ void TestReadInteraction::TestReadHandlerInvalidAttributePath(nlTestSuite * apSu
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = readHandler.OnReadRequest(std::move(readRequestbuf));
+    err = readHandler.OnReadInitialRequest(std::move(readRequestbuf));
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH);
     engine->Shutdown();
 }
@@ -560,7 +594,7 @@ void TestReadInteraction::TestReadClientGenerateTwoEventPathList(nlTestSuite * a
 #endif
 }
 
-void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * apContext)
+void TestReadInteraction::TestReadRoundtrip(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
     CHIP_ERROR err    = CHIP_NO_ERROR;
@@ -576,7 +610,6 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
-    NL_TEST_ASSERT(apSuite, !delegate.mGotReadStatusResponse);
 
     chip::app::EventPathParams eventPathParams[2];
     eventPathParams[0].mNodeId     = kTestNodeId;
@@ -589,17 +622,27 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     eventPathParams[1].mClusterId  = kTestClusterId;
     eventPathParams[1].mEventId    = kTestEventIdCritical;
 
-    ReadPrepareParams readPrepareParams;
-    readPrepareParams.mSessionHandle           = ctx.GetSessionLocalToPeer();
-    readPrepareParams.mpEventPathParamsList    = eventPathParams;
-    readPrepareParams.mEventPathParamsListSize = 2;
+    chip::app::AttributePathParams attributePathParams[2];
+    attributePathParams[0].mNodeId     = chip::kTestDeviceNodeId;
+    attributePathParams[0].mEndpointId = kTestEndpointId;
+    attributePathParams[0].mClusterId  = kTestClusterId;
+    attributePathParams[0].mFieldId    = 1;
+    attributePathParams[0].mListIndex  = 0;
+    attributePathParams[0].mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
 
+    ReadPrepareParams readPrepareParams;
+    readPrepareParams.mSessionHandle               = ctx.GetSessionLocalToPeer();
+    readPrepareParams.mpEventPathParamsList        = eventPathParams;
+    readPrepareParams.mEventPathParamsListSize     = 2;
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize = 1;
     err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(readPrepareParams);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
     NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
-    NL_TEST_ASSERT(apSuite, delegate.mGotReadStatusResponse);
+    NL_TEST_ASSERT(apSuite, delegate.mGotAttributeResponse);
+    NL_TEST_ASSERT(apSuite, delegate.mGotReport);
 
     // By now we should have closed all exchanges and sent all pending acks, so
     // there should be no queued-up things in the retransmit table.
@@ -608,6 +651,47 @@ void TestReadInteraction::TestReadEventRoundtrip(nlTestSuite * apSuite, void * a
     engine->Shutdown();
 }
 
+void TestReadInteraction::TestReadInvalidAttributePathRoundtrip(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+
+    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    // Shouldn't have anything in the retransmit table when starting the test.
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    GenerateEvents(apSuite, apContext);
+
+    MockInteractionModelApp delegate;
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    err           = engine->Init(&ctx.GetExchangeManager(), &delegate);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+    chip::app::AttributePathParams attributePathParams[2];
+    attributePathParams[0].mNodeId     = chip::kTestDeviceNodeId;
+    attributePathParams[0].mEndpointId = kTestEndpointId;
+    attributePathParams[0].mClusterId  = kInvalidTestClusterId;
+    attributePathParams[0].mFieldId    = 1;
+    attributePathParams[0].mListIndex  = 0;
+    attributePathParams[0].mFlags.Set(chip::app::AttributePathParams::Flags::kFieldIdValid);
+
+    ReadPrepareParams readPrepareParams;
+    readPrepareParams.mSessionHandle               = ctx.GetSessionLocalToPeer();
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize = 1;
+    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(readPrepareParams);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    InteractionModelEngine::GetInstance()->GetReportingEngine().Run();
+
+    NL_TEST_ASSERT(apSuite, !delegate.mGotReport);
+    // By now we should have closed all exchanges and sent all pending acks, so
+    // there should be no queued-up things in the retransmit table.
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    engine->Shutdown();
+}
 } // namespace app
 } // namespace chip
 
@@ -620,7 +704,7 @@ namespace {
 // clang-format off
 const nlTest sTests[] =
 {
-    NL_TEST_DEF("TestReadEventRoundtrip", chip::app::TestReadInteraction::TestReadEventRoundtrip),
+    NL_TEST_DEF("TestReadRoundtrip", chip::app::TestReadInteraction::TestReadRoundtrip),
     NL_TEST_DEF("CheckReadClient", chip::app::TestReadInteraction::TestReadClient),
     NL_TEST_DEF("CheckReadHandler", chip::app::TestReadInteraction::TestReadHandler),
     NL_TEST_DEF("TestReadClientGenerateAttributePathList", chip::app::TestReadInteraction::TestReadClientGenerateAttributePathList),
@@ -629,6 +713,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadClientGenerateTwoEventPathList", chip::app::TestReadInteraction::TestReadClientGenerateTwoEventPathList),
     NL_TEST_DEF("TestReadClientInvalidReport", chip::app::TestReadInteraction::TestReadClientInvalidReport),
     NL_TEST_DEF("TestReadHandlerInvalidAttributePath", chip::app::TestReadInteraction::TestReadHandlerInvalidAttributePath),
+    NL_TEST_DEF("TestReadInvalidAttributePathRoundtrip", chip::app::TestReadInteraction::TestReadInvalidAttributePathRoundtrip),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -133,7 +133,7 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     err = writer.Finalize(&readRequestbuf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    readHandler.OnReadRequest(std::move(readRequestbuf));
+    readHandler.OnReadInitialRequest(std::move(readRequestbuf));
     reportingEngine.Init();
     err = reportingEngine.BuildAndSendSingleReportData(&readHandler);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -198,11 +198,13 @@ CHIP_ERROR SendReadRequest()
 
     printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    readPrepareParams.mSessionHandle           = chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex);
-    readPrepareParams.mTimeout                 = gMessageTimeoutMsec;
-    readPrepareParams.mpEventPathParamsList    = eventPathParams;
-    readPrepareParams.mEventPathParamsListSize = 2;
-    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(readPrepareParams, gMessageTimeoutMsec);
+    readPrepareParams.mSessionHandle               = chip::SessionHandle(chip::kTestDeviceNodeId, 0, 0, gFabricIndex);
+    readPrepareParams.mTimeout                     = gMessageTimeoutMsec;
+    readPrepareParams.mpAttributePathParamsList    = &attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize = 1;
+    readPrepareParams.mpEventPathParamsList        = eventPathParams;
+    readPrepareParams.mEventPathParamsListSize     = 2;
+    err = chip::app::InteractionModelEngine::GetInstance()->SendReadRequest(readPrepareParams);
     SuccessOrExit(err);
 
 exit:

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2427,7 +2427,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief Defines the maximum number of path objects, limits the number of attributes being read or subscribed at the same time.
  */
 #ifndef CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS
-#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 8
+#define CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS 4
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
Need attribute test for Read

#### Change overview
--Add read attribute positive test
--Add read attribute negative test and fix the exchange context close
--Add more test for clusterInfo to check if A include B.
--Minor cleanup for awaiting response and onreadrequest rename
#### Testing
--Add read attribute positive test to read the right attribute path
--Add read attribute negative test to read the incorrect attribute path
--Add more test for clusterInfo to check if A include B.