### PR TITLE
Group Data Provider added.

### DIFF
--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
     "TestDataModelSerialization.cpp",
     "TestEventLogging.cpp",
     "TestEventPathParams.cpp",
+    "TestGroupDataProvider.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
     "TestReadInteraction.cpp",

--- a/src/app/tests/TestGroupDataProvider.cpp
+++ b/src/app/tests/TestGroupDataProvider.cpp
@@ -1,0 +1,407 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CommandPathParams
+ *
+ */
+
+#include <credentials/GroupDataProvider.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+#include <string.h>
+
+using namespace chip::Credentials;
+
+namespace chip {
+namespace app {
+namespace TestGroups {
+
+void TestEndpoints(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups              = GetGroupDataProvider();
+    chip::FabricIndex fabric                = 1;
+    GroupDataProvider::GroupMapping group1a = { .endpoint = 1, .group = 1 };
+    GroupDataProvider::GroupMapping group1b = { .endpoint = 1, .group = 2 };
+    GroupDataProvider::GroupMapping group1c = { .endpoint = 1, .group = 3 };
+    CHIP_ERROR err                          = CHIP_NO_ERROR;
+    bool exists                             = false;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    exists = groups->ExistsGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    err = groups->AddGroupMapping(fabric, group1a, "Group 1.1");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group1c, "Group 1.3");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    exists = groups->ExistsGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1b);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1c);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    err = groups->RemoveGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    exists = groups->ExistsGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1b);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1c);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    err = groups->AddGroupMapping(fabric, group1a, "Group 1.1b");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group1b, "Group 1.2");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    exists = groups->ExistsGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1b);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1c);
+    NL_TEST_ASSERT(apSuite, exists);
+
+    err = groups->RemoveGroupAllMappings(fabric, 1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    exists = groups->ExistsGroupMapping(fabric, group1a);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1b);
+    NL_TEST_ASSERT(apSuite, !exists);
+
+    exists = groups->ExistsGroupMapping(fabric, group1c);
+    NL_TEST_ASSERT(apSuite, !exists);
+}
+
+void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups              = GetGroupDataProvider();
+    chip::FabricIndex fabric                = 1;
+    GroupDataProvider::GroupMapping group1a = { .endpoint = 1, .group = 1 };
+    GroupDataProvider::GroupMapping group1b = { .endpoint = 1, .group = 3 };
+    GroupDataProvider::GroupMapping group2a = { .endpoint = 2, .group = 2 };
+    GroupDataProvider::GroupMapping group3a = { .endpoint = 3, .group = 1 };
+    GroupDataProvider::GroupMapping group3b = { .endpoint = 3, .group = 2 };
+    GroupDataProvider::GroupMapping group3c = { .endpoint = 3, .group = 3 };
+    CHIP_ERROR err                          = CHIP_NO_ERROR;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    err = groups->AddGroupMapping(fabric, group3b, "Group 3.2");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group2a, "Group 2.2");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group1b, "Group 1.3");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group3a, "Group 3.1");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group1a, "Group 1.1");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group3c, "Group 3.3");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->AddGroupMapping(fabric, group3a, "Group 3.1");
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    EndpointId endpoint                          = 1;
+    GroupDataProvider::GroupMappingIterator * it = groups->IterateGroupMappings(fabric, endpoint);
+    NL_TEST_ASSERT(apSuite, it);
+
+    // Endpoint 1
+    uint16_t count1 = it->Count();
+    uint16_t count2 = 0;
+    NL_TEST_ASSERT(apSuite, 2 == count1);
+    while (it->HasNext())
+    {
+        count2++;
+        GroupId gid = it->Next();
+        NL_TEST_ASSERT(apSuite, 1 == gid || 3 == gid);
+    }
+    NL_TEST_ASSERT(apSuite, count2 == count1);
+    delete it;
+
+    // Endpoint 3
+    endpoint = 3;
+    it       = groups->IterateGroupMappings(fabric, endpoint);
+    NL_TEST_ASSERT(apSuite, it);
+
+    count1 = it->Count();
+    count2 = 0;
+    NL_TEST_ASSERT(apSuite, 3 == count1);
+    while (it->HasNext())
+    {
+        count2++;
+        GroupId gid = it->Next();
+        NL_TEST_ASSERT(apSuite, gid > 0 && gid < 4);
+    }
+    NL_TEST_ASSERT(apSuite, count2 == count1);
+    delete it;
+}
+
+void TestStates(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups            = GetGroupDataProvider();
+    GroupDataProvider::GroupState state0a = { .state_index = 0, .group = 1, .key_set_index = 1 };
+    GroupDataProvider::GroupState state0b = { .state_index = 0, .group = 0, .key_set_index = 0 };
+    GroupDataProvider::GroupState state1a = { .state_index = 1, .group = 1, .key_set_index = 2 };
+    GroupDataProvider::GroupState state1b = { .state_index = 1, .group = 0, .key_set_index = 0 };
+    GroupDataProvider::GroupState state3  = { .state_index = 3, .group = 1, .key_set_index = 3 };
+    chip::FabricIndex fabric              = 1;
+    CHIP_ERROR err                        = CHIP_NO_ERROR;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    err = groups->SetGroupState(fabric, state0a);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetGroupState(fabric, state1a);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    // err = groups->GetStateCount(fabric, count);
+    // NL_TEST_ASSERT(apSuite, 2 == count);
+
+    err = groups->GetGroupState(fabric, state0b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, state0a.group == state0b.group);
+    NL_TEST_ASSERT(apSuite, state0a.key_set_index == state0b.key_set_index);
+
+    err = groups->GetGroupState(fabric, state1b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, state1a.group == state1b.group);
+    NL_TEST_ASSERT(apSuite, state1a.key_set_index == state1b.key_set_index);
+
+    err = groups->GetGroupState(fabric, state3);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+
+    err = groups->RemoveGroupState(fabric, 1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->GetGroupState(fabric, state0b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->GetGroupState(fabric, state1b);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+
+    // err = groups->GetStateCount(fabric, count);
+    // NL_TEST_ASSERT(apSuite, 1 == count);
+}
+
+void TestStateIterator(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups           = GetGroupDataProvider();
+    chip::FabricIndex fabric             = 1;
+    GroupDataProvider::GroupState state0 = { .state_index = 0, .group = 1, .key_set_index = 1 };
+    GroupDataProvider::GroupState state1 = { .state_index = 1, .group = 1, .key_set_index = 2 };
+    GroupDataProvider::GroupState state2 = { .state_index = 2, .group = 2, .key_set_index = 1 };
+    GroupDataProvider::GroupState state3 = { .state_index = 3, .group = 3, .key_set_index = 3 };
+    CHIP_ERROR err                       = CHIP_NO_ERROR;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    err = groups->SetGroupState(fabric, state2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetGroupState(fabric, state3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetGroupState(fabric, state0);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetGroupState(fabric, state1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    GroupDataProvider::GroupStateIterator * it = groups->IterateGroupStates(fabric);
+    NL_TEST_ASSERT(apSuite, it);
+
+    // Endpoint 1
+    uint16_t count1 = it->Count();
+    uint16_t count2 = 0;
+    NL_TEST_ASSERT(apSuite, 4 == count1);
+    while (it->HasNext())
+    {
+        count2++;
+        const GroupDataProvider::GroupState * state = it->Next();
+        NL_TEST_ASSERT(apSuite, state && state->group > 0 && state->group < 4);
+    }
+    NL_TEST_ASSERT(apSuite, count2 == count1);
+    delete it;
+}
+
+static GroupDataProvider::EpochKey epoch_keys0[3] = {
+    { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+    { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+    { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } }
+};
+static GroupDataProvider::EpochKey epoch_keys1[3] = {
+    { 0x1000000000000000, { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f } },
+    { 0x2000000000000000, { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f } },
+    { 0x3000000000000000, { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f } },
+};
+static GroupDataProvider::EpochKey epoch_keys2[3] = {
+    { 0xa000000000000000, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
+    { 0xb000000000000000, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
+    { 0xc000000000000000, { 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf } },
+};
+
+void TestKeys(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups       = GetGroupDataProvider();
+    GroupDataProvider::KeySet keys0a = { .key_set_index = 0, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys0b = { .key_set_index = 0, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys1a = { .key_set_index = 1, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys1b = { .key_set_index = 1, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys3  = { .key_set_index = 3, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    chip::FabricIndex fabric         = 1;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    memcpy(keys0a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+    memcpy(keys0b.epoch_keys, epoch_keys0, sizeof(epoch_keys0));
+    memcpy(keys1a.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+    memcpy(keys1b.epoch_keys, epoch_keys0, sizeof(epoch_keys0));
+    memcpy(keys3.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
+
+    err = groups->SetKeySet(fabric, keys0a);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetKeySet(fabric, keys1a);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    // err = groups->GetStateCount(fabric, count);
+    // NL_TEST_ASSERT(apSuite, 2 == count);
+
+    err = groups->GetKeySet(fabric, keys0b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, keys0a.policy == keys0b.policy);
+    NL_TEST_ASSERT(apSuite, !memcmp(keys0a.epoch_keys, keys0b.epoch_keys, sizeof(keys0a.epoch_keys)));
+
+    err = groups->GetKeySet(fabric, keys1b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+    NL_TEST_ASSERT(apSuite, keys1a.policy == keys1b.policy);
+    NL_TEST_ASSERT(apSuite, !memcmp(keys1a.epoch_keys, keys1b.epoch_keys, sizeof(keys1a.epoch_keys)));
+
+    err = groups->GetKeySet(fabric, keys3);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+
+    err = groups->RemoveKeySet(fabric, 1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->GetKeySet(fabric, keys0b);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->GetKeySet(fabric, keys1b);
+    NL_TEST_ASSERT(apSuite, CHIP_ERROR_KEY_NOT_FOUND == err);
+}
+
+void TestKeysIterator(nlTestSuite * apSuite, void * apContext)
+{
+    GroupDataProvider * groups      = GetGroupDataProvider();
+    GroupDataProvider::KeySet keys0 = { .key_set_index = 0, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys1 = { .key_set_index = 1, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys2 = { .key_set_index = 2, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys3 = { .key_set_index = 3, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    GroupDataProvider::KeySet keys4 = { .key_set_index = 4, .policy = GroupDataProvider::KeySet::SecurityPolicy::kStandard };
+    chip::FabricIndex fabric        = 1;
+    CHIP_ERROR err                  = CHIP_NO_ERROR;
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    memcpy(keys0.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+    memcpy(keys1.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
+    memcpy(keys2.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+    memcpy(keys3.epoch_keys, epoch_keys2, sizeof(epoch_keys2));
+    memcpy(keys4.epoch_keys, epoch_keys1, sizeof(epoch_keys1));
+
+    NL_TEST_ASSERT(apSuite, groups);
+
+    err = groups->SetKeySet(fabric, keys2);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetKeySet(fabric, keys3);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetKeySet(fabric, keys0);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetKeySet(fabric, keys4);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    err = groups->SetKeySet(fabric, keys1);
+    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == err);
+
+    GroupDataProvider::KeySetIterator * it = groups->IterateKeySets(fabric);
+    NL_TEST_ASSERT(apSuite, it);
+
+    uint16_t count1 = it->Count();
+    uint16_t count2 = 0;
+    NL_TEST_ASSERT(apSuite, 5 == count1);
+    while (it->HasNext())
+    {
+        count2++;
+        const GroupDataProvider::KeySet * keys = it->Next();
+        NL_TEST_ASSERT(apSuite, keys && keys->key_set_index >= 0 && keys->key_set_index <= 4);
+    }
+    NL_TEST_ASSERT(apSuite, count2 == count1);
+    delete it;
+}
+
+} // namespace TestGroups
+} // namespace app
+} // namespace chip
+
+namespace {
+const nlTest sTests[] = { NL_TEST_DEF("TestEndpoints", chip::app::TestGroups::TestEndpoints),
+                          NL_TEST_DEF("TestEndpointIterator", chip::app::TestGroups::TestEndpointIterator),
+                          NL_TEST_DEF("TestStates", chip::app::TestGroups::TestStates),
+                          NL_TEST_DEF("TestStateIterator", chip::app::TestGroups::TestStateIterator),
+                          NL_TEST_DEF("TestKeys", chip::app::TestGroups::TestKeys),
+                          NL_TEST_DEF("TestKeysIterator", chip::app::TestGroups::TestKeysIterator),
+                          NL_TEST_SENTINEL() };
+}
+
+int TestGroups()
+{
+    nlTestSuite theSuite = { "GroupDataProvider", &sTests[0], nullptr, nullptr };
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestGroups)

--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -30,6 +30,8 @@ static_library("credentials") {
     "DeviceAttestationVerifier.cpp",
     "DeviceAttestationVerifier.h",
     "GenerateChipX509Cert.cpp",
+    "GroupDataProvider.h",
+    "StaticGroupDataProvider.cpp",
     "examples/DeviceAttestationCredsExample.cpp",
     "examples/DeviceAttestationCredsExample.h",
     "examples/DeviceAttestationVerifierExample.cpp",

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -1,0 +1,178 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <lib/core/CHIPError.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+namespace chip {
+namespace Credentials {
+
+class GroupDataProvider
+{
+public:
+    static constexpr size_t kGroupNameLengthMax = 16;
+    static constexpr size_t kGroupEndpointsMax  = 16;
+
+    struct EpochKey
+    {
+        static constexpr size_t kLengthBytes = 16;
+        uint64_t start_time;
+        uint8_t key[kLengthBytes];
+    };
+
+    struct GroupMapping
+    {
+        EndpointId endpoint;
+        GroupId group;
+        bool operator==(const GroupMapping & other) { return this->endpoint == other.endpoint && this->group == other.group; }
+        GroupMapping & operator=(const GroupMapping & other)
+        {
+            if (this == &other)
+                return *this; // Guard self assignment
+            this->endpoint = other.endpoint;
+            this->group    = other.group;
+            return *this;
+        }
+    };
+
+    struct GroupState
+    {
+        uint16_t state_index;
+        chip::GroupId group;
+        uint16_t key_set_index;
+        bool operator==(const GroupState & other)
+        {
+            return this->state_index == other.state_index && this->group == other.group &&
+                this->key_set_index == other.key_set_index;
+        }
+    };
+
+    struct KeySet
+    {
+        enum class SecurityPolicy : uint8_t
+        {
+            kStandard   = 0,
+            kLowLatency = 1
+        };
+
+        uint16_t key_set_index;
+        SecurityPolicy policy;
+        EpochKey epoch_keys[3];
+    };
+
+    class GroupMappingIterator
+    {
+    public:
+        virtual ~GroupMappingIterator() = default;
+        virtual uint16_t Count()        = 0;
+        virtual bool HasNext()          = 0;
+        virtual GroupId Next() const    = 0;
+
+    protected:
+        GroupMappingIterator() = default;
+    };
+
+    class GroupStateIterator
+    {
+    public:
+        virtual ~GroupStateIterator()           = default;
+        virtual uint16_t Count()                = 0;
+        virtual bool HasNext()                  = 0;
+        virtual const GroupState * Next() const = 0;
+
+    protected:
+        GroupStateIterator() = default;
+    };
+
+    class KeySetIterator
+    {
+    public:
+        virtual ~KeySetIterator()           = default;
+        virtual uint16_t Count()            = 0;
+        virtual bool HasNext()              = 0;
+        virtual const KeySet * Next() const = 0;
+
+    protected:
+        KeySetIterator() = default;
+    };
+
+    struct GroupListener
+    {
+        void OnStateChanged(GroupState & old_state, GroupState & new_state);
+    };
+
+    GroupDataProvider()          = default;
+    virtual ~GroupDataProvider() = default;
+
+    // Not copyable
+    GroupDataProvider(const GroupDataProvider &) = delete;
+    GroupDataProvider & operator=(const GroupDataProvider &) = delete;
+
+    virtual CHIP_ERROR Init() = 0;
+    virtual void Finish()     = 0;
+
+    // Endpoints
+    virtual bool ExistsGroupMapping(chip::FabricIndex fabric, GroupMapping & mapping)                       = 0;
+    virtual CHIP_ERROR AddGroupMapping(chip::FabricIndex fabric, GroupMapping & mapping, const char * name) = 0;
+    virtual CHIP_ERROR RemoveGroupMapping(chip::FabricIndex fabric, GroupMapping & mapping)                 = 0;
+    virtual CHIP_ERROR RemoveGroupAllMappings(chip::FabricIndex fabric, EndpointId endpoint)                = 0;
+    virtual GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric, EndpointId endpoint)      = 0;
+
+    // States
+    virtual CHIP_ERROR SetGroupState(chip::FabricIndex fabric, GroupState & state)      = 0;
+    virtual CHIP_ERROR GetGroupState(chip::FabricIndex fabric, GroupState & state)      = 0;
+    virtual CHIP_ERROR RemoveGroupState(chip::FabricIndex fabric, uint16_t state_index) = 0;
+    virtual GroupStateIterator * IterateGroupStates(chip::FabricIndex fabric)           = 0;
+
+    // Keys
+    virtual CHIP_ERROR SetKeySet(chip::FabricIndex fabric, KeySet & keys)             = 0;
+    virtual CHIP_ERROR GetKeySet(chip::FabricIndex fabric, KeySet & keys)             = 0;
+    virtual CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric, uint16_t key_set_index) = 0;
+    virtual KeySetIterator * IterateKeySets(chip::FabricIndex fabric)                 = 0;
+
+    void SetListener(GroupListener * listener) { mListener = listener; };
+    void RemoveListener() { mListener = nullptr; };
+
+private:
+    GroupListener * mListener = nullptr;
+};
+
+/**
+ * Instance getter for the global GroupDataProvider.
+ *
+ * Callers have to externally synchronize usage of this function.
+ *
+ * @return The global Group Data Provider. Assume never null.
+ */
+GroupDataProvider * GetGroupDataProvider();
+
+/**
+ * Instance setter for the global GroupDataProvider.
+ *
+ * Callers have to externally synchronize usage of this function.
+ *
+ * If the `provider` is nullptr, no change is done.
+ *
+ * @param[in] provider the Group Data Provider
+ */
+void SetGroupDataProvider(GroupDataProvider * provider);
+
+} // namespace Credentials
+} // namespace chip

--- a/src/credentials/StaticGroupDataProvider.cpp
+++ b/src/credentials/StaticGroupDataProvider.cpp
@@ -1,0 +1,514 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "GroupDataProvider.h"
+#include <lib/core/CHIPConfig.h>
+#include <string.h>
+
+using namespace chip::DeviceLayer;
+
+namespace chip {
+namespace Credentials {
+namespace {
+
+#ifndef CHIP_CONFIG_GROUP_DATA_FABRICS_MAX
+#define CHIP_CONFIG_GROUP_DATA_FABRICS_MAX 4
+#endif
+
+#ifndef CHIP_CONFIG_GROUP_DATA_MAPPINGS_MAX
+#define CHIP_CONFIG_GROUP_DATA_MAPPINGS_MAX 16
+#endif
+
+#ifndef CHIP_CONFIG_GROUP_DATA_STATES_MAX
+#define CHIP_CONFIG_GROUP_DATA_STATES_MAX 16
+#endif
+
+#ifndef CHIP_CONFIG_GROUP_DATA_KEY_SETS_MAX
+#define CHIP_CONFIG_GROUP_DATA_KEY_SETS_MAX 16
+#endif
+
+static constexpr size_t kGroupFabricsMax    = CHIP_CONFIG_GROUP_DATA_FABRICS_MAX;
+static constexpr size_t kEndpointEntriesMax = CHIP_CONFIG_GROUP_DATA_MAPPINGS_MAX;
+static constexpr size_t kStateEntriesMax    = CHIP_CONFIG_GROUP_DATA_STATES_MAX;
+static constexpr size_t kKeyEntriesMax      = CHIP_CONFIG_GROUP_DATA_KEY_SETS_MAX;
+
+class StaticGroupsProvider : public GroupDataProvider
+{
+    struct EndpointEntry : public GroupMapping
+    {
+        bool in_use = false;
+    };
+
+    struct StateEntry : public GroupState
+    {
+        bool in_use = false;
+    };
+
+    struct KeysEntry : public KeySet
+    {
+        bool in_use = false;
+    };
+
+    struct Fabric
+    {
+        bool in_use = false;
+        chip::FabricIndex fabric_index;
+        EndpointEntry endpoints[kEndpointEntriesMax];
+        StateEntry states[kStateEntriesMax];
+        KeysEntry keys[kKeyEntriesMax];
+    };
+
+    class EndpointIterator : public GroupMappingIterator
+    {
+    public:
+        EndpointIterator(Fabric * fabric, chip::EndpointId endpoint) : mFabric(fabric), mEndpoint(endpoint) {}
+        uint16_t Count() override
+        {
+            uint16_t count = 0;
+            for (uint16_t i = 0; this->mFabric && i < kEndpointEntriesMax; ++i)
+            {
+                EndpointEntry & entry = this->mFabric->endpoints[i];
+                if (entry.in_use && entry.endpoint == this->mEndpoint)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+        bool HasNext() override
+        {
+            if (!mFirst)
+            {
+                this->mIndex++;
+            }
+            while (this->mFabric && this->mIndex < kEndpointEntriesMax)
+            {
+                EndpointEntry & entry = this->mFabric->endpoints[this->mIndex];
+                if (entry.in_use && entry.endpoint == this->mEndpoint)
+                {
+                    mFirst = false;
+                    return true;
+                }
+                this->mIndex++;
+            }
+            return false;
+        }
+        GroupId Next() const override { return kEndpointEntriesMax ? this->mFabric->endpoints[this->mIndex].group : 0; }
+
+    private:
+        Fabric * mFabric           = nullptr;
+        chip::EndpointId mEndpoint = 0;
+        uint16_t mIndex            = 0;
+        bool mFirst                = true;
+    };
+
+    class StateIterator : public GroupStateIterator
+    {
+    public:
+        StateIterator(Fabric * fabric) : mFabric(fabric) {}
+        uint16_t Count() override
+        {
+            uint16_t count = 0;
+            for (uint16_t i = 0; this->mFabric && i < kStateEntriesMax; ++i)
+            {
+                StateEntry & entry = this->mFabric->states[i];
+                if (entry.in_use)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+        bool HasNext() override
+        {
+            if (!mFirst)
+            {
+                this->mIndex++;
+            }
+            while (this->mFabric && this->mIndex < kStateEntriesMax)
+            {
+                StateEntry & entry = this->mFabric->states[this->mIndex];
+                if (entry.in_use)
+                {
+                    mFirst = false;
+                    return true;
+                }
+                this->mIndex++;
+            }
+            return false;
+        }
+        const GroupState * Next() const override
+        {
+            return this->mIndex < kStateEntriesMax ? &this->mFabric->states[this->mIndex] : nullptr;
+        }
+
+    private:
+        Fabric * mFabric = nullptr;
+        uint16_t mIndex  = 0;
+        bool mFirst      = true;
+    };
+
+    class KeysIterator : public KeySetIterator
+    {
+    public:
+        KeysIterator(Fabric * fabric) : mFabric(fabric) {}
+        uint16_t Count() override
+        {
+            uint16_t count = 0;
+            for (uint16_t i = 0; this->mFabric && i < kKeyEntriesMax; ++i)
+            {
+                KeysEntry & entry = this->mFabric->keys[i];
+                if (entry.in_use)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+        bool HasNext() override
+        {
+            if (!mFirst)
+            {
+                this->mIndex++;
+            }
+            while (this->mFabric && this->mIndex < kKeyEntriesMax)
+            {
+                KeysEntry & entry = this->mFabric->keys[this->mIndex];
+                if (entry.in_use)
+                {
+                    mFirst = false;
+                    return true;
+                }
+                this->mIndex++;
+            }
+            return false;
+        }
+        const KeySet * Next() const override
+        {
+            return this->mIndex < kKeyEntriesMax ? &this->mFabric->keys[this->mIndex] : nullptr;
+        }
+
+    private:
+        Fabric * mFabric = nullptr;
+        uint16_t mIndex  = 0;
+        bool mFirst      = true;
+    };
+
+    Fabric * GetFabric(chip::FabricIndex fabric_index)
+    {
+        Fabric * fabric = nullptr;
+        Fabric * unused = nullptr;
+        for (uint16_t i = 0; i < kGroupFabricsMax; i++)
+        {
+            fabric = &mFabrics[i];
+            if (fabric->in_use)
+            {
+                if (fabric->fabric_index == fabric_index)
+                {
+                    // Fabric in use
+                    return fabric;
+                }
+            }
+            else if (nullptr == unused)
+            {
+                // Remember the first unused entry
+                unused = fabric;
+            }
+        }
+        if (unused)
+        {
+            // Use the first available entry
+            unused->fabric_index = fabric_index;
+            unused->in_use       = true;
+            return unused;
+        }
+        // Fabric not found, and no unused entries left
+        return nullptr;
+    }
+
+public:
+    CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
+
+    void Finish() override {}
+
+    // Endpoints
+    bool ExistsGroupMapping(chip::FabricIndex fabric_index, GroupMapping & mapping) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        for (uint16_t i = 0; fabric && i < kEndpointEntriesMax; ++i)
+        {
+            EndpointEntry & entry = fabric->endpoints[i];
+            if (entry.in_use && (entry == mapping))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    CHIP_ERROR AddGroupMapping(chip::FabricIndex fabric_index, GroupMapping & mapping, const char * name) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        if (!fabric)
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+        // Search for existing mapping
+        for (uint16_t i = 0; i < kEndpointEntriesMax; ++i)
+        {
+            EndpointEntry & entry = fabric->endpoints[i];
+            if (entry.in_use && (entry == mapping))
+            {
+                // Duplicated
+                return CHIP_NO_ERROR;
+            }
+        }
+        // New mapping
+        for (uint16_t i = 0; i < kEndpointEntriesMax; ++i)
+        {
+            EndpointEntry & entry = fabric->endpoints[i];
+            if (!entry.in_use)
+            {
+                entry.group    = mapping.group;
+                entry.endpoint = mapping.endpoint;
+                entry.in_use   = true;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    CHIP_ERROR RemoveGroupMapping(chip::FabricIndex fabric_index, GroupMapping & mapping) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Search for existing mapping
+        for (uint16_t i = 0; fabric && i < kEndpointEntriesMax; ++i)
+        {
+            EndpointEntry & entry = fabric->endpoints[i];
+            if (entry.in_use && (entry == mapping))
+            {
+                // Found
+                entry.in_use = false;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR RemoveGroupAllMappings(chip::FabricIndex fabric_index, EndpointId endpoint) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Remove all mappings from fabric
+        for (uint16_t i = 0; fabric && i < kEndpointEntriesMax; ++i)
+        {
+            fabric->endpoints[i].in_use = false;
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    GroupMappingIterator * IterateGroupMappings(chip::FabricIndex fabric_index, EndpointId endpoint) override
+    {
+        return new EndpointIterator(GetFabric(fabric_index), endpoint);
+    }
+
+    // States
+    CHIP_ERROR SetGroupState(chip::FabricIndex fabric_index, GroupState & state) override
+    {
+        Fabric * fabric    = GetFabric(fabric_index);
+        StateEntry * entry = nullptr;
+
+        // Search for existing, or unused entry
+        for (uint16_t i = 0; fabric && i < kStateEntriesMax; ++i)
+        {
+            if (fabric->states[i].in_use)
+            {
+                if (fabric->states[i].state_index == state.state_index)
+                {
+                    // Reuse existing entry
+                    entry = &fabric->states[i];
+                    break;
+                }
+            }
+            else if (!entry)
+            {
+                // Unused entry
+                entry = &fabric->states[i];
+            }
+        }
+        if (entry)
+        {
+            entry->state_index   = state.state_index;
+            entry->group         = state.group;
+            entry->key_set_index = state.key_set_index;
+            entry->in_use        = true;
+            return CHIP_NO_ERROR;
+        }
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    CHIP_ERROR GetGroupState(chip::FabricIndex fabric_index, GroupState & state) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Search for existing state
+        for (uint16_t i = 0; fabric && i < kStateEntriesMax; ++i)
+        {
+            StateEntry & entry = fabric->states[i];
+            if (entry.in_use && entry.state_index == state.state_index)
+            {
+                // Found
+                state.group         = entry.group;
+                state.key_set_index = entry.key_set_index;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    CHIP_ERROR RemoveGroupState(chip::FabricIndex fabric_index, uint16_t state_index) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Search for existing state
+        for (uint16_t i = 0; fabric && i < kStateEntriesMax; ++i)
+        {
+            StateEntry & entry = fabric->states[i];
+            if (entry.in_use && entry.state_index == state_index)
+            {
+                // Found
+                entry.in_use = false;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    GroupStateIterator * IterateGroupStates(chip::FabricIndex fabric_index) override
+    {
+        return new StateIterator(GetFabric(fabric_index));
+    }
+
+    // Keys
+    CHIP_ERROR SetKeySet(chip::FabricIndex fabric_index, KeySet & keys) override
+    {
+        Fabric * fabric   = GetFabric(fabric_index);
+        KeysEntry * entry = nullptr;
+
+        // Search for existing, or unused entry
+        for (uint16_t i = 0; fabric && i < kKeyEntriesMax; ++i)
+        {
+            if (fabric->keys[i].in_use)
+            {
+                if (fabric->keys[i].key_set_index == keys.key_set_index)
+                {
+                    // Reuse existing entry
+                    entry = &fabric->keys[i];
+                    break;
+                }
+            }
+            else if (!entry)
+            {
+                // Unused entry
+                entry = &fabric->keys[i];
+            }
+        }
+        if (entry)
+        {
+            entry->key_set_index = keys.key_set_index;
+            entry->policy        = keys.policy;
+            memcpy(entry->epoch_keys, keys.epoch_keys, sizeof(entry->epoch_keys));
+            entry->in_use = true;
+            return CHIP_NO_ERROR;
+        }
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    CHIP_ERROR GetKeySet(chip::FabricIndex fabric_index, KeySet & keys) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Search for existing keys
+        for (uint16_t i = 0; fabric && i < kKeyEntriesMax; ++i)
+        {
+            KeysEntry & entry = fabric->keys[i];
+            if (entry.in_use && entry.key_set_index == keys.key_set_index)
+            {
+                // Found
+                keys.policy = entry.policy;
+                memcpy(keys.epoch_keys, entry.epoch_keys, sizeof(keys.epoch_keys));
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    CHIP_ERROR RemoveKeySet(chip::FabricIndex fabric_index, uint16_t key_set_index) override
+    {
+        Fabric * fabric = GetFabric(fabric_index);
+        // Search for existing keys
+        for (uint16_t i = 0; fabric && i < kKeyEntriesMax; ++i)
+        {
+            KeysEntry & entry = fabric->keys[i];
+            if (entry.in_use && entry.key_set_index == key_set_index)
+            {
+                // Found
+                entry.in_use = false;
+                return CHIP_NO_ERROR;
+            }
+        }
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+
+    KeySetIterator * IterateKeySets(chip::FabricIndex fabric_index) override { return new KeysIterator(GetFabric(fabric_index)); }
+
+private:
+    Fabric mFabrics[kGroupFabricsMax];
+};
+
+StaticGroupsProvider gDefaultGroupsProvider;
+
+GroupDataProvider * gGroupsProvider = &gDefaultGroupsProvider;
+
+} // namespace
+
+/**
+ * Instance getter for the global GroupDataProvider.
+ *
+ * Callers have to externally synchronize usage of this function.
+ *
+ * @return The global device attestation credentials provider. Assume never null.
+ */
+GroupDataProvider * GetGroupDataProvider()
+{
+    return gGroupsProvider;
+}
+
+/**
+ * Instance setter for the global GroupDataProvider.
+ *
+ * Callers have to externally synchronize usage of this function.
+ *
+ * If the `provider` is nullptr, no change is done.
+ *
+ * @param[in] provider the GroupDataProvider to start returning with the getter
+ */
+void SetGroupDataProvider(GroupDataProvider * provider)
+{
+    if (provider)
+    {
+        gGroupsProvider = provider;
+    }
+}
+
+} // namespace Credentials
+} // namespace chip


### PR DESCRIPTION
#### Problem
Group and Group Key Management clusters, as well as multicast communication require store tables of group related data, including endpoint mapping, and key sets. The Group Data Provider will provides storage of the group for use of the Matter stack, and group-related clusters. The new API will allow the applications to provide their own storage implementation, which will accommodate the memory requirements of diverse platforms.

#### Change overview
* Added Group Data Provider API interface.
* Added statically-sized, array-based implementation of the Group Data Provider.
* Added unit tests for the new interface.

#### Testing
* New unit tests run successfully.