### PR TITLE
Add IsAttributePathSupersetOf in ClusterInfo

### DIFF
--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -32,6 +32,25 @@ struct ClusterInfo
         kEventIdValid   = 0x03,
     };
 
+    bool IsAttributePathSupersetOf(const ClusterInfo & other) const
+    {
+        if ((other.mEndpointId != mEndpointId) || (other.mClusterId != mClusterId))
+        {
+            return false;
+        }
+
+        if (mFlags.Has(Flags::kFieldIdValid) && (mFieldId == 0xFFFFFFFF))
+        {
+            return true;
+        }
+
+        if (mFlags.Has(Flags::kFieldIdValid) && other.mFlags.Has(Flags::kFieldIdValid) && (mFieldId == other.mFieldId))
+        {
+            return true;
+        }
+        return false;
+    }
+
     ClusterInfo() {}
     bool IsDirty() { return mDirty; }
     void SetDirty() { mDirty = true; }

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -37,12 +37,74 @@ void TestDirty(nlTestSuite * apSuite, void * apContext)
     clusterInfo1.ClearDirty();
     NL_TEST_ASSERT(apSuite, !clusterInfo1.IsDirty());
 }
+
+void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContext)
+{
+    ClusterInfo clusterInfo1;
+    ClusterInfo clusterInfo2;
+    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+    clusterInfo1.mFieldId = 1;
+    clusterInfo2.mFieldId = 1;
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+
+    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kListIndexValid);
+    clusterInfo2.mListIndex = 1;
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+}
+
+void TestAttributePathIncludedDifferentFieldId(nlTestSuite * apSuite, void * apContext)
+{
+    ClusterInfo clusterInfo1;
+    ClusterInfo clusterInfo2;
+    clusterInfo1.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+    clusterInfo2.mFlags.Set(ClusterInfo::Flags::kFieldIdValid);
+    clusterInfo1.mFieldId = 1;
+    clusterInfo2.mFieldId = 2;
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    clusterInfo1.mFieldId = 0xFFFFFFFF;
+    clusterInfo2.mFieldId = 2;
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    clusterInfo1.mFieldId = 0xFFFFFFFF;
+    clusterInfo2.mFieldId = 0xFFFFFFFF;
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+    clusterInfo1.mFieldId = 1;
+    clusterInfo2.mFieldId = 0xFFFFFFFF;
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+}
+
+void TestAttributePathIncludedDifferentEndpointId(nlTestSuite * apSuite, void * apContext)
+{
+    ClusterInfo clusterInfo1;
+    ClusterInfo clusterInfo2;
+    clusterInfo1.mEndpointId = 1;
+    clusterInfo2.mEndpointId = 2;
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+}
+
+void TestAttributePathIncludedDifferentClusterId(nlTestSuite * apSuite, void * apContext)
+{
+    ClusterInfo clusterInfo1;
+    ClusterInfo clusterInfo2;
+    clusterInfo1.mClusterId = 1;
+    clusterInfo2.mClusterId = 2;
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsAttributePathSupersetOf(clusterInfo2));
+}
 } // namespace TestClusterInfo
 } // namespace app
 } // namespace chip
 
 namespace {
-const nlTest sTests[] = { NL_TEST_DEF("TestDirty", chip::app::TestClusterInfo::TestDirty), NL_TEST_SENTINEL() };
+const nlTest sTests[] = {
+    NL_TEST_DEF("TestDirty", chip::app::TestClusterInfo::TestDirty),
+    NL_TEST_DEF("TestAttributePathIncludedSameFieldId", chip::app::TestClusterInfo::TestAttributePathIncludedSameFieldId),
+    NL_TEST_DEF("TestAttributePathIncludedDifferentFieldId", chip::app::TestClusterInfo::TestAttributePathIncludedDifferentFieldId),
+    NL_TEST_DEF("TestAttributePathIncludedDifferentEndpointId",
+                chip::app::TestClusterInfo::TestAttributePathIncludedDifferentEndpointId),
+    NL_TEST_DEF("TestAttributePathIncludedDifferentClusterId",
+                chip::app::TestClusterInfo::TestAttributePathIncludedDifferentClusterId),
+    NL_TEST_SENTINEL()
+};
 }
 
 int TestClusterInfo()


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
Need IsAttributePathSupersetOf to filter duplicate path in Read

#### Change overview
Add IsAttributePathSupersetOf in ClusterInfo

#### Testing
Add unit test for IsAttributePathSupersetOf