### PR TITLE
[build] Add sysroot / system_libdir support

### DIFF
--- a/build/chip/linux/gen_gdbus_wrapper.py
+++ b/build/chip/linux/gen_gdbus_wrapper.py
@@ -66,6 +66,9 @@ def main(argv):
         subprocess.check_call(gdbus_args)
         sed_args = ["sed", "-i",
                     "s/config\.h/BuildConfig.h/g", options.output_c]
+        if sys.platform == "darwin":
+            sed_args = ["sed", "-i", "",
+                        "s/config\.h/BuildConfig.h/g", options.output_c]
         subprocess.check_call(sed_args)
 
     if options.output_h:

--- a/build/chip/tests.gni
+++ b/build/chip/tests.gni
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/platform/device.gni")
@@ -27,7 +28,8 @@ declare_args() {
 declare_args() {
   # Build executables for running individual tests.
   chip_link_tests =
-      chip_build_tests && (current_os == "linux" || current_os == "mac")
+      chip_build_tests && (current_os == "linux" || current_os == "mac") &&
+      current_cpu == target_cpu
 
   # Use source_set instead of static_lib for tests.
   chip_build_test_static_libraries = chip_device_platform != "efr32"

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/compiler/compiler.gni")
+import("${build_root}/config/sysroot.gni")
 import("${build_root}/config/target.gni")
 
 if (current_os == "mac") {
@@ -272,6 +273,10 @@ config("runtime_default") {
       "pthread",
       "rt",
     ]
+  }
+  if (sysroot != "") {
+    cflags = [ "--sysroot=${sysroot}" ]
+    ldflags = [ "--sysroot=${sysroot}" ]
   }
 }
 

--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -78,12 +78,6 @@ def SetConfigPath(options):
     sysroot = options.sysroot
     assert sysroot
 
-    # Compute the library path name based on the architecture.
-    arch = options.arch
-    if sysroot and not arch:
-        print("You must specify an architecture via -a if using a sysroot.")
-        sys.exit(1)
-
     libdir = sysroot + '/usr/' + options.system_libdir + '/pkgconfig'
     libdir += ':' + sysroot + '/usr/share/pkgconfig'
     os.environ['PKG_CONFIG_LIBDIR'] = libdir

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -48,6 +48,7 @@
 #   ignore_libs = true
 
 import("//build_overrides/build.gni")
+import("${build_root}/config/sysroot.gni")
 
 declare_args() {
   # A pkg-config wrapper to call instead of trying to find and call the right
@@ -59,6 +60,8 @@ declare_args() {
 
   # A optional pkg-config wrapper to use for tools built on the host.
   host_pkg_config = ""
+
+  system_libdir = "lib"
 }
 
 pkg_config_script = "${build_root}/config/linux/pkg-config.py"
@@ -81,6 +84,20 @@ if (host_pkg_config != "") {
   ]
 } else {
   host_pkg_config_args = pkg_config_args
+}
+
+if (sysroot != "") {
+  pkg_config_args += [
+    "-s",
+    sysroot,
+  ]
+
+  if (system_libdir != "") {
+    pkg_config_args += [
+      "--system_libdir",
+      system_libdir,
+    ]
+  }
 }
 
 template("pkg_config") {

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  sysroot = ""
+}

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -244,8 +244,8 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
                 break;
             }
         }
+        break;
     }
-        FALLTHROUGH;
     default:
         break;
     }

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -245,6 +245,7 @@ EmberAfStatus emberAfThermostatClusterServerPreAttributeChangedCallback(chip::En
             }
         }
     }
+        FALLTHROUGH;
     default:
         break;
     }

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -257,7 +257,7 @@ bool ReadFileIntoMem(const char * fileName, uint8_t * data, uint32_t & dataLen)
         ExitNow(res = false);
     }
 
-    VerifyOrExit(fileLen <= UINT32_MAX, res = false);
+    VerifyOrExit(chip::CanCastTo<uint32_t>(fileLen), res = false);
 
     dataLen = static_cast<uint32_t>(fileLen);
 


### PR DESCRIPTION
#### Problem
We are missing cross build options, since the project is becoming bigger and bigger, it is no longer acceptable for a 30minute build time on RPi

#### Change overview

- Add sysroot and system_libdir config for linux platforms

#### Testing

Manual Tested

Build

```
./gn_build.sh target_os=\"linux\" sysroot=\"`pwd`/armv7l-sysroot2\" target_cpu=\"arm\" system_libdir=\"lib/armv7-linux-gnueabihf\" is_clang=true
```

Copy build artifacts to raspberry pi.

Run