### PR TITLE
Close BLE connections after the Operational Network is provisioned on a Node

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -62,6 +62,15 @@ void RendezvousServer::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * even
     {
         app::Mdns::AdvertiseOperational();
         ChipLogError(Discovery, "Operational advertising enabled");
+#if CONFIG_NETWORK_LAYER_BLE
+        // Close all BLE connections now since the operational network is available.
+        Ble::BleLayer * bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
+        if (bleLayer != nullptr)
+        {
+            ChipLogProgress(Discovery, "Closing all BLE Connections");
+            bleLayer->CloseAllBleConnections();
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
#### Problem

Nodes should terminate their BLE connections after they have been provisioned on the operational network. 

Our current implementation leaves the BLE connection alive after commissioning is complete. 
This can prevent multiple commissioners on the same machine from being able to operate independently. 

#### Change overview

Close all BLE Connections after the operational network is provisioned.

#### Testing
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested that two iOS apps(changed the bundleID of CHIPTool to install it twice) are able to pair with accessories independent of each other. Tested with chip-tool on macOS as well. 
