### PR TITLE
Bump up timeout for darwin tests from 50 minutes to 75

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -277,7 +277,7 @@ jobs:
                    .environment/gn_out/.ninja_log
                    .environment/pigweed-venv/*.log
             - name: Setup Build, Run Build and Run Tests
-              timeout-minutes: 50
+              timeout-minutes: 75
               # Just go ahead and do the "all" build; on Darwin that's fairly
               # fast.  If this ever becomes slow, we can think about ways to do
               # the examples-linux-standalone.yaml tests on darwin without too

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -242,7 +242,7 @@ jobs:
             #   uses: github/codeql-action/analyze@v1
     build_darwin:
         name: Build on Darwin (clang, python_lib)
-        timeout-minutes: 75
+        timeout-minutes: 90
 
         env:
             BUILD_TYPE: clang


### PR DESCRIPTION
#### Problem
Darwin tests seem to timeout, especially as we add more tests:

https://github.com/project-chip/connectedhomeip/runs/3446908540

#### Change overview
Bump up timeout from 50 to 75 minutes and move the global timeout from 75 to 90 minutes.

#### Testing
Timeout change, no testing.
