### PR TITLE
[CI] Fix unit test TestConfigurationMgr random failure   

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR ChipLinuxStorageIni::CommitConfig(const std::string & configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
     std::ofstream ofs;
-    std::string tmpPath = configFile + '.' + std::to_string(gettid());
+    std::string tmpPath = configFile + '.' + std::to_string(gettid()) + ".tmp";
 
     ofs.open(tmpPath, std::ofstream::out | std::ofstream::trunc);
 

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -90,9 +90,7 @@ CHIP_ERROR ChipLinuxStorageIni::CommitConfig(const std::string & configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
     std::ofstream ofs;
-    std::string tmpPath = configFile;
-
-    tmpPath.append(".tmp");
+    std::string tmpPath = configFile + '.' + std::to_string(gettid());
 
     ofs.open(tmpPath, std::ofstream::out | std::ofstream::trunc);
 

--- a/src/platform/Linux/CHIPLinuxStorageIni.cpp
+++ b/src/platform/Linux/CHIPLinuxStorageIni.cpp
@@ -88,18 +88,20 @@ CHIP_ERROR ChipLinuxStorageIni::AddConfig(const std::string & configFile)
 // 3. Using rename() to overwrite the existing file
 CHIP_ERROR ChipLinuxStorageIni::CommitConfig(const std::string & configFile)
 {
-    CHIP_ERROR retval = CHIP_NO_ERROR;
-    std::ofstream ofs;
-    std::string tmpPath = configFile + '.' + std::to_string(gettid()) + ".tmp";
+    CHIP_ERROR retval   = CHIP_NO_ERROR;
+    std::string tmpPath = configFile + "-XXXXXX";
 
-    ofs.open(tmpPath, std::ofstream::out | std::ofstream::trunc);
-
-    if (ofs.is_open())
+    int fd = mkstemp(&tmpPath[0]);
+    if (fd != -1)
     {
+        std::ofstream ofs;
+
         ChipLogProgress(DeviceLayer, "writing settings to file (%s)", tmpPath.c_str());
 
+        ofs.open(tmpPath, std::ofstream::out | std::ofstream::trunc);
         mConfigStore.generate(ofs);
-        ofs.close();
+
+        close(fd);
 
         if (rename(tmpPath.c_str(), configFile.c_str()) == 0)
         {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The CI randomly failed with the following error:
[1630514648.709927][29145:29145] CHIP:DL: writing settings to file (/tmp/chip_factory.ini.tmp)
[1630514648.709969][29145:29145] CHIP:DL: failed to rename (/tmp/chip_factory.ini.tmp), No such file or directory (2)
[1630514648.709980][29145:29145] CHIP:DL: Configuration Manager initialization failed: ../../src/platform/Linux/CHIPLinuxStorageIni.cpp:113: CHIP Error 0x000000AF: Write to file failed

The root cause of this failure is the unit test run in parallel in CI and all share the same temp file on the storage which cause race condition.

#### Change overview
Use ramdam temporary file name to prevent racing on the shared file.

#### Testing
How was this tested? (at least one bullet point required)
* Covered by CI