### PR TITLE
Create PayloadContents inner class to avoid overhead of optional info

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -31,7 +31,7 @@
 
 namespace chip {
 
-static uint32_t chunk1PayloadRepresentation(const SetupPayload & payload)
+static uint32_t chunk1PayloadRepresentation(const PayloadContents & payload)
 {
     /* <1 digit> Represents:
      *     - <bits 1..0> Discriminator <bits 11.10>
@@ -54,7 +54,7 @@ static uint32_t chunk1PayloadRepresentation(const SetupPayload & payload)
     return result;
 }
 
-static uint32_t chunk2PayloadRepresentation(const SetupPayload & payload)
+static uint32_t chunk2PayloadRepresentation(const PayloadContents & payload)
 {
     /* <5 digits> Represents:
      *     - <bits 13..0> PIN Code <bits 13..0>
@@ -73,7 +73,7 @@ static uint32_t chunk2PayloadRepresentation(const SetupPayload & payload)
     return result;
 }
 
-static uint32_t chunk3PayloadRepresentation(const SetupPayload & payload)
+static uint32_t chunk3PayloadRepresentation(const PayloadContents & payload)
 {
     /* <4 digits> Represents:
      *     - <bits 12..0> PIN Code <bits 26..14>
@@ -87,55 +87,83 @@ static uint32_t chunk3PayloadRepresentation(const SetupPayload & payload)
     return result;
 }
 
-// TODO: issue #3663 - Unbounded stack in src/setup_payload
-#pragma GCC diagnostic push
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wstack-usage="
-#endif
-#pragma GCC diagnostic ignored "-Wvla"
-
-static std::string decimalStringWithPadding(uint32_t number, int minLength)
+static CHIP_ERROR decimalStringWithPadding(MutableCharSpan buffer, uint32_t number)
 {
-    char buf[minLength + 1];
-    snprintf(buf, sizeof(buf), "%0*" PRIu32, minLength, number);
-    return std::string(buf);
+    int len    = static_cast<int>(buffer.size() - 1);
+    int retval = snprintf(buffer.data(), buffer.size(), "%0*" PRIu32, len, number);
+
+    return (retval >= static_cast<int>(buffer.size())) ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
 }
 
-#pragma GCC diagnostic pop
-
-CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(std::string & outDecimalString)
+CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(MutableCharSpan & outBuffer)
 {
-    if (!mSetupPayload.isValidManualCode())
-    {
-        ChipLogError(SetupPayload, "Failed encoding invalid payload");
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
     static_assert(kManualSetupCodeChunk1CharLength + kManualSetupCodeChunk2CharLength + kManualSetupCodeChunk3CharLength ==
                       kManualSetupShortCodeCharLength,
-                  "Manual code length mismatch");
+                  "Manual code length mismatch (short)");
+    static_assert(kManualSetupShortCodeCharLength + kManualSetupVendorIdCharLength + kManualSetupProductIdCharLength ==
+                      kManualSetupLongCodeCharLength,
+                  "Manual code length mismatch (long)");
     static_assert(kManualSetupChunk1DiscriminatorMsbitsLength + kManualSetupChunk2DiscriminatorLsbitsLength ==
                       kManualSetupDiscriminatorFieldLengthInBits,
                   "Discriminator won't fit");
     static_assert(kManualSetupChunk2PINCodeLsbitsLength + kManualSetupChunk3PINCodeMsbitsLength == kSetupPINCodeFieldLengthInBits,
                   "PIN code won't fit");
 
-    uint32_t chunk1 = chunk1PayloadRepresentation(mSetupPayload);
-    uint32_t chunk2 = chunk2PayloadRepresentation(mSetupPayload);
-    uint32_t chunk3 = chunk3PayloadRepresentation(mSetupPayload);
-
-    std::string decimalString = decimalStringWithPadding(chunk1, kManualSetupCodeChunk1CharLength);
-    decimalString += decimalStringWithPadding(chunk2, kManualSetupCodeChunk2CharLength);
-    decimalString += decimalStringWithPadding(chunk3, kManualSetupCodeChunk3CharLength);
-
-    if (mSetupPayload.commissioningFlow == CommissioningFlow::kCustom)
+    if (!mPayloadContents.isValidManualCode())
     {
-        decimalString += decimalStringWithPadding(mSetupPayload.vendorID, kManualSetupVendorIdCharLength);
-        decimalString += decimalStringWithPadding(mSetupPayload.productID, kManualSetupProductIdCharLength);
+        ChipLogError(SetupPayload, "Failed encoding invalid payload");
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
 
-    outDecimalString = decimalString;
+    bool useLongCode = (mPayloadContents.commissioningFlow == CommissioningFlow::kCustom);
+
+    // Add two for the check digit and null terminator.
+    if ((useLongCode && outBuffer.size() < kManualSetupLongCodeCharLength + 2) ||
+        (!useLongCode && outBuffer.size() < kManualSetupShortCodeCharLength + 2))
+    {
+        ChipLogError(SetupPayload, "Failed encoding payload to buffer");
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    uint32_t chunk1 = chunk1PayloadRepresentation(mPayloadContents);
+    uint32_t chunk2 = chunk2PayloadRepresentation(mPayloadContents);
+    uint32_t chunk3 = chunk3PayloadRepresentation(mPayloadContents);
+
+    size_t offset = 0;
+
+    // Add one to the length of each chunk, since snprintf writes a null terminator.
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk1CharLength + 1), chunk1));
+    offset += kManualSetupCodeChunk1CharLength;
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk2CharLength + 1), chunk2));
+    offset += kManualSetupCodeChunk2CharLength;
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupCodeChunk3CharLength + 1), chunk3));
+    offset += kManualSetupCodeChunk3CharLength;
+
+    if (useLongCode)
+    {
+        ReturnErrorOnFailure(
+            decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupVendorIdCharLength + 1), mPayloadContents.vendorID));
+        offset += kManualSetupVendorIdCharLength;
+        ReturnErrorOnFailure(
+            decimalStringWithPadding(outBuffer.SubSpan(offset, kManualSetupProductIdCharLength + 1), mPayloadContents.productID));
+        offset += kManualSetupProductIdCharLength;
+    }
+
+    int checkDigit = Verhoeff10::CharToVal(Verhoeff10::ComputeCheckChar(outBuffer.data()));
+    ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, 2), static_cast<uint32_t>(checkDigit)));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(std::string & outDecimalString)
+{
+    // One extra char for the check digit, another for the null terminator.
+    char decimalString[kManualSetupLongCodeCharLength + 1 + 1] = "";
+    MutableCharSpan outBuffer(decimalString);
+
+    ReturnErrorOnFailure(payloadDecimalStringRepresentation(outBuffer));
+    outDecimalString.assign(decimalString);
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.h
+++ b/src/setup_payload/ManualSetupPayloadGenerator.h
@@ -40,6 +40,7 @@
 #include "SetupPayload.h"
 
 #include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
 
 #include <string>
 
@@ -48,12 +49,26 @@ namespace chip {
 class ManualSetupPayloadGenerator
 {
 private:
-    SetupPayload mSetupPayload;
+    PayloadContents mPayloadContents;
 
 public:
-    ManualSetupPayloadGenerator(const SetupPayload & payload) : mSetupPayload(payload) {}
+    ManualSetupPayloadGenerator(const PayloadContents & payload) : mPayloadContents(payload) {}
 
-    // Populates decimal string representation of the payload into outDecimalString
+    /**
+     * This function is called to encode the binary data of a payload to a
+     * decimal null-terminated string.
+     *
+     * @param[out] outBuffer
+     *                  Output buffer to write the decimal string.
+     *
+     * @retval #CHIP_NO_ERROR if the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT if the payload is invalid.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL if outBuffer has insufficient size.
+     */
+    CHIP_ERROR payloadDecimalStringRepresentation(MutableCharSpan & outBuffer);
+
+    // Populates decimal string representation of the payload into outDecimalString.
+    // Wrapper for using std::string.
     CHIP_ERROR payloadDecimalStringRepresentation(std::string & outDecimalString);
 };
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR generateBitSet(SetupPayload & payload, MutableByteSpan & bits, uint8_t * tlvDataStart,
+static CHIP_ERROR generateBitSet(PayloadContents & payload, MutableByteSpan & bits, uint8_t * tlvDataStart,
                                  size_t tlvDataLengthInBytes)
 {
     size_t offset                 = 0;
@@ -179,11 +179,11 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, MutableByteSpan & bits,
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR payloadBase38RepresentationWithTLV(SetupPayload & setupPayload, MutableCharSpan & outBuffer, MutableByteSpan bits,
+static CHIP_ERROR payloadBase38RepresentationWithTLV(PayloadContents & payload, MutableCharSpan & outBuffer, MutableByteSpan bits,
                                                      uint8_t * tlvDataStart, size_t tlvDataLengthInBytes)
 {
     memset(bits.data(), 0, bits.size());
-    ReturnErrorOnFailure(generateBitSet(setupPayload, bits, tlvDataStart, tlvDataLengthInBytes));
+    ReturnErrorOnFailure(generateBitSet(payload, bits, tlvDataStart, tlvDataLengthInBytes));
 
     CHIP_ERROR err   = CHIP_NO_ERROR;
     size_t prefixLen = strlen(kQRCodePrefix);
@@ -228,7 +228,7 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase38Representation(std::string 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR QRCodeSetupPayloadGenerator::payloadBase38RepresentationWithoutOptional(MutableCharSpan & outBuffer)
+CHIP_ERROR QRCodeBasicSetupPayloadGenerator::payloadBase38Representation(MutableCharSpan & outBuffer)
 {
     uint8_t bits[kTotalPayloadDataSizeInBytes];
     VerifyOrReturnError(mPayload.isValidQRCodePayload(), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -82,10 +82,26 @@ public:
      */
     CHIP_ERROR payloadBase38Representation(std::string & base38Representation, uint8_t * tlvDataStart, uint32_t tlvDataStartSize);
 
+private:
+    CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
+                                           size_t & tlvDataLengthInBytes);
+};
+
+/**
+ * A minimal QR code setup payload generator that omits any optional data,
+ * for compatibility with devices that don't support std::string or STL.
+ */
+class QRCodeBasicSetupPayloadGenerator
+{
+private:
+    PayloadContents mPayload;
+
+public:
+    QRCodeBasicSetupPayloadGenerator(const PayloadContents & payload) : mPayload(payload) {}
+
     /**
      * This function is called to encode the binary data of a payload to a
-     * base38 null-terminated string. The payload's optional data is ignored
-     * for compatibility with devices that don't support std::string or STL.
+     * base38 null-terminated string.
      *
      * @param[out] outBuffer
      *                  The buffer to copy the base38 to.
@@ -97,11 +113,7 @@ public:
      *               that an error occurred preventing the function from
      *               producing the requested string.
      */
-    CHIP_ERROR payloadBase38RepresentationWithoutOptional(MutableCharSpan & outBuffer);
-
-private:
-    CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
-                                           size_t & tlvDataLengthInBytes);
+    CHIP_ERROR payloadBase38Representation(MutableCharSpan & outBuffer);
 };
 
 } // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -46,7 +46,7 @@ bool IsVendorTag(uint8_t tag)
 // Check the Setup Payload for validity
 //
 // `vendor_id` and `product_id` are allowed all of uint16_t
-bool SetupPayload::isValidQRCodePayload()
+bool PayloadContents::isValidQRCodePayload() const
 {
     if (version >= 1 << kVersionFieldLengthInBits)
     {
@@ -83,7 +83,7 @@ bool SetupPayload::isValidQRCodePayload()
     return true;
 }
 
-bool SetupPayload::isValidManualCode()
+bool PayloadContents::isValidManualCode() const
 {
     // The discriminator for manual setup code is 4 most significant bits
     // in a regular 12 bit discriminator. Let's make sure that the provided
@@ -105,6 +105,13 @@ bool SetupPayload::isValidManualCode()
     }
 
     return true;
+}
+
+bool PayloadContents::operator==(PayloadContents & input) const
+{
+    return (this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
+            this->commissioningFlow == input.commissioningFlow && this->rendezvousInformation == input.rendezvousInformation &&
+            this->discriminator == input.discriminator && this->setUpPINCode == input.setUpPINCode);
 }
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, std::string data)
@@ -258,11 +265,7 @@ bool SetupPayload::operator==(SetupPayload & input)
     std::vector<OptionalQRCodeInfo> inputOptionalVendorData;
     std::vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
 
-    VerifyOrReturnError(this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
-                            this->commissioningFlow == input.commissioningFlow &&
-                            this->rendezvousInformation == input.rendezvousInformation &&
-                            this->discriminator == input.discriminator && this->setUpPINCode == input.setUpPINCode,
-                        false);
+    VerifyOrReturnError(PayloadContents::operator==(input), false);
 
     inputOptionalVendorData = input.getAllOptionalVendorData();
     VerifyOrReturnError(optionalVendorData.size() == inputOptionalVendorData.size(), false);

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -103,6 +103,25 @@ enum class CommissioningFlow : uint8_t
     kCustom,             ///< Commissioning steps should be retrieved from the distributed compliance ledger
 };
 
+/**
+ * A parent struct to hold onboarding payload contents without optional info,
+ * for compatibility with devices that don't support std::string or STL.
+ */
+struct PayloadContents
+{
+    uint8_t version                                  = 0;
+    uint16_t vendorID                                = 0;
+    uint16_t productID                               = 0;
+    CommissioningFlow commissioningFlow              = CommissioningFlow::kStandard;
+    RendezvousInformationFlags rendezvousInformation = RendezvousInformationFlag::kNone;
+    uint16_t discriminator                           = 0;
+    uint32_t setUpPINCode                            = 0;
+
+    bool isValidQRCodePayload() const;
+    bool isValidManualCode() const;
+    bool operator==(PayloadContents & input) const;
+};
+
 enum optionalQRCodeInfoType
 {
     optionalQRCodeInfoTypeUnknown,
@@ -146,21 +165,13 @@ struct OptionalQRCodeInfoExtension : OptionalQRCodeInfo
 bool IsCHIPTag(uint8_t tag);
 bool IsVendorTag(uint8_t tag);
 
-class SetupPayload
+class SetupPayload : public PayloadContents
 {
 
     friend class QRCodeSetupPayloadGenerator;
     friend class QRCodeSetupPayloadParser;
 
 public:
-    uint8_t version                                  = 0;
-    uint16_t vendorID                                = 0;
-    uint16_t productID                               = 0;
-    CommissioningFlow commissioningFlow              = CommissioningFlow::kStandard;
-    RendezvousInformationFlags rendezvousInformation = RendezvousInformationFlag::kNone;
-    uint16_t discriminator                           = 0;
-    uint32_t setUpPINCode                            = 0;
-
     /** @brief A function to add an optional vendor data
      * @param tag 7 bit [0-127] tag number
      * @param data String representation of data to add
@@ -209,8 +220,6 @@ public:
      **/
     CHIP_ERROR removeSerialNumber();
 
-    bool isValidQRCodePayload();
-    bool isValidManualCode();
     bool operator==(SetupPayload & input);
 
 private:

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -37,7 +37,7 @@ using namespace chip;
 
 namespace {
 
-bool CheckGenerator(const SetupPayload & payload, std::string expectedResult)
+bool CheckGenerator(const PayloadContents & payload, std::string expectedResult)
 {
     std::string result;
     ManualSetupPayloadGenerator generator(payload);
@@ -58,9 +58,9 @@ bool CheckGenerator(const SetupPayload & payload, std::string expectedResult)
     return same;
 }
 
-SetupPayload GetDefaultPayload()
+PayloadContents GetDefaultPayload()
 {
-    SetupPayload payload;
+    PayloadContents payload;
     payload.setUpPINCode  = 123456780;
     payload.discriminator = 2560;
 
@@ -69,7 +69,7 @@ SetupPayload GetDefaultPayload()
 
 void TestDecimalRepresentation_PartialPayload(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload = GetDefaultPayload();
+    PayloadContents payload = GetDefaultPayload();
 
     std::string expectedResult = "2361087535";
 
@@ -78,7 +78,7 @@ void TestDecimalRepresentation_PartialPayload(nlTestSuite * inSuite, void * inCo
 
 void TestDecimalRepresentation_PartialPayload_RequiresCustomFlow(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload      = GetDefaultPayload();
+    PayloadContents payload   = GetDefaultPayload();
     payload.commissioningFlow = CommissioningFlow::kCustom;
 
     std::string expectedResult = "63610875350000000000";
@@ -88,7 +88,7 @@ void TestDecimalRepresentation_PartialPayload_RequiresCustomFlow(nlTestSuite * i
 
 void TestDecimalRepresentation_FullPayloadWithZeros(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload      = GetDefaultPayload();
+    PayloadContents payload   = GetDefaultPayload();
     payload.commissioningFlow = CommissioningFlow::kCustom;
     payload.vendorID          = 1;
     payload.productID         = 1;
@@ -100,7 +100,7 @@ void TestDecimalRepresentation_FullPayloadWithZeros(nlTestSuite * inSuite, void 
 
 void TestDecimalRepresentation_FullPayloadWithoutZeros(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload      = GetDefaultPayload();
+    PayloadContents payload   = GetDefaultPayload();
     payload.commissioningFlow = CommissioningFlow::kCustom;
     payload.vendorID          = 45367;
     payload.productID         = 14526;
@@ -112,9 +112,9 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros(nlTestSuite * inSuite, vo
 
 void TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload = GetDefaultPayload();
-    payload.vendorID     = 45367;
-    payload.productID    = 14526;
+    PayloadContents payload = GetDefaultPayload();
+    payload.vendorID        = 45367;
+    payload.productID       = 14526;
 
     std::string expectedResult = "2361087535";
 
@@ -123,7 +123,7 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow(
 
 void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload;
+    PayloadContents payload;
     payload.setUpPINCode  = 0;
     payload.discriminator = 0;
 
@@ -134,7 +134,7 @@ void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
 
 void TestDecimalRepresentation_AllOnes(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload;
+    PayloadContents payload;
     payload.setUpPINCode      = 0x7FFFFFF;
     payload.discriminator     = 0xFFF;
     payload.commissioningFlow = CommissioningFlow::kCustom;
@@ -148,15 +148,15 @@ void TestDecimalRepresentation_AllOnes(nlTestSuite * inSuite, void * inContext)
 
 void TestDecimalRepresentation_InvalidPayload(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload  = GetDefaultPayload();
-    payload.discriminator = 0x1f00;
+    PayloadContents payload = GetDefaultPayload();
+    payload.discriminator   = 0x1f00;
 
     ManualSetupPayloadGenerator generator(payload);
     std::string result;
     NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
-void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError, const SetupPayload & payload,
+void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError, const PayloadContents & payload,
                          uint32_t pinCode, uint16_t discriminator, uint16_t vendorID, uint16_t productID)
 {
     NL_TEST_ASSERT(inSuite, actualError == expectedError);
@@ -168,8 +168,8 @@ void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERR
 
 void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload  = GetDefaultPayload();
-    payload.discriminator = 0xa1f;
+    PayloadContents payload = GetDefaultPayload();
+    payload.discriminator   = 0xa1f;
 
     {
         // Test short 11 digit code
@@ -201,14 +201,6 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
     }
 }
 
-void assertEmptyPayloadWithError(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError,
-                                 const SetupPayload & payload)
-{
-    NL_TEST_ASSERT(inSuite, actualError == expectedError);
-    NL_TEST_ASSERT(inSuite,
-                   payload.setUpPINCode == 0 && payload.discriminator == 0 && payload.productID == 0 && payload.vendorID == 0);
-}
-
 void TestPayloadParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload;
@@ -232,7 +224,7 @@ void TestPayloadParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 
 void TestGenerateAndParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload      = GetDefaultPayload();
+    PayloadContents payload   = GetDefaultPayload();
     payload.vendorID          = 1;
     payload.productID         = 1;
     payload.commissioningFlow = CommissioningFlow::kCustom;
@@ -249,7 +241,7 @@ void TestGenerateAndParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 
 void TestGenerateAndParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
 {
-    SetupPayload payload = GetDefaultPayload();
+    PayloadContents payload = GetDefaultPayload();
 
     ManualSetupPayloadGenerator generator(payload);
     std::string result;
@@ -309,7 +301,7 @@ void TestPayloadParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
 
 void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
 {
-    SetupPayload inPayload = GetDefaultPayload();
+    PayloadContents inPayload = GetDefaultPayload();
     SetupPayload outPayload;
 
     std::string result;
@@ -322,7 +314,7 @@ void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
 
 void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
 {
-    SetupPayload inPayload      = GetDefaultPayload();
+    PayloadContents inPayload   = GetDefaultPayload();
     inPayload.commissioningFlow = CommissioningFlow::kCustom;
     inPayload.vendorID          = 1;
     inPayload.productID         = 1;
@@ -334,6 +326,14 @@ void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
     ManualSetupPayloadParser(result).populatePayload(outPayload);
 
     NL_TEST_ASSERT(inSuite, inPayload == outPayload);
+}
+
+void assertEmptyPayloadWithError(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError,
+                                 const SetupPayload & payload)
+{
+    NL_TEST_ASSERT(inSuite, actualError == expectedError);
+    NL_TEST_ASSERT(inSuite,
+                   payload.setUpPINCode == 0 && payload.discriminator == 0 && payload.productID == 0 && payload.vendorID == 0);
 }
 
 void TestPayloadParser_InvalidEntry(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
#### Problem
What is being fixed?
* Enable use of Setup Payload Generators without requiring std::string and std::map
* Fixes remaining instance of #3663

#### Change overview
Create PayloadContents, a base class for SetupPayload that holds all payload fields other than optional QR info.
This allows embedded targets to generate both the Manual Pairing Code and the QR Code without any heap requirements.

Some context: the previous PR #8526 overlooked the std::map private members in the SetupPayload class. The gcc compiler did not construct these members, until an instance of SetupPayload or any of its members were passed by reference (e.g. when populating a field via ConfigurationManager). So this PR aims to provide a more lightweight way to hold the Onboarding Payload elements.

#### Testing
How was this tested? (at least one bullet point required)
* Modified helpers and tests in setup_payload/tests
