### PR TITLE
[chip-tool] Add command to open enhanced commissioning window

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -74,14 +74,24 @@ public:
     Ethernet() : PairingCommand("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet) {}
 };
 
+class OpenCommissioningWindow : public PairingCommand
+{
+public:
+    OpenCommissioningWindow() :
+        PairingCommand("open-commissioning-window", PairingMode::OpenCommissioningWindow, PairingNetworkType::None)
+    {}
+};
+
 void registerCommandsPairing(Commands & commands)
 {
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),         make_unique<PairBypass>(),  make_unique<PairQRCode>(),
-        make_unique<PairManualCode>(), make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),
-        make_unique<PairSoftAP>(),     make_unique<Ethernet>(),    make_unique<PairOnNetwork>(),
+        make_unique<Unpair>(),        make_unique<PairBypass>(),
+        make_unique<PairQRCode>(),    make_unique<PairManualCode>(),
+        make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
+        make_unique<PairSoftAP>(),    make_unique<Ethernet>(),
+        make_unique<PairOnNetwork>(), make_unique<OpenCommissioningWindow>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -97,6 +97,9 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::Ethernet:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;
+    case PairingMode::OpenCommissioningWindow:
+        err = OpenCommissioningWindow(remoteId, mTimeout, mIteration, mDiscriminator, mPairingWindowOption);
+        break;
     }
 
     return err;
@@ -147,6 +150,14 @@ CHIP_ERROR PairingCommand::PairWithoutSecurity(NodeId remoteId, PeerAddress addr
 CHIP_ERROR PairingCommand::Unpair(NodeId remoteId)
 {
     CHIP_ERROR err = GetExecContext()->commissioner->UnpairDevice(remoteId);
+    SetCommandExitStatus(err);
+    return err;
+}
+
+CHIP_ERROR PairingCommand::OpenCommissioningWindow(NodeId remoteId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
+                                                   uint8_t option)
+{
+    CHIP_ERROR err = GetExecContext()->commissioner->OpenCommissioningWindow(remoteId, timeout, iteration, discriminator, option);
     SetCommandExitStatus(err);
     return err;
 }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;
     case PairingMode::OpenCommissioningWindow:
-        err = OpenCommissioningWindow(remoteId, mTimeout, mIteration, mDiscriminator, mPairingWindowOption);
+        err = OpenCommissioningWindow(remoteId, mTimeout, mIteration, mDiscriminator, mCommissioningWindowOption);
         break;
     }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -104,7 +104,7 @@ public:
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             break;
         case PairingMode::OpenCommissioningWindow:
-            AddArgument("option", 0, UINT8_MAX, &mPairingWindowOption);
+            AddArgument("option", 0, UINT8_MAX, &mCommissioningWindowOption);
             AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
             AddArgument("iteration", 0, UINT16_MAX, &mIteration);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
@@ -162,7 +162,7 @@ private:
     uint16_t mIteration;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
-    uint8_t mPairingWindowOption;
+    uint8_t mCommissioningWindowOption;
     chip::ByteSpan mOperationalDataset;
     uint8_t mExtendedPanId[chip::Thread::kSizeExtendedPanId];
     chip::ByteSpan mSSID;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -38,6 +38,7 @@ enum class PairingMode
     SoftAP,
     Ethernet,
     OnNetwork,
+    OpenCommissioningWindow,
 };
 
 enum class PairingNetworkType
@@ -102,6 +103,12 @@ public:
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             break;
+        case PairingMode::OpenCommissioningWindow:
+            AddArgument("option", 0, UINT8_MAX, &mPairingWindowOption);
+            AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+            AddArgument("iteration", 0, UINT16_MAX, &mIteration);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            break;
         }
     }
 
@@ -132,6 +139,8 @@ private:
     CHIP_ERROR PairWithCode(NodeId remoteId, chip::SetupPayload payload);
     CHIP_ERROR PairWithoutSecurity(NodeId remoteId, PeerAddress address);
     CHIP_ERROR Unpair(NodeId remoteId);
+    CHIP_ERROR OpenCommissioningWindow(NodeId remoteId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
+                                       uint8_t option);
 
     void InitCallbacks();
     CHIP_ERROR SetupNetwork();
@@ -149,8 +158,11 @@ private:
     NodeId mRemoteId;
     uint16_t mRemotePort;
     uint64_t mFabricId;
+    uint16_t mTimeout;
+    uint16_t mIteration;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
+    uint8_t mPairingWindowOption;
     chip::ByteSpan mOperationalDataset;
     uint8_t mExtendedPanId[chip::Thread::kSizeExtendedPanId];
     chip::ByteSpan mSSID;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -357,8 +357,8 @@ void Device::OnOpenPairingWindowFailureResponse(void * context, uint8_t status)
     ChipLogError(Controller, "Failed to open pairing window on the device. Status %d", status);
 }
 
-CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, PairingWindowOption option, const ByteSpan & salt,
-                                           SetupPayload & setupPayload)
+CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, CommissioningWindowOption option,
+                                           const ByteSpan & salt, SetupPayload & setupPayload)
 {
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
@@ -368,9 +368,9 @@ CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration,
     Callback::Cancelable * successCallback = mOpenPairingSuccessCallback.Cancel();
     Callback::Cancelable * failureCallback = mOpenPairingFailureCallback.Cancel();
 
-    if (option != PairingWindowOption::kOriginalSetupCode)
+    if (option != CommissioningWindowOption::kOriginalSetupCode)
     {
-        bool randomSetupPIN = (option == PairingWindowOption::kTokenWithRandomPIN);
+        bool randomSetupPIN = (option == CommissioningWindowOption::kTokenWithRandomPIN);
         PASEVerifier verifier;
 
         ReturnErrorOnFailure(
@@ -397,7 +397,7 @@ CHIP_ERROR Device::OpenCommissioningWindow(uint16_t timeout, uint32_t iteration,
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Device::OpenPairingWindow(uint16_t timeout, PairingWindowOption option, SetupPayload & setupPayload)
+CHIP_ERROR Device::OpenPairingWindow(uint16_t timeout, CommissioningWindowOption option, SetupPayload & setupPayload)
 {
     ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -105,7 +105,7 @@ public:
     {}
     Device(const Device &) = delete;
 
-    enum class PairingWindowOption
+    enum class CommissioningWindowOption
     {
         kOriginalSetupCode = 0,
         kTokenWithRandomPIN,
@@ -291,16 +291,16 @@ public:
 
     /**
      * @brief
-     *   Trigger a paired device to re-enter the pairing mode. If an onboarding token is provided, the device will use
-     *   the provided setup PIN code and the discriminator to advertise itself for pairing availability. If the token
+     *   Trigger a paired device to re-enter the commissioning mode. If an onboarding token is provided, the device will use
+     *   the provided setup PIN code and the discriminator to advertise itself for commissioning availability. If the token
      *   is not provided, the device will use the manufacturer assigned setup PIN code and discriminator.
      *
-     *   The device will exit the pairing mode after a successful pairing, or after the given `timeout` time.
+     *   The device will exit the commissioning mode after a successful commissioning, or after the given `timeout` time.
      *
-     * @param[in] timeout         The pairing mode should terminate after this much time.
+     * @param[in] timeout         The commissioning mode should terminate after this much time.
      * @param[in] iteration       The PAKE iteration count associated with the PAKE Passcode ID and ephemeral
      *                            PAKE passcode verifier to be used for this commissioning.
-     * @param[in] option          The pairing window can be opened using the original setup code, or an
+     * @param[in] option          The commissioning window can be opened using the original setup code, or an
      *                            onboarding token can be generated using a random setup PIN code (or with
      *                            the PIN code provied in the setupPayload).
      * @param[in] salt            The PAKE Salt associated with the PAKE Passcode ID and ephemeral PAKE passcode
@@ -309,19 +309,19 @@ public:
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, PairingWindowOption option, const ByteSpan & salt,
-                                       SetupPayload & setupPayload);
+    CHIP_ERROR OpenCommissioningWindow(uint16_t timeout, uint32_t iteration, CommissioningWindowOption option,
+                                       const ByteSpan & salt, SetupPayload & setupPayload);
 
     /**
      * @brief
-     *   Trigger a paired device to re-enter the pairing mode. If an onboarding token is provided, the device will use
-     *   the provided setup PIN code and the discriminator to advertise itself for pairing availability. If the token
+     *   Trigger a paired device to re-enter the commissioning mode. If an onboarding token is provided, the device will use
+     *   the provided setup PIN code and the discriminator to advertise itself for commissioning availability. If the token
      *   is not provided, the device will use the manufacturer assigned setup PIN code and discriminator.
      *
-     *   The device will exit the pairing mode after a successful pairing, or after the given `timeout` time.
+     *   The device will exit the commissioning mode after a successful commissioning, or after the given `timeout` time.
      *
-     * @param[in] timeout         The pairing mode should terminate after this much time.
-     * @param[in] option          The pairing window can be opened using the original setup code, or an
+     * @param[in] timeout         The commissioning mode should terminate after this much time.
+     * @param[in] option          The commissioning window can be opened using the original setup code, or an
      *                            onboarding token can be generated using a random setup PIN code (or with
      *                            the PIN code provied in the setupPayload). This argument selects one of these
      *                            methods.
@@ -329,7 +329,7 @@ public:
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR OpenPairingWindow(uint16_t timeout, PairingWindowOption option, SetupPayload & setupPayload);
+    CHIP_ERROR OpenPairingWindow(uint16_t timeout, CommissioningWindowOption option, SetupPayload & setupPayload);
 
     /**
      *  In case there exists an open session to the device, mark it as expired.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1044,7 +1044,7 @@ CHIP_ERROR DeviceCommissioner::OperationalDiscoveryComplete(NodeId remoteDeviceI
 CHIP_ERROR DeviceCommissioner::OpenCommissioningWindow(NodeId deviceId, uint16_t timeout, uint16_t iteration,
                                                        uint16_t discriminator, uint8_t option)
 {
-    ChipLogProgress(Controller, "OperationalDiscoveryComplete for device ID %" PRIu64, deviceId);
+    ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, deviceId);
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
 
     Device * device = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1053,7 +1053,7 @@ CHIP_ERROR DeviceCommissioner::OpenCommissioningWindow(NodeId deviceId, uint16_t
     std::string QRCode;
     std::string manualPairingCode;
     SetupPayload payload;
-    Device::PairingWindowOption pairingWindowOption;
+    Device::CommissioningWindowOption commissioningWindowOption;
     ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
 
     payload.discriminator = discriminator;
@@ -1061,22 +1061,22 @@ CHIP_ERROR DeviceCommissioner::OpenCommissioningWindow(NodeId deviceId, uint16_t
     switch (option)
     {
     case 0:
-        pairingWindowOption = Device::PairingWindowOption::kOriginalSetupCode;
+        commissioningWindowOption = Device::CommissioningWindowOption::kOriginalSetupCode;
         break;
     case 1:
-        pairingWindowOption = Device::PairingWindowOption::kTokenWithRandomPIN;
+        commissioningWindowOption = Device::CommissioningWindowOption::kTokenWithRandomPIN;
         break;
     case 2:
-        pairingWindowOption = Device::PairingWindowOption::kTokenWithProvidedPIN;
+        commissioningWindowOption = Device::CommissioningWindowOption::kTokenWithProvidedPIN;
         break;
     default:
         ChipLogError(Controller, "Invalid Pairing Window option");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ReturnErrorOnFailure(device->OpenCommissioningWindow(timeout, iteration, pairingWindowOption, salt, payload));
+    ReturnErrorOnFailure(device->OpenCommissioningWindow(timeout, iteration, commissioningWindowOption, salt, payload));
 
-    if (pairingWindowOption != Device::PairingWindowOption::kOriginalSetupCode)
+    if (commissioningWindowOption != Device::CommissioningWindowOption::kOriginalSetupCode)
     {
         ReturnErrorOnFailure(ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode));
         ChipLogProgress(Controller, "Manual pairing code: [%s]", manualPairingCode.c_str());

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -496,15 +496,15 @@ public:
 
     /**
      * @brief
-     *   Trigger a paired device to re-enter the pairing mode. The device will exit the pairing mode
-     *   after a successful pairing, or after the given `timeout` time.
+     *   Trigger a paired device to re-enter the commissioning mode. The device will exit the commissioning mode
+     *   after a successful commissioning, or after the given `timeout` time.
      *
      * @param[in] deviceId        The device Id.
-     * @param[in] timeout         The pairing mode should terminate after this much time.
+     * @param[in] timeout         The commissioning mode should terminate after this much time.
      * @param[in] iteration       The PAKE iteration count associated with the PAKE Passcode ID and ephemeral
      *                            PAKE passcode verifier to be used for this commissioning.
      * @param[in] discriminator   The long discriminator for the DNS-SD advertisement.
-     * @param[in] option          The pairing window can be opened using the original setup code, or an
+     * @param[in] option          The commissioning window can be opened using the original setup code, or an
      *                            onboarding token can be generated using a random setup PIN code (or with
      *                            the PIN code provied in the setupPayload).
      *

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -549,7 +549,8 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
 
     GetCHIPDevice(env, handle, deviceId, &chipDevice);
 
-    err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::PairingWindowOption::kOriginalSetupCode, setupPayload);
+    err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kOriginalSetupCode,
+                                        setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -67,7 +67,7 @@
 
     [self.lock lock];
     err = self.cppDevice->OpenPairingWindow(
-        (uint16_t) duration, chip::Controller::Device::PairingWindowOption::kOriginalSetupCode, setupPayload);
+        (uint16_t) duration, chip::Controller::Device::CommissioningWindowOption::kOriginalSetupCode, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
@@ -113,7 +113,7 @@
 
     [self.lock lock];
     err = self.cppDevice->OpenPairingWindow(
-        (uint16_t) duration, chip::Controller::Device::PairingWindowOption::kTokenWithProvidedPIN, setupPayload);
+        (uint16_t) duration, chip::Controller::Device::CommissioningWindowOption::kTokenWithProvidedPIN, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* FR from csg, need to add Python controller command to open enhanced commissioning window for multi-admin feature
* Fixes #9419  

#### Change overview
 Add command to open enhanced commissioning window

#### Testing
How was this tested? (at least one bullet point required)
* ./chip-tool pairing open-commissioning-window 1 3 1000 3840
* Confirm all input parameters are correctly received by DeviceCommissioner

```
1630560270.447372][1379978:1379978] CHIP:DIS: Assigned compressed fabric ID: 0x164EB2D7917BBB8F, node ID: 0x000000000001B669
[1630560270.447377][1379978:1379978] CHIP:CTL: Joined the fabric at index 1. Compressed fabric ID is: 0x164EB2D7917BBB8F
[1630560270.447782][1379978:1379985] CHIP:DL: CHIP task running
[1630560270.447887][1379978:1379985] CHIP:CTL: Generated random node id: 0x3503D3C385CC9D63
[1630560270.448177][1379978:1379985] CHIP:CTL: OpenCommissioningWindow for device ID 3820129745657175395
[1630560270.448157][1379978:1379985] CHIP:CTL: OpenCommissioningWindow for timeout 3
[1630560270.448165][1379978:1379985] CHIP:CTL: OpenCommissioningWindow for iteration 1000
[1630560270.448169][1379978:1379985] CHIP:CTL: OpenCommissioningWindow for discriminator 3840
[1630560270.448173][1379978:1379985] CHIP:CTL: OpenCommissioningWindow for option 1
```
