### PR TITLE
Add provision to set values for Basic attributes at runtime

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -63,17 +63,24 @@ public:
     };
 
     CHIP_ERROR GetVendorName(char * buf, size_t bufSize);
+    CHIP_ERROR StoreVendorName(const char * buf, size_t bufSize);
     CHIP_ERROR GetVendorId(uint16_t & vendorId);
+    CHIP_ERROR StoreVendorId(uint16_t vendorId);
     CHIP_ERROR GetProductName(char * buf, size_t bufSize);
+    CHIP_ERROR StoreProductName(const char * buf, size_t bufSize);
     CHIP_ERROR GetProductId(uint16_t & productId);
+    CHIP_ERROR StoreProductId(uint16_t productId);
     CHIP_ERROR GetProductRevisionString(char * buf, size_t bufSize);
+    CHIP_ERROR StoreProductRevisionString(const char * buf, size_t bufSize);
     CHIP_ERROR GetProductRevision(uint16_t & productRev);
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen);
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf);
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
     CHIP_ERROR GetFirmwareRevisionString(char * buf, size_t bufSize);
+    CHIP_ERROR StoreFirmwareRevisionString(const char * buf, size_t bufSize);
     CHIP_ERROR GetFirmwareRevision(uint32_t & firmwareRev);
+    CHIP_ERROR StoreFirmwareRevision(uint32_t firmwareRev);
     CHIP_ERROR GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour, uint8_t & minute,
                                     uint8_t & second);
     CHIP_ERROR GetDeviceId(uint64_t & deviceId);
@@ -235,11 +242,27 @@ inline CHIP_ERROR ConfigurationManager::GetVendorName(char * buf, size_t bufSize
 }
 
 /**
+ * Store the name of vendor that produced the device.
+ */
+inline CHIP_ERROR ConfigurationManager::StoreVendorName(const char * buf, size_t bufSize)
+{
+    return static_cast<ImplClass *>(this)->_StoreVendorName(buf, bufSize);
+}
+
+/**
  * Id of the vendor that produced the device.
  */
 inline CHIP_ERROR ConfigurationManager::GetVendorId(uint16_t & vendorId)
 {
     return static_cast<ImplClass *>(this)->_GetVendorId(vendorId);
+}
+
+/**
+ * Store vendor Id
+ */
+inline CHIP_ERROR ConfigurationManager::StoreVendorId(uint16_t vendorId)
+{
+    return static_cast<ImplClass *>(this)->_StoreVendorId(vendorId);
 }
 
 /**
@@ -251,11 +274,27 @@ inline CHIP_ERROR ConfigurationManager::GetProductName(char * buf, size_t bufSiz
 }
 
 /**
+ * Store the name of the product assigned by the vendor.
+ */
+inline CHIP_ERROR ConfigurationManager::StoreProductName(const char * buf, size_t bufSize)
+{
+    return static_cast<ImplClass *>(this)->_StoreProductName(buf, bufSize);
+}
+
+/**
  * Device product id assigned by the vendor.
  */
 inline CHIP_ERROR ConfigurationManager::GetProductId(uint16_t & productId)
 {
     return static_cast<ImplClass *>(this)->_GetProductId(productId);
+}
+
+/*
+ * Store device product id assigned by the vendor.
+ */
+inline CHIP_ERROR ConfigurationManager::StoreProductId(uint16_t productId)
+{
+    return static_cast<ImplClass *>(this)->_StoreProductId(productId);
 }
 
 /**
@@ -264,6 +303,14 @@ inline CHIP_ERROR ConfigurationManager::GetProductId(uint16_t & productId)
 inline CHIP_ERROR ConfigurationManager::GetProductRevisionString(char * buf, size_t bufSize)
 {
     return static_cast<ImplClass *>(this)->_GetProductRevisionString(buf, bufSize);
+}
+
+/**
+ * Store Product revision string assigned by the vendor.
+ */
+inline CHIP_ERROR ConfigurationManager::StoreProductRevisionString(const char * buf, size_t bufSize)
+{
+    return static_cast<ImplClass *>(this)->_StoreProductRevisionString(buf, bufSize);
 }
 
 /**
@@ -299,9 +346,19 @@ inline CHIP_ERROR ConfigurationManager::GetFirmwareRevisionString(char * buf, si
     return static_cast<ImplClass *>(this)->_GetFirmwareRevisionString(buf, bufSize);
 }
 
+inline CHIP_ERROR ConfigurationManager::StoreFirmwareRevisionString(const char * buf, size_t bufSize)
+{
+    return static_cast<ImplClass *>(this)->_StoreFirmwareRevisionString(buf, bufSize);
+}
+
 inline CHIP_ERROR ConfigurationManager::GetFirmwareRevision(uint32_t & firmwareRev)
 {
     return static_cast<ImplClass *>(this)->_GetFirmwareRevision(firmwareRev);
+}
+
+inline CHIP_ERROR ConfigurationManager::StoreFirmwareRevision(uint32_t firmwareRev)
+{
+    return static_cast<ImplClass *>(this)->_StoreFirmwareRevision(firmwareRev);
 }
 
 inline CHIP_ERROR ConfigurationManager::GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour,

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -133,25 +133,136 @@ exit:
 template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME);
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err;
+    size_t vlen;
+
+    err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_VendorName, buf, bufSize, vlen);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME);
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreVendorName(const char * vname, size_t vsize)
+{
+    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_VendorName, vname, vsize);
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorId(uint16_t & vendorId)
+{
+    CHIP_ERROR err;
+    uint32_t val;
+
+    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_VendorId, val);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
+        return CHIP_NO_ERROR;
+    }
+    else
+    {
+        vendorId = static_cast<uint16_t>(val);
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreVendorId(uint16_t vendorId)
+{
+    return Impl()->WriteConfigValue(ImplClass::kConfigKey_VendorId, static_cast<uint32_t>(vendorId));
 }
 
 template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err;
+    size_t len;
+
+    err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_ProductName, buf, bufSize, len);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
+        return CHIP_NO_ERROR;
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreProductName(const char * pname, size_t psize)
+{
+    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_ProductName, pname, psize);
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductId(uint16_t & productId)
+{
+    CHIP_ERROR err;
+    uint32_t val;
+
+    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_ProductId, val);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
+        return CHIP_NO_ERROR;
+    }
+    else
+    {
+        productId = static_cast<uint16_t>(val);
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreProductId(uint16_t productId)
+{
+    return Impl()->WriteConfigValue(ImplClass::kConfigKey_ProductId, static_cast<uint32_t>(productId));
 }
 
 template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevisionString(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err;
+    size_t vlen;
+
+    err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_FirmwareRevisionString, buf, bufSize, vlen);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION_STRING);
+        return CHIP_NO_ERROR;
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreFirmwareRevisionString(const char * buf, size_t bufSize)
+{
+    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_FirmwareRevisionString, buf, bufSize);
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevision(uint32_t & firmwareRev)
+{
+    CHIP_ERROR err;
+
+    err = Impl()->ReadConfigValue(ImplClass::kConfigKey_FirmwareRevision, firmwareRev);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
+        return CHIP_NO_ERROR;
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreFirmwareRevision(uint32_t firmwareRev)
+{
+    return Impl()->WriteConfigValue(ImplClass::kConfigKey_FirmwareRevision, firmwareRev);
 }
 
 template <class ImplClass>
@@ -251,9 +362,23 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePrimary802154MACAdd
 template <class ImplClass>
 inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductRevisionString(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING);
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err;
+    size_t vlen;
+
+    err = Impl()->ReadConfigValueStr(ImplClass::kConfigKey_ProductRevisionString, buf, bufSize, vlen);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_PRODUCT_REVISION_STRING);
+        return CHIP_NO_ERROR;
+    }
+    return err;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreProductRevisionString(const char * vname, size_t vsize)
+{
+    return Impl()->WriteConfigValueStr(ImplClass::kConfigKey_ProductRevisionString, vname, vsize);
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -54,14 +54,21 @@ public:
 
     CHIP_ERROR _Init();
     CHIP_ERROR _GetVendorName(char * buf, size_t bufSize);
+    CHIP_ERROR _StoreVendorName(const char * buf, size_t bufSize);
     CHIP_ERROR _GetVendorId(uint16_t & vendorId);
+    CHIP_ERROR _StoreVendorId(uint16_t vendorId);
     CHIP_ERROR _GetProductName(char * buf, size_t bufSize);
+    CHIP_ERROR _StoreProductName(const char * buf, size_t bufSize);
     CHIP_ERROR _GetProductId(uint16_t & productId);
+    CHIP_ERROR _StoreProductId(uint16_t productId);
     CHIP_ERROR _GetProductRevisionString(char * buf, size_t bufSize);
+    CHIP_ERROR _StoreProductRevisionString(const char * buf, size_t bufSize);
     CHIP_ERROR _GetProductRevision(uint16_t & productRev);
     CHIP_ERROR _StoreProductRevision(uint16_t productRev);
     CHIP_ERROR _GetFirmwareRevisionString(char * buf, size_t bufSize);
+    CHIP_ERROR _StoreFirmwareRevisionString(const char * buf, size_t bufSize);
     CHIP_ERROR _GetFirmwareRevision(uint32_t & firmwareRev);
+    CHIP_ERROR _StoreFirmwareRevision(uint32_t firmwareRev);
     CHIP_ERROR _GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour, uint8_t & minute,
                                      uint8_t & second);
     CHIP_ERROR _GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen);
@@ -170,27 +177,6 @@ private:
 
 // Instruct the compiler to instantiate the template only when explicitly told to do so.
 extern template class Internal::GenericConfigurationManagerImpl<ConfigurationManagerImpl>;
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetVendorId(uint16_t & vendorId)
-{
-    vendorId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID);
-    return CHIP_NO_ERROR;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetProductId(uint16_t & productId)
-{
-    productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
-    return CHIP_NO_ERROR;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetFirmwareRevision(uint32_t & firmwareRev)
-{
-    firmwareRev = static_cast<uint32_t>(CHIP_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION);
-    return CHIP_NO_ERROR;
-}
 
 template <class ImplClass>
 inline CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetDeviceType(uint16_t & deviceType)

--- a/src/platform/Darwin/PosixConfig.cpp
+++ b/src/platform/Darwin/PosixConfig.cpp
@@ -70,6 +70,13 @@ const PosixConfig::Key PosixConfig::kConfigKey_OperationalDevicePrivateKey = { k
 const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation          = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorName                  = { kConfigNamespace_ChipConfig, "vendor-name" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorId                    = { kConfigNamespace_ChipConfig, "vendor-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductName                 = { kConfigNamespace_ChipConfig, "product-name" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductId                   = { kConfigNamespace_ChipConfig, "product-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductRevisionString       = { kConfigNamespace_ChipConfig, "product-rev-string" };
+const PosixConfig::Key PosixConfig::kConfigKey_FirmwareRevision            = { kConfigNamespace_ChipConfig, "firmware-rev" };
+const PosixConfig::Key PosixConfig::kConfigKey_FirmwareRevisionString      = { kConfigNamespace_ChipConfig, "firmware-rev-string" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Darwin/PosixConfig.h
+++ b/src/platform/Darwin/PosixConfig.h
@@ -77,6 +77,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -98,6 +98,13 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation          = EFR32ConfigKey(kChipConfig_KeyBase, 0x0D);
     static constexpr Key kConfigKey_CountryCode                 = EFR32ConfigKey(kChipConfig_KeyBase, 0x0E);
     static constexpr Key kConfigKey_Breadcrumb                  = EFR32ConfigKey(kChipConfig_KeyBase, 0x0F);
+    static constexpr Key kConfigKey_VendorName                  = EFR32ConfigKey(kChipConfig_KeyBase, 0x10);
+    static constexpr Key kConfigKey_VendorId                    = EFR32ConfigKey(kChipConfig_KeyBase, 0x11);
+    static constexpr Key kConfigKey_ProductName                 = EFR32ConfigKey(kChipConfig_KeyBase, 0x12);
+    static constexpr Key kConfigKey_ProductId                   = EFR32ConfigKey(kChipConfig_KeyBase, 0x13);
+    static constexpr Key kConfigKey_ProductRevisionString       = EFR32ConfigKey(kChipConfig_KeyBase, 0x14);
+    static constexpr Key kConfigKey_FirmwareRevision            = EFR32ConfigKey(kChipConfig_KeyBase, 0x15);
+    static constexpr Key kConfigKey_FirmwareRevisionString      = EFR32ConfigKey(kChipConfig_KeyBase, 0x16);
 
     static constexpr Key kConfigKey_GroupKeyBase = EFR32ConfigKey(kChipConfig_KeyBase, 0x10);
     static constexpr Key kConfigKey_GroupKeyMax  = EFR32ConfigKey(kChipConfig_KeyBase, 0x1F); // Allows 16 Group Keys to be created.

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -76,6 +76,13 @@ const ESP32Config::Key ESP32Config::kConfigKey_OperationalDevicePrivateKey = { k
 const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation          = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const ESP32Config::Key ESP32Config::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const ESP32Config::Key ESP32Config::kConfigKey_VendorName                  = { kConfigNamespace_ChipConfig, "vendor-name" };
+const ESP32Config::Key ESP32Config::kConfigKey_VendorId                    = { kConfigNamespace_ChipConfig, "vendor-id" };
+const ESP32Config::Key ESP32Config::kConfigKey_ProductName                 = { kConfigNamespace_ChipConfig, "product-name" };
+const ESP32Config::Key ESP32Config::kConfigKey_ProductId                   = { kConfigNamespace_ChipConfig, "product-id" };
+const ESP32Config::Key ESP32Config::kConfigKey_ProductRevisionString       = { kConfigNamespace_ChipConfig, "product-rev-string" };
+const ESP32Config::Key ESP32Config::kConfigKey_FirmwareRevision            = { kConfigNamespace_ChipConfig, "firmware-rev" };
+const ESP32Config::Key ESP32Config::kConfigKey_FirmwareRevisionString      = { kConfigNamespace_ChipConfig, "firmware-rev-string" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char ESP32Config::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -78,6 +78,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/K32W/K32WConfig.h
+++ b/src/platform/K32W/K32WConfig.h
@@ -112,6 +112,14 @@ public:
     static constexpr Key kConfigKey_GroupKey14 = K32WConfigKey(kPDMId_ChipConfig, 0x1D);
     static constexpr Key kConfigKey_GroupKey15 = K32WConfigKey(kPDMId_ChipConfig, 0x1E);
 
+    static constexpr Key kConfigKey_VendorName             = K32WConfigKey(kPDMId_ChipConfig, 0x1F);
+    static constexpr Key kConfigKey_VendorId               = K32WConfigKey(kPDMId_ChipConfig, 0x20);
+    static constexpr Key kConfigKey_ProductName            = K32WConfigKey(kPDMId_ChipConfig, 0x21);
+    static constexpr Key kConfigKey_ProductId              = K32WConfigKey(kPDMId_ChipConfig, 0x22);
+    static constexpr Key kConfigKey_ProductRevisionString  = K32WConfigKey(kPDMId_ChipConfig, 0x23);
+    static constexpr Key kConfigKey_FirmwareRevision       = K32WConfigKey(kPDMId_ChipConfig, 0x24);
+    static constexpr Key kConfigKey_FirmwareRevisionString = K32WConfigKey(kPDMId_ChipConfig, 0x25);
+
     static constexpr Key kConfigKey_GroupKeyBase = kConfigKey_GroupKey0;
     static constexpr Key kConfigKey_GroupKeyMax  = K32WConfigKey(kPDMId_ChipConfig, 0x1E);
     ; // Allows 16 Group Keys to be created.
@@ -120,7 +128,7 @@ public:
     static constexpr Key kMinConfigKey_ChipFactory = K32WConfigKey(kPDMId_ChipFactory, 0x00);
     static constexpr Key kMaxConfigKey_ChipFactory = K32WConfigKey(kPDMId_ChipFactory, 0x08);
     static constexpr Key kMinConfigKey_ChipConfig  = K32WConfigKey(kPDMId_ChipConfig, 0x00);
-    static constexpr Key kMaxConfigKey_ChipConfig  = K32WConfigKey(kPDMId_ChipConfig, 0x1E);
+    static constexpr Key kMaxConfigKey_ChipConfig  = K32WConfigKey(kPDMId_ChipConfig, 0x25);
     static constexpr Key kMinConfigKey_ChipCounter = K32WConfigKey(kPDMId_ChipCounter, 0x00);
     static constexpr Key kMaxConfigKey_ChipCounter = K32WConfigKey(kPDMId_ChipCounter, 0x1F); // Allows 32 Counters to be created.
     static constexpr Key kMinConfigKey_KVS         = K32WConfigKey(kPDMId_KVS, 0x00);

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -75,6 +75,13 @@ const PosixConfig::Key PosixConfig::kConfigKey_OperationalDevicePrivateKey = { k
 const PosixConfig::Key PosixConfig::kConfigKey_RegulatoryLocation          = { kConfigNamespace_ChipConfig, "regulatory-location" };
 const PosixConfig::Key PosixConfig::kConfigKey_CountryCode                 = { kConfigNamespace_ChipConfig, "country-code" };
 const PosixConfig::Key PosixConfig::kConfigKey_Breadcrumb                  = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorName                  = { kConfigNamespace_ChipConfig, "vendor-name" };
+const PosixConfig::Key PosixConfig::kConfigKey_VendorId                    = { kConfigNamespace_ChipConfig, "vendor-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductName                 = { kConfigNamespace_ChipConfig, "product-name" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductId                   = { kConfigNamespace_ChipConfig, "product-id" };
+const PosixConfig::Key PosixConfig::kConfigKey_ProductRevisionString       = { kConfigNamespace_ChipConfig, "product-rev-string" };
+const PosixConfig::Key PosixConfig::kConfigKey_FirmwareRevision            = { kConfigNamespace_ChipConfig, "firmware-rev" };
+const PosixConfig::Key PosixConfig::kConfigKey_FirmwareRevisionString      = { kConfigNamespace_ChipConfig, "firmware-rev-string" };
 
 // Prefix used for NVS keys that contain Chip group encryption keys.
 const char PosixConfig::kGroupKeyNamePrefix[] = "gk-";

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -79,6 +79,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/P6/P6Config.cpp
+++ b/src/platform/P6/P6Config.cpp
@@ -48,18 +48,25 @@ const char P6Config::kConfigNamespace_ChipConfig[]   = "chip-config";
 const char P6Config::kConfigNamespace_ChipCounters[] = "chip-counters";
 
 // Keys stored in the chip-factory namespace
-const P6Config::Key P6Config::kConfigKey_SerialNum           = { kConfigNamespace_ChipFactory, "serial-num" };
-const P6Config::Key P6Config::kConfigKey_MfrDeviceId         = { kConfigNamespace_ChipFactory, "device-id" };
-const P6Config::Key P6Config::kConfigKey_MfrDeviceCert       = { kConfigNamespace_ChipFactory, "device-cert" };
-const P6Config::Key P6Config::kConfigKey_MfrDeviceICACerts   = { kConfigNamespace_ChipFactory, "device-ca-certs" };
-const P6Config::Key P6Config::kConfigKey_MfrDevicePrivateKey = { kConfigNamespace_ChipFactory, "device-key" };
-const P6Config::Key P6Config::kConfigKey_ProductRevision     = { kConfigNamespace_ChipFactory, "product-rev" };
-const P6Config::Key P6Config::kConfigKey_ManufacturingDate   = { kConfigNamespace_ChipFactory, "mfg-date" };
-const P6Config::Key P6Config::kConfigKey_SetupPinCode        = { kConfigNamespace_ChipFactory, "pin-code" };
-const P6Config::Key P6Config::kConfigKey_SetupDiscriminator  = { kConfigNamespace_ChipFactory, "discriminator" };
-const P6Config::Key P6Config::kConfigKey_RegulatoryLocation  = { kConfigNamespace_ChipConfig, "regulatory-location" };
-const P6Config::Key P6Config::kConfigKey_CountryCode         = { kConfigNamespace_ChipConfig, "country-code" };
-const P6Config::Key P6Config::kConfigKey_Breadcrumb          = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const P6Config::Key P6Config::kConfigKey_SerialNum              = { kConfigNamespace_ChipFactory, "serial-num" };
+const P6Config::Key P6Config::kConfigKey_MfrDeviceId            = { kConfigNamespace_ChipFactory, "device-id" };
+const P6Config::Key P6Config::kConfigKey_MfrDeviceCert          = { kConfigNamespace_ChipFactory, "device-cert" };
+const P6Config::Key P6Config::kConfigKey_MfrDeviceICACerts      = { kConfigNamespace_ChipFactory, "device-ca-certs" };
+const P6Config::Key P6Config::kConfigKey_MfrDevicePrivateKey    = { kConfigNamespace_ChipFactory, "device-key" };
+const P6Config::Key P6Config::kConfigKey_ProductRevision        = { kConfigNamespace_ChipFactory, "product-rev" };
+const P6Config::Key P6Config::kConfigKey_ManufacturingDate      = { kConfigNamespace_ChipFactory, "mfg-date" };
+const P6Config::Key P6Config::kConfigKey_SetupPinCode           = { kConfigNamespace_ChipFactory, "pin-code" };
+const P6Config::Key P6Config::kConfigKey_SetupDiscriminator     = { kConfigNamespace_ChipFactory, "discriminator" };
+const P6Config::Key P6Config::kConfigKey_RegulatoryLocation     = { kConfigNamespace_ChipConfig, "regulatory-location" };
+const P6Config::Key P6Config::kConfigKey_CountryCode            = { kConfigNamespace_ChipConfig, "country-code" };
+const P6Config::Key P6Config::kConfigKey_Breadcrumb             = { kConfigNamespace_ChipConfig, "breadcrumb" };
+const P6Config::Key P6Config::kConfigKey_VendorName             = { kConfigNamespace_ChipConfig, "vendor-name" };
+const P6Config::Key P6Config::kConfigKey_VendorId               = { kConfigNamespace_ChipConfig, "vendor-id" };
+const P6Config::Key P6Config::kConfigKey_ProductName            = { kConfigNamespace_ChipConfig, "product-name" };
+const P6Config::Key P6Config::kConfigKey_ProductId              = { kConfigNamespace_ChipConfig, "product-id" };
+const P6Config::Key P6Config::kConfigKey_ProductRevisionString  = { kConfigNamespace_ChipConfig, "product-rev-string" };
+const P6Config::Key P6Config::kConfigKey_FirmwareRevision       = { kConfigNamespace_ChipConfig, "firmware-rev" };
+const P6Config::Key P6Config::kConfigKey_FirmwareRevisionString = { kConfigNamespace_ChipConfig, "firmware-rev-string" };
 
 // Keys stored in the chip-config namespace
 const P6Config::Key P6Config::kConfigKey_FabricId                    = { kConfigNamespace_ChipConfig, "fabric-id" };

--- a/src/platform/P6/P6Config.h
+++ b/src/platform/P6/P6Config.h
@@ -79,6 +79,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     static const char kGroupKeyNamePrefix[];
 

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -75,6 +75,13 @@ const ZephyrConfig::Key ZephyrConfig::kConfigKey_OperationalDevicePrivateKey = C
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_RegulatoryLocation          = CONFIG_KEY(NAMESPACE_CONFIG "regulatory-location");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_CountryCode                 = CONFIG_KEY(NAMESPACE_CONFIG "country-code");
 const ZephyrConfig::Key ZephyrConfig::kConfigKey_Breadcrumb                  = CONFIG_KEY(NAMESPACE_CONFIG "breadcrumb");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_VendorName                  = CONFIG_KEY(NAMESPACE_CONFIG "vendor-name");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_VendorId                    = CONFIG_KEY(NAMESPACE_CONFIG "vendor-id");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_ProductName                 = CONFIG_KEY(NAMESPACE_CONFIG "product-name");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_ProductId                   = CONFIG_KEY(NAMESPACE_CONFIG "product-id");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_ProductRevisionString       = CONFIG_KEY(NAMESPACE_CONFIG "product-rev-string");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_FirmwareRevision            = CONFIG_KEY(NAMESPACE_CONFIG "firmware-rev");
+const ZephyrConfig::Key ZephyrConfig::kConfigKey_FirmwareRevisionString      = CONFIG_KEY(NAMESPACE_CONFIG "firmware-rev-string");
 namespace {
 
 constexpr const char * sAllResettableConfigKeys[] = { ZephyrConfig::kConfigKey_FabricId,
@@ -91,7 +98,14 @@ constexpr const char * sAllResettableConfigKeys[] = { ZephyrConfig::kConfigKey_F
                                                       ZephyrConfig::kConfigKey_OperationalDevicePrivateKey,
                                                       ZephyrConfig::kConfigKey_RegulatoryLocation,
                                                       ZephyrConfig::kConfigKey_CountryCode,
-                                                      ZephyrConfig::kConfigKey_Breadcrumb };
+                                                      ZephyrConfig::kConfigKey_Breadcrumb,
+                                                      ZephyrConfig::kConfigKey_VendorName,
+                                                      ZephyrConfig::kConfigKey_VendorId,
+                                                      ZephyrConfig::kConfigKey_ProductName,
+                                                      ZephyrConfig::kConfigKey_ProductId,
+                                                      ZephyrConfig::kConfigKey_ProductRevisionString,
+                                                      ZephyrConfig::kConfigKey_FirmwareRevision,
+                                                      ZephyrConfig::kConfigKey_FirmwareRevisionString };
 
 // Data structure to be passed as a parameter of Zephyr's settings_load_subtree_direct() function
 struct ReadRequest

--- a/src/platform/Zephyr/ZephyrConfig.h
+++ b/src/platform/Zephyr/ZephyrConfig.h
@@ -67,6 +67,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -34,14 +34,21 @@ class ConfigurationManagerImpl final : public ConfigurationManager
 private:
     CHIP_ERROR _Init() { return CHIP_NO_ERROR; }
     CHIP_ERROR _GetVendorName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreVendorName(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetVendorId(uint16_t & vendorId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreVendorId(uint16_t vendorId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetProductName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreProductName(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetProductId(uint16_t & productId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreProductId(uint16_t productId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetProductRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreProductRevisionString(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetProductRevision(uint16_t & productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _StoreProductRevision(uint16_t productRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetFirmwareRevisionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreFirmwareRevisionString(const char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetFirmwareRevision(uint32_t & firmwareRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR _StoreFirmwareRevision(uint32_t firmwareRev) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR _GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour, uint8_t & minute,
                                      uint8_t & second)
     {

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -85,6 +85,13 @@ const MbedConfig::Key MbedConfig::kConfigKey_OperationalDevicePrivateKey = { CON
 const MbedConfig::Key MbedConfig::kConfigKey_RegulatoryLocation          = { CONFIG_KEY("regulatory-location") };
 const MbedConfig::Key MbedConfig::kConfigKey_CountryCode                 = { CONFIG_KEY("country-code") };
 const MbedConfig::Key MbedConfig::kConfigKey_Breadcrumb                  = { CONFIG_KEY("breadcrumb") };
+const MbedConfig::Key MbedConfig::kConfigKey_VendorName                  = { CONFIG_KEY("vendor-name") };
+const MbedConfig::Key MbedConfig::kConfigKey_VendorId                    = { CONFIG_KEY("vendor-id") };
+const MbedConfig::Key MbedConfig::kConfigKey_ProductName                 = { CONFIG_KEY("product-name") };
+const MbedConfig::Key MbedConfig::kConfigKey_ProductId                   = { CONFIG_KEY("product-id") };
+const MbedConfig::Key MbedConfig::kConfigKey_ProductRevisionString       = { CONFIG_KEY("product-rev-string") };
+const MbedConfig::Key MbedConfig::kConfigKey_FirmwareRevision            = { CONFIG_KEY("firmware-rev") };
+const MbedConfig::Key MbedConfig::kConfigKey_FirmwareRevisionString      = { CONFIG_KEY("firmware-rev-string") };
 
 CHIP_ERROR MbedConfig::ReadConfigValue(Key key, bool & val)
 {

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -76,6 +76,13 @@ public:
     static const Key kConfigKey_RegulatoryLocation;
     static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Breadcrumb;
+    static const Key kConfigKey_VendorName;
+    static const Key kConfigKey_VendorId;
+    static const Key kConfigKey_ProductName;
+    static const Key kConfigKey_ProductId;
+    static const Key kConfigKey_ProductRevisionString;
+    static const Key kConfigKey_FirmwareRevision;
+    static const Key kConfigKey_FirmwareRevisionString;
 
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);

--- a/src/platform/qpg/qpgConfig.h
+++ b/src/platform/qpg/qpgConfig.h
@@ -89,6 +89,13 @@ public:
     static constexpr Key kConfigKey_RegulatoryLocation          = QorvoConfigKey(kFileId_ChipConfig, 0x0D);
     static constexpr Key kConfigKey_CountryCode                 = QorvoConfigKey(kFileId_ChipConfig, 0x0E);
     static constexpr Key kConfigKey_Breadcrumb                  = QorvoConfigKey(kFileId_ChipConfig, 0x0F);
+    static constexpr Key kConfigKey_VendorName                  = QorvoConfigKey(kFileId_ChipConfig, 0x10);
+    static constexpr Key kConfigKey_VendorId                    = QorvoConfigKey(kFileId_ChipConfig, 0x11);
+    static constexpr Key kConfigKey_ProductName                 = QorvoConfigKey(kFileId_ChipConfig, 0x12);
+    static constexpr Key kConfigKey_ProductId                   = QorvoConfigKey(kFileId_ChipConfig, 0x13);
+    static constexpr Key kConfigKey_ProductRevisionString       = QorvoConfigKey(kFileId_ChipConfig, 0x14);
+    static constexpr Key kConfigKey_FirmwareRevision            = QorvoConfigKey(kFileId_ChipConfig, 0x15);
+    static constexpr Key kConfigKey_FirmwareRevisionString      = QorvoConfigKey(kFileId_ChipConfig, 0x16);
 
     static constexpr Key kConfigKey_GroupKeyBase = QorvoConfigKey(kFileId_ChipConfig, 0x10);
     static constexpr Key kConfigKey_GroupKeyMax  = QorvoConfigKey(kFileId_ChipConfig, 0x1F); // Allows 16 Group Keys to be created.


### PR DESCRIPTION
#### Problem
* Cannot set the values for basic attributes at runtime. 

#### Change overview
* Add Store methods, which will store the values in NVS and can be modified at runtime.

#### Testing
* Build all-clusters-app and checked the working of API's
