### PR TITLE
Stop disabling the stack-usage diagnostic in various places.

### DIFF
--- a/src/app/server/StorablePeerConnection.cpp
+++ b/src/app/server/StorablePeerConnection.cpp
@@ -28,7 +28,6 @@ StorablePeerConnection::StorablePeerConnection(PASESession & session, FabricInde
     mKeyId           = session.GetLocalKeyId();
 }
 
-#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
 {
     char key[KeySize()];
@@ -52,11 +51,6 @@ CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs
     ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
 
     return kvs.SyncDeleteKeyValue(key);
-}
-
-constexpr size_t StorablePeerConnection::KeySize()
-{
-    return sizeof(kStorablePeerConnectionKeyPrefix) + 2 * sizeof(uint16_t);
 }
 
 CHIP_ERROR StorablePeerConnection::GenerateKey(uint16_t id, char * key, size_t len)

--- a/src/app/server/StorablePeerConnection.h
+++ b/src/app/server/StorablePeerConnection.h
@@ -47,7 +47,10 @@ public:
     FabricIndex GetFabricIndex() { return mSession.mFabric; }
 
 private:
-    static constexpr size_t KeySize();
+    // KeySize is defined in the header so we always see its definition before
+    // its uses, which is necessary for a constexpr function to actually be
+    // treated as constexpr.
+    static constexpr size_t KeySize() { return sizeof(kStorablePeerConnectionKeyPrefix) + 2 * sizeof(uint16_t); }
 
     static CHIP_ERROR GenerateKey(uint16_t id, char * key, size_t len);
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -596,7 +596,6 @@ CHIP_ERROR CASESession::HandleSigmaR2_and_SendSigmaR3(System::PacketBufferHandle
     return CHIP_NO_ERROR;
 }
 
-#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle && msg)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -205,7 +205,10 @@ private:
     CHIP_ERROR ConstructTBS3Data(const ByteSpan & responderOpCert, uint8_t * tbsData, size_t & tbsDataLen);
     CHIP_ERROR RetrieveIPK(FabricId fabricId, MutableByteSpan & ipk);
 
-    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields) { return dataLen + (sizeof(uint64_t) * nFields); }
+    static constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields)
+    {
+        return dataLen + (sizeof(uint64_t) * nFields);
+    }
 
     void SendErrorMsg(SigmaErrorType errorCode);
 

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR FabricInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    char key[KeySize()];
+    char key[kKeySize];
     ReturnErrorOnFailure(GenerateKey(mFabric, key, sizeof(key)));
 
     StorableFabricInfo * info = chip::Platform::New<StorableFabricInfo>();
@@ -111,7 +111,7 @@ exit:
 CHIP_ERROR FabricInfo::FetchFromKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    char key[KeySize()];
+    char key[kKeySize];
     ReturnErrorOnFailure(GenerateKey(mFabric, key, sizeof(key)));
 
     StorableFabricInfo * info = chip::Platform::New<StorableFabricInfo>();
@@ -185,7 +185,7 @@ CHIP_ERROR FabricInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, FabricInde
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    char key[KeySize()];
+    char key[kKeySize];
     ReturnErrorOnFailure(GenerateKey(id, key, sizeof(key)));
 
     err = kvs->SyncDeleteKeyValue(key);
@@ -198,7 +198,7 @@ CHIP_ERROR FabricInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, FabricInde
 
 CHIP_ERROR FabricInfo::GenerateKey(FabricIndex id, char * key, size_t len)
 {
-    VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(len >= kKeySize, CHIP_ERROR_INVALID_ARGUMENT);
     int keySize = snprintf(key, len, "%s%x", kFabricTableKeyPrefix, id);
     VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
     VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);

--- a/src/transport/FabricTable.cpp
+++ b/src/transport/FabricTable.cpp
@@ -43,7 +43,6 @@ CHIP_ERROR FabricInfo::SetFabricLabel(const uint8_t * fabricLabel)
     return CHIP_NO_ERROR;
 }
 
-#pragma GCC diagnostic ignored "-Wstack-usage="
 CHIP_ERROR FabricInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -195,11 +194,6 @@ CHIP_ERROR FabricInfo::DeleteFromKVS(PersistentStorageDelegate * kvs, FabricInde
         ChipLogDetail(Discovery, "Fabric %d is not yet configured", id);
     }
     return err;
-}
-
-constexpr size_t FabricInfo::KeySize()
-{
-    return sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex);
 }
 
 CHIP_ERROR FabricInfo::GenerateKey(FabricIndex id, char * key, size_t len)

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -221,7 +221,10 @@ private:
 
     FabricId mFabricId = 0;
 
-    static constexpr size_t KeySize();
+    // KeySize is defined in the header so we always see its definition before
+    // its uses, which is necessary for a constexpr function to actually be
+    // treated as constexpr.
+    static constexpr size_t KeySize() { return sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex); }
 
     static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -221,10 +221,7 @@ private:
 
     FabricId mFabricId = 0;
 
-    // KeySize is defined in the header so we always see its definition before
-    // its uses, which is necessary for a constexpr function to actually be
-    // treated as constexpr.
-    static constexpr size_t KeySize() { return sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex); }
+    static constexpr size_t kKeySize = sizeof(kFabricTableKeyPrefix) + 2 * sizeof(FabricIndex);
 
     static CHIP_ERROR GenerateKey(FabricIndex id, char * key, size_t len);
 


### PR DESCRIPTION
The diagnostic was triggering for two reasons:

1) In FabricTable and StorablePeerConnection the constexpr function
used for the buffer size was defined _after_ the use, so the compiler
could not actually treat it as a compile-time constant.  Fixed by
moving the implementation into the header.

2) In CASESession the constexpr function was a non-static member, so
had an implicit `this` argument that is not constexpr, so was not
being treated as a compile-time constant.  Fixed by making it static.

#### Problem
We are disabling warnings that we should really not disable.

#### Change overview
Re-enable the warnings.

#### Testing
Compiles locally (with clang), and I checked that minimized testcases like this compile with gcc with `-Wstack-usage= -Werror`.  @ATmobica can you please confirm that this does not reintroduce the problem #9368 was aiming to fix?