### PR TITLE
Address some not-quite-resolved review comments from PR 8107

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -601,9 +601,6 @@ void Device::OnSessionEstablishmentError(CHIP_ERROR error)
 
 void Device::OnSessionEstablished()
 {
-    // TODO: the session should know which peer we are trying to connect to when started
-    mCASESession.SetPeerNodeId(mDeviceId);
-
     CHIP_ERROR err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &mCASESession,
                                                  SecureSession::SessionRole::kInitiator, mFabricIndex);
     if (err != CHIP_NO_ERROR)

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -90,6 +90,10 @@ public:
 
     virtual ~PASESession();
 
+    // TODO: The SetPeerNodeId method should not be exposed; we should not need
+    // to associate a node ID with a PASE session.
+    using PairingSession::SetPeerNodeId;
+
     /**
      * @brief
      *   Initialize using setup PIN code and wait for pairing requests.

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -40,13 +40,11 @@ public:
     // mPeerNodeId should be const and assigned at the construction, such that GetPeerNodeId will never return kUndefinedNodeId, and
     // SetPeerNodeId is not necessary.
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
-    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
 
     // TODO: the local key id should be allocateed at start
     // mLocalKeyId should be const and assigned at the construction, such that GetLocalKeyId will always return a valid key id , and
     // SetLocalKeyId is not necessary.
     uint16_t GetLocalKeyId() const { return mLocalKeyId; }
-    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
     bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
 
     uint16_t GetPeerKeyId() const
@@ -54,22 +52,11 @@ public:
         VerifyOrDie(mPeerKeyId.HasValue());
         return mPeerKeyId.Value();
     }
-    void SetPeerKeyId(uint16_t id) { mPeerKeyId.SetValue(id); }
     bool IsValidPeerKeyId() const { return mPeerKeyId.HasValue(); }
 
     // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     Transport::PeerAddress & GetPeerAddress() { return mPeerAddress; }
-    void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
-
-    // TODO: remove Clear, we should create a new instance instead reset the old instance.
-    void Clear()
-    {
-        mPeerNodeId  = kUndefinedNodeId;
-        mPeerAddress = Transport::PeerAddress::Uninitialized();
-        mPeerKeyId.ClearValue();
-        mLocalKeyId = kInvalidKeyId;
-    }
 
     /**
      * @brief
@@ -96,6 +83,21 @@ public:
     virtual const char * GetI2RSessionInfo() const = 0;
 
     virtual const char * GetR2ISessionInfo() const = 0;
+
+protected:
+    void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
+    void SetPeerKeyId(uint16_t id) { mPeerKeyId.SetValue(id); }
+    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
+    void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
+
+    // TODO: remove Clear, we should create a new instance instead reset the old instance.
+    void Clear()
+    {
+        mPeerNodeId  = kUndefinedNodeId;
+        mPeerAddress = Transport::PeerAddress::Uninitialized();
+        mPeerKeyId.ClearValue();
+        mLocalKeyId = kInvalidKeyId;
+    }
 
 private:
     NodeId mPeerNodeId = kUndefinedNodeId;


### PR DESCRIPTION
Just makes some PairingSession members that should only be used by
CASESession and PASESession protected.

#### Problem
Public setters for state that nothing outside the class and its subclasses should touch.

#### Change overview
Make the setters protected.

Also removes one place where we were setting the peer node id of a CASE session, since that gets set when the session is initialized.

#### Testing
Compiles, passes certification tests that use CASE and PASE.