### PR TITLE
[Hotfix] Only terminate BLE connections once we start processing a CASE session

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -62,15 +62,6 @@ void RendezvousServer::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * even
     {
         app::Mdns::AdvertiseOperational();
         ChipLogError(Discovery, "Operational advertising enabled");
-#if CONFIG_NETWORK_LAYER_BLE
-        // Close all BLE connections now since the operational network is available.
-        Ble::BleLayer * bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
-        if (bleLayer != nullptr)
-        {
-            ChipLogProgress(Discovery, "Closing all BLE Connections");
-            bleLayer->CloseAllBleConnections();
-        }
-#endif
     }
 }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -438,8 +438,8 @@ void InitServer(AppDelegate * delegate)
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::ServiceProvisioning::Id, &gCallbacks);
     SuccessOrExit(err);
 
-    err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalFabricTable(),
-                                                    &gSessionIDAllocator);
+    err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, chip::DeviceLayer::ConnectivityMgr().GetBleLayer(),
+                                                    &gSessions, &GetGlobalFabricTable(), &gSessionIDAllocator);
     SuccessOrExit(err);
 
 exit:

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -30,14 +30,15 @@ using namespace ::chip::Credentials;
 namespace chip {
 
 CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                                     SecureSessionMgr * sessionMgr, Transport::FabricTable * fabrics,
-                                                     SessionIDAllocator * idAllocator)
+                                                     Ble::BleLayer * bleLayer, SecureSessionMgr * sessionMgr,
+                                                     Transport::FabricTable * fabrics, SessionIDAllocator * idAllocator)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(sessionMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(fabrics != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    mBleLayer        = bleLayer;
     mSessionMgr      = sessionMgr;
     mFabrics         = fabrics;
     mExchangeManager = exchangeManager;
@@ -60,6 +61,15 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     // TODO - Identify which PASE base secure channel was used
     //        for commissioning and drop it once commissioning is complete.
     mSessionMgr->ExpireAllPairings(kUndefinedNodeId, kUndefinedFabricIndex);
+
+#if CONFIG_NETWORK_LAYER_BLE
+    // Close all BLE connections now since a CASE handshake has been initiated.
+    if (mBleLayer != nullptr)
+    {
+        ChipLogProgress(Discovery, "CASE handshake initiated, closing all BLE Connections");
+        mBleLayer->CloseAllBleConnections();
+    }
+#endif
 
     ReturnErrorOnFailure(mIDAllocator->Allocate(mSessionKeyId));
 

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <ble/BleLayer.h>
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/CASESession.h>

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -37,8 +37,8 @@ public:
     }
 
     CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                             SecureSessionMgr * sessionMgr, Transport::FabricTable * fabrics,
-                                             SessionIDAllocator * idAllocator);
+                                             Ble::BleLayer * bleLayer, SecureSessionMgr * sessionMgr,
+                                             Transport::FabricTable * fabrics, SessionIDAllocator * idAllocator);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
@@ -62,6 +62,7 @@ private:
     CASESession mPairingSession;
     uint16_t mSessionKeyId         = 0;
     SecureSessionMgr * mSessionMgr = nullptr;
+    Ble::BleLayer * mBleLayer      = nullptr;
 
     Transport::FabricTable * mFabrics = nullptr;
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -349,7 +349,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
     SessionIDAllocator idAllocator;
 
     NL_TEST_ASSERT(inSuite,
-                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &gTransportMgr,
+                   gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &gTransportMgr, nullptr,
                                                                 &ctx.GetSecureSessionManager(), &gDeviceFabrics,
                                                                 &idAllocator) == CHIP_NO_ERROR);
 


### PR DESCRIPTION
#### Problem
PR #9379 can sometimes end up terminating the BLE connection a little too early (before the last response over BLE is sent). 
Terminating BLE connections when the platform indicates that the operational network is provisioned can undercut command responses going over BLE and cause them to never be sent out.

#### Change overview
The goal here is to close BLE connections when we are already using the Operational Network and should not be using BLE. 
This PR closes all BLE connections on the device when a CASE session is started. 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Tested with chip-tool CLI + iOS chip-tool + m5Stack. Tired two iOS chip-tools as well to make sure the BLE connections aren't kept alive unnecessarily. 
Also tested with the python controller and confirmed that the EnableNetwork response is correctly delivered.

