### PR TITLE
Disallow VLAs in Matter code

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -200,6 +200,7 @@ config("strict_warnings") {
     "-Wextra",
     "-Wshadow",
     "-Wunreachable-code",
+    "-Wvla",
   ]
 
   cflags_cc = [ "-Wnon-virtual-dtor" ]

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -353,7 +353,11 @@ void {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}ListAttribu
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+    {{! TODO: This VLA is not OK.  See https://github.com/project-chip/connectedhomeip/issues/8558 }}
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     {{chipType}} data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         {{#if isStruct}}

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -555,9 +555,11 @@ static void TestAES_CCM_128DecryptInvalidCipherText(nlTestSuite * inSuite, void 
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, 0, vector->aad, vector->aad_len, vector->tag, vector->tag_len, vector->key,
-                                             vector->key_len, vector->iv, vector->iv_len, out_pt);
+                                             vector->key_len, vector->iv, vector->iv_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -575,9 +577,11 @@ static void TestAES_CCM_128DecryptInvalidKey(nlTestSuite * inSuite, void * inCon
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             nullptr, 0, vector->iv, vector->iv_len, out_pt);
+                                             nullptr, 0, vector->iv, vector->iv_len, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }
@@ -595,9 +599,11 @@ static void TestAES_CCM_128DecryptInvalidIVLen(nlTestSuite * inSuite, void * inC
         if (vector->pt_len > 0)
         {
             numOfTestsRan++;
-            uint8_t out_pt[vector->pt_len];
+            Platform::ScopedMemoryBuffer<uint8_t> out_pt;
+            out_pt.Alloc(vector->pt_len);
+            NL_TEST_ASSERT(inSuite, out_pt);
             CHIP_ERROR err = AES_CCM_decrypt(vector->ct, vector->ct_len, vector->aad, vector->aad_len, vector->tag, vector->tag_len,
-                                             vector->key, vector->key_len, vector->iv, 0, out_pt);
+                                             vector->key, vector->key_len, vector->iv, 0, out_pt.Get());
             NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
             break;
         }

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -84,8 +84,8 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::SetIssuerID(CHIPPersistentStorage
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    uint16_t idStringLen = 16;
-    char issuerIdString[idStringLen];
+    char issuerIdString[16];
+    uint16_t idStringLen = sizeof(issuerIdString);
     if (CHIP_NO_ERROR != storage->SyncGetKeyValue(CHIP_COMMISSIONER_CA_ISSUER_ID, issuerIdString, idStringLen)) {
         mIssuerId = arc4random();
         CHIP_LOG_ERROR("Assigned %d certificate issuer ID to the commissioner", mIssuerId);

--- a/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/CHIPCallbackBridge.zapt
@@ -45,11 +45,11 @@ void CHIP{{@partial-block}}Bridge::OnSuccessFn(void * context
       {{/chip_cluster_response_arguments}}
     });
     {{else if (isStrEqual partial-type "List")}}
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++)
     {
         {{#if isStruct}}
-        values[i] = @{
+        array[i] = @{
           {{#chip_attribute_list_entryTypes}}
           {{#if (isOctetString type)}}
           @"{{name}}" : [NSData dataWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size()],
@@ -61,15 +61,15 @@ void CHIP{{@partial-block}}Bridge::OnSuccessFn(void * context
           {{/chip_attribute_list_entryTypes}}
         };
         {{else if (isOctetString type)}}
-        values[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
+        array[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
         {{else if (isCharString type)}}
-        values[i] = [[NSString alloc] initWithBytes:entries[i]+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i]) encoding:NSUTF8StringEncoding];
+        array[i] = [[NSString alloc] initWithBytes:entries[i]+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i]) encoding:NSUTF8StringEncoding];
         {{else}}
-        values[i] = [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i]];
+        array[i] = [NSNumber numberWith{{asObjectiveCNumberType label type false}}:entries[i]];
         {{/if}}
     }
 
-    DispatchSuccess(context, @{ @"value": [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @{ @"value": array });
     {{else if (isOctetString partial-type)}}
     DispatchSuccess(context, @{ @"value": [NSData dataWithBytes: value.data() length: value.size()] });
     {{else if (isCharString partial-type)}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -80,126 +80,126 @@ void CHIPInt64sAttributeCallbackBridge::OnSuccessFn(void * context, int64_t valu
 void CHIPApplicationLauncherApplicationLauncherListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, uint16_t * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedShort:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedShort:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPAudioOutputAudioOutputListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _AudioOutputInfo * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"index" : [NSNumber numberWithUnsignedChar:entries[i].index],
             @"outputType" : [NSNumber numberWithUnsignedChar:entries[i].outputType],
             @"name" : [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPContentLauncherAcceptsHeaderListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, chip::ByteSpan * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
+        array[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPContentLauncherSupportedStreamingTypesListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, uint8_t * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedChar:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedChar:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPDescriptorDeviceListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _DeviceType * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"type" : [NSNumber numberWithUnsignedLong:entries[i].type],
             @"revision" : [NSNumber numberWithUnsignedShort:entries[i].revision],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPDescriptorServerListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, chip::ClusterId * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedLong:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedLong:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPDescriptorClientListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, chip::ClusterId * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedLong:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedLong:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPDescriptorPartsListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, chip::EndpointId * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedShort:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedShort:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPFixedLabelLabelListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _LabelStruct * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"label" : [NSData dataWithBytes:entries[i].label.data() length:entries[i].label.size()],
             @"value" : [NSData dataWithBytes:entries[i].value.data() length:entries[i].value.size()],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPGeneralCommissioningBasicCommissioningInfoListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _BasicCommissioningInfoType * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"FailSafeExpiryLengthMs" : [NSNumber numberWithUnsignedLong:entries[i].FailSafeExpiryLengthMs],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _NetworkInterfaceType * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"Name" : [NSData dataWithBytes:entries[i].Name.data() length:entries[i].Name.size()],
             @"FabricConnected" : [NSNumber numberWithBool:entries[i].FabricConnected],
             @"OffPremiseServicesReachableIPv4" : [NSNumber numberWithBool:entries[i].OffPremiseServicesReachableIPv4],
@@ -209,28 +209,28 @@ void CHIPGeneralDiagnosticsNetworkInterfacesListAttributeCallbackBridge::OnSucce
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPGroupKeyManagementGroupsListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _GroupState * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"VendorId" : [NSNumber numberWithUnsignedShort:entries[i].VendorId],
             @"VendorGroupId" : [NSNumber numberWithUnsignedShort:entries[i].VendorGroupId],
             @"GroupKeySetIndex" : [NSNumber numberWithUnsignedShort:entries[i].GroupKeySetIndex],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPGroupKeyManagementGroupKeysListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _GroupKey * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"VendorId" : [NSNumber numberWithUnsignedShort:entries[i].VendorId],
             @"GroupKeyIndex" : [NSNumber numberWithUnsignedShort:entries[i].GroupKeyIndex],
             @"GroupKeyRoot" : [NSData dataWithBytes:entries[i].GroupKeyRoot.data() length:entries[i].GroupKeyRoot.size()],
@@ -239,14 +239,14 @@ void CHIPGroupKeyManagementGroupKeysListAttributeCallbackBridge::OnSuccessFn(voi
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPMediaInputMediaInputListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _MediaInputInfo * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"index" : [NSNumber numberWithUnsignedChar:entries[i].index],
             @"inputType" : [NSNumber numberWithUnsignedChar:entries[i].inputType],
             @"name" : [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()],
@@ -254,15 +254,15 @@ void CHIPMediaInputMediaInputListListAttributeCallbackBridge::OnSuccessFn(void *
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _FabricDescriptor * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"FabricIndex" : [NSNumber numberWithUnsignedChar:entries[i].FabricIndex],
             @"RootPublicKey" : [NSData dataWithBytes:entries[i].RootPublicKey.data() length:entries[i].RootPublicKey.size()],
             @"VendorId" : [NSNumber numberWithUnsignedShort:entries[i].VendorId],
@@ -272,14 +272,14 @@ void CHIPOperationalCredentialsFabricsListListAttributeCallbackBridge::OnSuccess
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPTvChannelTvChannelListListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, _TvChannelInfo * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"majorNumber" : [NSNumber numberWithUnsignedShort:entries[i].majorNumber],
             @"minorNumber" : [NSNumber numberWithUnsignedShort:entries[i].minorNumber],
             @"name" : [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()],
@@ -289,64 +289,64 @@ void CHIPTvChannelTvChannelListListAttributeCallbackBridge::OnSuccessFn(void * c
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPTargetNavigatorTargetNavigatorListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _NavigateTargetTargetInfo * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"identifier" : [NSNumber numberWithUnsignedChar:entries[i].identifier],
             @"name" : [NSData dataWithBytes:entries[i].name.data() length:entries[i].name.size()],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPTestClusterListInt8uListAttributeCallbackBridge::OnSuccessFn(void * context, uint16_t count, uint8_t * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedChar:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedChar:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPTestClusterListOctetStringListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, chip::ByteSpan * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
+        array[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPTestClusterListStructOctetStringListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _TestListStructOctet * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"fabricIndex" : [NSNumber numberWithUnsignedLongLong:entries[i].fabricIndex],
             @"operationalCert" : [NSData dataWithBytes:entries[i].operationalCert.data() length:entries[i].operationalCert.size()],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _NeighborTable * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"ExtAddress" : [NSNumber numberWithUnsignedLongLong:entries[i].ExtAddress],
             @"Age" : [NSNumber numberWithUnsignedLong:entries[i].Age],
             @"Rloc16" : [NSNumber numberWithUnsignedShort:entries[i].Rloc16],
@@ -364,15 +364,15 @@ void CHIPThreadNetworkDiagnosticsNeighborTableListListAttributeCallbackBridge::O
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _RouteTable * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"ExtAddress" : [NSNumber numberWithUnsignedLongLong:entries[i].ExtAddress],
             @"Rloc16" : [NSNumber numberWithUnsignedShort:entries[i].Rloc16],
             @"RouterId" : [NSNumber numberWithUnsignedChar:entries[i].RouterId],
@@ -386,29 +386,29 @@ void CHIPThreadNetworkDiagnosticsRouteTableListListAttributeCallbackBridge::OnSu
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPThreadNetworkDiagnosticsSecurityPolicyListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _SecurityPolicy * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"RotationTime" : [NSNumber numberWithUnsignedShort:entries[i].RotationTime],
             @"Flags" : [NSNumber numberWithUnsignedChar:entries[i].Flags],
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, _OperationalDatasetComponents * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = @ {
+        array[i] = @ {
             @"ActiveTimestampPresent" : [NSNumber numberWithBool:entries[i].ActiveTimestampPresent],
             @"PendingTimestampPresent" : [NSNumber numberWithBool:entries[i].PendingTimestampPresent],
             @"MasterKeyPresent" : [NSNumber numberWithBool:entries[i].MasterKeyPresent],
@@ -424,18 +424,18 @@ void CHIPThreadNetworkDiagnosticsOperationalDatasetComponentsListAttributeCallba
         };
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeCallbackBridge::OnSuccessFn(
     void * context, uint16_t count, uint8_t * entries)
 {
-    id values[count];
+    id array = [NSMutableArray arrayWithCapacity:count];
     for (uint16_t i = 0; i < count; i++) {
-        values[i] = [NSNumber numberWithUnsignedChar:entries[i]];
+        array[i] = [NSNumber numberWithUnsignedChar:entries[i]];
     }
 
-    DispatchSuccess(context, @ { @"value" : [NSArray arrayWithObjects:values count:count] });
+    DispatchSuccess(context, @ { @"value" : array });
 };
 
 void CHIPAccountLoginClusterGetSetupPINResponseCallbackBridge::OnSuccessFn(void * context, uint8_t * setupPIN)

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -57,15 +57,16 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
         return err;
     }
 
-    uint8_t buf[read_size];
-    ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf, read_size, read_size));
+    Platform::ScopedMemoryBuffer<uint8_t> buf;
+    VerifyOrReturnError(buf.Alloc(read_size), CHIP_ERROR_NO_MEMORY);
+    ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf.Get(), read_size, read_size));
 
     size_t copy_size = std::min(value_size, read_size - offset_bytes);
     if (read_bytes_size != nullptr)
     {
         *read_bytes_size = copy_size;
     }
-    ::memcpy(value, buf + offset_bytes, copy_size);
+    ::memcpy(value, buf.Get() + offset_bytes, copy_size);
 
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -88,10 +88,11 @@ static uint32_t chunk3PayloadRepresentation(const SetupPayload & payload)
 }
 
 // TODO: issue #3663 - Unbounded stack in src/setup_payload
-#if !defined(__clang__)
 #pragma GCC diagnostic push
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wstack-usage="
 #endif
+#pragma GCC diagnostic ignored "-Wvla"
 
 static std::string decimalStringWithPadding(uint32_t number, int minLength)
 {
@@ -100,9 +101,7 @@ static std::string decimalStringWithPadding(uint32_t number, int minLength)
     return std::string(buf);
 }
 
-#if !defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
 
 CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(std::string & outDecimalString)
 {

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClientCallbacks.cpp
@@ -369,7 +369,10 @@ void ApplicationLauncherClusterApplicationLauncherListListAttributeFilter(TLV::T
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     uint16_t data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -398,7 +401,10 @@ void AudioOutputClusterAudioOutputListListAttributeFilter(TLV::TLVReader * tlvDa
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _AudioOutputInfo data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -433,7 +439,10 @@ void ContentLauncherClusterAcceptsHeaderListListAttributeFilter(TLV::TLVReader *
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::ByteSpan data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_STATUS_VOID(ReadByteSpan(message, messageLen, &data[i]));
@@ -464,7 +473,10 @@ void ContentLauncherClusterSupportedStreamingTypesListAttributeFilter(TLV::TLVRe
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     uint8_t data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -493,7 +505,10 @@ void DescriptorClusterDeviceListListAttributeFilter(TLV::TLVReader * tlvData, Ca
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _DeviceType data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(4);
@@ -525,7 +540,10 @@ void DescriptorClusterServerListListAttributeFilter(TLV::TLVReader * tlvData, Ca
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::ClusterId data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(4);
@@ -554,7 +572,10 @@ void DescriptorClusterClientListListAttributeFilter(TLV::TLVReader * tlvData, Ca
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::ClusterId data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(4);
@@ -583,7 +604,10 @@ void DescriptorClusterPartsListListAttributeFilter(TLV::TLVReader * tlvData, Cal
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::EndpointId data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -612,7 +636,10 @@ void FixedLabelClusterLabelListListAttributeFilter(TLV::TLVReader * tlvData, Cal
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _LabelStruct data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_STATUS_VOID(ReadByteSpan(message, 18, &data[i].label));
@@ -645,7 +672,10 @@ void GeneralCommissioningClusterBasicCommissioningInfoListListAttributeFilter(TL
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _BasicCommissioningInfoType data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(4);
@@ -675,7 +705,10 @@ void GeneralDiagnosticsClusterNetworkInterfacesListAttributeFilter(TLV::TLVReade
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _NetworkInterfaceType data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_STATUS_VOID(ReadByteSpan(message, 34, &data[i].Name));
@@ -719,7 +752,10 @@ void GroupKeyManagementClusterGroupsListAttributeFilter(TLV::TLVReader * tlvData
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _GroupState data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -754,7 +790,10 @@ void GroupKeyManagementClusterGroupKeysListAttributeFilter(TLV::TLVReader * tlvD
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _GroupKey data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -795,7 +834,10 @@ void MediaInputClusterMediaInputListListAttributeFilter(TLV::TLVReader * tlvData
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _MediaInputInfo data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -833,7 +875,10 @@ void OperationalCredentialsClusterFabricsListListAttributeFilter(TLV::TLVReader 
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _FabricDescriptor data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -877,7 +922,10 @@ void TvChannelClusterTvChannelListListAttributeFilter(TLV::TLVReader * tlvData, 
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _TvChannelInfo data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -919,7 +967,10 @@ void TargetNavigatorClusterTargetNavigatorListListAttributeFilter(TLV::TLVReader
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _NavigateTargetTargetInfo data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -951,7 +1002,10 @@ void TestClusterClusterListInt8uListAttributeFilter(TLV::TLVReader * tlvData, Ca
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     uint8_t data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -980,7 +1034,10 @@ void TestClusterClusterListOctetStringListAttributeFilter(TLV::TLVReader * tlvDa
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::ByteSpan data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_STATUS_VOID(ReadByteSpan(message, messageLen, &data[i]));
@@ -1010,7 +1067,10 @@ void TestClusterClusterListStructOctetStringListAttributeFilter(TLV::TLVReader *
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _TestListStructOctet data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(8);
@@ -1043,7 +1103,10 @@ void ThreadNetworkDiagnosticsClusterNeighborTableListListAttributeFilter(TLV::TL
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _NeighborTable data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(8);
@@ -1112,7 +1175,10 @@ void ThreadNetworkDiagnosticsClusterRouteTableListListAttributeFilter(TLV::TLVRe
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _RouteTable data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(8);
@@ -1169,7 +1235,10 @@ void ThreadNetworkDiagnosticsClusterSecurityPolicyListAttributeFilter(TLV::TLVRe
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _SecurityPolicy data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(2);
@@ -1202,7 +1271,10 @@ void ThreadNetworkDiagnosticsClusterOperationalDatasetComponentsListAttributeFil
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _OperationalDatasetComponents data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -1266,7 +1338,10 @@ void ThreadNetworkDiagnosticsClusterActiveNetworkFaultsListListAttributeFilter(T
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     uint8_t data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);

--- a/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
+++ b/zzz_generated/tv-app/zap-generated/CHIPClientCallbacks.cpp
@@ -369,7 +369,10 @@ void GeneralCommissioningClusterBasicCommissioningInfoListListAttributeFilter(TL
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _BasicCommissioningInfoType data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(4);
@@ -398,7 +401,10 @@ void OperationalCredentialsClusterFabricsListListAttributeFilter(TLV::TLVReader 
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     _FabricDescriptor data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_MESSAGE_LENGTH_VOID(1);
@@ -443,7 +449,10 @@ void OperationalCredentialsClusterTrustedRootCertificatesListAttributeFilter(TLV
 
     CHECK_MESSAGE_LENGTH_VOID(2);
     uint16_t count = Encoding::LittleEndian::Read16(message);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
     chip::ByteSpan data[count];
+#pragma GCC diagnostic pop
     for (size_t i = 0; i < count; i++)
     {
         CHECK_STATUS_VOID(ReadByteSpan(message, messageLen, &data[i]));


### PR DESCRIPTION
#### Problem
VLAs can be dangerous, especially when sized based on network inputs.

#### Change overview
Stop using VLAs in most places, whitelist a few places that are tracked by open issues, and add `-Wvla` so no more places will get added accidentally.

#### Testing
Compiles and passes CI.  No behavior changes.