### PR TITLE
Change temperature delta label to degrees Celsius

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -14,7 +14,7 @@
 @property (nonatomic, strong) UILabel * temperatureLabel;
 @property (nonatomic, strong) UITextField * minIntervalInSecondsTextField;
 @property (nonatomic, strong) UITextField * maxIntervalInSecondsTextField;
-@property (nonatomic, strong) UITextField * deltaInFahrenheitTextField;
+@property (nonatomic, strong) UITextField * deltaInCelsiusTextField;
 @property (nonatomic, strong) UIButton * sendReportingSetup;
 @end
 
@@ -51,7 +51,7 @@
 {
     [_minIntervalInSecondsTextField resignFirstResponder];
     [_maxIntervalInSecondsTextField resignFirstResponder];
-    [_deltaInFahrenheitTextField resignFirstResponder];
+    [_deltaInCelsiusTextField resignFirstResponder];
 }
 
 - (void)setupUI
@@ -120,15 +120,15 @@
     [maxIntervalInSecondsView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 
     // Delta
-    _deltaInFahrenheitTextField = [UITextField new];
-    _deltaInFahrenheitTextField.keyboardType = UIKeyboardTypeNumberPad;
-    UILabel * deltaInFahrenheitLabel = [UILabel new];
-    [deltaInFahrenheitLabel setText:@"Delta (°C):"];
-    UIView * deltaInFahrenheitView = [CHIPUIViewUtils viewWithLabel:deltaInFahrenheitLabel textField:_deltaInFahrenheitTextField];
-    [stackView addArrangedSubview:deltaInFahrenheitView];
+    _deltaInCelsiusTextField = [UITextField new];
+    _deltaInCelsiusTextField.keyboardType = UIKeyboardTypeNumberPad;
+    UILabel * deltaInCelsiusLabel = [UILabel new];
+    [deltaInCelsiusLabel setText:@"Delta (°C):"];
+    UIView * deltaInCelsiusView = [CHIPUIViewUtils viewWithLabel:deltaInCelsiusLabel textField:_deltaInCelsiusTextField];
+    [stackView addArrangedSubview:deltaInCelsiusView];
 
-    deltaInFahrenheitView.translatesAutoresizingMaskIntoConstraints = false;
-    [deltaInFahrenheitView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+    deltaInCelsiusView.translatesAutoresizingMaskIntoConstraints = false;
+    [deltaInCelsiusView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 
     // Reporting button
     _sendReportingSetup = [UIButton new];
@@ -194,10 +194,10 @@
 {
     int minIntervalSeconds = [_minIntervalInSecondsTextField.text intValue];
     int maxIntervalSeconds = [_maxIntervalInSecondsTextField.text intValue];
-    int deltaInFahrenheit = [_deltaInFahrenheitTextField.text intValue];
+    int deltaInCelsius = [_deltaInCelsiusTextField.text intValue];
 
     NSLog(@"Sending temp reporting values: min %@ max %@ value %@", @(minIntervalSeconds), @(maxIntervalSeconds),
-        @(deltaInFahrenheit));
+        @(deltaInCelsius));
 
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {
@@ -207,7 +207,7 @@
                 [cluster
                     configureAttributeMeasuredValueWithMinInterval:minIntervalSeconds
                                                        maxInterval:maxIntervalSeconds
-                                                            change:deltaInFahrenheit
+                                                            change:deltaInCelsius
                                                    responseHandler:^(NSError * error, NSDictionary * values) {
                                                        if (error == nil)
                                                            return;

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -196,8 +196,8 @@
     int maxIntervalSeconds = [_maxIntervalInSecondsTextField.text intValue];
     int deltaInCelsius = [_deltaInCelsiusTextField.text intValue];
 
-    NSLog(@"Sending temp reporting values: min %@ max %@ value %@", @(minIntervalSeconds), @(maxIntervalSeconds),
-        @(deltaInCelsius));
+    NSLog(
+        @"Sending temp reporting values: min %@ max %@ value %@", @(minIntervalSeconds), @(maxIntervalSeconds), @(deltaInCelsius));
 
     if (CHIPGetConnectedDevice(^(CHIPDevice * _Nullable chipDevice, NSError * _Nullable error) {
             if (chipDevice) {

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -123,7 +123,7 @@
     _deltaInFahrenheitTextField = [UITextField new];
     _deltaInFahrenheitTextField.keyboardType = UIKeyboardTypeNumberPad;
     UILabel * deltaInFahrenheitLabel = [UILabel new];
-    [deltaInFahrenheitLabel setText:@"Delta (F):"];
+    [deltaInFahrenheitLabel setText:@"Delta (°C):"];
     UIView * deltaInFahrenheitView = [CHIPUIViewUtils viewWithLabel:deltaInFahrenheitLabel textField:_deltaInFahrenheitTextField];
     [stackView addArrangedSubview:deltaInFahrenheitView];
 


### PR DESCRIPTION
#### Problem
iOS Temperature Sensor screen shows Delta field with unit as F. Related to #9295.

#### Change overview
Change iOS Temperature Sensor screen Delta field label to degrees Celsius.

#### Testing
How was this tested?
* Built with Xcode 12.5.1 and tested on iPhone with iOS 15 beta.
 