### PR TITLE
[Android] Support IP commissioning with known address

### DIFF
--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -92,6 +92,7 @@ class AndroidBuilder(Builder):
             gn_args['target_cpu'] = self.board.TargetCpuName()
             gn_args['android_ndk_root'] = os.environ['ANDROID_NDK_HOME']
             gn_args['android_sdk_root'] = os.environ['ANDROID_HOME']
+            gn_args['chip_use_clusters_for_ip_commissioning'] = 'true'
 
             args = '--args=%s' % (' '.join([
                 '%s="%s"' % (key, shlex.quote(value))

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -105,19 +105,19 @@ export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
 west build --cmake-only -d /OUTPUT/DIR/nrf-nrf5340-pump_controller -b nrf5340dk_nrf5340_cpuapp /TEST/BUILD/ROOT/examples/pump-controller-app/nrfconnect'
 
 # Generating android-arm-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
+gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating android-arm64-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-arm64-chip_tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
+gn gen --check --fail-on-unused-args {out}/android-arm64-chip_tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 
 # Generating android-x64-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-x64-chip_tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
+gn gen --check --fail-on-unused-args {out}/android-x64-chip_tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'

--- a/scripts/examples/android_app.sh
+++ b/scripts/examples/android_app.sh
@@ -37,7 +37,7 @@ fi
 
 # Build shared CHIP libs
 source scripts/activate.sh
-gn gen --check --fail-on-unused-args out/"android_$TARGET_CPU" --args="target_os=\"android\" target_cpu=\"$TARGET_CPU\" android_ndk_root=\"$ANDROID_NDK_HOME\" android_sdk_root=\"$ANDROID_HOME\""
+gn gen --check --fail-on-unused-args out/"android_$TARGET_CPU" --args="target_os=\"android\" target_cpu=\"$TARGET_CPU\" android_ndk_root=\"$ANDROID_NDK_HOME\" android_sdk_root=\"$ANDROID_HOME\" chip_use_clusters_for_ip_commissioning=\"true\""
 ninja -C out/"android_$TARGET_CPU" src/setup_payload/java src/controller/java default
 
 rsync -a out/"android_$TARGET_CPU"/lib/*.jar src/android/CHIPTool/app/libs

--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "androidx.annotation:annotation:1.1.0"
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -33,6 +33,7 @@ import com.google.chip.chiptool.attestation.AttestationTestFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.clusterclient.SensorClientFragment
 import com.google.chip.chiptool.echoclient.EchoClientFragment
+import com.google.chip.chiptool.provisioning.AddressCommissioningFragment
 import com.google.chip.chiptool.provisioning.DeviceProvisioningFragment
 import com.google.chip.chiptool.provisioning.ProvisionNetworkType
 import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
@@ -100,6 +101,10 @@ class CHIPToolActivity :
   override fun onProvisionThreadCredentialsClicked() {
     networkType = ProvisionNetworkType.THREAD
     showFragment(BarcodeFragment.newInstance(), false)
+  }
+
+  override fun onShowDeviceAddressInput() {
+    showFragment(AddressCommissioningFragment.newInstance(), false)
   }
 
   override fun handleEchoClientClicked() {
@@ -184,6 +189,7 @@ class CHIPToolActivity :
 
   companion object {
     private const val TAG = "CHIPToolActivity"
+    private const val ADDRESS_COMMISSIONING_FRAGMENT_TAG = "address_commissioning_fragment"
     private const val ARG_PROVISION_NETWORK_TYPE = "provision_network_type"
 
     var REQUEST_CODE_COMMISSIONING = 0xB003

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -114,6 +114,8 @@ class SelectActionFragment : Fragment() {
     fun handleSensorClicked()
     /** Notifies listener of attestation command button clicked. */
     fun handleAttestationTestClicked()
+    /** Notifies listener of a click to manually input the CHIP device address.. */
+    fun onShowDeviceAddressInput()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/AddressCommissioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/AddressCommissioningFragment.kt
@@ -1,0 +1,56 @@
+package com.google.chip.chiptool.provisioning
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.chip.chiptool.ChipClient
+import com.google.chip.chiptool.R
+import com.google.chip.chiptool.setuppayloadscanner.BarcodeFragment
+import com.google.chip.chiptool.setuppayloadscanner.CHIPDeviceInfo
+import com.google.chip.chiptool.util.FragmentUtil
+import kotlinx.android.synthetic.main.address_commissioning_fragment.addressEditText
+import kotlinx.android.synthetic.main.address_commissioning_fragment.commissionBtn
+import kotlinx.android.synthetic.main.address_commissioning_fragment.discriminatorEditText
+import kotlinx.android.synthetic.main.address_commissioning_fragment.pincodeEditText
+
+class AddressCommissioningFragment : Fragment() {
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    return inflater.inflate(R.layout.address_commissioning_fragment, container, false)
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    commissionBtn.setOnClickListener {
+      val address = addressEditText.text.toString()
+      val discriminator = discriminatorEditText.text.toString()
+      val pincode = pincodeEditText.text.toString()
+
+      if (address.isEmpty() || discriminator.isEmpty() || pincode.isEmpty()) {
+        Log.e(TAG, "Address, discriminator, or pincode was empty: $address $discriminator $pincode")
+        return@setOnClickListener
+      }
+
+      FragmentUtil.getHost(this, BarcodeFragment.Callback::class.java)?.onCHIPDeviceInfoReceived(
+        CHIPDeviceInfo(
+          discriminator = discriminator.toInt(),
+          setupPinCode = pincode.toLong(),
+          ipAddress = address
+        )
+      )
+    }
+  }
+
+  companion object {
+    private const val TAG = "AddressCommissioningFragment"
+
+    fun newInstance(): AddressCommissioningFragment = AddressCommissioningFragment()
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -62,7 +62,11 @@ class DeviceProvisioningFragment : Fragment() {
     deviceInfo = checkNotNull(requireArguments().getParcelable(ARG_DEVICE_INFO))
     return inflater.inflate(R.layout.single_fragment_container, container, false).apply {
       if (savedInstanceState == null) {
-        startConnectingToDevice()
+        if (deviceInfo.ipAddress != null) {
+          pairDeviceWithAddress()
+        } else {
+          startConnectingToDevice()
+        }
       }
     }
   }
@@ -71,6 +75,23 @@ class DeviceProvisioningFragment : Fragment() {
     super.onStop()
     gatt = null
     scope.cancel()
+  }
+
+  private fun pairDeviceWithAddress() {
+    // IANA CHIP port
+    val port = 5540
+    val id = DeviceIdUtil.getNextAvailableId(requireContext())
+    val deviceController = ChipClient.getDeviceController(requireContext())
+    DeviceIdUtil.setNextAvailableId(requireContext(), id + 1)
+    deviceController.setCompletionListener(ConnectionCallback())
+    deviceController.pairDeviceWithAddress(
+      id,
+      deviceInfo.ipAddress,
+      port,
+      deviceInfo.discriminator,
+      deviceInfo.setupPinCode,
+      null
+    )
   }
 
   private fun startConnectingToDevice() {
@@ -117,6 +138,17 @@ class DeviceProvisioningFragment : Fragment() {
   inner class ConnectionCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {
       Log.d(TAG, "onConnectDeviceComplete")
+    }
+
+    /**
+     * This would only happen in the on-network case. In other cases, we need network commissioning
+     * first before this callback can be invoked, so we would use the callback implementation in
+     * EnterNetworkFragment.
+     */
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+      Log.d(TAG, "Commissioning complete for $nodeId with errorCode $errorCode")
+      FragmentUtil.getHost(this@DeviceProvisioningFragment, Callback::class.java)
+        ?.onCommissioningComplete(0)
     }
 
     override fun onStatusUpdate(status: Int) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -40,8 +40,10 @@ import com.google.android.gms.vision.CameraSource
 import com.google.android.gms.vision.barcode.Barcode
 import com.google.android.gms.vision.barcode.BarcodeDetector
 import com.google.chip.chiptool.R
+import com.google.chip.chiptool.SelectActionFragment
 import com.google.chip.chiptool.util.FragmentUtil
 import java.io.IOException
+import kotlinx.android.synthetic.main.barcode_fragment.view.inputAddressBtn
 
 /** Launches the camera to scan for QR code. */
 class BarcodeFragment : Fragment(), CHIPBarcodeProcessor.BarcodeDetectionListener {
@@ -65,6 +67,12 @@ class BarcodeFragment : Fragment(), CHIPBarcodeProcessor.BarcodeDetectionListene
     ): View {
         return inflater.inflate(R.layout.barcode_fragment, container, false).apply {
             cameraSourceView = findViewById(R.id.camera_view)
+            inputAddressBtn.setOnClickListener {
+                FragmentUtil.getHost(
+                    this@BarcodeFragment,
+                    SelectActionFragment.Callback::class.java
+                )?.onShowDeviceAddressInput()
+            }
         }
     }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
@@ -26,13 +26,14 @@ import kotlinx.android.parcel.Parcelize
 /** Class to hold the CHIP device information. */
 @Parcelize
 data class CHIPDeviceInfo(
-  val version: Int,
-  val vendorId: Int,
-  val productId: Int,
-  val discriminator: Int,
-  val setupPinCode: Long,
-  val optionalQrCodeInfoMap: Map<Int, QrCodeInfo>,
-  val discoveryCapabilities: Set<DiscoveryCapability>
+  val version: Int = 0,
+  val vendorId: Int = 0,
+  val productId: Int = 0,
+  val discriminator: Int = 0,
+  val setupPinCode: Long = 0L,
+  val optionalQrCodeInfoMap: Map<Int, QrCodeInfo> = mapOf(),
+  val discoveryCapabilities: Set<DiscoveryCapability> = setOf(),
+  val ipAddress: String? = null,
 ) : Parcelable {
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/FragmentUtil.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/FragmentUtil.kt
@@ -18,6 +18,7 @@
 
 package com.google.chip.chiptool.util
 
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import java.util.Locale
 

--- a/src/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <TextView
+      android:id="@+id/address_commissioning_fragment_title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/address_commissioning_title_text"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      android:textSize="16sp"
+      android:layout_marginTop="16dp"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <androidx.constraintlayout.helper.widget.Flow
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:constraint_referenced_ids="addressLabel,addressEditText,discriminatorLabel,discriminatorEditText,pincodeLabel,pincodeEditText"
+      app:flow_horizontalStyle="packed"
+      app:flow_wrapMode="aligned"
+      app:flow_maxElementsWrap="2"
+      app:flow_horizontalBias="0.0"
+      app:flow_horizontalGap="8dp"
+      android:layout_margin="16dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/address_commissioning_fragment_title" />
+
+  <TextView
+      android:id="@+id/addressLabel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="8dp"
+      android:textSize="16sp"
+      android:text="@string/enter_device_address_label_text" />
+
+  <EditText
+      android:id="@+id/addressEditText"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:inputType="text" />
+
+  <TextView
+      android:id="@+id/discriminatorLabel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="8dp"
+      android:textSize="16sp"
+      android:text="@string/enter_discriminator_label_text" />
+
+  <EditText
+      android:id="@+id/discriminatorEditText"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:inputType="number"
+      android:text="@string/default_discriminator" />
+
+  <TextView
+      android:id="@+id/pincodeLabel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="8dp"
+      android:textSize="16sp"
+      android:text="@string/enter_pincode_label_text" />
+
+  <EditText
+      android:id="@+id/pincodeEditText"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      android:inputType="number"
+      android:text="@string/default_pincode" />
+
+  <Button
+      android:id="@+id/commissionBtn"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      android:text="@string/commission_btn_text"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="1.0"
+      app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/barcode_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/barcode_fragment.xml
@@ -1,15 +1,51 @@
-<LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.chip.chiptool.setuppayloadscanner.CameraSourceView
-        android:id="@+id/camera_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="vertical">
-    </com.google.chip.chiptool.setuppayloadscanner.CameraSourceView>
-</LinearLayout>
+  <com.google.chip.chiptool.setuppayloadscanner.CameraSourceView
+      android:id="@+id/camera_view"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/manualCodeEditText"
+      android:layout_gravity="center"
+      android:gravity="center"
+      android:orientation="vertical" />
+
+  <Button
+      android:id="@+id/inputAddressBtn"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="8dp"
+      android:text="@string/input_address_btn_text"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <Button
+      android:id="@+id/manualCodeBtn"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="1"
+      android:text="Submit"
+      android:padding="8dp"
+      app:layout_constraintTop_toBottomOf="@id/camera_view"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+
+  <EditText
+      android:id="@+id/manualCodeEditText"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:inputType="text"
+      android:padding="8dp"
+      android:text="MT:YNJV793700A50324800"
+      app:layout_constraintTop_toBottomOf="@id/camera_view"
+      app:layout_constraintEnd_toStartOf="@id/manualCodeBtn"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="camera_unavailable_alert_title">Camera unavailable</string>
     <string name="camera_unavailable_alert_subtitle">Error launching camera to scan the QR code.</string>
     <string name="camera_unavailable_alert_exit">Exit</string>
+    <string name="input_address_btn_text">Input device address</string>
 
     <string name="send_echo_btn_text">Send echo</string>
     <string name="echo_status_connecting">Connecting…</string>
@@ -34,6 +35,14 @@
     <string name="enter_endpoint_id_hint_text">Enter Endpoint ID</string>
     <string name="echo_input_hint_text">Enter message for device</string>
     <string name="update_device_address_btn_text">Update address</string>
+
+    <string name="address_commissioning_title_text">Commission with IP address</string>
+    <string name="default_discriminator">3840</string>
+    <string name="default_pincode">20202021</string>
+    <string name="enter_device_address_label_text">Device address</string>
+    <string name="enter_discriminator_label_text">Discriminator</string>
+    <string name="enter_pincode_label_text">Pincode</string>
+    <string name="commission_btn_text">Commission</string>
 
     <string name="send_command_on_btn_text">On</string>
     <string name="send_command_off_btn_text">Off</string>

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -86,6 +86,12 @@ public class ChipDeviceController {
     }
   }
 
+  public void pairDeviceWithAddress(
+      long deviceId, String address, int port, int discriminator, long pinCode, byte[] csrNonce) {
+    pairDeviceWithAddress(
+        deviceControllerPtr, deviceId, address, port, discriminator, pinCode, csrNonce);
+  }
+
   public void unpairDevice(long deviceId) {
     unpairDevice(deviceControllerPtr, deviceId);
   }
@@ -236,6 +242,15 @@ public class ChipDeviceController {
 
   private native void pairDevice(
       long deviceControllerPtr, long deviceId, int connectionId, long pinCode, byte[] csrNonce);
+
+  private native void pairDeviceWithAddress(
+      long deviceControllerPtr,
+      long deviceId,
+      String address,
+      int port,
+      int discriminator,
+      long pinCode,
+      byte[] csrNonce);
 
   private native void unpairDevice(long deviceControllerPtr, long deviceId);
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -200,6 +200,7 @@ if (chip_device_platform != "none") {
       chip_device_config_enable_mdns = chip_mdns != "none"
       defines += [
         "CHIP_DEVICE_CONFIG_ENABLE_MDNS=${chip_device_config_enable_mdns}",
+        "CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING=${chip_use_clusters_for_ip_commissioning}",
         "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"",
       ]
     }


### PR DESCRIPTION
#### Problem
* No IP commissioning support on Android, which is especially needed for e2e tests

#### Change overview
* Turn on `chip_use_clusters_for_ip_commissioning` for Android
* Add UI in CHIPTool to call `pairDevice()` with a known address
* Discovery is not implemented yet

<img src="https://user-images.githubusercontent.com/77706079/131427237-436b9c91-c90a-4ade-841a-882c0a820f7e.png" width="250"/> | 

#### Testing
* Commissioned and controlled all-clusters-app running on macOS
* Unsure how to test Thread here
