### PR TITLE
Fix mis-spellings of "commissioning" and confusing CommissioningComplete documentation.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -515,9 +515,12 @@ public:
 
     /**
      *  This function call causes the DeviceCommissioner to send a
-     *  CommissioningComplete command to the given node.  At least sometimes.
-     *  Depending on which commissioning state machine we might or might not be
-     *  using.
+     *  CommissioningComplete command to the given node.  At least when
+     *  mIsIPRendezvous is false, which seems to be an incredibly broken
+     *  workaround for
+     *  <https://github.com/project-chip/connectedhomeip/issues/8010>.  Chances
+     *  are, this function and its callsites should just be removed when that
+     *  issue is fixed.
      */
     CHIP_ERROR CommissioningComplete(NodeId remoteDeviceId);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -514,8 +514,10 @@ public:
                                        uint8_t option);
 
     /**
-     *  This function call indicates commissioning complete and sends commissioining complete
-     *  complete event to the application.
+     *  This function call causes the DeviceCommissioner to send a
+     *  CommissioningComplete command to the given node.  At least sometimes.
+     *  Depending on which commissioning state machine we might or might not be
+     *  using.
      */
     CHIP_ERROR CommissioningComplete(NodeId remoteDeviceId);
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -98,8 +98,8 @@ ChipError::StorageType pychip_DeviceController_GetAddressAndPort(chip::Controlle
                                                                  uint16_t * outPort);
 ChipError::StorageType pychip_DeviceController_GetCompressedFabricId(chip::Controller::DeviceCommissioner * devCtrl,
                                                                      uint64_t * outFabricId);
-ChipError::StorageType pychip_DeviceController_CommissioiningComplete(chip::Controller::DeviceCommissioner * devCtrl,
-                                                                      chip::NodeId nodeId);
+ChipError::StorageType pychip_DeviceController_CommissioningComplete(chip::Controller::DeviceCommissioner * devCtrl,
+                                                                     chip::NodeId nodeId);
 ChipError::StorageType pychip_DeviceController_GetFabricId(chip::Controller::DeviceCommissioner * devCtrl, uint64_t * outFabricId);
 
 // Rendezvous
@@ -255,8 +255,8 @@ ChipError::StorageType pychip_DeviceController_GetCompressedFabricId(chip::Contr
     return CHIP_NO_ERROR.AsInteger();
 }
 
-ChipError::StorageType pychip_DeviceController_CommissioiningComplete(chip::Controller::DeviceCommissioner * devCtrl,
-                                                                      chip::NodeId nodeId)
+ChipError::StorageType pychip_DeviceController_CommissioningComplete(chip::Controller::DeviceCommissioner * devCtrl,
+                                                                     chip::NodeId nodeId)
 {
     return devCtrl->CommissioningComplete(nodeId).AsInteger();
 }

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -213,7 +213,7 @@ class ChipDeviceController(object):
 
     def CommissioningComplete(self, nodeid):
         return self._ChipStack.Call(
-            lambda: self._dmLib.pychip_DeviceController_CommissioiningComplete(
+            lambda: self._dmLib.pychip_DeviceController_CommissioningComplete(
                 self.devCtrl, nodeid)
         )
 


### PR DESCRIPTION
There is no 'i' between the 'o' and 'n'.

And DeviceCommissioner::CommissioningComplete sends commands, not
messages.  And not always.

#### Problem
See above

#### Change overview
Spelling and comment fixes.

#### Testing
No behavior changes expected.