### PR TITLE
Mbed OS docker image cleanup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,12 +91,12 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "openocdPath": "${env:OPENOCD_PATH/bin}",
             "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
-                "${env:OPENOCD_PATH/scripts}"
+                "${env:OPENOCD_PATH}/scripts"
             ],
             "configFiles": ["${input:mbedTarget}.tcl"],
             "overrideLaunchCommands": [
@@ -124,7 +124,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -151,12 +151,12 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "openocdPath": "${env:OPENOCD_PATH/bin}",
             "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
-                "${env:OPENOCD_PATH/scripts}"
+                "${env:OPENOCD_PATH}/scripts"
             ],
             "configFiles": ["${input:mbedTarget}.tcl"],
             "overrideLaunchCommands": [
@@ -176,7 +176,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -194,9 +194,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-unit-tests.elf",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "openocd",
             "openocdPath": "${env:OPENOCD_PATH/bin}",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH}/scripts"
@@ -227,8 +227,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-unit-tests.elf",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
                 "-enable-pretty-printing",
@@ -254,9 +254,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-unit-tests.elf",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "openocd",
             "openocdPath": "${env:OPENOCD_PATH/bin}",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH/scripts}"
@@ -279,8 +279,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-unit-tests.elf",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
                 "monitor reset halt",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,7 +91,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "openocdPath": "${env:OPENOCD_PATH/bin}",
             "servertype": "openocd",
             "searchDir": [
@@ -124,7 +124,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -151,7 +151,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "openocdPath": "${env:OPENOCD_PATH/bin}",
             "servertype": "openocd",
             "searchDir": [
@@ -176,7 +176,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,9 +91,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "servertype": "openocd",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
             "openocdPath": "${env:OPENOCD_PATH/bin}",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
+            "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH/scripts}"
@@ -124,8 +124,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
             "servertype": "external",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
                 "-enable-pretty-printing",
@@ -151,9 +151,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "servertype": "openocd",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
             "openocdPath": "${env:OPENOCD_PATH/bin}",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
+            "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH/scripts}"
@@ -176,8 +176,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
+            "armToolchainPath": "${workspaceRoot}/.environment/cipd/pigweed/bin/",
             "servertype": "external",
-            "armToolchainPath": "${env:MBED_GCC_ARM_PATH}",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
                 "monitor reset halt",

--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -34,5 +34,5 @@ RUN set -x \
 # ------------------------------------------------------------------------------
 # Configure environment variables
 ENV OPENOCD_PATH=/opt/openocd/
-ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
+
 ENV PATH="${PATH}:${OPENOCD_PATH}/bin"

--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -34,5 +34,6 @@ RUN set -x \
 # ------------------------------------------------------------------------------
 # Configure environment variables
 ENV OPENOCD_PATH=/opt/openocd/
+ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 
 ENV PATH="${PATH}:${OPENOCD_PATH}/bin"

--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -16,37 +16,9 @@ RUN set -x \
     && : # last line
 
 # ------------------------------------------------------------------------------
-# Install Mbed-OS sources
-RUN set -x \
-    && (mkdir -p /opt/mbed-os \
-    && cd /opt/mbed-os \
-    && wget --progress=dot:giga https://github.com/ARMmbed/mbed-os/archive/mbed-os-6.7.0.tar.gz \
-    && tar --strip-components=1 -xzf mbed-os-6.7.0.tar.gz \
-    && rm mbed-os-6.7.0.tar.gz) \
-    && : # last line
-
-# ------------------------------------------------------------------------------
 # Install Python modules
 RUN set -x \
     && pip3 install --no-cache-dir -U mbed-cli mbed-tools \
-    && pip3 install --no-cache-dir --ignore-installed -r /opt/mbed-os/requirements.txt \
-    && : # last line
-
-# ------------------------------------------------------------------------------
-# Install ARM Toolchain (gcc-arm-none-eabi-9-2019-q4)
-RUN set -x \
-    && (mkdir -p /opt/mbed-os-toolchain \
-    && cd /opt/mbed-os-toolchain \
-    && wget --progress=dot:giga https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 \
-    && tar -xjf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 \
-    && rm gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 \
-    && : ) # last line
-
-# ------------------------------------------------------------------------------
-# Configure mbed build system
-RUN set -x \
-    && mbed config -G GCC_ARM_PATH /opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/ \
-    && mbed toolchain -G -s GCC_ARM \
     && : # last line
 
 # ------------------------------------------------------------------------------
@@ -61,8 +33,6 @@ RUN set -x \
 
 # ------------------------------------------------------------------------------
 # Configure environment variables
-ENV MBED_GCC_ARM_PATH=/opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/
-ENV MBED_OS_PATH=/opt/mbed-os/
 ENV OPENOCD_PATH=/opt/openocd/
-
-ENV PATH="${PATH}:${MBED_GCC_ARM_PATH}:${OPENOCD_PATH}/bin"
+ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
+ENV PATH="${PATH}:${OPENOCD_PATH}/bin"

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -23,8 +23,6 @@ COPY --from=nrf /opt/NordicSemiconductor/nrfconnect /opt/NordicSemiconductor/nrf
 COPY --from=android /opt/android/sdk /opt/android/sdk
 COPY --from=android /opt/android/android-ndk-r21b /opt/android/android-ndk-r21b
 
-COPY --from=mbedos /opt/mbed-os /opt/mbed-os
-COPY --from=mbedos /opt/mbed-os-toolchain/ /opt/mbed-os-toolchain/
 COPY --from=mbedos /opt/openocd/ /opt/openocd/
 
 COPY --from=p6 /opt/ModusToolbox /opt/ModusToolbox
@@ -54,8 +52,6 @@ ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV EFR32_BOARD=BRD4161A
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b
-ENV MBED_GCC_ARM_PATH=/opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/
-ENV MBED_OS_PATH=/opt/mbed-os/
 ENV OPENOCD_PATH=/opt/openocd/
 ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.15 Version bump resason: Add python package `tabulate`
+0.5.16

--- a/scripts/examples/mbed_example.sh
+++ b/scripts/examples/mbed_example.sh
@@ -34,29 +34,29 @@ PROFILE=release
 
 for i in "$@"; do
     case $i in
-    -a=* | --app=*)
-        APP="${i#*=}"
-        shift
-        ;;
-    -b=* | --board=*)
-        TARGET_BOARD="${i#*=}"
-        shift
-        ;;
-    -t=* | --toolchain=*)
-        TOOLCHAIN="${i#*=}"
-        shift
-        ;;
-    -p=* | --profile=*)
-        PROFILE="${i#*=}"
-        shift
-        ;;
-    -c=* | --command=*)
-        COMMAND="${i#*=}"
-        shift
-        ;;
-    *)
-        # unknown option
-        ;;
+        -a=* | --app=*)
+            APP="${i#*=}"
+            shift
+            ;;
+        -b=* | --board=*)
+            TARGET_BOARD="${i#*=}"
+            shift
+            ;;
+        -t=* | --toolchain=*)
+            TOOLCHAIN="${i#*=}"
+            shift
+            ;;
+        -p=* | --profile=*)
+            PROFILE="${i#*=}"
+            shift
+            ;;
+        -c=* | --command=*)
+            COMMAND="${i#*=}"
+            shift
+            ;;
+        *)
+            # unknown option
+            ;;
     esac
 done
 
@@ -128,5 +128,5 @@ if [[ "$COMMAND" == *"flash"* ]]; then
     MBED_FLASH_SCRIPTS_PATH=$CHIP_ROOT/config/mbed/scripts
 
     # Flash application
-    "${OPENOCD_PATH}"/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
+    "$OPENOCD_PATH"/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
 fi

--- a/scripts/examples/mbed_example.sh
+++ b/scripts/examples/mbed_example.sh
@@ -34,29 +34,29 @@ PROFILE=release
 
 for i in "$@"; do
     case $i in
-        -a=* | --app=*)
-            APP="${i#*=}"
-            shift
-            ;;
-        -b=* | --board=*)
-            TARGET_BOARD="${i#*=}"
-            shift
-            ;;
-        -t=* | --toolchain=*)
-            TOOLCHAIN="${i#*=}"
-            shift
-            ;;
-        -p=* | --profile=*)
-            PROFILE="${i#*=}"
-            shift
-            ;;
-        -c=* | --command=*)
-            COMMAND="${i#*=}"
-            shift
-            ;;
-        *)
-            # unknown option
-            ;;
+    -a=* | --app=*)
+        APP="${i#*=}"
+        shift
+        ;;
+    -b=* | --board=*)
+        TARGET_BOARD="${i#*=}"
+        shift
+        ;;
+    -t=* | --toolchain=*)
+        TOOLCHAIN="${i#*=}"
+        shift
+        ;;
+    -p=* | --profile=*)
+        PROFILE="${i#*=}"
+        shift
+        ;;
+    -c=* | --command=*)
+        COMMAND="${i#*=}"
+        shift
+        ;;
+    *)
+        # unknown option
+        ;;
     esac
 done
 
@@ -128,5 +128,5 @@ if [[ "$COMMAND" == *"flash"* ]]; then
     MBED_FLASH_SCRIPTS_PATH=$CHIP_ROOT/config/mbed/scripts
 
     # Flash application
-    openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
+    ${OPENOCD_PATH}/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
 fi

--- a/scripts/examples/mbed_example.sh
+++ b/scripts/examples/mbed_example.sh
@@ -128,5 +128,5 @@ if [[ "$COMMAND" == *"flash"* ]]; then
     MBED_FLASH_SCRIPTS_PATH=$CHIP_ROOT/config/mbed/scripts
 
     # Flash application
-    ${OPENOCD_PATH}/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
+    "${OPENOCD_PATH}"/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-$APP-example.elf verify reset exit"
 fi

--- a/scripts/tests/mbed/mbed_unit_tests.sh
+++ b/scripts/tests/mbed/mbed_unit_tests.sh
@@ -32,25 +32,25 @@ PROFILE=release
 
 for i in "$@"; do
     case $i in
-    -b=* | --board=*)
-        TARGET_BOARD="${i#*=}"
-        shift
-        ;;
-    -t=* | --toolchain=*)
-        TOOLCHAIN="${i#*=}"
-        shift
-        ;;
-    -p=* | --profile=*)
-        PROFILE="${i#*=}"
-        shift
-        ;;
-    -c=* | --command=*)
-        COMMAND="${i#*=}"
-        shift
-        ;;
-    *)
-        # unknown option
-        ;;
+        -b=* | --board=*)
+            TARGET_BOARD="${i#*=}"
+            shift
+            ;;
+        -t=* | --toolchain=*)
+            TOOLCHAIN="${i#*=}"
+            shift
+            ;;
+        -p=* | --profile=*)
+            PROFILE="${i#*=}"
+            shift
+            ;;
+        -c=* | --command=*)
+            COMMAND="${i#*=}"
+            shift
+            ;;
+        *)
+            # unknown option
+            ;;
     esac
 done
 

--- a/scripts/tests/mbed/mbed_unit_tests.sh
+++ b/scripts/tests/mbed/mbed_unit_tests.sh
@@ -32,25 +32,25 @@ PROFILE=release
 
 for i in "$@"; do
     case $i in
-        -b=* | --board=*)
-            TARGET_BOARD="${i#*=}"
-            shift
-            ;;
-        -t=* | --toolchain=*)
-            TOOLCHAIN="${i#*=}"
-            shift
-            ;;
-        -p=* | --profile=*)
-            PROFILE="${i#*=}"
-            shift
-            ;;
-        -c=* | --command=*)
-            COMMAND="${i#*=}"
-            shift
-            ;;
-        *)
-            # unknown option
-            ;;
+    -b=* | --board=*)
+        TARGET_BOARD="${i#*=}"
+        shift
+        ;;
+    -t=* | --toolchain=*)
+        TOOLCHAIN="${i#*=}"
+        shift
+        ;;
+    -p=* | --profile=*)
+        PROFILE="${i#*=}"
+        shift
+        ;;
+    -c=* | --command=*)
+        COMMAND="${i#*=}"
+        shift
+        ;;
+    *)
+        # unknown option
+        ;;
     esac
 done
 
@@ -117,5 +117,5 @@ if [[ "$COMMAND" == *"flash"* ]]; then
     MBED_FLASH_SCRIPTS_PATH=$CHIP_ROOT/config/mbed/scripts
 
     # Flash application
-    openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-unit-tests.elf verify reset exit"
+    "$OPENOCD_PATH"/bin/openocd -f "$MBED_FLASH_SCRIPTS_PATH/$TARGET_BOARD".tcl -c "program $BUILD_DIRECTORY/chip-mbed-unit-tests.elf verify reset exit"
 fi


### PR DESCRIPTION
#### Problem
Cleanup Mbed OS docker image. After integration improvement, we use more tools and libraries from Pigweed. 

#### Change overview
Remove Mbed-os sources installing - now it is the third-party library
Remove ARM toolchain installing - we use Pigweed version of it
Improve flashing and debugging script and VScode launch tasks.

#### Testing
Build and run docker images locally. Build, flash and debug Mbed OS applications. 
