### PR TITLE
Define namespace chip inside asn1/ASN1OID.h

### DIFF
--- a/src/lib/asn1/ASN1.h
+++ b/src/lib/asn1/ASN1.h
@@ -26,9 +26,12 @@
 
 #pragma once
 
-#include <lib/support/DLLUtil.h>
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#include <asn1/ASN1OID.h>
+#endif
 
 #include <lib/asn1/ASN1Error.h>
+#include <lib/support/DLLUtil.h>
 
 namespace chip {
 namespace TLV {
@@ -46,10 +49,6 @@ class TLVReader;
 
 namespace chip {
 namespace ASN1 {
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-#include <asn1/ASN1OID.h>
-#endif
 
 static constexpr size_t kMaxConstructedAndEncapsulatedTypesDepth = 10;
 

--- a/src/lib/asn1/gen_asn1oid.py
+++ b/src/lib/asn1/gen_asn1oid.py
@@ -236,6 +236,11 @@ TEMPLATE = '''/*
 
 #pragma once
 
+#include <cstdint>
+
+namespace chip {
+namespace ASN1 {
+
 enum OIDCategory
 %(oid_category_enums)s
 
@@ -277,6 +282,9 @@ const OIDNameTableEntry sOIDNameTable[] =
 %(oid_name_table)s
 
 #endif // ASN1_DEFINE_OID_NAME_TABLE
+
+} // namespace ASN1
+} // namespace chip
 '''
 
 oid_category_enums = "{\n"


### PR DESCRIPTION
#### Problem
`asn1/ASN1OID.h` is included in a namespace context.

#### Change overview
Move the namespace define into `asn1/ASN1OID.h`

**Note**: Sorry, There are several patches. First 3 patches are PR #9387, only last patch is the target of this PR. Please only review last patch.

#### Testing
Verified using unit tests.