### PR TITLE
Point to the overall build guide in the chip-tool build instructions.

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -12,6 +12,9 @@ An example application that uses CHIP to send messages to a CHIP server.
 
 ## Building the Example Application
 
+See [the build guide](../../docs/guides/BUILDING.md#prerequisites) for general
+background on build prerequisites.
+
 Building the example application is quite straightforward. It can either be done
 as part of an overall "build everything" build:
 


### PR DESCRIPTION
Makes it easier to find those for someone who tries to start by just
building chip-tool.

#### Problem
Looking at the README.md for chip-tool it's not obvious how to get to a point where a build will succeed.

#### Change overview
Add a link to the build guide.

#### Testing
None, sorry.