### PR TITLE
Roll back Telink CI to previous docker file version for now to get it green.

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:latest
+            image: connectedhomeip/chip-build-telink:0.5.1
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
The updated docker file does not seem to work right.

#### Problem
Telink CI fails on ToT

#### Change overview
Roll back to the previous docker file version (without the changes from #9163) to fix that for now.

#### Testing
Ran CI in my clone of the repo, it passed.