### PR TITLE
Workaround: Temorarily enable BLE during Enhanced Commissioning Window

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -299,7 +299,12 @@ CHIP_ERROR OpenEnhancedCommissioningWindow(uint16_t commissioningTimeoutSeconds,
 
     ReturnErrorOnFailure(gDeviceDiscriminatorCache.UpdateDiscriminator(discriminator));
 
-    gAdvDelegate.SetBLE(false);
+// TODO: Do not turn on BLE when opening the Enhanced Commissioning Window.
+#if CONFIG_NETWORK_LAYER_BLE
+    gAdvDelegate.SetBLE(true);
+    params.SetAdvertisementDelegate(&gAdvDelegate);
+    params.SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer()).SetPeerAddress(Transport::PeerAddress::BLE());
+#endif // CONFIG_NETWORK_LAYER_BLE
     params.SetPASEVerifier(verifier).SetAdvertisementDelegate(&gAdvDelegate);
 
     ReturnErrorOnFailure(


### PR DESCRIPTION
#### Problem
Our SDK currently doesn't offer a mechanism for an App to know whether a commissionable node is available on-network or via BLE. 
It's impossible to know which mechanism to use (this is different from CLI based tests where the tester knows exactly what their test case is). In addition to that the on-network API requires an IP Address. Which is unreasonable to expect an app/non-tester to provide.
https://github.com/project-chip/connectedhomeip/issues/9343

**Problem:** In addition to that, we recently disabled BLE advertisements while opening the Enhanced Commissioning Window. 
Prior to that, we could use the same commissioning mechanism(BLE) to pair an accessory regardless of which commissioning mode the accessory was in. 

While we address this issue with the underlying SDK, we should continue to allow BLE based commissioning even on Enhanced Commissioning Windows so that we can re-enable test and integration for this and restore prior functionality. 

#### Change overview
Enabled BLE during the enhanced commissioning flow again. 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested that CHIPTool iOS is able to pair with an accessory put into Enhanced Commissioning mode via the chip-tool CLI.
