### PR TITLE
Do not hardcode the UDP listen port in ChipDeviceController

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -109,7 +109,7 @@ DeviceController::DeviceController()
     mExchangeMgr              = nullptr;
     mStorageDelegate          = nullptr;
     mPairedDevicesInitialized = false;
-    mListenPort               = CHIP_PORT;
+    mListenPort               = 0;
 }
 
 CHIP_ERROR DeviceController::Init(ControllerInitParams params)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -109,7 +109,6 @@ DeviceController::DeviceController()
     mExchangeMgr              = nullptr;
     mStorageDelegate          = nullptr;
     mPairedDevicesInitialized = false;
-    mListenPort               = 0;
 }
 
 CHIP_ERROR DeviceController::Init(ControllerInitParams params)
@@ -120,6 +119,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     {
         mSystemLayer = params.systemLayer;
         mInetLayer   = params.inetLayer;
+        mListenPort  = params.listenPort;
     }
     else
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -103,7 +103,7 @@ struct ControllerInitParams
 
     uint16_t controllerVendorId;
 
-    /* The port used by the controller to listen for and send messages.
+    /* The port used for operational communication to listen for and send messages over UDP/TCP.
      * The default value of `0` will pick any available port. */
     uint16_t listenPort = 0;
 };

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -102,6 +102,10 @@ struct ControllerInitParams
     ByteSpan controllerRCAC;
 
     uint16_t controllerVendorId;
+
+    /* The port used by the controller to listen for and send messages.
+     * The default value of `0` will pick any available port. */
+    uint16_t listenPort = 0;
 };
 
 enum CommissioningStage : uint8_t


### PR DESCRIPTION
#### Problem

TLDR; Same PR as this https://github.com/project-chip/connectedhomeip/pull/9309, but for the C++ library 

ChipDeviceController hardcodes the UDP listen port to CHIP_PORT. This makes it impossible to have more than one instance of any of the controllers that use this on the same host. 
The target device is unable to tell which one is which and messages arrive to both which results in communication failure.

#### Change overview
Do not hardcode the UDP listen port.

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested pairing with two instances of the chip-tool cli with the same accessory. 
