### PR TITLE
Revert "Close BLE connections after the Operational Network is provisioned on a Node (#9379)"

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -62,15 +62,6 @@ void RendezvousServer::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * even
     {
         app::Mdns::AdvertiseOperational();
         ChipLogError(Discovery, "Operational advertising enabled");
-#if CONFIG_NETWORK_LAYER_BLE
-        // Close all BLE connections now since the operational network is available.
-        Ble::BleLayer * bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
-        if (bleLayer != nullptr)
-        {
-            ChipLogProgress(Discovery, "Closing all BLE Connections");
-            bleLayer->CloseAllBleConnections();
-        }
-#endif
     }
 }
 


### PR DESCRIPTION
This reverts PR https://github.com/project-chip/connectedhomeip/pull/9379 commit 6a6446f3676986a2355687b6cb89a8132ebecf43.

#### Problem
The reply of `EnableNetwork` command needs to be sent via BLE. Closing BLE connections will cause pairing over BLE to fail.
If  we'd like to close the BLE session, we can close it on the controller.

#### Change overview
Revert.

#### Testing
How was this tested? (at least one bullet point required)
* Pair with `chip-tool` and  `chip-dev-ctrl`. Pairing with BLE is working again now.
