### PR TITLE
Fix incorrect boundary condition for MakeZclCharString.

### DIFF
--- a/src/lib/support/ZclString.cpp
+++ b/src/lib/support/ZclString.cpp
@@ -19,9 +19,10 @@
 
 namespace chip {
 
-// ZCL strings are stored as pascal-strings (first byte contains the length of the
-// data), so the maximum string length is the maximum of uint8_t
-constexpr size_t kBufferMaximumSize = std::numeric_limits<uint8_t>::max();
+// ZCL strings are stored as pascal-strings (first byte contains the length of
+// the data), and a length of 255 means "invalid string" so the maximum actually
+// allowed string length is 254.
+constexpr size_t kBufferMaximumSize = 254;
 
 CHIP_ERROR MakeZclCharString(MutableByteSpan & buffer, const char * cString)
 {

--- a/src/lib/support/tests/TestZclString.cpp
+++ b/src/lib/support/tests/TestZclString.cpp
@@ -81,15 +81,29 @@ static void TestZclStringEqualsMaximumSize(nlTestSuite * inSuite, void * inConte
 {
     uint8_t bufferMemory[256];
     MutableByteSpan zclString(bufferMemory);
+    chip::Platform::ScopedMemoryBuffer<char> cString254;
+    NL_TEST_ASSERT(inSuite, cString254.Calloc(1024));
+    memset(cString254.Get(), 'A', 254);
+
+    CHIP_ERROR err = MakeZclCharString(zclString, cString254.Get());
+
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, zclString.data()[0] == 254);
+    NL_TEST_ASSERT(inSuite, allCharactersSame(zclString.data()) == true);
+}
+
+static void TestSizeZclStringBiggerThanMaximumSize_Length_255(nlTestSuite * inSuite, void * inContext)
+{
+    uint8_t bufferMemory[256];
+    MutableByteSpan zclString(bufferMemory);
     chip::Platform::ScopedMemoryBuffer<char> cString255;
     NL_TEST_ASSERT(inSuite, cString255.Calloc(1024));
     memset(cString255.Get(), 'A', 255);
 
     CHIP_ERROR err = MakeZclCharString(zclString, cString255.Get());
 
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, zclString.data()[0] == 255);
-    NL_TEST_ASSERT(inSuite, allCharactersSame(zclString.data()) == true);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG);
+    NL_TEST_ASSERT(inSuite, zclString.data()[0] == 0);
 }
 
 static void TestSizeZclStringBiggerThanMaximumSize_Length_256(nlTestSuite * inSuite, void * inContext)
@@ -148,6 +162,7 @@ int TestZclString_Teardown(void * inContext)
 static const nlTest sTests[] = { NL_TEST_DEF_FN(TestZclStringWhenBufferIsZero),
                                  NL_TEST_DEF_FN(TestZclStringLessThanMaximumSize_Length_64),
                                  NL_TEST_DEF_FN(TestZclStringEqualsMaximumSize),
+                                 NL_TEST_DEF_FN(TestSizeZclStringBiggerThanMaximumSize_Length_255),
                                  NL_TEST_DEF_FN(TestSizeZclStringBiggerThanMaximumSize_Length_256),
                                  NL_TEST_DEF_FN(TestZclStringBiggerThanMaximumSize_Length_257),
                                  NL_TEST_SENTINEL() };


### PR DESCRIPTION
A length of 255 is not valid for ZCL strings: it means "invalid string".

#### Problem
Invalid string length being allowed.

#### Change overview
Stop allowing it.

#### Testing
Unit tests updated.