### PR TITLE
Fix Mbed OS debug profile building

### DIFF
--- a/src/app/server/StorablePeerConnection.cpp
+++ b/src/app/server/StorablePeerConnection.cpp
@@ -28,6 +28,7 @@ StorablePeerConnection::StorablePeerConnection(PASESession & session, FabricInde
     mKeyId           = session.GetLocalKeyId();
 }
 
+#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
 {
     char key[KeySize()];

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -596,6 +596,7 @@ CHIP_ERROR CASESession::HandleSigmaR2_and_SendSigmaR3(System::PacketBufferHandle
     return CHIP_NO_ERROR;
 }
 
+#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle && msg)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -43,6 +43,7 @@ CHIP_ERROR FabricInfo::SetFabricLabel(const uint8_t * fabricLabel)
     return CHIP_NO_ERROR;
 }
 
+#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR FabricInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
The `error: stack usage might be unbounded [-Werror=stack-usage=]` occurs when you build Mbed OS example with debug profile. 
There are 3 files with unbounded stack issue:
StorablePeerConnection.cpp
CASESession.cpp
FabricTable.cpp
The error occurs because several functions allocate stack space based on an argument, with no upper bound. 

For example:
```
CHIP_ERROR FabricInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
{
    CHIP_ERROR err = CHIP_NO_ERROR;

    char key[KeySize()];
```

We added diagnostic ignored pragma before these functions as the simplest solution, but maybe a more comprehensive solution will be required.

#### Change overview
Add `#pragma GCC diagnostic ignored "-Wstack-usage="` in identified places. 

#### Testing
Build Mbed os examples with debug profile manually
