### PR TITLE
Better handling of repeated CASE and PASE protocol messages

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -224,7 +224,8 @@ private:
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 
-    Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::CASE_SigmaErr;
+    Protocols::SecureChannel::MsgType mNextExpectedMsg  = Protocols::SecureChannel::MsgType::CASE_SigmaErr;
+    Protocols::SecureChannel::MsgType mLastProcessedMsg = Protocols::SecureChannel::MsgType::CASE_SigmaErr;
 
     Crypto::Hash_SHA256_stream mCommissioningHash;
     Crypto::P256PublicKey mRemotePubKey;

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -270,7 +270,8 @@ private:
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 
-    Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
+    Protocols::SecureChannel::MsgType mNextExpectedMsg  = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
+    Protocols::SecureChannel::MsgType mLastProcessedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
 
 #ifdef ENABLE_HSM_SPAKE
     Spake2pHSM_P256_SHA256_HKDF_HMAC mSpake2p;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -208,6 +208,16 @@ void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
 }
 
+void SecurePairingHandshakeWithDuplicatePacketTest(nlTestSuite * inSuite, void * inContext)
+{
+    TestSecurePairingDelegate delegateCommissioner;
+    PASESession pairingCommissioner;
+    gLoopback.Reset();
+    gLoopback.mSendDuplicateMessage = true;
+    SecurePairingHandshakeTestCommon(inSuite, inContext, pairingCommissioner, delegateCommissioner);
+    gLoopback.Reset();
+}
+
 void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inContext)
 {
     TestSecurePairingDelegate delegateCommissioner;
@@ -339,6 +349,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("WaitInit",    SecurePairingWaitTest),
     NL_TEST_DEF("Start",       SecurePairingStartTest),
     NL_TEST_DEF("Handshake",   SecurePairingHandshakeTest),
+    NL_TEST_DEF("Handshake with duplicate packets",   SecurePairingHandshakeWithDuplicatePacketTest),
     NL_TEST_DEF("Handshake with packet loss", SecurePairingHandshakeWithPacketLossTest),
     NL_TEST_DEF("Failed Handshake", SecurePairingFailedHandshake),
     NL_TEST_DEF("Serialize",   SecurePairingSerializeTest),

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -71,8 +71,25 @@ public:
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;
 
+        // If there's a cached duplicate packet pass it to handler before sending the current packet.
+        // This is being done here since a lot of tests (e.g. TestCASESession) use the loopback transport to
+        // send the next message while handling the current message.
+        // If the duplicate message is not injected prior to handling the current message, it can alter
+        // the order in which duplicate messages are received by the protocol state machine.
+        if (mSendDuplicateMessage && !mDuplicateMessage.IsNull())
+        {
+            HandleMessageReceived(mDuplicateMsgReceiver, std::move(mDuplicateMessage));
+        }
+
         if (mNumMessagesToDrop == 0)
         {
+            // Cache the packet so it can be received as a duplicate.
+            if (mSendDuplicateMessage)
+            {
+                mDuplicateMessage     = msgBuf.CloneData();
+                mDuplicateMsgReceiver = address;
+            }
+
             System::PacketBufferHandle receivedMessage = msgBuf.CloneData();
             HandleMessageReceived(address, std::move(receivedMessage));
         }
@@ -94,6 +111,12 @@ public:
         mDroppedMessageCount = 0;
         mSentMessageCount    = 0;
         mMessageSendError    = CHIP_NO_ERROR;
+
+        if (mSendDuplicateMessage && !mDuplicateMessage.IsNull())
+        {
+            mDuplicateMessage = System::PacketBufferHandle();
+        }
+        mSendDuplicateMessage = false;
     }
 
     // Hook for subclasses to perform custom logic on message drops.
@@ -103,6 +126,11 @@ public:
     uint32_t mDroppedMessageCount = 0;
     uint32_t mSentMessageCount    = 0;
     CHIP_ERROR mMessageSendError  = CHIP_NO_ERROR;
+
+    bool mSendDuplicateMessage = false;
+
+    System::PacketBufferHandle mDuplicateMessage;
+    Transport::PeerAddress mDuplicateMsgReceiver;
 };
 
 } // namespace Test


### PR DESCRIPTION
#### Problem
PASE and CASE session establishment state machines error out if a duplicate packet is received.

#### Change overview
This PR adds tracking of last message that was processed by the state machine. If the same message is received again, it ignores the message instead of failing the session establishment.

#### Testing
Added two new unit tests in `TestCASESession` and `TestPASESession` to test these conditions.
