### PR TITLE
K32W0 fixes: SRAM usage reduction, fix KVS factory reset

### DIFF
--- a/examples/lighting-app/k32w/BUILD.gn
+++ b/examples/lighting-app/k32w/BUILD.gn
@@ -73,8 +73,8 @@ k32w_executable("light_app") {
     "${chip_root}/src/lib",
     "${chip_root}/third_party/mbedtls:mbedtls",
     "${k32w_platform_dir}/app/support:freertos_mbedtls_utils",
-    "${openthread_root}:libopenthread-cli-mtd",
-    "${openthread_root}:libopenthread-mtd",
+    "${openthread_root}:libopenthread-cli-ftd",
+    "${openthread_root}:libopenthread-ftd",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/examples/lighting-app/k32w/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/k32w/include/CHIPProjectConfig.h
@@ -176,9 +176,23 @@
  */
 #define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)
 
+/**
+ * CONFIG_CHIP_NFC_COMMISSIONING, CHIP_DEVICE_CONFIG_ENABLE_NFC
+ *
+ * Set these defines to 1 if NFC Commissioning is needed
+ */
 #define CONFIG_CHIP_NFC_COMMISSIONING 1
-
 #define CHIP_DEVICE_CONFIG_ENABLE_NFC 1
+
+/**
+ *  @def CHIP_CONFIG_MAX_DEVICE_ADMINS
+ *
+ *  @brief
+ *    Maximum number of administrators that can provision the device. Each admin
+ *    can provision the device with their unique operational credentials and manage
+ *    their access control lists.
+ */
+#define CHIP_CONFIG_MAX_DEVICE_ADMINS 4 // 3 fabrics + 1 for rotation slack
 
 /**
  * CHIP_CONFIG_EVENT_LOGGING_DEFAULT_IMPORTANCE

--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -145,7 +145,7 @@ CHIP_ERROR AppTask::Init()
 
     K32W_LOG("Current Firmware Version: %s", currentFirmwareRev);
 
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
+#if CONFIG_CHIP_NFC_COMMISSIONING
     PlatformMgr().AddEventHandler(ThreadProvisioningHandler, 0);
 #endif
 
@@ -500,7 +500,7 @@ void AppTask::BleHandler(AppEvent * aEvent)
     }
 }
 
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
+#if CONFIG_CHIP_NFC_COMMISSIONING
 void AppTask::ThreadProvisioningHandler(const ChipDeviceEvent * event, intptr_t)
 {
     if (event->Type == DeviceEventType::kCHIPoBLEAdvertisingChange && event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)

--- a/examples/lock-app/k32w/BUILD.gn
+++ b/examples/lock-app/k32w/BUILD.gn
@@ -75,8 +75,8 @@ k32w_executable("lock_app") {
     "${chip_root}/third_party/mbedtls:mbedtls",
     "${chip_root}/third_party/simw-top-mini:se05x",
     "${k32w_platform_dir}/app/support:freertos_mbedtls_utils",
-    "${openthread_root}:libopenthread-cli-ftd",
-    "${openthread_root}:libopenthread-ftd",
+    "${openthread_root}:libopenthread-cli-mtd",
+    "${openthread_root}:libopenthread-mtd",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/examples/lock-app/k32w/include/CHIPProjectConfig.h
+++ b/examples/lock-app/k32w/include/CHIPProjectConfig.h
@@ -176,9 +176,30 @@
  */
 #define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)
 
+/**
+ * CONFIG_CHIP_NFC_COMMISSIONING, CHIP_DEVICE_CONFIG_ENABLE_NFC
+ *
+ * Set these defines to 1 if NFC Commissioning is needed
+ */
 #define CONFIG_CHIP_NFC_COMMISSIONING 1
-
 #define CHIP_DEVICE_CONFIG_ENABLE_NFC 1
+
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_FTD
+ *
+ * E-Lock Demo Application is a Thread SED (Sleepy End Device)
+ */
+#define CHIP_DEVICE_CONFIG_THREAD_FTD 0
+
+/**
+ *  @def CHIP_CONFIG_MAX_DEVICE_ADMINS
+ *
+ *  @brief
+ *    Maximum number of administrators that can provision the device. Each admin
+ *    can provision the device with their unique operational credentials and manage
+ *    their access control lists.
+ */
+#define CHIP_CONFIG_MAX_DEVICE_ADMINS 4 // 3 fabrics + 1 for rotation slack
 
 /**
  * CHIP_CONFIG_EVENT_LOGGING_DEFAULT_IMPORTANCE

--- a/examples/platform/k32w/app/project_include/OpenThreadConfig.h
+++ b/examples/platform/k32w/app/project_include/OpenThreadConfig.h
@@ -52,6 +52,11 @@
 #define OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE 0
 #define OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE 0
 #define OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE 0
+#define OPENTHREAD_CONFIG_TCP_ENABLE 0
+
+#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 44
+
+//#define OPENTHREAD_CONFIG_LOG_LEVEL                            OT_LOG_LEVEL_DEBG
 
 // Use the NXP-supplied default platform configuration for remainder
 // of OpenThread config options.

--- a/src/lwip/k32w/lwipopts.h
+++ b/src/lwip/k32w/lwipopts.h
@@ -55,9 +55,19 @@
 
 #define LWIP_SOCKET 0
 
-// TODO: seems like this is unnecessary on Thread-only platforms
+#if INET_CONFIG_ENABLE_RAW_ENDPOINT
 #define LWIP_RAW 1
 #define MEMP_NUM_RAW_PCB (5)
+#else
+#define LWIP_RAW 0
+#define MEMP_NUM_RAW_PCB 0
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#define LWIP_TCP 1
+#else
+#define LWIP_TCP 0
+#define MEMP_NUM_TCP_PCB 0
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 // TODO: verify count
 #define MEMP_NUM_UDP_PCB (7)
@@ -126,7 +136,7 @@
 
 // TODO: make LWIP_DEBUG conditional on build type
 
-#define LWIP_DEBUG 1
+#define LWIP_DEBUG 0
 #define MEMP_OVERFLOW_CHECK (0)
 #define MEMP_SANITY_CHECK (0)
 #define MEM_DEBUG (LWIP_DBG_OFF)

--- a/src/platform/K32W/BUILD.gn
+++ b/src/platform/K32W/BUILD.gn
@@ -53,8 +53,6 @@ static_library("K32W") {
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 
   if (chip_enable_openthread) {
-    public_deps += [ "${openthread_root}:libopenthread-ftd" ]
-
     sources += [
       "../OpenThread/OpenThreadUtils.cpp",
       "ThreadStackManagerImpl.cpp",

--- a/src/platform/K32W/K32WConfig.cpp
+++ b/src/platform/K32W/K32WConfig.cpp
@@ -381,16 +381,15 @@ CHIP_ERROR K32WConfig::FactoryResetConfigInternal(Key firstKey, Key lastKey)
     CHIP_ERROR err;
 
     // Iterate over all the CHIP Config PDM ID records and delete each one
-    err = ForEachRecord(kMinConfigKey_ChipConfig, kMaxConfigKey_ChipConfig, false,
-                        [](const Key & pdmKey, const size_t & length) -> CHIP_ERROR {
-                            CHIP_ERROR err2;
+    err = ForEachRecord(firstKey, lastKey, false, [](const Key & pdmKey, const size_t & length) -> CHIP_ERROR {
+        CHIP_ERROR err2;
 
-                            err2 = ClearConfigValue(pdmKey);
-                            SuccessOrExit(err2);
+        err2 = ClearConfigValue(pdmKey);
+        SuccessOrExit(err2);
 
-                        exit:
-                            return err2;
-                        });
+    exit:
+        return err2;
+    });
 
     // Return success at end of iterations.
     if (err == CHIP_END_OF_INPUT)

--- a/src/platform/K32W/ThreadStackManagerImpl.cpp
+++ b/src/platform/K32W/ThreadStackManagerImpl.cpp
@@ -81,18 +81,6 @@ extern "C" void otTaskletsSignalPending(otInstance * p_instance)
     ThreadStackMgrImpl().SignalThreadActivityPending();
 }
 
-#if (!defined(cPWR_UsePowerDownMode) || (cPWR_UsePowerDownMode == 0))
-/**
- * Glue function called directly by the OpenThread stack when system event processing work
- * is pending.
- */
-extern "C" void otSysEventSignalPending(void)
-{
-    BaseType_t yieldRequired = ThreadStackMgrImpl().SignalThreadActivityPendingFromISR();
-    portYIELD_FROM_ISR(yieldRequired);
-}
-#endif
-
 extern "C" void * pvPortCallocRtos(size_t num, size_t size)
 {
     size_t totalAllocSize = (size_t)(num * size);

--- a/src/platform/K32W/args.gni
+++ b/src/platform/K32W/args.gni
@@ -23,6 +23,9 @@ lwip_platform = "k32w"
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false
 
+chip_inet_config_enable_tcp_endpoint = false
+chip_inet_config_enable_raw_endpoint = false
+
 chip_build_tests = false
 
 chip_mdns = "platform"


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* SRAM consumption was too high on K32W0
* KVS bug that didn't erase all storage at factoryreset

#### Change overview
As described in https://github.com/project-chip/connectedhomeip/issues/9261 several SRAM optimizations were needed:
* decrease the number of Fabrics to 4 (from 16);
* use OT MTD lib for the E-Lock App (which is an SED);
* disable LWIP TCP/RAW/Debug/packet buffers.

Also, fix a bug in KVS where the deletion of some keys was not done properly.

#### Testing
* manual testing
