### PR TITLE
Fix Issue #9462: Misplaced validation in YAML test suites.

### DIFF
--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -322,14 +322,14 @@ function chip_tests_item_response_parameters(options)
         }
       }
 
-      const unusedResponseValues = responseValues.filter(response => 'value' in response);
-      unusedResponseValues.forEach(unusedResponseValue => {
-        printErrorAndExit(this,
-            'Missing "' + unusedResponseValue.name + '" in response arguments list:\n\t* '
-                + responseArgs.map(response => response.name).join('\n\t* '));
-      });
-
       return responseArg;
+    });
+
+    const unusedResponseValues = responseValues.filter(response => 'value' in response);
+    unusedResponseValues.forEach(unusedResponseValue => {
+      printErrorAndExit(this,
+          'Missing "' + unusedResponseValue.name + '" in response arguments list:\n\t* '
+              + responseArgs.map(response => response.name).join('\n\t* '));
     });
 
     return responses;


### PR DESCRIPTION
#### Problem
* Fixes #9462 Misplaced validation in YAML test suites.

#### Change overview
Validation moved down the function.

#### Testing
* New test suite created with multiple named arguments in the response.
* Code auto generated successfully
* Test suites run successfully (scripts/tests/test_suites.sh)