### PR TITLE
Fix typo in nrf builder for pump controller

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -51,7 +51,7 @@ class NrfApp(Enum):
             return 'chip-nrf-shell'
         elif self == NrfApp.PUMP:
             return 'chip-nrf-pump-example'
-        elif self == NrfApp.CONTROLLER:
+        elif self == NrfApp.PUMP_CONTROLLER:
             return 'chip-nrf-pump-controller-example'
         else:
             raise Exception('Unknown app type: %r' % self)


### PR DESCRIPTION
#### Problem
Failed to 'copy artifacts' when building pump app

#### Change overview
Fix typo: `.CONTROLLER' to `.PUMP_CONTROLLER`

#### Testing
Ran manually in vscode: `./scripts/build/build_examples.py --app pump-controller --app pump --board nrf52840 build --copy-artifacts-to /tmp/abc`
