### PR TITLE
[android] Exit to the main screen after commissioning

### DIFF
--- a/docs/guides/nrfconnect_android_commissioning.md
+++ b/docs/guides/nrfconnect_android_commissioning.md
@@ -185,22 +185,22 @@ device successfully joins the Thread network.
 
 ## Sending CHIP commands
 
-Once the device is commissioned, the following screen appears:
-
-![CHIPTool device control screen](./images/CHIPTool_device_commissioned.jpg)
-
-The two textboxes at the top contain **Fabric ID** and **Node ID** of the last
-commissioned device.
+Once the device is commissioned, the main application screen appears.
 
 Check the IPv6 connectivity with the device using the following steps:
 
-1. Tap **UPDATE ADDRESS** to learn or refresh the IPv6 address of the device.
+1. Tap **LIGHT ON/OFF & LEVEL CLUSTER**. The following screen appears:
+
+   ![CHIPTool device control screen](./images/CHIPTool_device_commissioned.jpg)
+
+   The two textboxes at the top contain **Fabric ID** and **Node ID** of the
+   last commissioned device.
+2. Tap **UPDATE ADDRESS** to learn or refresh the IPv6 address of the device.
    CHIPTool will use a built-in DNS-SD client to resolve **Fabric ID** and
    **Node ID** of the device to its IPv6 address. The result of the operation,
    be it the address or an error message, will be displayed at the bottom of the
    screen.
-
-2. Tap the following buttons to change the lock state of the nRF Connect door
+3. Tap the following buttons to change the lock state of the nRF Connect door
    lock example application referenced in this guide:
 
     - **ON** and **OFF** buttons lock and unlock the door, respectively.

--- a/docs/guides/nrfconnect_android_commissioning.md
+++ b/docs/guides/nrfconnect_android_commissioning.md
@@ -191,10 +191,11 @@ Check the IPv6 connectivity with the device using the following steps:
 
 1. Tap **LIGHT ON/OFF & LEVEL CLUSTER**. The following screen appears:
 
-   ![CHIPTool device control screen](./images/CHIPTool_device_commissioned.jpg)
+    ![CHIPTool device control screen](./images/CHIPTool_device_commissioned.jpg)
 
-   The two textboxes at the top contain **Fabric ID** and **Node ID** of the
-   last commissioned device.
+    The two textboxes at the top contain **Fabric ID** and **Node ID** of the
+    last commissioned device.
+
 2. Tap **UPDATE ADDRESS** to learn or refresh the IPv6 address of the device.
    CHIPTool will use a built-in DNS-SD client to resolve **Fabric ID** and
    **Node ID** of the device to its IPv6 address. The result of the operation,

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -83,11 +83,7 @@ class CHIPToolActivity :
 
   override fun onCommissioningComplete(code: Int) {
     ChipClient.getDeviceController(this).close()
-    if (code == 0) {
-      showFragment(OnOffClientFragment.newInstance(), false)
-    } else {
-      showFragment(SelectActionFragment.newInstance(), false)
-    }
+    showFragment(SelectActionFragment.newInstance(), false)
   }
 
   override fun handleScanQrCodeClicked() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -82,6 +82,12 @@ class CHIPToolActivity :
   }
 
   override fun onCommissioningComplete(code: Int) {
+    runOnUiThread {
+      Toast.makeText(
+          this,
+          getString(R.string.commissioning_completed, code),
+          Toast.LENGTH_SHORT).show()
+    }
     ChipClient.getDeviceController(this).close()
     showFragment(SelectActionFragment.newInstance(), false)
   }

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="rendezvous_over_ble_pairing_failure_text">Pairing failed</string>
     <string name="rendezvous_over_ble_commissioning_success_text">Network commissioning completed</string>
     <string name="rendezvous_over_ble_commissioning_failure_text">Network commissioning failed</string>
+    <string name="commissioning_completed">Commissioning completed with result: %1$d</string>
 
     <string name="attestation_test_btn_text">Attestation Test</string>
     <string name="attestation_fetching_status">Fetching…</string>


### PR DESCRIPTION
#### Problem
Currently, Android CHIPTool automatically switches to the Light On/Off screen after commissioning a device
reglardless of its device type, which is not optimal for devices such as sensors.

#### Change overview
Exit to the main screen, instead, so a user may select a suitable screen to control a given device.

#### Testing
Tested manually with nRF Connect Lighting Example.
