### PR TITLE
doc: nrfconnect: clarify mcumgr usage

### DIFF
--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -36,27 +36,32 @@ To upgrade your device firmware over Bluetooth LE, you can use the PC command
 line tool provided by the [mcumgr](https://github.com/zephyrproject-rtos/mcumgr)
 project.
 
-> **_WARNING:_** mcumgr tool using Bluetooth LE is available only for Linux and
-> macOS systems. On Windows, there is no support for Device Firmware Upgrade
-> over Bluetooth LE yet.
+> **_WARNING:_**
+> - The mcumgr tool using Bluetooth LE is available only for Linux and
+>   macOS systems. On Windows, there is no support for Device Firmware Upgrade
+>   over Bluetooth LE yet.
+> - It might not be possible to connect to the nRF device when using the mcumgr on Linux with the Bluetooth LE adapter.
+>   In such cases, you can use Zephyr's Bluetooth HCI USB sample and program it to your device.
+>   For example, to build the sample for the nRF52840 DK, use the following command:
+>
+>       cd zephyr/samples/bluetooth/hci_usb && west build -b nrf52840dk_nrf52840 – -DCONFIG_BT_LL_SW_SPLIT=y
 
 Complete the following steps to perform DFU using mcumgr:
-
-1. Install the tool by following the
-   [mcumgr command line tool installation instructions](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/device_mgmt/index.html#command-line-tool).
-2. Push the appropriate button on the device to enable the software update
-   functionality (if it is not enabled by default) and start the Bluetooth LE
-   advertising of SMP service. See the user interface section in the example
-   documentation to check the button number.
-3. Push the appropriate button on the device to start the Bluetooth LE
-   advertising. See the user interface section in the example documentation to
-   check the button number.
 
 > **_NOTE:_** In all of the commands listed in the following steps, replace
 > `ble-hci-number` with the Bluetooth hci integer value (for example, `0`) and
 > `ble-device-name` with the CHIP device name advertised over Bluetooth LE (for
 > example, `MatterLock`).
 
+1.  Install the tool by following the
+    [mcumgr command line tool installation instructions](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/device_mgmt/index.html#command-line-tool).
+2.  Push the appropriate button on the device to enable the software update
+    functionality (if it is not enabled by default) and start the Bluetooth LE
+    advertising of SMP service. See the user interface section in the example
+    documentation to check the button number.
+3.  Observe that the LED on the device is flashing (short flash on), which means that the Bluetooth LE
+    advertising has started. See the user interface section in the example documentation to
+    check the LED number.
 4.  Upload the firmware image to the device by running the following command in
     your example directory:
 

--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -37,14 +37,17 @@ line tool provided by the [mcumgr](https://github.com/zephyrproject-rtos/mcumgr)
 project.
 
 > **_WARNING:_**
-> - The mcumgr tool using Bluetooth LE is available only for Linux and
->   macOS systems. On Windows, there is no support for Device Firmware Upgrade
->   over Bluetooth LE yet.
-> - It might not be possible to connect to the nRF device when using the mcumgr on Linux with the Bluetooth LE adapter.
->   In such cases, you can use Zephyr's Bluetooth HCI USB sample and program it to your device.
->   For example, to build the sample for the nRF52840 DK, use the following command:
 >
->       cd zephyr/samples/bluetooth/hci_usb && west build -b nrf52840dk_nrf52840 – -DCONFIG_BT_LL_SW_SPLIT=y
+> -   The mcumgr tool using Bluetooth LE is available only for Linux and macOS
+>     systems. On Windows, there is no support for Device Firmware Upgrade over
+>     Bluetooth LE yet.
+> -   It might not be possible to connect to the nRF device when using the
+>     mcumgr on Linux with the built-in Bluetooth LE adapter. In such cases, you can use
+>     Zephyr's Bluetooth HCI USB sample and program it to a Nordic Semiconductor's development kit to form an external Bluetooth LE adapter.
+>     For example, to build the sample for the nRF52840 DK, use the following
+>     command:
+>
+>         cd zephyr/samples/bluetooth/hci_usb && west build -b nrf52840dk_nrf52840 -- -DCONFIG_BT_LL_SW_SPLIT=y
 
 Complete the following steps to perform DFU using mcumgr:
 
@@ -59,9 +62,9 @@ Complete the following steps to perform DFU using mcumgr:
     functionality (if it is not enabled by default) and start the Bluetooth LE
     advertising of SMP service. See the user interface section in the example
     documentation to check the button number.
-3.  Observe that the LED on the device is flashing (short flash on), which means that the Bluetooth LE
-    advertising has started. See the user interface section in the example documentation to
-    check the LED number.
+3.  Observe that the LED on the device is flashing (short flash on), which means
+    that the Bluetooth LE advertising has started. See the user interface
+    section in the example documentation to check the LED number.
 4.  Upload the firmware image to the device by running the following command in
     your example directory:
 

--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -42,8 +42,9 @@ project.
 >     systems. On Windows, there is no support for Device Firmware Upgrade over
 >     Bluetooth LE yet.
 > -   It might not be possible to connect to the nRF device when using the
->     mcumgr on Linux with the built-in Bluetooth LE adapter. In such cases, you can use
->     Zephyr's Bluetooth HCI USB sample and program it to a Nordic Semiconductor's development kit to form an external Bluetooth LE adapter.
+>     mcumgr on Linux with the built-in Bluetooth LE adapter. In such cases, you
+>     can use Zephyr's Bluetooth HCI USB sample and program it to a Nordic
+>     Semiconductor's development kit to form an external Bluetooth LE adapter.
 >     For example, to build the sample for the nRF52840 DK, use the following
 >     command:
 >


### PR DESCRIPTION
Added a note about issues with mcumgr and BLE adapter.
Rephrased deprecated step.
Moved note to avoid breaking step order.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

#### Problem
An mcumgr-related issue can hinder connection to the nRF device.

#### Change overview
Added a note with a build command that enables using BT HCI device.
Plus made some secondary style changes on the same page.

#### Testing
Doc changes only.
