### PR TITLE
Use short-log for embedded platforms

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -35,6 +35,9 @@ buildconfig_header("chip_buildconfig") {
   chip_config_memory_management_platform =
       chip_config_memory_management == "platform"
 
+  chip_config_short_error_str =
+      chip_config_short_error_str || chip_target_style_embedded
+
   # TODO - Move CHIP_PROJECT_CONFIG_INCLUDE, CHIP_PLATFORM_CONFIG_INCLUDE here.
   # Currently those are also used from src/system.
   defines = [


### PR DESCRIPTION
#### Problem
Save memory for embedded platforms

#### Change overview
Use short log to save buffer size of `sErrorStr`

#### Testing
Manually build images.