### PR TITLE
Define trace.h for tracing CHIP_ERRORs instead of ChipLogFunctError

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -39,8 +39,8 @@ CHIP_ERROR Command::Init(Messaging::ExchangeManager * apExchangeMgr, Interaction
     Logging::LogTracer tracer(__func__);
 
     // Error if already initialized.
-    VerifyOrReturnError(apExchangeMgr != nullptr, tracer.logError(CHIP_ERROR_INCORRECT_STATE));
-    VerifyOrReturnError(mpExchangeMgr == nullptr, tracer.logError(CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrReturnError(apExchangeMgr != nullptr, tracer.LogError(CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrReturnError(mpExchangeMgr == nullptr, tracer.LogError(CHIP_ERROR_INCORRECT_STATE));
 
     mpExchangeMgr = apExchangeMgr;
     mpDelegate    = apDelegate;
@@ -59,7 +59,7 @@ CHIP_ERROR Command::Reset()
     mCommandMessageWriter.Reset();
 
     System::PacketBufferHandle commandPacket = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
-    VerifyOrReturnError(!commandPacket.IsNull(), tracer.logError(CHIP_ERROR_NO_MEMORY));
+    VerifyOrReturnError(!commandPacket.IsNull(), tracer.LogError(CHIP_ERROR_NO_MEMORY));
 
     mCommandMessageWriter.Init(std::move(commandPacket));
 
@@ -99,9 +99,9 @@ CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle && payload,
     CHIP_ERROR err;
     while (CHIP_NO_ERROR == (err = commandListReader.Next()))
     {
-        VerifyOrReturnError(chip::TLV::AnonymousTag == commandListReader.GetTag(), tracer.logError(CHIP_ERROR_INVALID_TLV_TAG));
+        VerifyOrReturnError(chip::TLV::AnonymousTag == commandListReader.GetTag(), tracer.LogError(CHIP_ERROR_INVALID_TLV_TAG));
         VerifyOrReturnError(chip::TLV::kTLVType_Structure == commandListReader.GetType(),
-                            tracer.logError(CHIP_ERROR_WRONG_TLV_TYPE));
+                            tracer.LogError(CHIP_ERROR_WRONG_TLV_TYPE));
 
         CommandDataElement::Parser commandElement;
 
@@ -116,7 +116,7 @@ CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle && payload,
     }
     else if (CHIP_NO_ERROR != err)
     {
-        return tracer.logError(err);
+        return tracer.LogError(err);
     }
 
     return CHIP_NO_ERROR;
@@ -146,7 +146,7 @@ CHIP_ERROR Command::PrepareCommand(const CommandPathParams & aCommandPathParams,
     Logging::LogTracer tracer(__func__);
 
     VerifyOrReturnError(mState == CommandState::Initialized || mState == CommandState::AddCommand,
-                        tracer.logError(CHIP_ERROR_INCORRECT_STATE));
+                        tracer.LogError(CHIP_ERROR_INCORRECT_STATE));
 
     CommandDataElement::Builder commandDataElement;
     commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
@@ -225,7 +225,7 @@ CHIP_ERROR Command::FinalizeCommandsMessage(System::PacketBufferHandle & command
 {
     Logging::LogTracer tracer(__func__);
 
-    VerifyOrReturnError(mState == CommandState::AddCommand, tracer.logError(CHIP_ERROR_INCORRECT_STATE));
+    VerifyOrReturnError(mState == CommandState::AddCommand, tracer.LogError(CHIP_ERROR_INCORRECT_STATE));
 
     CommandList::Builder commandListBuilder;
     commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();

--- a/src/lib/support/logging/Trace.h
+++ b/src/lib/support/logging/Trace.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace Logging {
+
+/// Provides the ability to add tracing code to methods. Will do
+/// ChipLog tracing if CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING is set
+/// and will be optimized away by the compiler if the define is not set
+///
+/// Typical usage:
+///     LogTracer tracer(__func__);
+///
+///     VerifyOrReturnError(somecondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT));
+///     VerifyOrReturnError(otherCondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT, "othercondition"));
+///
+///     return CHIP_NO_ERROR;
+class LogTracer
+{
+#if CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING
+public:
+    LogTracer(const char * name) : mName(name) {}
+    inline CHIP_ERROR logError(CHIP_ERROR err)
+    {
+        ChipLogError(NotSpecified, "%s in %s", ErrorStr(err), mName);
+        return err;
+    }
+
+    inline CHIP_ERROR logError(CHIP_ERROR err, const char * context)
+    {
+        ChipLogError(NotSpecified, "%s/%s in %s", ErrorStr(err), context, mName);
+        return err;
+    }
+
+private:
+    const char * mName;
+
+#else
+public:
+    LogTracer(const char *) {}
+    inline constexpr CHIP_ERROR logError(CHIP_ERROR err) { return err; }
+    inline constexpr CHIP_ERROR logError(CHIP_ERROR err, const char *) { return err; }
+#endif
+};
+
+} // namespace Logging
+} // namespace chip
+
+#define ReturnTracedErrorOnFailure(expr, tracer)                                                                                   \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
+        {                                                                                                                          \
+            return tracer.logError(__err);                                                                                         \
+        }                                                                                                                          \
+    } while (false)

--- a/src/lib/support/logging/Trace.h
+++ b/src/lib/support/logging/Trace.h
@@ -29,8 +29,8 @@ namespace Logging {
 /// Typical usage:
 ///     LogTracer tracer(__func__);
 ///
-///     VerifyOrReturnError(somecondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT));
-///     VerifyOrReturnError(otherCondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT, "othercondition"));
+///     VerifyOrReturnError(somecondition, tracer.LogError(CHIP_ERROR_INVALID_ARGUMENT));
+///     VerifyOrReturnError(otherCondition, tracer.LogError(CHIP_ERROR_INVALID_ARGUMENT, "othercondition"));
 ///
 ///     ReturnTracedErrorOnFailure(foo.Bar(), tracer);
 ///     ReturnTracedErrorOnFailure(foo.Baz(), tracer);
@@ -41,13 +41,13 @@ class LogTracer
 #if CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING
 public:
     LogTracer(const char * name) : mName(name) {}
-    inline CHIP_ERROR logError(CHIP_ERROR err)
+    CHIP_ERROR LogError(CHIP_ERROR err)
     {
         ChipLogError(NotSpecified, "%s in %s", ErrorStr(err), mName);
         return err;
     }
 
-    inline CHIP_ERROR logError(CHIP_ERROR err, const char * context)
+    CHIP_ERROR LogError(CHIP_ERROR err, const char * context)
     {
         ChipLogError(NotSpecified, "%s/%s in %s", ErrorStr(err), context, mName);
         return err;
@@ -59,8 +59,8 @@ private:
 #else
 public:
     LogTracer(const char *) {}
-    inline constexpr CHIP_ERROR logError(CHIP_ERROR err) { return err; }
-    inline constexpr CHIP_ERROR logError(CHIP_ERROR err, const char *) { return err; }
+    constexpr CHIP_ERROR LogError(CHIP_ERROR err) { return err; }
+    constexpr CHIP_ERROR LogError(CHIP_ERROR err, const char *) { return err; }
 #endif
 };
 
@@ -73,6 +73,6 @@ public:
         auto __err = (expr);                                                                                                       \
         if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
-            return tracer.logError(__err);                                                                                         \
+            return tracer.LogError(__err);                                                                                         \
         }                                                                                                                          \
     } while (false)

--- a/src/lib/support/logging/Trace.h
+++ b/src/lib/support/logging/Trace.h
@@ -32,6 +32,9 @@ namespace Logging {
 ///     VerifyOrReturnError(somecondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT));
 ///     VerifyOrReturnError(otherCondition, tracer.log(CHIP_ERROR_INVALID_ARGUMENT, "othercondition"));
 ///
+///     ReturnTracedErrorOnFailure(foo.Bar(), tracer);
+///     ReturnTracedErrorOnFailure(foo.Baz(), tracer);
+///
 ///     return CHIP_NO_ERROR;
 class LogTracer
 {


### PR DESCRIPTION
#### Problem
One of the apparently common uses for `got exit` pattern seems to be the desire to 'log on error'.

got exit however has readability disadvantages: it forces variable declarations at the top (C-style).


#### Change overview
Define a `LogTracer` class that can be used to trace errors. For now I just made it trace function name (as opposed to file::name from before since function  name seemed more relevant).

Keep the same conditional between enable/disable of such tracer.

#### Testing
Compilation passes.
