### PR TITLE
Propagate the interface id from avahi in the Linux MDNS impl.

### DIFF
--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -605,8 +605,13 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
 
             Platform::CopyString(service.mName, name);
             CopyTypeWithoutProtocol(service.mType, type);
-            service.mProtocol               = GetProtocolInType(type);
-            service.mAddressType            = ToAddressType(protocol);
+            service.mProtocol    = GetProtocolInType(type);
+            service.mAddressType = ToAddressType(protocol);
+            service.mInterface   = INET_NULL_INTERFACEID;
+            if (interface != AVAHI_IF_UNSPEC)
+            {
+                service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
+            }
             service.mType[kMdnsTypeMaxSize] = 0;
             context->mServices.push_back(service);
         }
@@ -686,6 +691,11 @@ void MdnsAvahi::HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex inte
         result.mProtocol    = GetProtocolInType(type);
         result.mPort        = port;
         result.mAddressType = ToAddressType(protocol);
+        result.mInterface   = INET_NULL_INTERFACEID;
+        if (interface != AVAHI_IF_UNSPEC)
+        {
+            result.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
+        }
         Platform::CopyString(result.mHostName, host_name);
         // Returned value is full QName, want only host part.
         char * dot = strchr(result.mHostName, '.');


### PR DESCRIPTION
Without this resolving something to a link-local IP won't work right.

Fixes https://github.com/project-chip/connectedhomeip/issues/8232

Fix is by @samadDotDev

#### Problem
See above

#### Change overview
Propagate the interface ID from avahi to our code

#### Testing
Probably needs to be tested manually; we don't have CI tests for this so far...  I don't have a Linux box on hand to test with, but @samadDotDev confirmed that this fixes issues around link-local addresses for him.