### PR TITLE
Add some linux cross compilers

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -59,10 +59,18 @@ if (host_toolchain == "") {
 
 if (_chip_defaults.custom_toolchain != "") {
   _default_toolchain = _chip_defaults.custom_toolchain
-} else if (target_os == host_os) {
-  _default_toolchain = host_toolchain
 } else if (target_os == "all") {
   _default_toolchain = "${_pigweed_overrides.dir_pw_toolchain}/default"
+} else if (target_os == "linux") {
+  if (_chip_defaults.is_clang) {
+    _target_compiler = "clang"
+  } else {
+    _target_compiler = "gcc"
+  }
+
+  _default_toolchain = "${_build_overrides.build_root}/toolchain/linux:linux_${target_cpu}_${_target_compiler}"
+} else if (target_os == host_os && target_cpu == host_cpu) {
+  _default_toolchain = host_toolchain
 } else if (target_os == "freertos") {
   if (target_cpu == "arm") {
     _default_toolchain = "${_build_overrides.build_root}/toolchain/arm_gcc"

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -53,53 +53,67 @@ config("abi_default") {
     ]
   } else if (current_os == "ios") {
     # iOS ABI currently set by chip_xcode_build_connector.sh
-  } else if (current_cpu == "arm" || current_cpu == "arm64") {
-    if (arm_arch != "") {
-      cflags += [ "-march=${arm_arch}" ]
-    }
-    if (arm_cpu != "") {
-      cflags += [ "-mcpu=${arm_cpu}" ]
-    }
-    if (arm_tune != "") {
-      cflags += [ "-mtune=${arm_tune}" ]
-    }
-    if (arm_abi != "") {
-      cflags += [ "-mabi=${arm_abi}" ]
-    }
-    if (arm_fpu != "") {
-      cflags += [ "-mfpu=${arm_fpu}" ]
-    }
-    if (arm_float_abi != "") {
-      cflags += [ "-mfloat-abi=${arm_float_abi}" ]
-    }
-    if (arm_use_thumb) {
-      cflags += [ "-mthumb" ]
-    }
-  } else if (current_cpu == "x86" || current_cpu == "x86_64") {
-    if (x86_arch != "") {
-      cflags += [ "-march=${x86_arch}" ]
-    }
-    if (x86_cpu != "") {
-      cflags += [ "-mcpu=${x86_cpu}" ]
-    }
-    if (x86_tune != "") {
-      cflags += [ "-mtune=${x86_tune}" ]
-    }
+  }
 
-    if (current_cpu == "x86_64") {
-      cflags += [
-        "-msse4.2",
-        "-mpopcnt",
-        "-m64",
-      ]
-    } else if (current_cpu == "x86") {
-      cflags += [
-        "-mssse3",
-        "-mfpmath=sse",
-        "-m32",
-      ]
+  if (current_os != "mac" && current_os != "ios") {
+    if (current_cpu == "arm" || current_cpu == "arm64") {
+      if (current_os == "linux" && is_clang) {
+        if (current_cpu == "arm") {
+          cflags += [ "--target=armv7-linux-gnueabihf" ]
+        } else if (current_cpu == "arm64") {
+          cflags += [ "--target=aarch64-linux-gnu" ]
+        }
+      }
+
+      if (arm_arch != "") {
+        cflags += [ "-march=${arm_arch}" ]
+      }
+      if (arm_cpu != "") {
+        cflags += [ "-mcpu=${arm_cpu}" ]
+      }
+      if (arm_tune != "") {
+        cflags += [ "-mtune=${arm_tune}" ]
+      }
+      if (arm_abi != "") {
+        cflags += [ "-mabi=${arm_abi}" ]
+      }
+      if (arm_fpu != "") {
+        cflags += [ "-mfpu=${arm_fpu}" ]
+      }
+      if (arm_float_abi != "") {
+        cflags += [ "-mfloat-abi=${arm_float_abi}" ]
+      }
+      if (arm_use_thumb) {
+        cflags += [ "-mthumb" ]
+      }
+    }
+    if (current_cpu == "x86" || current_cpu == "x86_64") {
+      if (x86_arch != "") {
+        cflags += [ "-march=${x86_arch}" ]
+      }
+      if (x86_cpu != "") {
+        cflags += [ "-mcpu=${x86_cpu}" ]
+      }
+      if (x86_tune != "") {
+        cflags += [ "-mtune=${x86_tune}" ]
+      }
+
+      if (current_cpu == "x86_64") {
+        cflags += [
+          "-msse4.2",
+          "-mpopcnt",
+          "-m64",
+        ]
+      } else if (current_cpu == "x86") {
+        cflags += [
+          "-mssse3",
+          "-mfpmath=sse",
+          "-m32",
+        ]
+      }
     }
   }
+
   asmflags = cflags
   ldflags = cflags
 }

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -1,0 +1,93 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+import("${build_root}/toolchain/gcc_toolchain.gni")
+
+gcc_toolchain("linux_x64_gcc") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "x64"
+    is_clang = false
+  }
+}
+
+gcc_toolchain("linux_x64_clang") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "x64"
+    is_clang = true
+  }
+}
+
+gcc_toolchain("linux_x86_gcc") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "x86"
+    is_clang = false
+  }
+}
+
+gcc_toolchain("linux_x86_clang") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "x86"
+    is_clang = true
+  }
+}
+
+gcc_toolchain("linux_arm_gcc") {
+  _toolprefix = "arm-linux-gnueabihf-"
+
+  cc = "${_toolprefix}gcc"
+  cxx = "${_toolprefix}g++"
+  ar = "${_toolprefix}ar"
+
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "arm"
+    is_clang = false
+  }
+}
+
+gcc_toolchain("linux_arm_clang") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "arm"
+    is_clang = true
+  }
+}
+
+gcc_toolchain("linux_arm64_gcc") {
+  _toolprefix = "aarch64-linux-gnu-"
+
+  cc = "${_toolprefix}gcc"
+  cxx = "${_toolprefix}g++"
+  ar = "${_toolprefix}ar"
+
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "arm64"
+    is_clang = false
+  }
+}
+
+gcc_toolchain("linux_arm64_clang") {
+  toolchain_args = {
+    current_os = "linux"
+    current_cpu = "arm64"
+    is_clang = true
+  }
+}

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -72,6 +72,25 @@ for define in "${defines[@]}"; do
 done
 target_defines=[${target_defines:1}]
 
+declare target_cpu=
+case $PLATFORM_PREFERRED_ARCH in
+    i386)
+        target_cpu=x86
+        ;;
+    x86_64)
+        target_cpu=x64
+        ;;
+    armv7)
+        target_cpu=arm
+        ;;
+    arm64)
+        target_cpu=arm64
+        ;;
+    *)
+        echo >&2
+        ;;
+esac
+
 declare target_cflags='"-target","'"$PLATFORM_PREFERRED_ARCH"'-'"$LLVM_TARGET_TRIPLE_VENDOR"'-'"$LLVM_TARGET_TRIPLE_OS_VERSION"'"'
 
 read -r -a archs <<<"$ARCHS"
@@ -93,7 +112,7 @@ declare -a args=(
     'chip_device_project_config_include=""'
     'chip_inet_project_config_include=""'
     'chip_system_project_config_include=""'
-    'target_cpu="'"$PLATFORM_PREFERRED_ARCH"'"'
+    'target_cpu="'"$target_cpu"'"'
     'target_defines='"$target_defines"
     'target_cflags=['"$target_cflags"']'
 )


### PR DESCRIPTION
#### Problem

Currently setting arguments like target_cpu="arm64" does not
have the desired outcome on Linux.

#### Change overview

Fix this by setting an appropriate compiler based on this option.
This adds 32 and 64 bit Intel and ARM compilers initially.

#### Testing

Tested by

```
for compiler in gcc clang; do
  for arch in x64 x86 arm arm64; do
    d=out/${arch}_${compiler} &&
    case $compiler in gcc) is_clang=false ;; clang) is_clang=true ;; esac &&
    gn gen $d --args="is_clang=$is_clang target_cpu=\"$arch\" chip_crypto=\"mbedtls\" " &&
    ninja -C $d TestManualCode &&
  done &&
done
```

on a debian based system with g++ cross compilers installed. This tests
all combinations but really it boils down to

```
gn gen out/arm64 --args='target_cpu="arm64" chip_crypto="mbedtls"' && ninja -C out/arm64 TestManualCode
file out/arm64/tests/TestManualCode
out/arm64/tests/TestManualCode: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=b4e854373e20c7f8873205f174c30c3b7bf3a7dc, for GNU/Linux 3.7.0, with debug_info, not stripped
```

Building something more complex like chip-tool or building with OpenSSL
will require providing additional development libraries in the build
environment which is generally done via the --sysroot option.