### PR TITLE
Fix temperature value and unit displayed in iOS ChipTool (#9295)

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -153,14 +153,14 @@
 
 - (void)updateTempInUI:(int)newTemp
 {
-    double tempInCelsius = (double)newTemp / 100;
-    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-    [formatter setNumberStyle: NSNumberFormatterDecimalStyle];
+    double tempInCelsius = (double) newTemp / 100;
+    NSNumberFormatter * formatter = [[NSNumberFormatter alloc] init];
+    [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
     formatter.minimumFractionDigits = 0;
     formatter.maximumFractionDigits = 2;
     [formatter setRoundingMode:NSNumberFormatterRoundFloor];
-    _temperatureLabel.text = [NSString stringWithFormat:@"%@ °C",
-                              [formatter stringFromNumber:[NSNumber numberWithFloat:tempInCelsius]]];
+    _temperatureLabel.text =
+        [NSString stringWithFormat:@"%@ °C", [formatter stringFromNumber:[NSNumber numberWithFloat:tempInCelsius]]];
     NSLog(@"Status: Updated temp in UI to %@", _temperatureLabel.text);
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -76,7 +76,7 @@
 
     // Temperature label
     _temperatureLabel = [UILabel new];
-    _temperatureLabel.text = @"°F";
+    _temperatureLabel.text = @"°C";
     _temperatureLabel.textColor = UIColor.blackColor;
     _temperatureLabel.textAlignment = NSTextAlignmentCenter;
     _temperatureLabel.font = [UIFont systemFontOfSize:50 weight:UIFontWeightThin];
@@ -153,7 +153,14 @@
 
 - (void)updateTempInUI:(int)newTemp
 {
-    _temperatureLabel.text = [NSString stringWithFormat:@"%@ °F", @(newTemp)];
+    double tempInCelsius = (double)newTemp / 100;
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    [formatter setNumberStyle: NSNumberFormatterDecimalStyle];
+    formatter.minimumFractionDigits = 0;
+    formatter.maximumFractionDigits = 2;
+    [formatter setRoundingMode:NSNumberFormatterRoundFloor];
+    _temperatureLabel.text = [NSString stringWithFormat:@"%@ °C",
+                              [formatter stringFromNumber:[NSNumber numberWithFloat:tempInCelsius]]];
     NSLog(@"Status: Updated temp in UI to %@", _temperatureLabel.text);
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed?
* Fixes #9295
  * Convert attribute measured value to ºC by dividing by 100
  * Display temperature with two decimal places and in ºC

#### Change overview
* Convert attribute measured value to ºC by dividing by 100
* Display temperature with two decimal places and in ºC


#### Testing
How was this tested? (at least one bullet point required)
* Tested manually on iOS 14 using Xcode 13 beta 5, and a custom Linux device
