### PR TITLE
Remove dead codes PeerConnectionState::Reset

### DIFF
--- a/src/transport/MessageCounter.h
+++ b/src/transport/MessageCounter.h
@@ -48,7 +48,6 @@ public:
     virtual ~MessageCounter() = 0;
 
     virtual Type GetType()                        = 0;
-    virtual void Reset()                          = 0;
     virtual uint32_t Value()                      = 0; /** Get current value */
     virtual CHIP_ERROR Advance()                  = 0; /** Advance the counter */
     virtual CHIP_ERROR SetCounter(uint32_t count) = 0; /** Set the counter to the specified value */
@@ -63,9 +62,6 @@ public:
     ~GlobalUnencryptedMessageCounter() override {}
 
     Type GetType() override { return GlobalUnencrypted; }
-    void Reset() override
-    { /* null op */
-    }
     uint32_t Value() override { return value; }
     CHIP_ERROR Advance() override
     {
@@ -74,7 +70,6 @@ public:
     }
     CHIP_ERROR SetCounter(uint32_t count) override
     {
-        Reset();
         value = count;
         return CHIP_NO_ERROR;
     }
@@ -91,9 +86,6 @@ public:
 
     CHIP_ERROR Init();
     Type GetType() override { return GlobalEncrypted; }
-    void Reset() override
-    { /* null op */
-    }
     uint32_t Value() override { return persisted.GetValue(); }
     CHIP_ERROR Advance() override { return persisted.Advance(); }
     CHIP_ERROR SetCounter(uint32_t count) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
@@ -128,7 +120,6 @@ public:
     ~LocalSessionMessageCounter() override {}
 
     Type GetType() override { return Session; }
-    void Reset() override { value = kInitialValue; }
     uint32_t Value() override { return value; }
     CHIP_ERROR Advance() override
     {
@@ -137,7 +128,6 @@ public:
     }
     CHIP_ERROR SetCounter(uint32_t count) override
     {
-        Reset();
         value = count;
         return CHIP_NO_ERROR;
     }

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -86,18 +86,6 @@ public:
                 mLocalKeyID != UINT16_MAX);
     }
 
-    /**
-     *  Reset the connection state to a completely uninitialized status.
-     */
-    void Reset()
-    {
-        mPeerAddress        = PeerAddress::Uninitialized();
-        mPeerNodeId         = kUndefinedNodeId;
-        mLastActivityTimeMs = 0;
-        mSecureSession.Reset();
-        mSessionMessageCounter.Reset();
-    }
-
     CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
                                  MessageAuthenticationCode & mac) const
     {

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -94,12 +94,6 @@ CHIP_ERROR SecureSession::Init(const Crypto::P256Keypair & local_keypair, const 
     return InitFromSecret(ByteSpan(secret, secret.Length()), salt, infoType, role);
 }
 
-void SecureSession::Reset()
-{
-    mKeyAvailable = false;
-    memset(mKeys, 0, sizeof(mKeys));
-}
-
 CHIP_ERROR SecureSession::GetIV(const PacketHeader & header, uint8_t * iv, size_t len)
 {
 

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -122,11 +122,6 @@ public:
      */
     size_t EncryptionOverhead();
 
-    /**
-     * Clears the internal state of secure session back to the state of a new object.
-     */
-    void Reset();
-
 private:
     static constexpr size_t kAES_CCM128_Key_Length = 16;
 

--- a/src/transport/SessionMessageCounter.h
+++ b/src/transport/SessionMessageCounter.h
@@ -34,12 +34,6 @@ namespace Transport {
 class SessionMessageCounter
 {
 public:
-    void Reset()
-    {
-        mLocalMessageCounter.Reset();
-        mPeerMessageCounter.Reset();
-    }
-
     MessageCounter & GetLocalMessageCounter() { return mLocalMessageCounter; }
     PeerMessageCounter & GetPeerMessageCounter() { return mPeerMessageCounter; }
 


### PR DESCRIPTION
#### Problem
`PeerConnectionState::Reset` isn't being used at all

#### Change overview
Remove `PeerConnectionState::Reset` and all its related functions

#### Testing
Manually verified using unit-tests.