### PR TITLE
ESP32: Enable and use Rendezvous BLE (and its dependencies) only when Bluetooth is enabled in menuconfig

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -59,6 +59,12 @@ chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                is_debug)
 
+if(CONFIG_BT_ENABLED)
+chip_gn_arg_append("chip_config_network_layer_ble"           "true")
+else()
+chip_gn_arg_append("chip_config_network_layer_ble"           "false")
+endif()
+
 if(CONFIG_ENABLE_PW_RPC)
     string(APPEND chip_gn_args "import(\"//build_overrides/pigweed.gni\")\n")
     chip_gn_arg_append("remove_default_configs"             "[\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_build:cpp17\"]")

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -497,10 +497,12 @@ menu "CHIP Device Layer"
     endmenu
 
     menu "BLE Options"
+        visible if BT_ENABLED
 
         config ENABLE_CHIPOBLE
             bool "Enable CHIP-over-BLE (CHIPoBLE) Support"
             default y
+            depends on BT_ENABLED
             help
                 Enables support for sending and receiving CHIP messages over a BLE connection.
 

--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -46,7 +46,8 @@ menu "Demo"
 
     choice
       prompt "Rendezvous Mode"
-      default RENDEZVOUS_MODE_BLE
+      default RENDEZVOUS_MODE_BLE if BT_ENABLED
+      default RENDEZVOUS_MODE_SOFTAP
       help
           Specifies the Rendezvous mode of the peripheral.
 
@@ -56,6 +57,7 @@ menu "Demo"
           bool "Soft-AP"
       config RENDEZVOUS_MODE_BLE
           bool "BLE"
+          depends on BT_ENABLED
       config RENDEZVOUS_MODE_ON_NETWORK
           bool "On-Network"
       config RENDEZVOUS_MODE_SOFTAP_ON_NETWORK


### PR DESCRIPTION
Enable and use Rendezvous BLE (and its dependencies) only when Bluetooth is enabled in menuconfig

#### Problem
Compilation failure for Rendezvous SoftAP by disabling BLE

#### Change overview
The relevant config options are enabled only when BLE is enabled

#### Testing
Compile esp32 all-clusters-app (BLE Rendezvous is default)
Disable Bluetooth from menuconfig and compile esp32 all-clusters-app (SoftAP Rendezvous is auto chosen)