### PR TITLE
linux: Enable SoftAp if Wi-Fi is not provisioned

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -150,6 +150,13 @@ int ChipLinuxAppInit(int argc, char ** argv)
         {
             ChipLogError(NotSpecified, "Wi-Fi Management taking too long to start - device configuration will be reset.");
         }
+
+        if (rendezvousFlags.Has(RendezvousInformationFlag::kSoftAP) &&
+            chip::DeviceLayer::ConnectivityMgrImpl().IsWiFiStationProvisioned() == false)
+        {
+            ConnectivityMgr().SetWiFiAPMode(ConnectivityManager::kWiFiAPMode_Enabled);
+            ChipLogProgress(NotSpecified, "SoftAp enabled.");
+        }
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -40,8 +40,8 @@ source_set("app-main") {
     defines += [ "PW_RPC_ENABLED" ]
   }
   if (chip_ip_commissioning) {
-    # BLE and on-network. Code defaults to BLE if this is not set.
-    defines += [ "CONFIG_RENDEZVOUS_MODE=6" ]
+    # SoftAp, BLE and on-network. Code defaults to BLE if this is not set.
+    defines += [ "CONFIG_RENDEZVOUS_MODE=7" ]
   }
   if (chip_build_libshell) {
     defines += [ "ENABLE_CHIP_SHELL" ]


### PR DESCRIPTION
Enable automatically SoftAp when the application starts and Wi-Fi
is not provisioned. External service (or commands) should be used to
set ip address to the local network interface. DHCP server should be
also running at SoftAp wireless interface (suggestion dnsmasq).

GN argument chip_ip_commissioning should be set to 'true' in order
to enable CONFIG_RENDEZVOUS_MODE 7 (SoftAp/BLE/On-network).

#### Problem
SoftAp is not automatically started when Wi-Fi is not provisioned.

#### Change overview
Calls wpa_supplicant proxy to create a new network for SoftAp when Wi-Fi is not provisioned.

#### Testing
(linux) all-clusters-app$ gn gen out/host  --args='chip_ip_commissioning=true' && ninja -C out/host
*** enabled dnsmaq on Wi-Fi interface
*** assigned ip 169.254.0.1

(another host) chip-tool $./out/host/chip-tool pairing softap ssid "password" 0 20202021 3840 169.254.0.1 5540