### PR TITLE
Decouple ObjectPool from SystemLayer

### DIFF
--- a/src/inet/AsyncDNSResolverSockets.cpp
+++ b/src/inet/AsyncDNSResolverSockets.cpp
@@ -310,10 +310,10 @@ void AsyncDNSResolverSockets::DNSResultEventHandler(chip::System::Layer * aLayer
 void AsyncDNSResolverSockets::NotifyChipThread(DNSResolver * resolver)
 {
     // Post work item via Timer Event for the CHIP thread
-    chip::System::Layer & lSystemLayer = resolver->SystemLayer();
+    chip::System::Layer * lSystemLayer = resolver->Layer().SystemLayer();
 
     ChipLogDetail(Inet, "Posting DNS completion event to CHIP thread.");
-    lSystemLayer.ScheduleWork(AsyncDNSResolverSockets::DNSResultEventHandler, resolver);
+    lSystemLayer->ScheduleWork(AsyncDNSResolverSockets::DNSResultEventHandler, resolver);
 }
 
 void * AsyncDNSResolverSockets::AsyncDNSThreadRun(void * args)

--- a/src/inet/EndPointBasis.cpp
+++ b/src/inet/EndPointBasis.cpp
@@ -43,5 +43,19 @@ void EndPointBasis::InitEndPointBasis(InetLayer & aInetLayer, void * aAppState)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 }
 
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+void EndPointBasis::DeferredFree(chip::System::Object::ReleaseDeferralErrorTactic aTactic)
+{
+    if (!CHIP_SYSTEM_CONFIG_USE_SOCKETS || IsLWIPEndPoint())
+    {
+        DeferredRelease(Layer().SystemLayer(), aTactic);
+    }
+    else
+    {
+        Release();
+    }
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+
 } // namespace Inet
 } // namespace chip

--- a/src/inet/EndPointBasis.h
+++ b/src/inet/EndPointBasis.h
@@ -176,19 +176,5 @@ inline bool EndPointBasis::IsOpenEndPoint() const
     return lResult;
 }
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-inline void EndPointBasis::DeferredFree(chip::System::Object::ReleaseDeferralErrorTactic aTactic)
-{
-    if (!CHIP_SYSTEM_CONFIG_USE_SOCKETS || IsLWIPEndPoint())
-    {
-        DeferredRelease(aTactic);
-    }
-    else
-    {
-        Release();
-    }
-}
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
 } // namespace Inet
 } // namespace chip

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -658,11 +658,13 @@ done:
     return (lPacketInfo);
 }
 
-CHIP_ERROR IPEndPointBasis::PostPacketBufferEvent(chip::System::Layer & aLayer, System::Object & aTarget,
+CHIP_ERROR IPEndPointBasis::PostPacketBufferEvent(chip::System::Layer * aLayer, System::Object & aTarget,
                                                   System::EventType aEventType, System::PacketBufferHandle && aBuffer)
 {
+    VerifyOrReturnError(aLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
     const CHIP_ERROR error =
-        aLayer.PostEvent(aTarget, aEventType, (uintptr_t) System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(aBuffer));
+        aLayer->PostEvent(aTarget, aEventType, (uintptr_t) System::LwIPPacketBufferView::UnsafeGetLwIPpbuf(aBuffer));
     if (error == CHIP_NO_ERROR)
     {
         // If PostEvent() succeeded, it has ownership of the buffer, so we need to release it (without freeing it).
@@ -941,7 +943,7 @@ CHIP_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
         mSocket = ::socket(family, aType, aProtocol);
         if (mSocket == -1)
             return chip::System::MapErrorPOSIX(errno);
-        ReturnErrorOnFailure(SystemLayer().StartWatchingSocket(mSocket, &mWatch));
+        ReturnErrorOnFailure(Layer().SystemLayer()->StartWatchingSocket(mSocket, &mWatch));
 
         mAddrType = aAddressType;
 

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -123,7 +123,7 @@ protected:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 public:
     static struct netif * FindNetifFromInterfaceId(InterfaceId aInterfaceId);
-    static CHIP_ERROR PostPacketBufferEvent(chip::System::Layer & aLayer, System::Object & aTarget, System::EventType aEventType,
+    static CHIP_ERROR PostPacketBufferEvent(chip::System::Layer * aLayer, System::Object & aTarget, System::EventType aEventType,
                                             System::PacketBufferHandle && aBuffer);
 
 protected:

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -532,7 +532,7 @@ CHIP_ERROR InetLayer::NewRawEndPoint(IPVersion ipVer, IPProtocol ipProto, RawEnd
 
     VerifyOrReturnError(State == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
 
-    *retEndPoint = RawEndPoint::sPool.TryCreate(*mSystemLayer);
+    *retEndPoint = RawEndPoint::sPool.TryCreate();
     if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "Raw");
@@ -572,7 +572,7 @@ CHIP_ERROR InetLayer::NewTCPEndPoint(TCPEndPoint ** retEndPoint)
 
     VerifyOrReturnError(State == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
 
-    *retEndPoint = TCPEndPoint::sPool.TryCreate(*mSystemLayer);
+    *retEndPoint = TCPEndPoint::sPool.TryCreate();
     if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "TCP");
@@ -612,7 +612,7 @@ CHIP_ERROR InetLayer::NewUDPEndPoint(UDPEndPoint ** retEndPoint)
 
     VerifyOrReturnError(State == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
 
-    *retEndPoint = UDPEndPoint::sPool.TryCreate(*mSystemLayer);
+    *retEndPoint = UDPEndPoint::sPool.TryCreate();
     if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "UDP");
@@ -787,7 +787,7 @@ CHIP_ERROR InetLayer::ResolveHostAddress(const char * hostName, uint16_t hostNam
     VerifyOrExit(hostNameLen <= NL_DNS_HOSTNAME_MAX_LEN, err = INET_ERROR_HOST_NAME_TOO_LONG);
     VerifyOrExit(maxAddrs > 0, err = CHIP_ERROR_NO_MEMORY);
 
-    resolver = DNSResolver::sPool.TryCreate(*mSystemLayer);
+    resolver = DNSResolver::sPool.TryCreate();
     if (resolver != nullptr)
     {
         resolver->InitInetLayerBasis(*this);

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -215,7 +215,7 @@ CHIP_ERROR RawEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, Int
     ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, 0, intfId));
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_queue_t dispatchQueue = SystemLayer().GetDispatchQueue();
+    dispatch_queue_t dispatchQueue = Layer().SystemLayer()->GetDispatchQueue();
     if (dispatchQueue != nullptr)
     {
         unsigned long fd = static_cast<unsigned long>(mSocket);
@@ -350,7 +350,7 @@ CHIP_ERROR RawEndPoint::BindIPv6LinkLocal(InterfaceId intfId, const IPAddress & 
 
 optfail:
     res = chip::System::MapErrorPOSIX(errno);
-    SystemLayer().StopWatchingSocket(&mWatch);
+    Layer().SystemLayer()->StopWatchingSocket(&mWatch);
     close(mSocket);
     mSocket   = INET_INVALID_SOCKET_FD;
     mAddrType = kIPAddressType_Unknown;
@@ -424,8 +424,8 @@ CHIP_ERROR RawEndPoint::Listen(IPEndPointBasis::OnMessageReceivedFunct onMessage
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Wait for ability to read on this endpoint.
-    ReturnErrorOnFailure(SystemLayer().SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
-    ReturnErrorOnFailure(SystemLayer().RequestCallbackOnPendingRead(mWatch));
+    ReturnErrorOnFailure(Layer().SystemLayer()->SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
+    ReturnErrorOnFailure(Layer().SystemLayer()->RequestCallbackOnPendingRead(mWatch));
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     return CHIP_NO_ERROR;
@@ -467,7 +467,7 @@ void RawEndPoint::Close()
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
         if (mSocket != INET_INVALID_SOCKET_FD)
         {
-            SystemLayer().StopWatchingSocket(&mWatch);
+            Layer().SystemLayer()->StopWatchingSocket(&mWatch);
             close(mSocket);
             mSocket = INET_INVALID_SOCKET_FD;
         }
@@ -930,11 +930,10 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void * arg, struct raw_pcb * pcb, struct
 u8_t RawEndPoint::LwIPReceiveRawMessage(void * arg, struct raw_pcb * pcb, struct pbuf * p, ip_addr_t * addr)
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 {
-    RawEndPoint * ep                   = static_cast<RawEndPoint *>(arg);
-    chip::System::Layer & lSystemLayer = ep->SystemLayer();
-    IPPacketInfo * pktInfo             = NULL;
-    uint8_t enqueue                    = 1;
-    System::PacketBufferHandle buf     = System::PacketBufferHandle::Adopt(p);
+    RawEndPoint * ep               = static_cast<RawEndPoint *>(arg);
+    IPPacketInfo * pktInfo         = NULL;
+    uint8_t enqueue                = 1;
+    System::PacketBufferHandle buf = System::PacketBufferHandle::Adopt(p);
 
     // Filtering based on the saved ICMP6 types (the only protocol currently supported.)
     if ((ep->IPVer == kIPVersion_6) && (ep->IPProto == kIPProtocol_ICMPv6))
@@ -988,7 +987,7 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void * arg, struct raw_pcb * pcb, struct
             pktInfo->DestPort  = 0;
         }
 
-        PostPacketBufferEvent(lSystemLayer, *ep, kInetEvent_RawDataReceived, std::move(buf));
+        PostPacketBufferEvent(ep->Layer().SystemLayer(), *ep, kInetEvent_RawDataReceived, std::move(buf));
     }
 
     return enqueue;

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -243,7 +243,7 @@ CHIP_ERROR TCPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_queue_t dispatchQueue = SystemLayer().GetDispatchQueue();
+    dispatch_queue_t dispatchQueue = Layer().SystemLayer()->GetDispatchQueue();
     if (dispatchQueue != nullptr)
     {
         unsigned long fd = static_cast<unsigned long>(mSocket);
@@ -308,10 +308,10 @@ CHIP_ERROR TCPEndPoint::Listen(uint16_t backlog)
         fcntl(mSocket, F_SETFL, flags | O_NONBLOCK);
 
         // Wait for ability to read on this endpoint.
-        res = SystemLayer().SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this));
+        res = Layer().SystemLayer()->SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this));
         if (res == CHIP_NO_ERROR)
         {
-            res = SystemLayer().RequestCallbackOnPendingRead(mWatch);
+            res = Layer().SystemLayer()->RequestCallbackOnPendingRead(mWatch);
         }
     }
 
@@ -520,7 +520,7 @@ CHIP_ERROR TCPEndPoint::Connect(const IPAddress & addr, uint16_t port, Interface
         return res;
     }
 
-    ReturnErrorOnFailure(SystemLayer().SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
+    ReturnErrorOnFailure(Layer().SystemLayer()->SetCallback(mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(this)));
 
     // Once Connecting or Connected, bump the reference count.  The corresponding Release()
     // [or on LwIP, DeferredRelease()] will happen in DoClose().
@@ -530,7 +530,7 @@ CHIP_ERROR TCPEndPoint::Connect(const IPAddress & addr, uint16_t port, Interface
     {
         State = kState_Connected;
         // Wait for ability to read on this endpoint.
-        ReturnErrorOnFailure(SystemLayer().RequestCallbackOnPendingRead(mWatch));
+        ReturnErrorOnFailure(Layer().SystemLayer()->RequestCallbackOnPendingRead(mWatch));
         if (OnConnectComplete != nullptr)
             OnConnectComplete(this, CHIP_NO_ERROR);
     }
@@ -538,7 +538,7 @@ CHIP_ERROR TCPEndPoint::Connect(const IPAddress & addr, uint16_t port, Interface
     {
         State = kState_Connecting;
         // Wait for ability to write on this endpoint.
-        ReturnErrorOnFailure(SystemLayer().RequestCallbackOnPendingWrite(mWatch));
+        ReturnErrorOnFailure(Layer().SystemLayer()->RequestCallbackOnPendingWrite(mWatch));
     }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
@@ -565,17 +565,13 @@ void TCPEndPoint::StartConnectTimerIfSet()
 {
     if (mConnectTimeoutMsecs > 0)
     {
-        chip::System::Layer & lSystemLayer = SystemLayer();
-
-        lSystemLayer.StartTimer(mConnectTimeoutMsecs, TCPConnectTimeoutHandler, this);
+        Layer().SystemLayer()->StartTimer(mConnectTimeoutMsecs, TCPConnectTimeoutHandler, this);
     }
 }
 
 void TCPEndPoint::StopConnectTimer()
 {
-    chip::System::Layer & lSystemLayer = SystemLayer();
-
-    lSystemLayer.CancelTimer(TCPConnectTimeoutHandler, this);
+    Layer().SystemLayer()->CancelTimer(TCPConnectTimeoutHandler, this);
 }
 
 void TCPEndPoint::TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState)
@@ -803,7 +799,7 @@ CHIP_ERROR TCPEndPoint::Send(System::PacketBufferHandle && data, bool push)
         mSendQueue = std::move(data);
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
         // Wait for ability to write on this endpoint.
-        ReturnErrorOnFailure(SystemLayer().RequestCallbackOnPendingWrite(mWatch));
+        ReturnErrorOnFailure(Layer().SystemLayer()->RequestCallbackOnPendingWrite(mWatch));
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
     }
     else
@@ -1218,7 +1214,7 @@ void TCPEndPoint::SetIdleTimeout(uint32_t timeoutMS)
 
     if (!isIdleTimerRunning && mIdleTimeout)
     {
-        SystemLayer().StartTimer(INET_TCP_IDLE_CHECK_INTERVAL, InetLayer::HandleTCPInactivityTimer, &lInetLayer);
+        Layer().SystemLayer()->StartTimer(INET_TCP_IDLE_CHECK_INTERVAL, InetLayer::HandleTCPInactivityTimer, &lInetLayer);
     }
 }
 #endif // INET_TCP_IDLE_CHECK_INTERVAL > 0
@@ -1421,7 +1417,7 @@ CHIP_ERROR TCPEndPoint::DriveSending()
             if (mSendQueue.IsNull())
             {
                 // Do not wait for ability to write on this endpoint.
-                err = SystemLayer().ClearCallbackOnPendingWrite(mWatch);
+                err = Layer().SystemLayer()->ClearCallbackOnPendingWrite(mWatch);
                 if (err != CHIP_NO_ERROR)
                 {
                     break;
@@ -1528,10 +1524,10 @@ void TCPEndPoint::HandleConnectComplete(CHIP_ERROR err)
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
         // Wait for ability to read or write on this endpoint.
-        err = SystemLayer().RequestCallbackOnPendingRead(mWatch);
+        err = Layer().SystemLayer()->RequestCallbackOnPendingRead(mWatch);
         if (err == CHIP_NO_ERROR)
         {
-            err = SystemLayer().RequestCallbackOnPendingWrite(mWatch);
+            err = Layer().SystemLayer()->RequestCallbackOnPendingWrite(mWatch);
         }
         if (err != CHIP_NO_ERROR)
         {
@@ -1670,7 +1666,7 @@ CHIP_ERROR TCPEndPoint::DoClose(CHIP_ERROR err, bool suppressCallback)
                     ChipLogError(Inet, "SO_LINGER: %d", errno);
             }
 
-            SystemLayer().StopWatchingSocket(&mWatch);
+            Layer().SystemLayer()->StopWatchingSocket(&mWatch);
             close(mSocket);
             mSocket = INET_INVALID_SOCKET_FD;
         }
@@ -1822,9 +1818,7 @@ exit:
 
 void TCPEndPoint::ScheduleNextTCPUserTimeoutPoll(uint32_t aTimeOut)
 {
-    chip::System::Layer & lSystemLayer = SystemLayer();
-
-    lSystemLayer.StartTimer(aTimeOut, TCPUserTimeoutHandler, this);
+    Layer().SystemLayer()->StartTimer(aTimeOut, TCPUserTimeoutHandler, this);
 }
 
 #if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
@@ -1866,17 +1860,13 @@ void TCPEndPoint::StartTCPUserTimeoutTimer()
 
 void TCPEndPoint::StopTCPUserTimeoutTimer()
 {
-    chip::System::Layer & lSystemLayer = SystemLayer();
-
-    lSystemLayer.CancelTimer(TCPUserTimeoutHandler, this);
-
+    Layer().SystemLayer()->CancelTimer(TCPUserTimeoutHandler, this);
     mUserTimeoutTimerRunning = false;
 }
 
 void TCPEndPoint::RestartTCPUserTimeoutTimer()
 {
     StopTCPUserTimeoutTimer();
-
     StartTCPUserTimeoutTimer();
 }
 
@@ -2192,7 +2182,7 @@ err_t TCPEndPoint::LwIPHandleConnectComplete(void * arg, struct tcp_pcb * tpcb, 
     {
         CHIP_ERROR conErr;
         TCPEndPoint * ep                   = static_cast<TCPEndPoint *>(arg);
-        chip::System::Layer & lSystemLayer = ep->SystemLayer();
+        chip::System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         if (lwipErr == ERR_OK)
         {
@@ -2203,7 +2193,8 @@ err_t TCPEndPoint::LwIPHandleConnectComplete(void * arg, struct tcp_pcb * tpcb, 
 
         // Post callback to HandleConnectComplete.
         conErr = chip::System::MapErrorLwIP(lwipErr);
-        if (lSystemLayer.PostEvent(*ep, kInetEvent_TCPConnectComplete, static_cast<uintptr_t>(conErr.AsInteger())) != CHIP_NO_ERROR)
+        if (lSystemLayer->PostEvent(*ep, kInetEvent_TCPConnectComplete, static_cast<uintptr_t>(conErr.AsInteger())) !=
+            CHIP_NO_ERROR)
             res = ERR_ABRT;
     }
     else
@@ -2223,7 +2214,7 @@ err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpc
     {
         TCPEndPoint * listenEP             = static_cast<TCPEndPoint *>(arg);
         TCPEndPoint * conEP                = NULL;
-        chip::System::Layer & lSystemLayer = listenEP->SystemLayer();
+        chip::System::Layer * lSystemLayer = listenEP->Layer().SystemLayer();
 
         // Tell LwIP we've accepted the connection so it can decrement the listen PCB's pending_accepts counter.
         tcp_accepted(listenEP->mTCP);
@@ -2268,7 +2259,7 @@ err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpc
             tcp_err(tpcb, LwIPHandleError);
 
             // Post a callback to the HandleConnectionReceived() function, passing it the new end point.
-            if (lSystemLayer.PostEvent(*listenEP, kInetEvent_TCPConnectionReceived, (uintptr_t) conEP) != CHIP_NO_ERROR)
+            if (lSystemLayer->PostEvent(*listenEP, kInetEvent_TCPConnectionReceived, (uintptr_t) conEP) != CHIP_NO_ERROR)
             {
                 err = CHIP_ERROR_CONNECTION_ABORTED;
                 conEP->Release(); // for the Retain() above
@@ -2278,7 +2269,7 @@ err_t TCPEndPoint::LwIPHandleIncomingConnection(void * arg, struct tcp_pcb * tpc
 
         // Otherwise, there was an error accepting the connection, so post a callback to the HandleError function.
         else
-            lSystemLayer.PostEvent(*listenEP, kInetEvent_TCPError, static_cast<uintptr_t>(err.AsInteger()));
+            lSystemLayer->PostEvent(*listenEP, kInetEvent_TCPError, static_cast<uintptr_t>(err.AsInteger()));
     }
     else
         err = CHIP_ERROR_CONNECTION_ABORTED;
@@ -2301,10 +2292,10 @@ err_t TCPEndPoint::LwIPHandleDataReceived(void * arg, struct tcp_pcb * tpcb, str
     if (arg != NULL)
     {
         TCPEndPoint * ep                   = static_cast<TCPEndPoint *>(arg);
-        chip::System::Layer & lSystemLayer = ep->SystemLayer();
+        chip::System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         // Post callback to HandleDataReceived.
-        if (lSystemLayer.PostEvent(*ep, kInetEvent_TCPDataReceived, (uintptr_t) p) != CHIP_NO_ERROR)
+        if (lSystemLayer->PostEvent(*ep, kInetEvent_TCPDataReceived, (uintptr_t) p) != CHIP_NO_ERROR)
             res = ERR_ABRT;
     }
     else
@@ -2323,10 +2314,10 @@ err_t TCPEndPoint::LwIPHandleDataSent(void * arg, struct tcp_pcb * tpcb, u16_t l
     if (arg != NULL)
     {
         TCPEndPoint * ep                   = static_cast<TCPEndPoint *>(arg);
-        chip::System::Layer & lSystemLayer = ep->SystemLayer();
+        chip::System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         // Post callback to HandleDataReceived.
-        if (lSystemLayer.PostEvent(*ep, kInetEvent_TCPDataSent, (uintptr_t) len) != CHIP_NO_ERROR)
+        if (lSystemLayer->PostEvent(*ep, kInetEvent_TCPDataSent, (uintptr_t) len) != CHIP_NO_ERROR)
             res = ERR_ABRT;
     }
     else
@@ -2343,7 +2334,7 @@ void TCPEndPoint::LwIPHandleError(void * arg, err_t lwipErr)
     if (arg != NULL)
     {
         TCPEndPoint * ep                   = static_cast<TCPEndPoint *>(arg);
-        chip::System::Layer & lSystemLayer = ep->SystemLayer();
+        chip::System::Layer * lSystemLayer = ep->Layer().SystemLayer();
 
         // At this point LwIP has already freed the PCB.  Since the thread that owns the TCPEndPoint may
         // try to use the PCB before it receives the TCPError event posted below, we set the PCB to NULL
@@ -2355,7 +2346,7 @@ void TCPEndPoint::LwIPHandleError(void * arg, err_t lwipErr)
 
         // Post callback to HandleError.
         CHIP_ERROR err = chip::System::MapErrorLwIP(lwipErr);
-        lSystemLayer.PostEvent(*ep, kInetEvent_TCPError, static_cast<uintptr_t>(err.AsInteger()));
+        lSystemLayer->PostEvent(*ep, kInetEvent_TCPError, static_cast<uintptr_t>(err.AsInteger()));
     }
 }
 
@@ -2433,7 +2424,7 @@ CHIP_ERROR TCPEndPoint::GetSocket(IPAddressType addrType)
         mSocket = ::socket(family, SOCK_STREAM | SOCK_FLAGS, 0);
         if (mSocket == -1)
             return chip::System::MapErrorPOSIX(errno);
-        ReturnErrorOnFailure(SystemLayer().StartWatchingSocket(mSocket, &mWatch));
+        ReturnErrorOnFailure(Layer().SystemLayer()->StartWatchingSocket(mSocket, &mWatch));
         mAddrType = addrType;
 
         // If creating an IPv6 socket, tell the kernel that it will be IPv6 only.  This makes it
@@ -2629,7 +2620,7 @@ void TCPEndPoint::ReceiveData()
             else
                 State = kState_Closing;
             // Do not wait for ability to read on this endpoint.
-            (void) SystemLayer().ClearCallbackOnPendingRead(mWatch);
+            (void) Layer().SystemLayer()->ClearCallbackOnPendingRead(mWatch);
             // Call the app's OnPeerClose.
             if (OnPeerClose != nullptr)
                 OnPeerClose(this);
@@ -2727,7 +2718,7 @@ void TCPEndPoint::HandleIncomingConnection()
     {
         // Put the new end point into the Connected state.
         conEP->mSocket = conSocket;
-        err            = SystemLayer().StartWatchingSocket(conSocket, &conEP->mWatch);
+        err            = Layer().SystemLayer()->StartWatchingSocket(conSocket, &conEP->mWatch);
         if (err == CHIP_NO_ERROR)
         {
             conEP->State = kState_Connected;
@@ -2739,10 +2730,10 @@ void TCPEndPoint::HandleIncomingConnection()
             conEP->Retain();
 
             // Wait for ability to read on this endpoint.
-            err = conEP->SystemLayer().SetCallback(conEP->mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(conEP));
+            err = conEP->Layer().SystemLayer()->SetCallback(conEP->mWatch, HandlePendingIO, reinterpret_cast<intptr_t>(conEP));
             if (err == CHIP_NO_ERROR)
             {
-                err = conEP->SystemLayer().RequestCallbackOnPendingRead(conEP->mWatch);
+                err = conEP->Layer().SystemLayer()->RequestCallbackOnPendingRead(conEP->mWatch);
             }
             if (err == CHIP_NO_ERROR)
             {

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -67,16 +67,15 @@ DLL_EXPORT void Object::Release()
 
 DLL_EXPORT bool Object::TryCreate(size_t aOctets)
 {
-    bool lReturn = false;
-
-    if (__sync_bool_compare_and_swap(&this->mRefCount, 0, 1))
+    if (!__sync_bool_compare_and_swap(&this->mRefCount, 0, 1))
     {
-        this->AppState = nullptr;
-        memset(reinterpret_cast<char *>(this) + sizeof(*this), 0, aOctets - sizeof(*this));
-        lReturn = true;
+        return false; // object already in use
     }
 
-    return lReturn;
+    this->AppState = nullptr;
+    memset(reinterpret_cast<char *>(this) + sizeof(*this), 0, aOctets - sizeof(*this));
+
+    return true;
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -50,7 +50,6 @@ DLL_EXPORT void Object::Release()
 
     if (oldCount == 1)
     {
-        this->mSystemLayer = nullptr;
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
         std::lock_guard<std::mutex> lock(*mMutexRef);
         this->mPrev->mNext = this->mNext;
@@ -66,17 +65,14 @@ DLL_EXPORT void Object::Release()
     }
 }
 
-DLL_EXPORT bool Object::TryCreate(Layer & aLayer, size_t aOctets)
+DLL_EXPORT bool Object::TryCreate(size_t aOctets)
 {
     bool lReturn = false;
 
-    if (__sync_bool_compare_and_swap(&this->mSystemLayer, nullptr, &aLayer))
+    if (__sync_bool_compare_and_swap(&this->mRefCount, 0, 1))
     {
-        this->mRefCount = 0;
-        this->AppState  = nullptr;
+        this->AppState = nullptr;
         memset(reinterpret_cast<char *>(this) + sizeof(*this), 0, aOctets - sizeof(*this));
-
-        this->Retain();
         lReturn = true;
     }
 
@@ -84,10 +80,11 @@ DLL_EXPORT bool Object::TryCreate(Layer & aLayer, size_t aOctets)
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-void Object::DeferredRelease(Object::ReleaseDeferralErrorTactic aTactic)
+void Object::DeferredRelease(Layer * aSystemLayer, Object::ReleaseDeferralErrorTactic aTactic)
 {
-    Layer & lSystemLayer = *this->mSystemLayer;
-    CHIP_ERROR lError    = lSystemLayer.PostEvent(*this, chip::System::kEvent_ReleaseObj, 0);
+    VerifyOrReturn(aSystemLayer != nullptr, ChipLogError(chipSystemLayer, "aSystemLayer is nullptr"));
+
+    CHIP_ERROR lError = aSystemLayer->PostEvent(*this, chip::System::kEvent_ReleaseObj, 0);
 
     if (lError != CHIP_NO_ERROR)
     {
@@ -102,7 +99,7 @@ void Object::DeferredRelease(Object::ReleaseDeferralErrorTactic aTactic)
 
         case kReleaseDeferralErrorTactic_Die:
             VerifyOrDieWithMsg(false, chipSystemLayer, "Object::DeferredRelease %p->PostEvent failed err(%" CHIP_ERROR_FORMAT ")",
-                               &lSystemLayer, lError.Format());
+                               aSystemLayer, lError.Format());
             break;
         }
     }

--- a/src/system/SystemObject.h
+++ b/src/system/SystemObject.h
@@ -83,7 +83,7 @@ class DLL_EXPORT Object
     friend class ObjectPool;
 
 public:
-    Object() : mSystemLayer(nullptr)
+    Object() : mRefCount(0)
     {
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
         mNext = nullptr;
@@ -93,8 +93,8 @@ public:
 
     virtual ~Object() {}
 
-    /** Test whether this object is retained by \c aLayer. Concurrency safe. */
-    bool IsRetained(const Layer & aLayer) const;
+    /** Test whether this object is retained. Concurrency safe. */
+    bool IsRetained() const;
 
     void Retain();
     void Release();
@@ -110,7 +110,7 @@ protected:
         kReleaseDeferralErrorTactic_Die,     /**< Die with message. */
     };
 
-    void DeferredRelease(ReleaseDeferralErrorTactic aTactic);
+    void DeferredRelease(Layer * aSystemLayer, ReleaseDeferralErrorTactic aTactic);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 private:
@@ -123,11 +123,10 @@ private:
     std::mutex * mMutexRef;
 #endif
 
-    Layer * volatile mSystemLayer; /**< Pointer to the layer object that owns this object. */
-    unsigned int mRefCount;        /**< Count of remaining calls to Release before object is dead. */
+    unsigned int mRefCount; /**< Count of remaining calls to Release before object is dead. */
 
-    /** If not already retained, attempt initial retention of this object for \c aLayer and zero up to \c aOctets. */
-    bool TryCreate(Layer & aLayer, size_t aOctets);
+    /** If not already retained, attempt initial retention of this object and zero up to \c aOctets. */
+    bool TryCreate(size_t aOctets);
 
 public:
     void * AppState; /**< Generic pointer to app-specific data associated with the object. */
@@ -135,16 +134,16 @@ public:
 
 /**
  *  @brief
- *      Tests whether this object is retained by \c aLayer.
+ *      Tests whether this object is retained.
  *
  *  @note
  *      No memory barrier is applied. If this returns \c false in one thread context, then it does not imply that another thread
- *      cannot have previously retained the object for \c aLayer. If it returns \c true, then the logic using \c aLayer is
+ *      cannot have previously retained the object for \c aLayer. If it returns \c true, then the logic using \c mRefCount is
  *      responsible for ensuring concurrency safety for this object.
  */
-inline bool Object::IsRetained(const Layer & aLayer) const
+inline bool Object::IsRetained() const
 {
-    return this->mSystemLayer == &aLayer;
+    return this->mRefCount > 0;
 }
 
 /**
@@ -154,16 +153,6 @@ inline bool Object::IsRetained(const Layer & aLayer) const
 inline void Object::Retain()
 {
     __sync_fetch_and_add(&this->mRefCount, 1);
-}
-
-/**
- *  @brief
- *      Returns a reference to the CHIP System Layer object provided when the object was initially retained from its corresponding
- *      object pool instance. The object is assumed to be live.
- */
-inline Layer & Object::SystemLayer() const
-{
-    return *this->mSystemLayer;
 }
 
 /**
@@ -193,7 +182,7 @@ class ObjectPool
 public:
     void Reset();
 
-    T * TryCreate(Layer & aLayer);
+    T * TryCreate();
     void GetStatistics(chip::System::Stats::count_t & aNumInUse, chip::System::Stats::count_t & aHighWatermark);
 
     /**
@@ -270,17 +259,17 @@ inline void ObjectPool<T, N>::Reset()
 
 /**
  *  @brief
- *      Tries to initially retain the first object in the pool that is not retained by any layer.
+ *      Tries to initially retain the first object in the pool that is not retained.
  */
 template <class T, unsigned int N>
-inline T * ObjectPool<T, N>::TryCreate(Layer & aLayer)
+inline T * ObjectPool<T, N>::TryCreate()
 {
     T * lReturn = nullptr;
 
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
     T * newNode = new T();
 
-    if (newNode->TryCreate(aLayer, sizeof(T)))
+    if (newNode->TryCreate(sizeof(T)))
     {
         std::lock_guard<std::mutex> lock(mMutex);
         Object * p = &mDummyHead;
@@ -305,7 +294,7 @@ inline T * ObjectPool<T, N>::TryCreate(Layer & aLayer)
     {
         T & lObject = reinterpret_cast<T *>(mArena.uMemory)[lIndex];
 
-        if (lObject.TryCreate(aLayer, sizeof(T)))
+        if (lObject.TryCreate(sizeof(T)))
         {
             lReturn = &lObject;
             break;
@@ -352,7 +341,7 @@ inline bool ObjectPool<T, N>::ForEachActiveObjectInner(void * context, Lambda la
     {
         T & lObject = reinterpret_cast<T *>(mArena.uMemory)[i];
 
-        if (lObject.mSystemLayer != nullptr)
+        if (lObject.IsRetained())
         {
             if (!lambda(context, static_cast<void *>(&lObject)))
                 return false;
@@ -392,7 +381,7 @@ inline void ObjectPool<T, N>::GetNumObjectsInUse(unsigned int aStartIndex, unsig
     {
         T & lObject = reinterpret_cast<T *>(mArena.uMemory)[lIndex];
 
-        if (lObject.mSystemLayer != nullptr)
+        if (lObject.IsRetained())
         {
             count++;
         }

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -110,8 +110,8 @@ void Timer::Clear()
     VerifyOrReturn(__sync_bool_compare_and_swap(&mOnComplete, lOnComplete, nullptr));
 
     // Since this thread changed the state of mOnComplete, release the timer.
-    AppState = nullptr;
-	mSystemLayer = nullptr;
+    AppState     = nullptr;
+    mSystemLayer = nullptr;
 }
 
 void Timer::HandleComplete()
@@ -127,8 +127,8 @@ void Timer::HandleComplete()
     VerifyOrReturn(__sync_bool_compare_and_swap(&this->mOnComplete, lOnComplete, nullptr), );
 
     // Since this thread changed the state of mOnComplete, release the timer.
-    AppState = nullptr;
-	mSystemLayer = nullptr;
+    AppState     = nullptr;
+    mSystemLayer = nullptr;
     this->Release();
 
     // Invoke the app's callback, if it's still valid.

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -81,15 +81,16 @@ ObjectPool<Timer, CHIP_SYSTEM_CONFIG_NUM_TIMERS> Timer::sPool;
 
 Timer * Timer::New(System::Layer & systemLayer, uint32_t delayMilliseconds, TimerCompleteCallback onComplete, void * appState)
 {
-    Timer * timer = Timer::sPool.TryCreate(systemLayer);
+    Timer * timer = Timer::sPool.TryCreate();
     if (timer == nullptr)
     {
         ChipLogError(chipSystemLayer, "Timer pool EMPTY");
     }
     else
     {
-        timer->AppState    = appState;
-        timer->mAwakenTime = Clock::GetMonotonicMilliseconds() + static_cast<Clock::MonotonicMilliseconds>(delayMilliseconds);
+        timer->AppState     = appState;
+        timer->mSystemLayer = &systemLayer;
+        timer->mAwakenTime  = Clock::GetMonotonicMilliseconds() + static_cast<Clock::MonotonicMilliseconds>(delayMilliseconds);
         if (!__sync_bool_compare_and_swap(&timer->mOnComplete, nullptr, onComplete))
         {
             chipDie();
@@ -110,12 +111,13 @@ void Timer::Clear()
 
     // Since this thread changed the state of mOnComplete, release the timer.
     AppState = nullptr;
+	mSystemLayer = nullptr;
 }
 
 void Timer::HandleComplete()
 {
     // Save information needed to perform the callback.
-    Layer & lLayer                          = this->SystemLayer();
+    Layer * lLayer                          = this->mSystemLayer;
     const TimerCompleteCallback lOnComplete = this->mOnComplete;
     void * lAppState                        = this->AppState;
 
@@ -126,11 +128,12 @@ void Timer::HandleComplete()
 
     // Since this thread changed the state of mOnComplete, release the timer.
     AppState = nullptr;
+	mSystemLayer = nullptr;
     this->Release();
 
     // Invoke the app's callback, if it's still valid.
     if (lOnComplete != nullptr)
-        lOnComplete(&lLayer, lAppState);
+        lOnComplete(lLayer, lAppState);
 }
 
 Timer * Timer::List::Add(Timer * add)

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -227,6 +227,8 @@ private:
     Clock::MonotonicMilliseconds mAwakenTime;
     Timer * mNextTimer;
 
+    Layer * mSystemLayer;
+
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     dispatch_source_t mTimerSource = nullptr;
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH

--- a/src/system/WatchableEventManagerLwIP.cpp
+++ b/src/system/WatchableEventManagerLwIP.cpp
@@ -145,10 +145,6 @@ CHIP_ERROR WatchableEventManager::PostEvent(Object & aTarget, EventType aEventTy
 {
     VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
-    // Sanity check that this instance and the target layer haven't been "crossed".
-    VerifyOrDieWithMsg(aTarget.IsRetained(*mSystemLayer), chipSystemLayer, "wrong poster! [target %p != this %p]",
-                       &(aTarget.SystemLayer()), mSystemLayer);
-
     CHIP_ERROR lReturn = PlatformEventing::PostEvent(*mSystemLayer, aTarget, aEventType, aArgument);
     if (lReturn != CHIP_NO_ERROR)
     {
@@ -199,10 +195,6 @@ CHIP_ERROR WatchableEventManager::DispatchEvent(Event aEvent)
 CHIP_ERROR WatchableEventManager::HandleEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
 {
     VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-
-    // Sanity check that this instance and the target layer haven't been "crossed".
-    VerifyOrDieWithMsg(aTarget.IsRetained(*mSystemLayer), chipSystemLayer, "wrong handler! [target %p != this %p]",
-                       &(aTarget.SystemLayer()), mSystemLayer);
 
     // Prevent the target object from being freed while dispatching the event.
     aTarget.Retain();

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -138,15 +138,13 @@ struct TestContext sContext;
 void TestObject::CheckIteration(nlTestSuite * inSuite, void * aContext)
 {
     TestContext & lContext = *static_cast<TestContext *>(aContext);
-    Layer lLayer;
     unsigned int i;
 
-    lLayer.Init();
     sPool.Reset();
 
     for (i = 0; i < kPoolSize; ++i)
     {
-        TestObject * lCreated = sPool.TryCreate(lLayer);
+        TestObject * lCreated = sPool.TryCreate();
 
         NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
         lCreated->Init();
@@ -154,8 +152,7 @@ void TestObject::CheckIteration(nlTestSuite * inSuite, void * aContext)
 
     i = 0;
     sPool.ForEachActiveObject([&](TestObject * lCreated) {
-        NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained(lLayer));
-        NL_TEST_ASSERT(lContext.mTestSuite, &(lCreated->SystemLayer()) == &lLayer);
+        NL_TEST_ASSERT(lContext.mTestSuite, lCreated->IsRetained());
         i++;
         return true;
     });
@@ -170,8 +167,6 @@ void TestObject::CheckIteration(nlTestSuite * inSuite, void * aContext)
         return true;
     });
     NL_TEST_ASSERT(lContext.mTestSuite, i == kPoolSize / 2);
-
-    lLayer.Shutdown();
 }
 
 // Test Object retention
@@ -179,15 +174,13 @@ void TestObject::CheckIteration(nlTestSuite * inSuite, void * aContext)
 void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
 {
     TestContext & lContext = *static_cast<TestContext *>(aContext);
-    Layer lLayer;
     unsigned int i;
 
-    lLayer.Init();
     sPool.Reset();
 
     for (i = 0; i < kPoolSize; ++i)
     {
-        TestObject * lCreated = sPool.TryCreate(lLayer);
+        TestObject * lCreated = sPool.TryCreate();
 
         NL_TEST_ASSERT(lContext.mTestSuite, lCreated != nullptr);
 
@@ -209,8 +202,6 @@ void TestObject::CheckRetention(nlTestSuite * inSuite, void * aContext)
         return true;
     });
     NL_TEST_ASSERT(lContext.mTestSuite, i == kPoolSize);
-
-    lLayer.Shutdown();
 }
 
 // Test Object concurrency
@@ -238,10 +229,7 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
     const unsigned int kNumObjects = kPoolSize / kNumThreads;
     TestObject * lObject           = nullptr;
     TestContext & lContext         = *static_cast<TestContext *>(aContext);
-    Layer lLayer;
     unsigned int i;
-
-    lLayer.Init();
 
     // Take this thread's share of objects
 
@@ -250,11 +238,10 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
         lObject = nullptr;
         while (lObject == nullptr)
         {
-            lObject = sPool.TryCreate(lLayer);
+            lObject = sPool.TryCreate();
         }
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained(lLayer));
-        NL_TEST_ASSERT(lContext.mTestSuite, &(lObject->SystemLayer()) == &lLayer);
+        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained());
 
         lObject->Init();
         lObject->Delay(lContext.mAccumulator);
@@ -267,19 +254,16 @@ void * TestObject::CheckConcurrencyThread(void * aContext)
         lObject = nullptr;
         while (lObject == nullptr)
         {
-            lObject = sPool.TryCreate(lLayer);
+            lObject = sPool.TryCreate();
         }
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained(lLayer));
-        NL_TEST_ASSERT(lContext.mTestSuite, &(lObject->SystemLayer()) == &lLayer);
+        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained());
 
         lObject->Init();
         lObject->Delay(lContext.mAccumulator);
 
         lObject->Release();
     }
-
-    lLayer.Shutdown();
 
     return aContext;
 }
@@ -358,20 +342,16 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     const int kNumObjects  = kPoolSize;
     TestObject * lObject   = nullptr;
     TestContext & lContext = *static_cast<TestContext *>(aContext);
-    Layer lLayer;
     chip::System::Stats::count_t lNumInUse;
     chip::System::Stats::count_t lHighWatermark;
-
-    lLayer.Init();
 
     // Take all objects one at a time and check the watermark
     // increases monotonically
     for (int i = 0; i < kNumObjects; ++i)
     {
-        lObject = sPool.TryCreate(lLayer);
+        lObject = sPool.TryCreate();
 
-        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained(lLayer));
-        NL_TEST_ASSERT(lContext.mTestSuite, &(lObject->SystemLayer()) == &lLayer);
+        NL_TEST_ASSERT(lContext.mTestSuite, lObject->IsRetained());
 
         sPool.GetStatistics(lNumInUse, lHighWatermark);
         NL_TEST_ASSERT(lContext.mTestSuite, lNumInUse == (i + 1));
@@ -381,7 +361,7 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     }
 
     // Fail an allocation and check that both stats don't change
-    NL_TEST_ASSERT(lContext.mTestSuite, sPool.TryCreate(lLayer) == nullptr);
+    NL_TEST_ASSERT(lContext.mTestSuite, sPool.TryCreate() == nullptr);
 
     sPool.GetStatistics(lNumInUse, lHighWatermark);
     NL_TEST_ASSERT(lContext.mTestSuite, lNumInUse == kNumObjects);
@@ -390,13 +370,11 @@ void TestObject::CheckHighWatermark(nlTestSuite * inSuite, void * aContext)
     // Free the last object and check that the watermark does not
     // change.
     lObject->Release();
-    NL_TEST_ASSERT(lContext.mTestSuite, !lObject->IsRetained(lLayer));
+    NL_TEST_ASSERT(lContext.mTestSuite, !lObject->IsRetained());
 
     sPool.GetStatistics(lNumInUse, lHighWatermark);
     NL_TEST_ASSERT(lContext.mTestSuite, lNumInUse == (kNumObjects - 1));
     NL_TEST_ASSERT(lContext.mTestSuite, lHighWatermark == kNumObjects);
-
-    lLayer.Shutdown();
 }
 #endif // !CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the ObjectPool is coupled with SystemLayer and only be used by SystemLayer and InetLayer components. The purpose of this coupling is to guarantee the ObjectPool APIs are thread safe by atomically checking if the object has been retained and setting the object to 'retained' on those embedded systems which do not support std::mutex.

*  __sync_bool_compare_and_swap(&this->mSystemLayer, nullptr, &aLayer))
 
 * Actually, we can leverage another existing field mRefCount to do the same check and set atomically. So mSystemLayer can be saved from each Object.
 
 * __sync_bool_compare_and_swap(&this->mRefCount, 0, 1)
 
 * We could decouple ObjectPool from SystemLayer to make ObjectPool more generic and to be used by higher layers (such as apps) which do not have access to SystemLayer. 

#### Change overview
Decouple ObjectPool from SystemLayer

#### Testing
How was this tested? (at least one bullet point required)
* Regression test is covered by unit test ./TestSystemObject 

