### PR TITLE
Wait for Wi-Fi management to start up (#8834)

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -65,6 +65,7 @@ using namespace chip::Transport;
 using chip::Shell::Engine;
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
 /*
  * The device shall check every kWifiStartCheckTimeUsec whether Wi-Fi management
  * has been fully initialized. If after kWifiStartCheckAttempts Wi-Fi management
@@ -73,6 +74,7 @@ using chip::Shell::Engine;
  */
 static constexpr useconds_t kWifiStartCheckTimeUsec = 100 * 1000; // 100 ms
 static constexpr uint8_t kWifiStartCheckAttempts    = 5;
+#endif
 
 namespace {
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -88,7 +88,7 @@ void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 static bool EnsureWifiIsStarted()
 {
-    for (int cnt = 0; cnt < kWifiStartCheckAttempts; cnt++) 
+    for (int cnt = 0; cnt < kWifiStartCheckAttempts; cnt++)
     {
         if (chip::DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
         {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -65,7 +65,7 @@ using namespace chip::Transport;
 using chip::Shell::Engine;
 #endif
 
-static constexpr useconds_t kWifiStartCheckTime = 100*1000; // 100 ms
+static constexpr useconds_t kWifiStartCheckTime  = 100 * 1000; // 100 ms
 static constexpr uint8_t kWifiStartCheckAttempts = 5;
 
 namespace {

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -633,6 +633,11 @@ void ConnectivityManagerImpl::StartWiFiManagement()
                                                 kWpaSupplicantObjectPath, nullptr, _OnWpaProxyReady, nullptr);
 }
 
+bool ConnectivityManagerImpl::IsWiFiManagementStarted()
+{
+    return mWpaSupplicant.state == GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED;
+}
+
 void ConnectivityManagerImpl::DriveAPState()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -108,6 +108,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void StartWiFiManagement();
+    bool IsWiFiManagementStarted();
 #endif
 
 private:


### PR DESCRIPTION
#### Problem
What is being fixed?
* Wi-Fi management takes a while to startup asynchrounously on Linux and this causes the app to assume Wi-Fi is not provisioned, reset fabric setting, and continue in pairing mode. What a user perceives is that the device has been unpaired and needs to be paired with again.

#### Change overview
Poll for Wi-Fi Management to start for five attempts every 100 ms.

#### Testing
How was this tested?
* Manually tested with all-clusters-app on a custom Linux system build.