### PR TITLE
Provide destination and endpoint while requesting for reports

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -376,7 +376,7 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval, mMaxInterval{{#if isAnalog}}, mChange{{/if}});
+        return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), GetExecContext()->localId, 1, mMinInterval, mMaxInterval{{#if isAnalog}}, mChange{{/if}});
     }
 
 private:

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -1065,6 +1065,10 @@ typedef struct
              *  being sent.
              */
             uint32_t reportableChange;
+            /** The node id to which the report should be sent. */
+            chip::NodeId reportDestination;
+            /** The endpoint to which the report should be sent. */
+            chip::EndpointId destinationEndpoint;
         } reported;
         struct
         {

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -159,7 +159,7 @@ CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::WriteAttribute{{asUpperCamel
 
 {{/if}}
 {{#if isReportableAttribute}}
-CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ConfigureAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
+CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ConfigureAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     COMMAND_HEADER("Report{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}", {{asUpperCamelCase parent.name}}::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -169,7 +169,9 @@ CHIP_ERROR {{asUpperCamelCase parent.name}}Cluster::ConfigureAttribute{{asUpperC
        .Put32({{#if isGlobalAttribute}}Globals{{else}}{{asUpperCamelCase parent.name}}{{/if}}::Attributes::Ids::{{asUpperCamelCase name}})
        .Put8({{atomicTypeId}})
        .Put16(minInterval)
-       .Put16(maxInterval);
+       .Put16(maxInterval)
+       .Put64(reportDestination)
+       .Put16(destinationEndpoint);
     {{#if isAnalog}}
     buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>(change));
     {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClusters.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters.zapt
@@ -40,7 +40,7 @@ public:
     {{/chip_server_cluster_attributes}}
     {{#chip_server_cluster_attributes}}
     {{#if isReportableAttribute}}
-    CHIP_ERROR ConfigureAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}});
+    CHIP_ERROR ConfigureAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}});
     CHIP_ERROR ReportAttribute{{asUpperCamelCase name}}(Callback::Cancelable * onReportCallback);
     {{/if}}
     {{/chip_server_cluster_attributes}}

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -971,14 +971,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_PresentValu
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue(chip::Controller::Device * device,
                                                                                        chip::EndpointId ZCLendpointId,
+                                                                                       chip::NodeId destinationNodeId,
+                                                                                       chip::EndpointId destinationEndpoint,
                                                                                        uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::BinaryInputBasicCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributePresentValue(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                        maxInterval)
+        .ConfigureAttributePresentValue(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                        destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -1004,13 +1006,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags(chip::Controller::Device * device,
                                                                                       chip::EndpointId ZCLendpointId,
+                                                                                      chip::NodeId destinationNodeId,
+                                                                                      chip::EndpointId destinationEndpoint,
                                                                                       uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::BinaryInputBasicCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeStatusFlags(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval)
+        .ConfigureAttributeStatusFlags(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                       destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -1442,17 +1447,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_CurrentHue(chip
     return cluster.ReadAttributeCurrentHue(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_ColorControl_CurrentHue(chip::Controller::Device * device,
-                                                                                 chip::EndpointId ZCLendpointId,
-                                                                                 uint16_t minInterval, uint16_t maxInterval,
-                                                                                 uint8_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_ColorControl_CurrentHue(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                    chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                    uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ColorControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentHue(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval,
-                                      change)
+        .ConfigureAttributeCurrentHue(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                      destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -1466,17 +1471,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_CurrentSaturati
     return cluster.ReadAttributeCurrentSaturation(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation(chip::Controller::Device * device,
-                                                                                        chip::EndpointId ZCLendpointId,
-                                                                                        uint16_t minInterval, uint16_t maxInterval,
-                                                                                        uint8_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                           chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                           uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ColorControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentSaturation(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                             maxInterval, change)
+        .ConfigureAttributeCurrentSaturation(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                             destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -1500,16 +1505,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_CurrentX(chip::
     return cluster.ReadAttributeCurrentX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_ColorControl_CurrentX(chip::Controller::Device * device,
-                                                                               chip::EndpointId ZCLendpointId, uint16_t minInterval,
-                                                                               uint16_t maxInterval, uint16_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_ColorControl_CurrentX(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                  chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                  uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ColorControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval,
-                                    change)
+        .ConfigureAttributeCurrentX(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                    destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -1523,16 +1529,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_CurrentY(chip::
     return cluster.ReadAttributeCurrentY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_ColorControl_CurrentY(chip::Controller::Device * device,
-                                                                               chip::EndpointId ZCLendpointId, uint16_t minInterval,
-                                                                               uint16_t maxInterval, uint16_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_ColorControl_CurrentY(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                  chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                  uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ColorControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval,
-                                    change)
+        .ConfigureAttributeCurrentY(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                    destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -1567,17 +1574,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_ColorControl_ColorTemperatur
     return cluster.ReadAttributeColorTemperature(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_ColorControl_ColorTemperature(chip::Controller::Device * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       uint16_t minInterval, uint16_t maxInterval,
-                                                                                       uint16_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_ColorControl_ColorTemperature(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                          chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                          uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ColorControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeColorTemperature(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                            maxInterval, change)
+        .ConfigureAttributeColorTemperature(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                            destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -2532,14 +2539,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_DoorLock_LockState(chip::Con
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_DoorLock_LockState(chip::Controller::Device * device,
-                                                                            chip::EndpointId ZCLendpointId, uint16_t minInterval,
-                                                                            uint16_t maxInterval)
+                                                                            chip::EndpointId ZCLendpointId,
+                                                                            chip::NodeId destinationNodeId,
+                                                                            chip::EndpointId destinationEndpoint,
+                                                                            uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::DoorLockCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeLockState(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval)
+        .ConfigureAttributeLockState(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                     destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -3225,17 +3235,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_LevelControl_CurrentLevel(ch
     return cluster.ReadAttributeCurrentLevel(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_LevelControl_CurrentLevel(chip::Controller::Device * device,
-                                                                                   chip::EndpointId ZCLendpointId,
-                                                                                   uint16_t minInterval, uint16_t maxInterval,
-                                                                                   uint8_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_LevelControl_CurrentLevel(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                      chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                      uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::LevelControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentLevel(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                        maxInterval, change)
+        .ConfigureAttributeCurrentLevel(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                        destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -3628,13 +3638,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OccupancySensing_Occupancy(c
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_OccupancySensing_Occupancy(chip::Controller::Device * device,
                                                                                     chip::EndpointId ZCLendpointId,
+                                                                                    chip::NodeId destinationNodeId,
+                                                                                    chip::EndpointId destinationEndpoint,
                                                                                     uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OccupancySensingCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeOccupancy(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval)
+        .ConfigureAttributeOccupancy(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                     destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -3734,14 +3747,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_OnOff_OnOff(chip::Controller
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_OnOff_OnOff(chip::Controller::Device * device,
-                                                                     chip::EndpointId ZCLendpointId, uint16_t minInterval,
+                                                                     chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+                                                                     chip::EndpointId destinationEndpoint, uint16_t minInterval,
                                                                      uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::OnOffCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeOnOff(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval)
+        .ConfigureAttributeOnOff(gBooleanAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                 destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -4004,17 +4019,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_PressureMeasurement_Measured
     return cluster.ReadAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue(chip::Controller::Device * device,
-                                                                                           chip::EndpointId ZCLendpointId,
-                                                                                           uint16_t minInterval,
-                                                                                           uint16_t maxInterval, int16_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                              chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                              uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::PressureMeasurementCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                         maxInterval, change)
+        .ConfigureAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                         destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -4111,17 +4126,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_PumpConfigurationAndControl_
     return cluster.ReadAttributeCapacity(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity(chip::Controller::Device * device,
-                                                                                              chip::EndpointId ZCLendpointId,
-                                                                                              uint16_t minInterval,
-                                                                                              uint16_t maxInterval, int16_t change)
+chip::ChipError::StorageType chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity(
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::PumpConfigurationAndControlCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCapacity(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval,
-                                    change)
+        .ConfigureAttributeCapacity(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                    destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -4169,14 +4183,15 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_RelativeHumidityMeasurement_
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::RelativeHumidityMeasurementCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeMeasuredValue(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                         maxInterval, change)
+        .ConfigureAttributeMeasuredValue(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                         destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -4399,17 +4414,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Switch_CurrentPosition(chip:
     return cluster.ReadAttributeCurrentPosition(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_Switch_CurrentPosition(chip::Controller::Device * device,
-                                                                                chip::EndpointId ZCLendpointId,
-                                                                                uint16_t minInterval, uint16_t maxInterval,
-                                                                                uint8_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_Switch_CurrentPosition(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                   chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                   uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::SwitchCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeCurrentPosition(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                           maxInterval, change)
+        .ConfigureAttributeCurrentPosition(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                           destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -4548,17 +4563,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_TemperatureMeasurement_Measu
     return cluster.ReadAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue(chip::Controller::Device * device,
-                                                                                              chip::EndpointId ZCLendpointId,
-                                                                                              uint16_t minInterval,
-                                                                                              uint16_t maxInterval, int16_t change)
+chip::ChipError::StorageType chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue(
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::TemperatureMeasurementCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                         maxInterval, change)
+        .ConfigureAttributeMeasuredValue(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                         destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -5131,17 +5145,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_Thermostat_LocalTemperature(
     return cluster.ReadAttributeLocalTemperature(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_Thermostat_LocalTemperature(chip::Controller::Device * device,
-                                                                                     chip::EndpointId ZCLendpointId,
-                                                                                     uint16_t minInterval, uint16_t maxInterval,
-                                                                                     int16_t change)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_Thermostat_LocalTemperature(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                        chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                        uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::ThermostatCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeLocalTemperature(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                            maxInterval, change)
+        .ConfigureAttributeLocalTemperature(gInt16sAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                            destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -6335,14 +6349,15 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_CurrentPositi
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeCurrentPositionLiftPercentage(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                         minInterval, maxInterval, change)
+                                                         destinationNodeId, destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -6358,14 +6373,15 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_CurrentPositi
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeCurrentPositionTiltPercentage(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                         minInterval, maxInterval, change)
+                                                         destinationNodeId, destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -6379,17 +6395,17 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_OperationalSt
     return cluster.ReadAttributeOperationalStatus(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel()).AsInteger();
 }
 
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus(chip::Controller::Device * device,
-                                                                                          chip::EndpointId ZCLendpointId,
-                                                                                          uint16_t minInterval,
-                                                                                          uint16_t maxInterval)
+chip::ChipError::StorageType
+chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
+                                                             chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint,
+                                                             uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeOperationalStatus(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                             maxInterval)
+        .ConfigureAttributeOperationalStatus(gInt8uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                             destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 
@@ -6404,14 +6420,15 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_TargetPositio
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeTargetPositionLiftPercent100ths(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                           minInterval, maxInterval, change)
+                                                           destinationNodeId, destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -6426,14 +6443,15 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_TargetPositio
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeTargetPositionTiltPercent100ths(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                           minInterval, maxInterval, change)
+                                                           destinationNodeId, destinationEndpoint, minInterval, maxInterval, change)
         .AsInteger();
 }
 
@@ -6459,14 +6477,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_CurrentPositi
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeCurrentPositionLiftPercent100ths(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                            minInterval, maxInterval, change)
+                                                            destinationNodeId, destinationEndpoint, minInterval, maxInterval,
+                                                            change)
         .AsInteger();
 }
 
@@ -6482,14 +6502,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_CurrentPositi
 }
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths(
-    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
+    chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId,
+    chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
         .ConfigureAttributeCurrentPositionTiltPercent100ths(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(),
-                                                            minInterval, maxInterval, change)
+                                                            destinationNodeId, destinationEndpoint, minInterval, maxInterval,
+                                                            change)
         .AsInteger();
 }
 
@@ -6568,14 +6590,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_WindowCovering_SafetyStatus(
 
 chip::ChipError::StorageType chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus(chip::Controller::Device * device,
                                                                                      chip::EndpointId ZCLendpointId,
+                                                                                     chip::NodeId destinationNodeId,
+                                                                                     chip::EndpointId destinationEndpoint,
                                                                                      uint16_t minInterval, uint16_t maxInterval)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::WindowCoveringCluster cluster;
     cluster.Associate(device, ZCLendpointId);
     return cluster
-        .ConfigureAttributeSafetyStatus(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval,
-                                        maxInterval)
+        .ConfigureAttributeSafetyStatus(gInt16uAttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId,
+                                        destinationEndpoint, minInterval, maxInterval)
         .AsInteger();
 }
 

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -3705,12 +3705,12 @@ class ChipClusters:
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-    def ConfigureAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, minInterval: int, maxInterval: int, change: int, imEnabled):
+    def ConfigureAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, destNode: ctypes.c_uint64, destEndpoint: int, minInterval: int, maxInterval: int, change: int, imEnabled):
         func = getattr(self, "Cluster{}_ConfigureAttribute{}".format(cluster, attribute), None)
         if not func:
             raise UnknownAttribute(cluster, attribute)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, minInterval, maxInterval, change))
+        funcCaller(lambda: func(device, endpoint, destNode, destEndpoint, minInterval, maxInterval, change))
 
     def WriteAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, value, imEnabled):
         func = getattr(self, "Cluster{}_WriteAttribute{}".format(cluster, attribute), None)
@@ -4451,14 +4451,14 @@ class ChipClusters:
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_OutOfService(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterBinaryInputBasic_ReadAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid)
-    def ClusterBinaryInputBasic_ConfigureAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterBinaryInputBasic_ConfigureAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterBinaryInputBasic_WriteAttributePresentValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: bool):
         return self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterBinaryInputBasic_ReadAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, ZCLgroupid)
-    def ClusterBinaryInputBasic_ConfigureAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterBinaryInputBasic_ConfigureAttributeStatusFlags(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterBinaryInputBasic_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterBinding_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4498,30 +4498,30 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_BridgedDeviceBasic_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterColorControl_ReadAttributeCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue(device, ZCLendpoint, ZCLgroupid)
-    def ClusterColorControl_ConfigureAttributeCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentHue(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterColorControl_ConfigureAttributeCurrentHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentHue(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterColorControl_ReadAttributeCurrentSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation(device, ZCLendpoint, ZCLgroupid)
-    def ClusterColorControl_ConfigureAttributeCurrentSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterColorControl_ConfigureAttributeCurrentSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterColorControl_ReadAttributeRemainingTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime(device, ZCLendpoint, ZCLgroupid)
     def ClusterColorControl_ReadAttributeCurrentX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX(device, ZCLendpoint, ZCLgroupid)
-    def ClusterColorControl_ConfigureAttributeCurrentX(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentX(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterColorControl_ConfigureAttributeCurrentX(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentX(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterColorControl_ReadAttributeCurrentY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY(device, ZCLendpoint, ZCLgroupid)
-    def ClusterColorControl_ConfigureAttributeCurrentY(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentY(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterColorControl_ConfigureAttributeCurrentY(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentY(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterColorControl_ReadAttributeDriftCompensation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation(device, ZCLendpoint, ZCLgroupid)
     def ClusterColorControl_ReadAttributeCompensationText(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_CompensationText(device, ZCLendpoint, ZCLgroupid)
     def ClusterColorControl_ReadAttributeColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature(device, ZCLendpoint, ZCLgroupid)
-    def ClusterColorControl_ConfigureAttributeColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_ColorTemperature(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterColorControl_ConfigureAttributeColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_ColorControl_ColorTemperature(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterColorControl_ReadAttributeColorMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode(device, ZCLendpoint, ZCLgroupid)
     def ClusterColorControl_ReadAttributeColorControlOptions(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4656,8 +4656,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterDoorLock_ReadAttributeLockState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState(device, ZCLendpoint, ZCLgroupid)
-    def ClusterDoorLock_ConfigureAttributeLockState(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_DoorLock_LockState(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterDoorLock_ConfigureAttributeLockState(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_DoorLock_LockState(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterDoorLock_ReadAttributeLockType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType(device, ZCLendpoint, ZCLgroupid)
     def ClusterDoorLock_ReadAttributeActuatorEnabled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4746,8 +4746,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterLevelControl_ReadAttributeCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel(device, ZCLendpoint, ZCLgroupid)
-    def ClusterLevelControl_ConfigureAttributeCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_LevelControl_CurrentLevel(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterLevelControl_ConfigureAttributeCurrentLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_LevelControl_CurrentLevel(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterLevelControl_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterLowPower_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4768,8 +4768,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_OtaSoftwareUpdateProvider_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterOccupancySensing_ReadAttributeOccupancy(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy(device, ZCLendpoint, ZCLgroupid)
-    def ClusterOccupancySensing_ConfigureAttributeOccupancy(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_OccupancySensing_Occupancy(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterOccupancySensing_ConfigureAttributeOccupancy(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_OccupancySensing_Occupancy(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterOccupancySensing_ReadAttributeOccupancySensorType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType(device, ZCLendpoint, ZCLgroupid)
     def ClusterOccupancySensing_ReadAttributeOccupancySensorTypeBitmap(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4778,8 +4778,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_OccupancySensing_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterOnOff_ReadAttributeOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff(device, ZCLendpoint, ZCLgroupid)
-    def ClusterOnOff_ConfigureAttributeOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_OnOff_OnOff(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterOnOff_ConfigureAttributeOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_OnOff_OnOff(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterOnOff_ReadAttributeGlobalSceneControl(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl(device, ZCLendpoint, ZCLgroupid)
     def ClusterOnOff_ReadAttributeOnTime(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4816,8 +4816,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterPressureMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
-    def ClusterPressureMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterPressureMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterPressureMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
     def ClusterPressureMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4836,8 +4836,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_EffectiveControlMode(device, ZCLendpoint, ZCLgroupid)
     def ClusterPumpConfigurationAndControl_ReadAttributeCapacity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity(device, ZCLendpoint, ZCLgroupid)
-    def ClusterPumpConfigurationAndControl_ConfigureAttributeCapacity(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterPumpConfigurationAndControl_ConfigureAttributeCapacity(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterPumpConfigurationAndControl_ReadAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode(device, ZCLendpoint, ZCLgroupid)
     def ClusterPumpConfigurationAndControl_WriteAttributeOperationMode(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: int):
@@ -4846,8 +4846,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterRelativeHumidityMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
-    def ClusterRelativeHumidityMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterRelativeHumidityMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterRelativeHumidityMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
     def ClusterRelativeHumidityMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4874,8 +4874,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_Switch_NumberOfPositions(device, ZCLendpoint, ZCLgroupid)
     def ClusterSwitch_ReadAttributeCurrentPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition(device, ZCLendpoint, ZCLgroupid)
-    def ClusterSwitch_ConfigureAttributeCurrentPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_Switch_CurrentPosition(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterSwitch_ConfigureAttributeCurrentPosition(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_Switch_CurrentPosition(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterSwitch_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterTvChannel_ReadAttributeTvChannelList(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4892,8 +4892,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_TargetNavigator_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterTemperatureMeasurement_ReadAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLgroupid)
-    def ClusterTemperatureMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterTemperatureMeasurement_ConfigureAttributeMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterTemperatureMeasurement_ReadAttributeMinMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue(device, ZCLendpoint, ZCLgroupid)
     def ClusterTemperatureMeasurement_ReadAttributeMaxMeasuredValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -4992,8 +4992,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
     def ClusterThermostat_ReadAttributeLocalTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature(device, ZCLendpoint, ZCLgroupid)
-    def ClusterThermostat_ConfigureAttributeLocalTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_Thermostat_LocalTemperature(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterThermostat_ConfigureAttributeLocalTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_Thermostat_LocalTemperature(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterThermostat_ReadAttributeAbsMinHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit(device, ZCLendpoint, ZCLgroupid)
     def ClusterThermostat_ReadAttributeAbsMaxHeatSetpointLimit(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -5206,34 +5206,34 @@ class ChipClusters:
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_ConfigStatus(device, ZCLendpoint, ZCLgroupid)
     def ClusterWindowCovering_ReadAttributeCurrentPositionLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeCurrentPositionLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeCurrentPositionLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeCurrentPositionTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeCurrentPositionTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeCurrentPositionTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeOperationalStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeOperationalStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeOperationalStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeTargetPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeTargetPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeTargetPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeTargetPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeTargetPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeTargetPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeEndProductType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType(device, ZCLendpoint, ZCLgroupid)
     def ClusterWindowCovering_ReadAttributeCurrentPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeCurrentPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeCurrentPositionLiftPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeCurrentPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeCurrentPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeCurrentPositionTiltPercent100ths(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeInstalledOpenLimitLift(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift(device, ZCLendpoint, ZCLgroupid)
     def ClusterWindowCovering_ReadAttributeInstalledClosedLimitLift(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
@@ -5248,8 +5248,8 @@ class ChipClusters:
         return self._chipLib.chip_ime_WriteAttribute_WindowCovering_Mode(device, ZCLendpoint, ZCLgroupid, value)
     def ClusterWindowCovering_ReadAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, ZCLgroupid)
-    def ClusterWindowCovering_ConfigureAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, minInterval, maxInterval, change)
+    def ClusterWindowCovering_ConfigureAttributeSafetyStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
     def ClusterWindowCovering_ReadAttributeClusterRevision(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision(device, ZCLendpoint, ZCLgroupid)
 
@@ -5448,7 +5448,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ConfigureAttribute PresentValue
-        self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_PresentValue.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic WriteAttribute PresentValue
         self._chipLib.chip_ime_WriteAttribute_BinaryInputBasic_PresentValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_bool]
@@ -5457,7 +5457,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_StatusFlags.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ConfigureAttribute StatusFlags
-        self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_BinaryInputBasic_StatusFlags.restype = ctypes.c_uint32
         # Cluster BinaryInputBasic ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_BinaryInputBasic_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5583,13 +5583,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.restype = ctypes.c_uint32
         # Cluster ColorControl ConfigureAttribute CurrentHue
-        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentHue.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentSaturation
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl ConfigureAttribute CurrentSaturation
-        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute RemainingTime
         self._chipLib.chip_ime_ReadAttribute_ColorControl_RemainingTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5598,13 +5598,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentX.restype = ctypes.c_uint32
         # Cluster ColorControl ConfigureAttribute CurrentX
-        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentX.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentX.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentY
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentY.restype = ctypes.c_uint32
         # Cluster ColorControl ConfigureAttribute CurrentY
-        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentY.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_ColorControl_CurrentY.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute DriftCompensation
         self._chipLib.chip_ime_ReadAttribute_ColorControl_DriftCompensation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5616,7 +5616,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl ConfigureAttribute ColorTemperature
-        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_ColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_ColorControl_ColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_ColorControl_ColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute ColorMode
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ColorMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -5902,7 +5902,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.restype = ctypes.c_uint32
         # Cluster DoorLock ConfigureAttribute LockState
-        self._chipLib.chip_ime_ConfigureAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_DoorLock_LockState.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute LockType
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6111,7 +6111,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ConfigureAttribute CurrentLevel
-        self._chipLib.chip_ime_ConfigureAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_LevelControl_CurrentLevel.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6234,7 +6234,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_Occupancy.restype = ctypes.c_uint32
         # Cluster OccupancySensing ConfigureAttribute Occupancy
-        self._chipLib.chip_ime_ConfigureAttribute_OccupancySensing_Occupancy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_OccupancySensing_Occupancy.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_OccupancySensing_Occupancy.restype = ctypes.c_uint32
         # Cluster OccupancySensing ReadAttribute OccupancySensorType
         self._chipLib.chip_ime_ReadAttribute_OccupancySensing_OccupancySensorType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6268,7 +6268,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.restype = ctypes.c_uint32
         # Cluster OnOff ConfigureAttribute OnOff
-        self._chipLib.chip_ime_ConfigureAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_OnOff_OnOff.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute GlobalSceneControl
         self._chipLib.chip_ime_ReadAttribute_OnOff_GlobalSceneControl.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6349,7 +6349,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement ConfigureAttribute MeasuredValue
-        self._chipLib.chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_ConfigureAttribute_PressureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster PressureMeasurement ReadAttribute MinMeasuredValue
         self._chipLib.chip_ime_ReadAttribute_PressureMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6380,7 +6380,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_Capacity.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ConfigureAttribute Capacity
-        self._chipLib.chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_ConfigureAttribute_PumpConfigurationAndControl_Capacity.restype = ctypes.c_uint32
         # Cluster PumpConfigurationAndControl ReadAttribute OperationMode
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_OperationMode.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6396,7 +6396,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement ConfigureAttribute MeasuredValue
-        self._chipLib.chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_RelativeHumidityMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster RelativeHumidityMeasurement ReadAttribute MinMeasuredValue
         self._chipLib.chip_ime_ReadAttribute_RelativeHumidityMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6465,7 +6465,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Switch_CurrentPosition.restype = ctypes.c_uint32
         # Cluster Switch ConfigureAttribute CurrentPosition
-        self._chipLib.chip_ime_ConfigureAttribute_Switch_CurrentPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_Switch_CurrentPosition.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_Switch_CurrentPosition.restype = ctypes.c_uint32
         # Cluster Switch ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6507,7 +6507,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement ConfigureAttribute MeasuredValue
-        self._chipLib.chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_ConfigureAttribute_TemperatureMeasurement_MeasuredValue.restype = ctypes.c_uint32
         # Cluster TemperatureMeasurement ReadAttribute MinMeasuredValue
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_MinMeasuredValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -6686,7 +6686,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.restype = ctypes.c_uint32
         # Cluster Thermostat ConfigureAttribute LocalTemperature
-        self._chipLib.chip_ime_ConfigureAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
+        self._chipLib.chip_ime_ConfigureAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_int16]
         self._chipLib.chip_ime_ConfigureAttribute_Thermostat_LocalTemperature.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute AbsMinHeatSetpointLimit
         self._chipLib.chip_ime_ReadAttribute_Thermostat_AbsMinHeatSetpointLimit.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7039,31 +7039,31 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute CurrentPositionLiftPercentage
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionTiltPercentage
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute CurrentPositionTiltPercentage
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute OperationalStatus
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_OperationalStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute OperationalStatus
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_OperationalStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute TargetPositionLiftPercent100ths
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute TargetPositionLiftPercent100ths
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute TargetPositionTiltPercent100ths
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_TargetPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute TargetPositionTiltPercent100ths
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_TargetPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute EndProductType
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_EndProductType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7072,13 +7072,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute CurrentPositionLiftPercent100ths
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionLiftPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute CurrentPositionTiltPercent100ths
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_CurrentPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute CurrentPositionTiltPercent100ths
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_CurrentPositionTiltPercent100ths.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute InstalledOpenLimitLift
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_InstalledOpenLimitLift.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -7102,7 +7102,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_SafetyStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ConfigureAttribute SafetyStatus
-        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_ConfigureAttribute_WindowCovering_SafetyStatus.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -137,16 +137,16 @@ chip::ChipError::StorageType chip_ime_ReadAttribute_{{asUpperCamelCase parent.na
 }
 
 {{#if isReportableAttribute}}
-chip::ChipError::StorageType chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
+chip::ChipError::StorageType chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::NodeId destinationNodeId, chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#if isAnalog}}, {{chipType}} change{{/if}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
     chip::Controller::{{asUpperCamelCase parent.name}}Cluster cluster;
     cluster.Associate(device, ZCLendpointId);
 {{#if isList}}
     chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback> * onSuccessCallback = new chip::Callback::Callback<{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback>(On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeResponse, nullptr);
-    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
+    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccessCallback->Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId, destinationEndpoint, minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
 {{else}}
-    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
+    return cluster.ConfigureAttribute{{asUpperCamelCase name}}(g{{chipCallback.name}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), destinationNodeId, destinationEndpoint, minInterval, maxInterval{{#if isAnalog}}, change{{/if}}).AsInteger();
 {{/if}}
 }
 {{/if}}

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -99,12 +99,12 @@ class ChipClusters:
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-    def ConfigureAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, minInterval: int, maxInterval: int, change: int, imEnabled):
+    def ConfigureAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, destNode: ctypes.c_uint64, destEndpoint: int, minInterval: int, maxInterval: int, change: int, imEnabled):
         func = getattr(self, "Cluster{}_ConfigureAttribute{}".format(cluster, attribute), None)
         if not func:
             raise UnknownAttribute(cluster, attribute)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, minInterval, maxInterval, change))
+        funcCaller(lambda: func(device, endpoint, destNode, destEndpoint, minInterval, maxInterval, change))
 
     def WriteAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, value, imEnabled):
         func = getattr(self, "Cluster{}_WriteAttribute{}".format(cluster, attribute), None)
@@ -136,8 +136,8 @@ class ChipClusters:
     def Cluster{{asUpperCamelCase parent.name}}_ReadAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLgroupid)
 {{#if isReportableAttribute}}
-    def Cluster{{asUpperCamelCase parent.name}}_ConfigureAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
-        return self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, minInterval, maxInterval, change)
+    def Cluster{{asUpperCamelCase parent.name}}_ConfigureAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLDestNode: ctypes.c_uint64, ZCLDestEndpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}(device, ZCLendpoint, ZCLDestNode, ZCLDestEndpoint, minInterval, maxInterval, change)
 {{/if}}
 {{#if isWritableAttribute}}
     def Cluster{{asUpperCamelCase parent.name}}_WriteAttribute{{asUpperCamelCase name}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, value: {{ asPythonType chipType }}):
@@ -171,7 +171,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{#if isReportableAttribute}}
         # Cluster {{asUpperCamelCase parent.name}} ConfigureAttribute {{asUpperCamelCase name}}
-        self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#if isAnalog}}, ctypes.{{asPythonCType chipType}}{{/if}}]
+        self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#if isAnalog}}, ctypes.{{asPythonCType chipType}}{{/if}}]
         self._chipLib.chip_ime_ConfigureAttribute_{{asUpperCamelCase parent.name}}_{{asUpperCamelCase name}}.restype = ctypes.c_uint32
 {{/if}}
 {{#if isWritableAttribute}}

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc-src.zapt
@@ -300,7 +300,7 @@ private:
 
 {{/if}}
 {{#if isReportableAttribute}}
-- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler
+- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval reportDestinationNode:(uint64_t)reportDestinationNode destinationEndpoint:(uint16_t)destinationEndpoint{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
     if (!onSuccess) {
@@ -318,7 +318,7 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
+        err = self.cppCluster.ConfigureAttribute{{asUpperCamelCase name}}(onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval{{#if isAnalog}}, change{{/if}});
     });
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPClustersObjc.zapt
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttribute{{asUpperCamelCase name}}WithValue:({{asObjectiveCBasicType type}})value responseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{#if isReportableAttribute}}
-- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler;
+- (void) configureAttribute{{asUpperCamelCase name}}WithMinInterval:(uint16_t)minInterval  maxInterval:(uint16_t)maxInterval reportDestinationNode:(uint64_t)reportDestinationNode destinationEndpoint:(uint16_t)destinationEndpoint{{#if isAnalog}} change:({{chipType}})change{{/if}} responseHandler:(ResponseHandler)responseHandler;
 - (void) reportAttribute{{asUpperCamelCase name}}WithResponseHandler:(ResponseHandler)responseHandler;
 {{/if}}
 {{/chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
+++ b/src/darwin/Framework/CHIP/templates/clusters-tests.zapt
@@ -134,26 +134,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0000_BindOnOff_Test
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Binding to OnOff Cluster complete"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPBinding * bindingCluster = [[CHIPBinding alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(bindingCluster);
-    [bindingCluster bind:kDeviceId groupId:0
-              endpointId:1
-               clusterId:6
-         responseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Reporting Test Binding status : %@", err);
-        XCTAssertEqual(err.code, 0);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-
-- (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0000_ConfigureOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff configured"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -162,6 +143,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     XCTAssertNotNil(onOffCluster);
     [onOffCluster configureAttributeOnOffWithMinInterval:0
                                              maxInterval:1
+                                   reportDestinationNode:kDeviceId
+                                     destinationEndpoint:1
                                          responseHandler:^(NSError * err, NSDictionary * values) {
         NSLog(@"Reporting Test Configure status: %@", err);
 
@@ -172,7 +155,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0002_ReportOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0001_ReportOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"First report received"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -189,7 +172,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0002_StopReportOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff cancelled"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -198,6 +181,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     XCTAssertNotNil(onOffCluster);
     [onOffCluster configureAttributeOnOffWithMinInterval:0
                                              maxInterval:0xffff
+                                   reportDestinationNode:kDeviceId
+                                     destinationEndpoint:1
                                          responseHandler:^(NSError * err, NSDictionary * values) {
         NSLog(@"Reporting Test Cancel Reports status: %@", err);
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -189,11 +189,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeAttributePresentValueWithValue:(bool)value responseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributePresentValueWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                       responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributePresentValueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeStatusFlagsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeStatusFlagsWithMinInterval:(uint16_t)minInterval
                                          maxInterval:(uint16_t)maxInterval
+                               reportDestinationNode:(uint64_t)reportDestinationNode
+                                 destinationEndpoint:(uint16_t)destinationEndpoint
                                      responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeStatusFlagsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;
@@ -364,12 +368,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentHueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentHueWithMinInterval:(uint16_t)minInterval
                                         maxInterval:(uint16_t)maxInterval
+                              reportDestinationNode:(uint64_t)reportDestinationNode
+                                destinationEndpoint:(uint16_t)destinationEndpoint
                                              change:(uint8_t)change
                                     responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentHueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeCurrentSaturationWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentSaturationWithMinInterval:(uint16_t)minInterval
                                                maxInterval:(uint16_t)maxInterval
+                                     reportDestinationNode:(uint64_t)reportDestinationNode
+                                       destinationEndpoint:(uint16_t)destinationEndpoint
                                                     change:(uint8_t)change
                                            responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentSaturationWithResponseHandler:(ResponseHandler)responseHandler;
@@ -377,12 +385,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentXWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentXWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(uint16_t)change
                                   responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentXWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeCurrentYWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentYWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(uint16_t)change
                                   responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentYWithResponseHandler:(ResponseHandler)responseHandler;
@@ -391,6 +403,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeColorTemperatureWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeColorTemperatureWithMinInterval:(uint16_t)minInterval
                                               maxInterval:(uint16_t)maxInterval
+                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                    change:(uint16_t)change
                                           responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeColorTemperatureWithResponseHandler:(ResponseHandler)responseHandler;
@@ -553,6 +567,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeLockStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeLockStateWithMinInterval:(uint16_t)minInterval
                                        maxInterval:(uint16_t)maxInterval
+                             reportDestinationNode:(uint64_t)reportDestinationNode
+                               destinationEndpoint:(uint16_t)destinationEndpoint
                                    responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeLockStateWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeLockTypeWithResponseHandler:(ResponseHandler)responseHandler;
@@ -752,6 +768,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentLevelWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentLevelWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                                change:(uint8_t)change
                                       responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentLevelWithResponseHandler:(ResponseHandler)responseHandler;
@@ -891,6 +909,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeOccupancyWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeOccupancyWithMinInterval:(uint16_t)minInterval
                                        maxInterval:(uint16_t)maxInterval
+                             reportDestinationNode:(uint64_t)reportDestinationNode
+                               destinationEndpoint:(uint16_t)destinationEndpoint
                                    responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeOccupancyWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeOccupancySensorTypeWithResponseHandler:(ResponseHandler)responseHandler;
@@ -918,6 +938,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeOnOffWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeOnOffWithMinInterval:(uint16_t)minInterval
                                    maxInterval:(uint16_t)maxInterval
+                         reportDestinationNode:(uint64_t)reportDestinationNode
+                           destinationEndpoint:(uint16_t)destinationEndpoint
                                responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeOnOffWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeGlobalSceneControlWithResponseHandler:(ResponseHandler)responseHandler;
@@ -979,6 +1001,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(int16_t)change
                                        responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1002,6 +1026,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCapacityWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCapacityWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(int16_t)change
                                   responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCapacityWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1020,6 +1046,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(uint16_t)change
                                        responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1085,6 +1113,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentPositionWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentPositionWithMinInterval:(uint16_t)minInterval
                                              maxInterval:(uint16_t)maxInterval
+                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                   change:(uint8_t)change
                                          responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentPositionWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1133,6 +1163,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(int16_t)change
                                        responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeMeasuredValueWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1220,6 +1252,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeLocalTemperatureWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeLocalTemperatureWithMinInterval:(uint16_t)minInterval
                                               maxInterval:(uint16_t)maxInterval
+                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                    change:(int16_t)change
                                           responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeLocalTemperatureWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1392,29 +1426,39 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentPositionLiftPercentageWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentPositionLiftPercentageWithMinInterval:(uint16_t)minInterval
                                                            maxInterval:(uint16_t)maxInterval
+                                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                                 change:(uint8_t)change
                                                        responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentPositionLiftPercentageWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeCurrentPositionTiltPercentageWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentPositionTiltPercentageWithMinInterval:(uint16_t)minInterval
                                                            maxInterval:(uint16_t)maxInterval
+                                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                                 change:(uint8_t)change
                                                        responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentPositionTiltPercentageWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeOperationalStatusWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeOperationalStatusWithMinInterval:(uint16_t)minInterval
                                                maxInterval:(uint16_t)maxInterval
+                                     reportDestinationNode:(uint64_t)reportDestinationNode
+                                       destinationEndpoint:(uint16_t)destinationEndpoint
                                            responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeOperationalStatusWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeTargetPositionLiftPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeTargetPositionLiftPercent100thsWithMinInterval:(uint16_t)minInterval
                                                              maxInterval:(uint16_t)maxInterval
+                                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                                   change:(uint16_t)change
                                                          responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeTargetPositionLiftPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeTargetPositionTiltPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeTargetPositionTiltPercent100thsWithMinInterval:(uint16_t)minInterval
                                                              maxInterval:(uint16_t)maxInterval
+                                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                                   change:(uint16_t)change
                                                          responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeTargetPositionTiltPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1422,12 +1466,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeCurrentPositionLiftPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentPositionLiftPercent100thsWithMinInterval:(uint16_t)minInterval
                                                               maxInterval:(uint16_t)maxInterval
+                                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                                    change:(uint16_t)change
                                                           responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentPositionLiftPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeCurrentPositionTiltPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeCurrentPositionTiltPercent100thsWithMinInterval:(uint16_t)minInterval
                                                               maxInterval:(uint16_t)maxInterval
+                                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                                    change:(uint16_t)change
                                                           responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeCurrentPositionTiltPercent100thsWithResponseHandler:(ResponseHandler)responseHandler;
@@ -1440,6 +1488,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)readAttributeSafetyStatusWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)configureAttributeSafetyStatusWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                       responseHandler:(ResponseHandler)responseHandler;
 - (void)reportAttributeSafetyStatusWithResponseHandler:(ResponseHandler)responseHandler;
 - (void)readAttributeClusterRevisionWithResponseHandler:(ResponseHandler)responseHandler;

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.mm
@@ -5512,6 +5512,8 @@ private:
 
 - (void)configureAttributePresentValueWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                       responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -5529,7 +5531,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributePresentValue(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributePresentValue(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -5588,6 +5591,8 @@ private:
 
 - (void)configureAttributeStatusFlagsWithMinInterval:(uint16_t)minInterval
                                          maxInterval:(uint16_t)maxInterval
+                               reportDestinationNode:(uint64_t)reportDestinationNode
+                                 destinationEndpoint:(uint16_t)destinationEndpoint
                                      responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -5605,7 +5610,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributeStatusFlags(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributeStatusFlags(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -6861,6 +6867,8 @@ private:
 
 - (void)configureAttributeCurrentHueWithMinInterval:(uint16_t)minInterval
                                         maxInterval:(uint16_t)maxInterval
+                              reportDestinationNode:(uint64_t)reportDestinationNode
+                                destinationEndpoint:(uint16_t)destinationEndpoint
                                              change:(uint8_t)change
                                     responseHandler:(ResponseHandler)responseHandler
 {
@@ -6880,7 +6888,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentHue(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -6938,6 +6946,8 @@ private:
 
 - (void)configureAttributeCurrentSaturationWithMinInterval:(uint16_t)minInterval
                                                maxInterval:(uint16_t)maxInterval
+                                     reportDestinationNode:(uint64_t)reportDestinationNode
+                                       destinationEndpoint:(uint16_t)destinationEndpoint
                                                     change:(uint8_t)change
                                            responseHandler:(ResponseHandler)responseHandler
 {
@@ -6957,7 +6967,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentSaturation(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -7042,6 +7052,8 @@ private:
 
 - (void)configureAttributeCurrentXWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(uint16_t)change
                                   responseHandler:(ResponseHandler)responseHandler
 {
@@ -7061,7 +7073,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentX(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -7119,6 +7131,8 @@ private:
 
 - (void)configureAttributeCurrentYWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(uint16_t)change
                                   responseHandler:(ResponseHandler)responseHandler
 {
@@ -7138,7 +7152,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentY(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -7251,6 +7265,8 @@ private:
 
 - (void)configureAttributeColorTemperatureWithMinInterval:(uint16_t)minInterval
                                               maxInterval:(uint16_t)maxInterval
+                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                    change:(uint16_t)change
                                           responseHandler:(ResponseHandler)responseHandler
 {
@@ -7270,7 +7286,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeColorTemperature(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -9918,6 +9934,8 @@ private:
 
 - (void)configureAttributeLockStateWithMinInterval:(uint16_t)minInterval
                                        maxInterval:(uint16_t)maxInterval
+                             reportDestinationNode:(uint64_t)reportDestinationNode
+                               destinationEndpoint:(uint16_t)destinationEndpoint
                                    responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -9935,7 +9953,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributeLockState(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributeLockState(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -11895,6 +11914,8 @@ private:
 
 - (void)configureAttributeCurrentLevelWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                                change:(uint8_t)change
                                       responseHandler:(ResponseHandler)responseHandler
 {
@@ -11914,7 +11935,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentLevel(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -13103,6 +13124,8 @@ private:
 
 - (void)configureAttributeOccupancyWithMinInterval:(uint16_t)minInterval
                                        maxInterval:(uint16_t)maxInterval
+                             reportDestinationNode:(uint64_t)reportDestinationNode
+                               destinationEndpoint:(uint16_t)destinationEndpoint
                                    responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -13120,7 +13143,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributeOccupancy(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributeOccupancy(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -13432,6 +13456,8 @@ private:
 
 - (void)configureAttributeOnOffWithMinInterval:(uint16_t)minInterval
                                    maxInterval:(uint16_t)maxInterval
+                         reportDestinationNode:(uint64_t)reportDestinationNode
+                           destinationEndpoint:(uint16_t)destinationEndpoint
                                responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -13449,7 +13475,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributeOnOff(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributeOnOff(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -14207,6 +14234,8 @@ private:
 
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(int16_t)change
                                        responseHandler:(ResponseHandler)responseHandler
 {
@@ -14226,7 +14255,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeMeasuredValue(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -14513,6 +14542,8 @@ private:
 
 - (void)configureAttributeCapacityWithMinInterval:(uint16_t)minInterval
                                       maxInterval:(uint16_t)maxInterval
+                            reportDestinationNode:(uint64_t)reportDestinationNode
+                              destinationEndpoint:(uint16_t)destinationEndpoint
                                            change:(int16_t)change
                                   responseHandler:(ResponseHandler)responseHandler
 {
@@ -14532,7 +14563,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCapacity(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -14684,6 +14715,8 @@ private:
 
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(uint16_t)change
                                        responseHandler:(ResponseHandler)responseHandler
 {
@@ -14703,7 +14736,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeMeasuredValue(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -15353,6 +15386,8 @@ private:
 
 - (void)configureAttributeCurrentPositionWithMinInterval:(uint16_t)minInterval
                                              maxInterval:(uint16_t)maxInterval
+                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                   change:(uint8_t)change
                                          responseHandler:(ResponseHandler)responseHandler
 {
@@ -15372,7 +15407,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentPosition(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -15776,6 +15811,8 @@ private:
 
 - (void)configureAttributeMeasuredValueWithMinInterval:(uint16_t)minInterval
                                            maxInterval:(uint16_t)maxInterval
+                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                 change:(int16_t)change
                                        responseHandler:(ResponseHandler)responseHandler
 {
@@ -15795,7 +15832,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeMeasuredValue(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -17430,6 +17467,8 @@ private:
 
 - (void)configureAttributeLocalTemperatureWithMinInterval:(uint16_t)minInterval
                                               maxInterval:(uint16_t)maxInterval
+                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                    change:(int16_t)change
                                           responseHandler:(ResponseHandler)responseHandler
 {
@@ -17449,7 +17488,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeLocalTemperature(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -20660,6 +20699,8 @@ private:
 
 - (void)configureAttributeCurrentPositionLiftPercentageWithMinInterval:(uint16_t)minInterval
                                                            maxInterval:(uint16_t)maxInterval
+                                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                                 change:(uint8_t)change
                                                        responseHandler:(ResponseHandler)responseHandler
 {
@@ -20679,7 +20720,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentPositionLiftPercentage(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -20737,6 +20778,8 @@ private:
 
 - (void)configureAttributeCurrentPositionTiltPercentageWithMinInterval:(uint16_t)minInterval
                                                            maxInterval:(uint16_t)maxInterval
+                                                 reportDestinationNode:(uint64_t)reportDestinationNode
+                                                   destinationEndpoint:(uint16_t)destinationEndpoint
                                                                 change:(uint8_t)change
                                                        responseHandler:(ResponseHandler)responseHandler
 {
@@ -20756,7 +20799,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentPositionTiltPercentage(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -20814,6 +20857,8 @@ private:
 
 - (void)configureAttributeOperationalStatusWithMinInterval:(uint16_t)minInterval
                                                maxInterval:(uint16_t)maxInterval
+                                     reportDestinationNode:(uint64_t)reportDestinationNode
+                                       destinationEndpoint:(uint16_t)destinationEndpoint
                                            responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -20832,7 +20877,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeOperationalStatus(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -20890,6 +20935,8 @@ private:
 
 - (void)configureAttributeTargetPositionLiftPercent100thsWithMinInterval:(uint16_t)minInterval
                                                              maxInterval:(uint16_t)maxInterval
+                                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                                   change:(uint16_t)change
                                                          responseHandler:(ResponseHandler)responseHandler
 {
@@ -20909,7 +20956,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeTargetPositionLiftPercent100ths(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -20967,6 +21014,8 @@ private:
 
 - (void)configureAttributeTargetPositionTiltPercent100thsWithMinInterval:(uint16_t)minInterval
                                                              maxInterval:(uint16_t)maxInterval
+                                                   reportDestinationNode:(uint64_t)reportDestinationNode
+                                                     destinationEndpoint:(uint16_t)destinationEndpoint
                                                                   change:(uint16_t)change
                                                          responseHandler:(ResponseHandler)responseHandler
 {
@@ -20986,7 +21035,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeTargetPositionTiltPercent100ths(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -21071,6 +21120,8 @@ private:
 
 - (void)configureAttributeCurrentPositionLiftPercent100thsWithMinInterval:(uint16_t)minInterval
                                                               maxInterval:(uint16_t)maxInterval
+                                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                                    change:(uint16_t)change
                                                           responseHandler:(ResponseHandler)responseHandler
 {
@@ -21090,7 +21141,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentPositionLiftPercent100ths(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -21148,6 +21199,8 @@ private:
 
 - (void)configureAttributeCurrentPositionTiltPercent100thsWithMinInterval:(uint16_t)minInterval
                                                               maxInterval:(uint16_t)maxInterval
+                                                    reportDestinationNode:(uint64_t)reportDestinationNode
+                                                      destinationEndpoint:(uint16_t)destinationEndpoint
                                                                    change:(uint16_t)change
                                                           responseHandler:(ResponseHandler)responseHandler
 {
@@ -21167,7 +21220,7 @@ private:
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
         err = self.cppCluster.ConfigureAttributeCurrentPositionTiltPercent100ths(
-            onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval, change);
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval, change);
     });
 
     if (err != CHIP_NO_ERROR) {
@@ -21387,6 +21440,8 @@ private:
 
 - (void)configureAttributeSafetyStatusWithMinInterval:(uint16_t)minInterval
                                           maxInterval:(uint16_t)maxInterval
+                                reportDestinationNode:(uint64_t)reportDestinationNode
+                                  destinationEndpoint:(uint16_t)destinationEndpoint
                                       responseHandler:(ResponseHandler)responseHandler
 {
     CHIPDefaultSuccessCallbackBridge * onSuccess = new CHIPDefaultSuccessCallbackBridge(responseHandler, [self callbackQueue]);
@@ -21404,7 +21459,8 @@ private:
 
     __block CHIP_ERROR err;
     dispatch_sync([self chipWorkQueue], ^{
-        err = self.cppCluster.ConfigureAttributeSafetyStatus(onSuccess->Cancel(), onFailure->Cancel(), minInterval, maxInterval);
+        err = self.cppCluster.ConfigureAttributeSafetyStatus(
+            onSuccess->Cancel(), onFailure->Cancel(), reportDestinationNode, destinationEndpoint, minInterval, maxInterval);
     });
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -152,27 +152,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0000_BindOnOff_Test
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Binding to OnOff Cluster complete"];
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPBinding * bindingCluster = [[CHIPBinding alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(bindingCluster);
-    [bindingCluster bind:kDeviceId
-                 groupId:0
-              endpointId:1
-               clusterId:6
-         responseHandler:^(NSError * err, NSDictionary * values) {
-             NSLog(@"Reporting Test Binding status : %@", err);
-             XCTAssertEqual(err.code, 0);
-             [expectation fulfill];
-         }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-
-- (void)testSendClusterTestCluster_Reporting_0001_ConfigureOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0000_ConfigureOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff configured"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -181,6 +161,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     XCTAssertNotNil(onOffCluster);
     [onOffCluster configureAttributeOnOffWithMinInterval:0
                                              maxInterval:1
+                                   reportDestinationNode:kDeviceId
+                                     destinationEndpoint:1
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Reporting Test Configure status: %@", err);
 
@@ -191,7 +173,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0002_ReportOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0001_ReportOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"First report received"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -207,7 +189,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
-- (void)testSendClusterTestCluster_Reporting_0003_StopReportOnOff_Test
+- (void)testSendClusterTestCluster_Reporting_0002_StopReportOnOff_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Reporting OnOff cancelled"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
@@ -216,6 +198,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     XCTAssertNotNil(onOffCluster);
     [onOffCluster configureAttributeOnOffWithMinInterval:0
                                              maxInterval:0xffff
+                                   reportDestinationNode:kDeviceId
+                                     destinationEndpoint:1
                                          responseHandler:^(NSError * err, NSDictionary * values) {
                                              NSLog(@"Reporting Test Cancel Reports status: %@", err);
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -3675,8 +3675,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributePresentValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                      mMaxInterval);
+        return cluster.ConfigureAttributePresentValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                      GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -3755,8 +3755,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeStatusFlags(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                     mMaxInterval);
+        return cluster.ConfigureAttributeStatusFlags(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                     GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -5541,8 +5541,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                    mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentHue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                    GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -5623,8 +5623,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentSaturation(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                           mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentSaturation(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                           GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -5739,8 +5739,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentX(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                  mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentX(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                  GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -5821,8 +5821,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentY(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                  mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentY(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                  GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -5971,8 +5971,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeColorTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                          mMaxInterval, mChange);
+        return cluster.ConfigureAttributeColorTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                          GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -9430,8 +9430,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeLockState(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                   mMaxInterval);
+        return cluster.ConfigureAttributeLockState(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                   GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -12202,8 +12202,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                      mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentLevel(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                      GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -13839,8 +13839,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeOccupancy(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                   mMaxInterval);
+        return cluster.ConfigureAttributeOccupancy(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                   GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -14263,8 +14263,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeOnOff(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                               mMaxInterval);
+        return cluster.ConfigureAttributeOnOff(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), GetExecContext()->localId,
+                                               1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -15303,8 +15303,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                       mMaxInterval, mChange);
+        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                       GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -15703,8 +15703,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCapacity(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                  mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCapacity(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                  GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -15928,8 +15928,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                       mMaxInterval, mChange);
+        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                       GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -16843,8 +16843,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeCurrentPosition(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                         mMaxInterval, mChange);
+        return cluster.ConfigureAttributeCurrentPosition(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                         GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -17436,8 +17436,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                       mMaxInterval, mChange);
+        return cluster.ConfigureAttributeMeasuredValue(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                       GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -19553,8 +19553,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeLocalTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                          mMaxInterval, mChange);
+        return cluster.ConfigureAttributeLocalTemperature(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                          GetExecContext()->localId, 1, mMinInterval, mMaxInterval, mChange);
     }
 
 private:
@@ -23779,7 +23779,8 @@ public:
         }
 
         return cluster.ConfigureAttributeCurrentPositionLiftPercentage(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                       mMinInterval, mMaxInterval, mChange);
+                                                                       GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                       mChange);
     }
 
 private:
@@ -23861,7 +23862,8 @@ public:
         }
 
         return cluster.ConfigureAttributeCurrentPositionTiltPercentage(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                       mMinInterval, mMaxInterval, mChange);
+                                                                       GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                       mChange);
     }
 
 private:
@@ -23941,8 +23943,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeOperationalStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                           mMaxInterval);
+        return cluster.ConfigureAttributeOperationalStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                           GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:
@@ -24023,7 +24025,8 @@ public:
         }
 
         return cluster.ConfigureAttributeTargetPositionLiftPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                         mMinInterval, mMaxInterval, mChange);
+                                                                         GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                         mChange);
     }
 
 private:
@@ -24105,7 +24108,8 @@ public:
         }
 
         return cluster.ConfigureAttributeTargetPositionTiltPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                         mMinInterval, mMaxInterval, mChange);
+                                                                         GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                         mChange);
     }
 
 private:
@@ -24221,7 +24225,8 @@ public:
         }
 
         return cluster.ConfigureAttributeCurrentPositionLiftPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                          mMinInterval, mMaxInterval, mChange);
+                                                                          GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                          mChange);
     }
 
 private:
@@ -24303,7 +24308,8 @@ public:
         }
 
         return cluster.ConfigureAttributeCurrentPositionTiltPercent100ths(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                                                          mMinInterval, mMaxInterval, mChange);
+                                                                          GetExecContext()->localId, 1, mMinInterval, mMaxInterval,
+                                                                          mChange);
     }
 
 private:
@@ -24586,8 +24592,8 @@ public:
             return err;
         }
 
-        return cluster.ConfigureAttributeSafetyStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel(), mMinInterval,
-                                                      mMaxInterval);
+        return cluster.ConfigureAttributeSafetyStatus(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
+                                                      GetExecContext()->localId, 1, mMinInterval, mMaxInterval);
     }
 
 private:

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -1265,8 +1265,9 @@ CHIP_ERROR BinaryInputBasicCluster::WriteAttributePresentValue(Callback::Cancela
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ConfigureAttributePresentValue(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                   uint16_t maxInterval)
+                                                                   Callback::Cancelable * onFailureCallback,
+                                                                   NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                   uint16_t minInterval, uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportBinaryInputBasicPresentValue", BinaryInputBasic::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -1276,7 +1277,9 @@ CHIP_ERROR BinaryInputBasicCluster::ConfigureAttributePresentValue(Callback::Can
         .Put32(BinaryInputBasic::Attributes::Ids::PresentValue)
         .Put8(16)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -1298,8 +1301,9 @@ CHIP_ERROR BinaryInputBasicCluster::ReadAttributeStatusFlags(Callback::Cancelabl
 }
 
 CHIP_ERROR BinaryInputBasicCluster::ConfigureAttributeStatusFlags(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                  uint16_t maxInterval)
+                                                                  Callback::Cancelable * onFailureCallback,
+                                                                  NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                  uint16_t minInterval, uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportBinaryInputBasicStatusFlags", BinaryInputBasic::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -1309,7 +1313,9 @@ CHIP_ERROR BinaryInputBasicCluster::ConfigureAttributeStatusFlags(Callback::Canc
         .Put32(BinaryInputBasic::Attributes::Ids::StatusFlags)
         .Put8(24)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -2619,7 +2625,8 @@ CHIP_ERROR ColorControlCluster::ReadAttributeCurrentHue(Callback::Cancelable * o
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentHue(Callback::Cancelable * onSuccessCallback,
-                                                             Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                             Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                             EndpointId destinationEndpoint, uint16_t minInterval,
                                                              uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportColorControlCurrentHue", ColorControl::Id);
@@ -2630,7 +2637,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentHue(Callback::Cancelabl
         .Put32(ColorControl::Attributes::Ids::CurrentHue)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -2653,8 +2662,9 @@ CHIP_ERROR ColorControlCluster::ReadAttributeCurrentSaturation(Callback::Cancela
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
-                                                                    Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                    uint16_t maxInterval, uint8_t change)
+                                                                    Callback::Cancelable * onFailureCallback,
+                                                                    NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                    uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportColorControlCurrentSaturation", ColorControl::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -2664,7 +2674,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentSaturation(Callback::Ca
         .Put32(ColorControl::Attributes::Ids::CurrentSaturation)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -2699,7 +2711,8 @@ CHIP_ERROR ColorControlCluster::ReadAttributeCurrentX(Callback::Cancelable * onS
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentX(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                           Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                           EndpointId destinationEndpoint, uint16_t minInterval,
                                                            uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportColorControlCurrentX", ColorControl::Id);
@@ -2710,7 +2723,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentX(Callback::Cancelable 
         .Put32(ColorControl::Attributes::Ids::CurrentX)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -2733,7 +2748,8 @@ CHIP_ERROR ColorControlCluster::ReadAttributeCurrentY(Callback::Cancelable * onS
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentY(Callback::Cancelable * onSuccessCallback,
-                                                           Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                           Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                           EndpointId destinationEndpoint, uint16_t minInterval,
                                                            uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportColorControlCurrentY", ColorControl::Id);
@@ -2744,7 +2760,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentY(Callback::Cancelable 
         .Put32(ColorControl::Attributes::Ids::CurrentY)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -2791,8 +2809,9 @@ CHIP_ERROR ColorControlCluster::ReadAttributeColorTemperature(Callback::Cancelab
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                   uint16_t maxInterval, uint16_t change)
+                                                                   Callback::Cancelable * onFailureCallback,
+                                                                   NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                   uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportColorControlColorTemperature", ColorControl::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -2802,7 +2821,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeColorTemperature(Callback::Can
         .Put32(ColorControl::Attributes::Ids::ColorTemperature)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -4841,8 +4862,8 @@ CHIP_ERROR DoorLockCluster::ReadAttributeLockState(Callback::Cancelable * onSucc
 }
 
 CHIP_ERROR DoorLockCluster::ConfigureAttributeLockState(Callback::Cancelable * onSuccessCallback,
-                                                        Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                        uint16_t maxInterval)
+                                                        Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                        EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportDoorLockLockState", DoorLock::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -4852,7 +4873,9 @@ CHIP_ERROR DoorLockCluster::ConfigureAttributeLockState(Callback::Cancelable * o
         .Put32(DoorLock::Attributes::Ids::LockState)
         .Put8(48)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -6408,7 +6431,8 @@ CHIP_ERROR LevelControlCluster::ReadAttributeCurrentLevel(Callback::Cancelable *
 }
 
 CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                               Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                               EndpointId destinationEndpoint, uint16_t minInterval,
                                                                uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportLevelControlCurrentLevel", LevelControl::Id);
@@ -6419,7 +6443,9 @@ CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancela
         .Put32(LevelControl::Attributes::Ids::CurrentLevel)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -7809,7 +7835,8 @@ CHIP_ERROR OccupancySensingCluster::ReadAttributeOccupancy(Callback::Cancelable 
 }
 
 CHIP_ERROR OccupancySensingCluster::ConfigureAttributeOccupancy(Callback::Cancelable * onSuccessCallback,
-                                                                Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                                Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                                EndpointId destinationEndpoint, uint16_t minInterval,
                                                                 uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportOccupancySensingOccupancy", OccupancySensing::Id);
@@ -7820,7 +7847,9 @@ CHIP_ERROR OccupancySensingCluster::ConfigureAttributeOccupancy(Callback::Cancel
         .Put32(OccupancySensing::Attributes::Ids::Occupancy)
         .Put8(24)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -8126,7 +8155,8 @@ CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Cancelable * onSuccessCall
 }
 
 CHIP_ERROR OnOffCluster::ConfigureAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 uint16_t minInterval, uint16_t maxInterval)
+                                                 NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                                 uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportOnOffOnOff", OnOff::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -8136,7 +8166,9 @@ CHIP_ERROR OnOffCluster::ConfigureAttributeOnOff(Callback::Cancelable * onSucces
         .Put32(OnOff::Attributes::Ids::OnOff)
         .Put8(16)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -8712,6 +8744,7 @@ CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Canc
 
 CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
+                                                                       NodeId reportDestination, EndpointId destinationEndpoint,
                                                                        uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportPressureMeasurementMeasuredValue", PressureMeasurement::Id);
@@ -8722,7 +8755,9 @@ CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback:
         .Put32(PressureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -8852,6 +8887,7 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeCapacity(Callback::C
 
 CHIP_ERROR PumpConfigurationAndControlCluster::ConfigureAttributeCapacity(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
+                                                                          NodeId reportDestination, EndpointId destinationEndpoint,
                                                                           uint16_t minInterval, uint16_t maxInterval,
                                                                           int16_t change)
 {
@@ -8863,7 +8899,9 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ConfigureAttributeCapacity(Callba
         .Put32(PumpConfigurationAndControl::Attributes::Ids::Capacity)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -8938,8 +8976,9 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ReadAttributeMeasuredValue(Callba
 
 CHIP_ERROR RelativeHumidityMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                                Callback::Cancelable * onFailureCallback,
-                                                                               uint16_t minInterval, uint16_t maxInterval,
-                                                                               uint16_t change)
+                                                                               NodeId reportDestination,
+                                                                               EndpointId destinationEndpoint, uint16_t minInterval,
+                                                                               uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportRelativeHumidityMeasurementMeasuredValue", RelativeHumidityMeasurement::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -8949,7 +8988,9 @@ CHIP_ERROR RelativeHumidityMeasurementCluster::ConfigureAttributeMeasuredValue(C
         .Put32(RelativeHumidityMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -9494,7 +9535,8 @@ CHIP_ERROR SwitchCluster::ReadAttributeCurrentPosition(Callback::Cancelable * on
 }
 
 CHIP_ERROR SwitchCluster::ConfigureAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback,
-                                                            Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                            Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                            EndpointId destinationEndpoint, uint16_t minInterval,
                                                             uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportSwitchCurrentPosition", Switch::Id);
@@ -9505,7 +9547,9 @@ CHIP_ERROR SwitchCluster::ConfigureAttributeCurrentPosition(Callback::Cancelable
         .Put32(Switch::Attributes::Ids::CurrentPosition)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -9811,6 +9855,7 @@ CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::C
 
 CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
+                                                                          NodeId reportDestination, EndpointId destinationEndpoint,
                                                                           uint16_t minInterval, uint16_t maxInterval,
                                                                           int16_t change)
 {
@@ -9822,7 +9867,9 @@ CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callba
         .Put32(TemperatureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -10935,7 +10982,8 @@ CHIP_ERROR ThermostatCluster::ReadAttributeLocalTemperature(Callback::Cancelable
 }
 
 CHIP_ERROR ThermostatCluster::ConfigureAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                                 Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                                 EndpointId destinationEndpoint, uint16_t minInterval,
                                                                  uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportThermostatLocalTemperature", Thermostat::Id);
@@ -10946,7 +10994,9 @@ CHIP_ERROR ThermostatCluster::ConfigureAttributeLocalTemperature(Callback::Cance
         .Put32(Thermostat::Attributes::Ids::LocalTemperature)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -12699,10 +12749,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionLiftPercentage(Cal
                                              BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
-                                                                                  Callback::Cancelable * onFailureCallback,
-                                                                                  uint16_t minInterval, uint16_t maxInterval,
-                                                                                  uint8_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercentage(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringCurrentPositionLiftPercentage", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12712,7 +12761,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercentag
         .Put32(WindowCovering::Attributes::Ids::CurrentPositionLiftPercentage)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -12734,10 +12785,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionTiltPercentage(Cal
                                              BasicAttributeFilter<Int8uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
-                                                                                  Callback::Cancelable * onFailureCallback,
-                                                                                  uint16_t minInterval, uint16_t maxInterval,
-                                                                                  uint8_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercentage(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringCurrentPositionTiltPercentage", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12747,7 +12797,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercentag
         .Put32(WindowCovering::Attributes::Ids::CurrentPositionTiltPercentage)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -12771,6 +12823,7 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeOperationalStatus(Callback::Cance
 
 CHIP_ERROR WindowCoveringCluster::ConfigureAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback,
                                                                       Callback::Cancelable * onFailureCallback,
+                                                                      NodeId reportDestination, EndpointId destinationEndpoint,
                                                                       uint16_t minInterval, uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportWindowCoveringOperationalStatus", WindowCovering::Id);
@@ -12781,7 +12834,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeOperationalStatus(Callback::
         .Put32(WindowCovering::Attributes::Ids::OperationalStatus)
         .Put8(24)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 
@@ -12802,10 +12857,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeTargetPositionLiftPercent100ths(C
                                              BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                    Callback::Cancelable * onFailureCallback,
-                                                                                    uint16_t minInterval, uint16_t maxInterval,
-                                                                                    uint16_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionLiftPercent100ths(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringTargetPositionLiftPercent100ths", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12815,7 +12869,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionLiftPercent100
         .Put32(WindowCovering::Attributes::Ids::TargetPositionLiftPercent100ths)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -12837,10 +12893,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeTargetPositionTiltPercent100ths(C
                                              BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                    Callback::Cancelable * onFailureCallback,
-                                                                                    uint16_t minInterval, uint16_t maxInterval,
-                                                                                    uint16_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionTiltPercent100ths(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringTargetPositionTiltPercent100ths", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12850,7 +12905,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeTargetPositionTiltPercent100
         .Put32(WindowCovering::Attributes::Ids::TargetPositionTiltPercent100ths)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -12884,10 +12941,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionLiftPercent100ths(
                                              BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                     Callback::Cancelable * onFailureCallback,
-                                                                                     uint16_t minInterval, uint16_t maxInterval,
-                                                                                     uint16_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercent100ths(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringCurrentPositionLiftPercent100ths", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12897,7 +12953,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionLiftPercent10
         .Put32(WindowCovering::Attributes::Ids::CurrentPositionLiftPercent100ths)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -12919,10 +12977,9 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeCurrentPositionTiltPercent100ths(
                                              BasicAttributeFilter<Int16uAttributeCallback>);
 }
 
-CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                                     Callback::Cancelable * onFailureCallback,
-                                                                                     uint16_t minInterval, uint16_t maxInterval,
-                                                                                     uint16_t change)
+CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercent100ths(
+    Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+    EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval, uint16_t change)
 {
     COMMAND_HEADER("ReportWindowCoveringCurrentPositionTiltPercent100ths", WindowCovering::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -12932,7 +12989,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeCurrentPositionTiltPercent10
         .Put32(WindowCovering::Attributes::Ids::CurrentPositionTiltPercent100ths)
         .Put8(33)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -13032,7 +13091,8 @@ CHIP_ERROR WindowCoveringCluster::ReadAttributeSafetyStatus(Callback::Cancelable
 }
 
 CHIP_ERROR WindowCoveringCluster::ConfigureAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                                 Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                                 EndpointId destinationEndpoint, uint16_t minInterval,
                                                                  uint16_t maxInterval)
 {
     COMMAND_HEADER("ReportWindowCoveringSafetyStatus", WindowCovering::Id);
@@ -13043,7 +13103,9 @@ CHIP_ERROR WindowCoveringCluster::ConfigureAttributeSafetyStatus(Callback::Cance
         .Put32(WindowCovering::Attributes::Ids::SafetyStatus)
         .Put8(25)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     COMMAND_FOOTER();
 }
 

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -216,10 +216,12 @@ public:
     CHIP_ERROR WriteAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           bool value);
     CHIP_ERROR ConfigureAttributePresentValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              uint16_t minInterval, uint16_t maxInterval);
+                                              NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                              uint16_t maxInterval);
     CHIP_ERROR ReportAttributePresentValue(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeStatusFlags(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                             uint16_t minInterval, uint16_t maxInterval);
+                                             NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                             uint16_t maxInterval);
     CHIP_ERROR ReportAttributeStatusFlags(Callback::Cancelable * onReportCallback);
 };
 
@@ -415,21 +417,26 @@ public:
     CHIP_ERROR WriteAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value);
     CHIP_ERROR ConfigureAttributeCurrentHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                            uint16_t minInterval, uint16_t maxInterval, uint8_t change);
+                                            NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                            uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentHue(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                   uint16_t maxInterval, uint8_t change);
+                                                   Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                   EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval,
+                                                   uint8_t change);
     CHIP_ERROR ReportAttributeCurrentSaturation(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentX(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint16_t minInterval, uint16_t maxInterval, uint16_t change);
+                                          NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                          uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeCurrentX(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentY(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint16_t minInterval, uint16_t maxInterval, uint16_t change);
+                                          NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                          uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeCurrentY(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                  uint16_t maxInterval, uint16_t change);
+                                                  Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                  EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval,
+                                                  uint16_t change);
     CHIP_ERROR ReportAttributeColorTemperature(Callback::Cancelable * onReportCallback);
 
 private:
@@ -541,7 +548,8 @@ public:
     CHIP_ERROR ReadAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeLockState(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                           uint16_t minInterval, uint16_t maxInterval);
+                                           NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeLockState(Callback::Cancelable * onReportCallback);
 
 private:
@@ -756,7 +764,8 @@ public:
     CHIP_ERROR ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              uint16_t minInterval, uint16_t maxInterval, uint8_t change);
+                                              NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                              uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback);
 
 private:
@@ -899,7 +908,8 @@ public:
                                                       Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeOccupancy(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                           uint16_t minInterval, uint16_t maxInterval);
+                                           NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                           uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOccupancy(Callback::Cancelable * onReportCallback);
 };
 
@@ -935,7 +945,8 @@ public:
     CHIP_ERROR WriteAttributeStartUpOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                           uint8_t value);
     CHIP_ERROR ConfigureAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                       uint16_t minInterval, uint16_t maxInterval);
+                                       NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                       uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOnOff(Callback::Cancelable * onReportCallback);
 
 private:
@@ -1001,7 +1012,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -1026,7 +1038,8 @@ public:
     CHIP_ERROR WriteAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint8_t value);
     CHIP_ERROR ConfigureAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                          NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                          uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeCapacity(Callback::Cancelable * onReportCallback);
 };
 
@@ -1043,7 +1056,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, uint16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -1112,7 +1126,8 @@ public:
     CHIP_ERROR ReadAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeCurrentPosition(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                                 uint16_t minInterval, uint16_t maxInterval, uint8_t change);
+                                                 NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                                 uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentPosition(Callback::Cancelable * onReportCallback);
 };
 
@@ -1170,7 +1185,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -1326,8 +1342,9 @@ public:
     CHIP_ERROR WriteAttributeSystemMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                         uint8_t value);
     CHIP_ERROR ConfigureAttributeLocalTemperature(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                  uint16_t maxInterval, int16_t change);
+                                                  Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                  EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval,
+                                                  int16_t change);
     CHIP_ERROR ReportAttributeLocalTemperature(Callback::Cancelable * onReportCallback);
 
 private:
@@ -1531,35 +1548,42 @@ public:
     CHIP_ERROR WriteAttributeMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                   uint8_t value);
     CHIP_ERROR ConfigureAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                               Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                               EndpointId destinationEndpoint, uint16_t minInterval,
                                                                uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentPositionLiftPercentage(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                               Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                               EndpointId destinationEndpoint, uint16_t minInterval,
                                                                uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentPositionTiltPercentage(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeOperationalStatus(Callback::Cancelable * onSuccessCallback,
-                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                   uint16_t maxInterval);
+                                                   Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                   EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval);
     CHIP_ERROR ReportAttributeOperationalStatus(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                                 Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                                 EndpointId destinationEndpoint, uint16_t minInterval,
                                                                  uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeTargetPositionLiftPercent100ths(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                 Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                                 Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                                 EndpointId destinationEndpoint, uint16_t minInterval,
                                                                  uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeTargetPositionTiltPercent100ths(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                  uint16_t maxInterval, uint16_t change);
+                                                                  Callback::Cancelable * onFailureCallback,
+                                                                  NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                  uint16_t minInterval, uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeCurrentPositionLiftPercent100ths(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onSuccessCallback,
-                                                                  Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                  uint16_t maxInterval, uint16_t change);
+                                                                  Callback::Cancelable * onFailureCallback,
+                                                                  NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                  uint16_t minInterval, uint16_t maxInterval, uint16_t change);
     CHIP_ERROR ReportAttributeCurrentPositionTiltPercent100ths(Callback::Cancelable * onReportCallback);
     CHIP_ERROR ConfigureAttributeSafetyStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              uint16_t minInterval, uint16_t maxInterval);
+                                              NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                              uint16_t maxInterval);
     CHIP_ERROR ReportAttributeSafetyStatus(Callback::Cancelable * onReportCallback);
 
 private:

--- a/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-app/zap-generated/CHIPClusters.cpp
@@ -104,8 +104,9 @@ CHIP_ERROR FlowMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelab
 }
 
 CHIP_ERROR FlowMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                   uint16_t maxInterval, int16_t change)
+                                                                   Callback::Cancelable * onFailureCallback,
+                                                                   NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                   uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportFlowMeasurementMeasuredValue", FlowMeasurement::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -115,7 +116,9 @@ CHIP_ERROR FlowMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Can
         .Put32(FlowMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -185,6 +188,7 @@ CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Canc
 
 CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
+                                                                       NodeId reportDestination, EndpointId destinationEndpoint,
                                                                        uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportPressureMeasurementMeasuredValue", PressureMeasurement::Id);
@@ -195,7 +199,9 @@ CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback:
         .Put32(PressureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -265,6 +271,7 @@ CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::C
 
 CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
+                                                                          NodeId reportDestination, EndpointId destinationEndpoint,
                                                                           uint16_t minInterval, uint16_t maxInterval,
                                                                           int16_t change)
 {
@@ -276,7 +283,9 @@ CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callba
         .Put32(TemperatureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }

--- a/zzz_generated/pump-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/pump-app/zap-generated/CHIPClusters.h
@@ -43,7 +43,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -60,7 +61,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -77,7 +79,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.cpp
@@ -104,8 +104,9 @@ CHIP_ERROR FlowMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelab
 }
 
 CHIP_ERROR FlowMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
-                                                                   Callback::Cancelable * onFailureCallback, uint16_t minInterval,
-                                                                   uint16_t maxInterval, int16_t change)
+                                                                   Callback::Cancelable * onFailureCallback,
+                                                                   NodeId reportDestination, EndpointId destinationEndpoint,
+                                                                   uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportFlowMeasurementMeasuredValue", FlowMeasurement::Id);
     buf.Put8(kFrameControlGlobalCommand)
@@ -115,7 +116,9 @@ CHIP_ERROR FlowMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Can
         .Put32(FlowMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -541,7 +544,8 @@ CHIP_ERROR LevelControlCluster::ReadAttributeCurrentLevel(Callback::Cancelable *
 }
 
 CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
-                                                               Callback::Cancelable * onFailureCallback, uint16_t minInterval,
+                                                               Callback::Cancelable * onFailureCallback, NodeId reportDestination,
+                                                               EndpointId destinationEndpoint, uint16_t minInterval,
                                                                uint16_t maxInterval, uint8_t change)
 {
     COMMAND_HEADER("ReportLevelControlCurrentLevel", LevelControl::Id);
@@ -552,7 +556,9 @@ CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancela
         .Put32(LevelControl::Attributes::Ids::CurrentLevel)
         .Put8(32)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put8(static_cast<uint8_t>(change));
     COMMAND_FOOTER();
 }
@@ -744,6 +750,7 @@ CHIP_ERROR PressureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Canc
 
 CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback,
+                                                                       NodeId reportDestination, EndpointId destinationEndpoint,
                                                                        uint16_t minInterval, uint16_t maxInterval, int16_t change)
 {
     COMMAND_HEADER("ReportPressureMeasurementMeasuredValue", PressureMeasurement::Id);
@@ -754,7 +761,9 @@ CHIP_ERROR PressureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback:
         .Put32(PressureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -884,6 +893,7 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ReadAttributeCapacity(Callback::C
 
 CHIP_ERROR PumpConfigurationAndControlCluster::ConfigureAttributeCapacity(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
+                                                                          NodeId reportDestination, EndpointId destinationEndpoint,
                                                                           uint16_t minInterval, uint16_t maxInterval,
                                                                           int16_t change)
 {
@@ -895,7 +905,9 @@ CHIP_ERROR PumpConfigurationAndControlCluster::ConfigureAttributeCapacity(Callba
         .Put32(PumpConfigurationAndControl::Attributes::Ids::Capacity)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }
@@ -970,6 +982,7 @@ CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::C
 
 CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                           Callback::Cancelable * onFailureCallback,
+                                                                          NodeId reportDestination, EndpointId destinationEndpoint,
                                                                           uint16_t minInterval, uint16_t maxInterval,
                                                                           int16_t change)
 {
@@ -981,7 +994,9 @@ CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callba
         .Put32(TemperatureMeasurement::Attributes::Ids::MeasuredValue)
         .Put8(41)
         .Put16(minInterval)
-        .Put16(maxInterval);
+        .Put16(maxInterval)
+        .Put64(reportDestination)
+        .Put16(destinationEndpoint);
     buf.Put16(static_cast<uint16_t>(change));
     COMMAND_FOOTER();
 }

--- a/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.h
+++ b/zzz_generated/pump-controller-app/zap-generated/CHIPClusters.h
@@ -43,7 +43,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -75,7 +76,8 @@ public:
     CHIP_ERROR ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                              uint16_t minInterval, uint16_t maxInterval, uint8_t change);
+                                              NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                              uint16_t maxInterval, uint8_t change);
     CHIP_ERROR ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback);
 
 private:
@@ -113,7 +115,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 
@@ -138,7 +141,8 @@ public:
     CHIP_ERROR WriteAttributeOperationMode(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                            uint8_t value);
     CHIP_ERROR ConfigureAttributeCapacity(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                          uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                          NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                          uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeCapacity(Callback::Cancelable * onReportCallback);
 };
 
@@ -155,7 +159,8 @@ public:
     CHIP_ERROR ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
-                                               uint16_t minInterval, uint16_t maxInterval, int16_t change);
+                                               NodeId reportDestination, EndpointId destinationEndpoint, uint16_t minInterval,
+                                               uint16_t maxInterval, int16_t change);
     CHIP_ERROR ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback);
 };
 


### PR DESCRIPTION
#### Problem
Reporting should not require a client to setup a binding table entry.

#### Change overview
Add target destination (node and endpoint) to `ConfigureAttribute` commands. This command is used for turning on/off reporting for an attribute. The node generating the report will use the target information to dispatch the reports.

#### Testing
Removed the binding steps from the current unit test, and ensure it continues to work (receive reports).
