### PR TITLE
Improve ReadDone callback in IM read

### DIFF
--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -196,13 +196,12 @@ public:
     }
 
     /**
-     * Notification that a read client has completed the read interaction.
+     * Notification that a read client has completed the read interaction successfully.
      * @param[in]  apReadClient  A current read client which can identify the read client to the consumer, particularly
      * during multiple read interactions
-     * @param[in]  aError  notify final error regarding the current read interaction
      * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
      */
-    virtual CHIP_ERROR ReadDone(const ReadClient * apReadClient, CHIP_ERROR aError) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR ReadDone(const ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     virtual ~InteractionModelDelegate() = default;
 };

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -60,11 +60,11 @@ void ReadClient::ShutdownInternal(CHIP_ERROR aError)
 {
     mpExchangeMgr = nullptr;
     mpExchangeCtx = nullptr;
-    if (mpDelegate != nullptr)
+    if (mpDelegate != nullptr && aError == CHIP_NO_ERROR)
     {
-        mpDelegate->ReadDone(this, aError);
-        mpDelegate = nullptr;
+        mpDelegate->ReadDone(this);
     }
+    mpDelegate = nullptr;
     mInitialReport = true;
     MoveToState(ClientState::Uninitialized);
 }

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -165,13 +165,10 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
+    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient) override
     {
-        if (aError == CHIP_NO_ERROR)
-        {
-            mGotReadStatusResponse = true;
-        }
-        return aError;
+        mGotReadStatusResponse = true;
+        return CHIP_NO_ERROR;
     }
 
     bool mGotEventResponse      = false;

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -450,13 +450,10 @@ public:
         printf("ReadError with err %" CHIP_ERROR_FORMAT, aError.Format());
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
+    CHIP_ERROR ReadDone(const chip::app::ReadClient * apReadClient) override
     {
-        if (aError == CHIP_NO_ERROR)
-        {
-            HandleReadComplete();
-        }
-        return aError;
+        HandleReadComplete();
+        return CHIP_NO_ERROR;
     }
     CHIP_ERROR CommandResponseStatus(const chip::app::CommandSender * apCommandSender,
                                      const chip::Protocols::SecureChannel::GeneralStatusCode aGeneralCode,


### PR DESCRIPTION
#### Problem
-- ReadDone don't need to pass the error

#### Change overview
-- ReadDone is used to mark the complete of current interaction, no need
to pass error to application, and readError has already passed the error
to application.

#### Testing
The existing test covers.
