### PR TITLE
Account for KVS collisions in NVM identifiers

### DIFF
--- a/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR RestoreFromFlash()
         {
             ChipLogProgress(DeviceLayer, "KVS, Error while restoring Matter key [%s] from flash with PDM id: %i", key_string_id,
                             pdm_internal_id);
-            break;
+            return err;
         }
 
         if (key_string_id_size)
@@ -162,7 +162,11 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
 
             if (iter == g_key_ids_set.end())
             {
-                assert(g_key_ids_set.size() < kMaxNumberOfKeys);
+                if (g_key_ids_set.size() >= kMaxNumberOfKeys)
+                {
+                    return CHIP_ERROR_NO_MEMORY;
+                }
+
                 g_key_ids_set.insert(key_id);
 
                 put_key = true;
@@ -188,20 +192,20 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
         if (err == CHIP_NO_ERROR)
         {
             pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + kMaxNumberOfKeys);
-            ChipLogProgress(DeviceLayer, "KVS, save in flash the Matter key [%s] with PDM id: %i", key,
-                            pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, save in flash the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
 
             err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueStr(pdm_internal_id, key, strlen(key));
 
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the Matter key [%s] with PDM id: %i",
-                                key, pdm_internal_id);
+                ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the Matter key [%s] with PDM id: %i", key,
+                                pdm_internal_id);
             }
         }
         else
         {
-            ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the value of the Matter key [%s] with PDM id: %i", key,
+                            pdm_internal_id);
         }
     }
 

--- a/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
@@ -24,8 +24,8 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <lib/support/CHIPMem.h>
-#include <platform/nxp/k32w/k32w0/K32W0Config.h>
 #include <platform/KeyValueStoreManager.h>
+#include <platform/nxp/k32w/k32w0/K32W0Config.h>
 #include <set>
 #include <string>
 
@@ -77,8 +77,8 @@ CHIP_ERROR RestoreFromFlash()
          */
 
         pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + kMaxNumberOfKeys);
-        err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueStr(pdm_internal_id, key_string_id,
-                                                                          kMaxKeyValueBytes, key_string_id_size);
+        err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueStr(pdm_internal_id, key_string_id, kMaxKeyValueBytes,
+                                                                          key_string_id_size);
 
         if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
@@ -87,7 +87,8 @@ CHIP_ERROR RestoreFromFlash()
         }
         else if (err != CHIP_NO_ERROR)
         {
-            ChipLogProgress(DeviceLayer, "KVS, Error while restoring Matter key [%s] from flash with PDM id: %i", key_string_id, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, Error while restoring Matter key [%s] from flash with PDM id: %i", key_string_id,
+                            pdm_internal_id);
             break;
         }
 
@@ -98,11 +99,13 @@ CHIP_ERROR RestoreFromFlash()
             if (!g_kvs_map.insert(std::make_pair(std::string(key_string_id), key_id)).second)
             {
                 /* key collision is not expected when restoring from flash */
-                ChipLogProgress(DeviceLayer, "KVS, Unexpected collision while restoring Matter key [%s] from flash with PDM id: %i", key_string_id, pdm_internal_id);
+                ChipLogProgress(DeviceLayer, "KVS, Unexpected collision while restoring Matter key [%s] from flash with PDM id: %i",
+                                key_string_id, pdm_internal_id);
             }
             else
             {
-                ChipLogProgress(DeviceLayer, "KVS, restored Matter key [%s] from flash with PDM id: %i", key_string_id, pdm_internal_id);
+                ChipLogProgress(DeviceLayer, "KVS, restored Matter key [%s] from flash with PDM id: %i", key_string_id,
+                                pdm_internal_id);
             }
         }
     }
@@ -118,18 +121,19 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     CHIP_ERROR err     = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     uint8_t pdm_id_kvs = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
     std::unordered_map<std::string, uint8_t>::const_iterator it;
-    size_t read_bytes = 0;
-    uint8_t key_id    = 0;
+    size_t read_bytes        = 0;
+    uint8_t key_id           = 0;
     uint16_t pdm_internal_id = 0;
 
     VerifyOrExit((key != NULL) && (value != NULL) && (RestoreFromFlash() == CHIP_NO_ERROR), err = CHIP_ERROR_INVALID_ARGUMENT);
 
     if ((it = g_kvs_map.find(key)) != g_kvs_map.end())
     {
-        key_id = it->second;
+        key_id          = it->second;
         pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id);
 
-        err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueBin(pdm_internal_id, (uint8_t *) value, value_size, read_bytes);
+        err =
+            chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueBin(pdm_internal_id, (uint8_t *) value, value_size, read_bytes);
         *read_bytes_size = read_bytes;
 
         ChipLogProgress(DeviceLayer, "KVS, get Matter key [%s] with PDM id: %i", key, pdm_internal_id);
@@ -175,7 +179,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     if (put_key)
     {
         pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id);
-        ChipLogProgress(DeviceLayer, "KVS, save in flash Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+        ChipLogProgress(DeviceLayer, "KVS, save in flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
 
         g_kvs_map.insert(std::make_pair(std::string(key), key_id));
         err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueBin(pdm_internal_id, (uint8_t *) value, value_size);
@@ -184,18 +188,20 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
         if (err == CHIP_NO_ERROR)
         {
             pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + kMaxNumberOfKeys);
-            ChipLogProgress(DeviceLayer, "KVS, save in flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, save in flash the Matter key [%s] with PDM id: %i", key,
+                            pdm_internal_id);
 
             err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueStr(pdm_internal_id, key, strlen(key));
 
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+                ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the Matter key [%s] with PDM id: %i",
+                                key, pdm_internal_id);
             }
         }
         else
         {
-            ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, Error while saving in flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
         }
     }
 
@@ -207,15 +213,15 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 {
     CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     std::unordered_map<std::string, uint8_t>::const_iterator it;
-    uint8_t pdm_id_kvs = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
-    uint8_t key_id     = 0;
+    uint8_t pdm_id_kvs       = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
+    uint8_t key_id           = 0;
     uint16_t pdm_internal_id = 0;
 
     VerifyOrExit((key != NULL) && (RestoreFromFlash() == CHIP_NO_ERROR), err = CHIP_ERROR_INVALID_ARGUMENT);
 
     if ((it = g_kvs_map.find(key)) != g_kvs_map.end())
     {
-        key_id = it->second;
+        key_id          = it->second;
         pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id);
 
         g_key_ids_set.erase(key_id);
@@ -228,18 +234,22 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
         if (err == CHIP_NO_ERROR)
         {
             pdm_internal_id = chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + kMaxNumberOfKeys);
-            ChipLogProgress(DeviceLayer, "KVS, delete from flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, delete from flash the value of the Matter key [%s] with PDM id: %i", key,
+                            pdm_internal_id);
 
             err = chip::DeviceLayer::Internal::K32WConfig::ClearConfigValue(pdm_internal_id);
 
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogProgress(DeviceLayer, "KVS, Error while deleting from flash the value of the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+                ChipLogProgress(DeviceLayer,
+                                "KVS, Error while deleting from flash the value of the Matter key [%s] with PDM id: %i", key,
+                                pdm_internal_id);
             }
         }
         else
         {
-            ChipLogProgress(DeviceLayer, "KVS, Error while deleting from flash the Matter key [%s] with PDM id: %i", key, pdm_internal_id);
+            ChipLogProgress(DeviceLayer, "KVS, Error while deleting from flash the Matter key [%s] with PDM id: %i", key,
+                            pdm_internal_id);
         }
     }
 

--- a/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
@@ -24,39 +24,104 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <lib/support/CHIPMem.h>
-#include <platform/KeyValueStoreManager.h>
 #include <platform/nxp/k32w/k32w0/K32W0Config.h>
+#include <platform/KeyValueStoreManager.h>
+#include <set>
 #include <string>
 
 #include "PDM.h"
+
+#include <unordered_map>
 
 namespace chip {
 namespace DeviceLayer {
 namespace PersistedStorage {
 
 /* TODO: adjust this value */
-#define MAX_NO_OF_KEYS 255
+#define MAX_NO_OF_KEYS 20
 
 KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
+
+/* hashmap having:
+ * 	- the matter key string as key;
+ * 	- internal PDM identifier as value;
+ */
+std::unordered_map<std::string, uint8_t> g_kvs_map;
+
+/* list containing used PDM identifiers */
+std::list<uint8_t> g_key_ids_list;
+
+/* max no of bytes for a key */
+#define MAX_KEY_VALUE 255
+
+/* used to check if we need to restore values from flash (e.g.: reset) */
+static bool g_restored_from_flash = FALSE;
+
+CHIP_ERROR RestoreFromFlash()
+{
+    CHIP_ERROR err                    = CHIP_NO_ERROR;
+    uint8_t key_id                    = 0;
+    char key_string_id[MAX_KEY_VALUE] = { 0 };
+    size_t key_string_id_size         = 0;
+    uint8_t pdm_id_kvs                = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
+
+    if (g_restored_from_flash)
+    {
+        /* already restored from flash, nothing to do */
+        return err;
+    }
+
+    for (key_id = 0; key_id < MAX_NO_OF_KEYS; key_id++)
+    {
+        /* key was saved as string in flash (key_string_id) using (key_id + MAX_NO_OF_KEYS) as PDM key
+         * value corresponding to key_string_id was saved in flash using key_id as PDM key
+         */
+
+        err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueStr(
+            chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + MAX_NO_OF_KEYS), key_string_id, MAX_KEY_VALUE,
+            key_string_id_size);
+
+        if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+        {
+            continue;
+        }
+
+        if (key_string_id_size)
+        {
+            g_key_ids_list.push_back(key_id);
+            g_kvs_map.insert(std::make_pair(std::string(key_string_id), key_id));
+            key_string_id_size = 0;
+
+            ChipLogProgress(DeviceLayer, "KVS, restored key [%s] from flash with PDM key: %i", key_string_id, key_id);
+        }
+    }
+
+    g_restored_from_flash = TRUE;
+
+    return err;
+}
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,
                                           size_t offset_bytes)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    std::hash<std::string> hash_fn;
-    uint16_t key_id;
+    CHIP_ERROR err     = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     uint8_t pdm_id_kvs = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
-    size_t read_bytes;
+    std::unordered_map<std::string, uint8_t>::const_iterator it;
+    size_t read_bytes = 0;
+    uint8_t key_id    = 0;
 
-    VerifyOrExit((key != NULL) && (value != NULL), err = CHIP_ERROR_INVALID_ARGUMENT);
-    key_id = hash_fn(key) % MAX_NO_OF_KEYS;
+    VerifyOrExit((key != NULL) && (value != NULL) && (RestoreFromFlash() == CHIP_NO_ERROR), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    ChipLogProgress(DeviceLayer, "KVS, get key id:: %i", key_id);
+    if ((it = g_kvs_map.find(key)) != g_kvs_map.end())
+    {
+        key_id = it->second;
 
-    err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueBin(
-        chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id), (uint8_t *) value, value_size, read_bytes);
+        err = chip::DeviceLayer::Internal::K32WConfig::ReadConfigValueBin(
+            chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id), (uint8_t *) value, value_size, read_bytes);
+        *read_bytes_size = read_bytes;
 
-    *read_bytes_size = read_bytes;
+        ChipLogProgress(DeviceLayer, "KVS, get key [%s] with PDM key: %i", key, key_id);
+    }
 
 exit:
     return err;
@@ -64,18 +129,51 @@ exit:
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    std::hash<std::string> hash_fn;
-    uint16_t key_id;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+    uint8_t key_id;
+    bool_t put_key     = FALSE;
     uint8_t pdm_id_kvs = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
+    std::unordered_map<std::string, uint8_t>::const_iterator it;
 
-    VerifyOrExit((key != NULL) && (value != NULL), err = CHIP_ERROR_INVALID_ARGUMENT);
-    key_id = hash_fn(key) % MAX_NO_OF_KEYS;
+    VerifyOrExit((key != NULL) && (value != NULL) && (RestoreFromFlash() == CHIP_NO_ERROR), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    ChipLogProgress(DeviceLayer, "KVS, put key id:: %i", key_id);
+    if ((it = g_kvs_map.find(key)) == g_kvs_map.end()) /* new key */
+    {
+        for (key_id = 0; key_id < MAX_NO_OF_KEYS; key_id++)
+        {
+            std::list<uint8_t>::iterator iter = std::find(g_key_ids_list.begin(), g_key_ids_list.end(), key_id);
 
-    err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueBin(
-        chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id), (uint8_t *) value, value_size);
+            if (iter == g_key_ids_list.end())
+            {
+                g_key_ids_list.push_back(key_id);
+
+                put_key = TRUE;
+                break;
+            }
+        }
+    }
+    else /* overwrite key */
+    {
+        put_key = TRUE;
+        key_id  = it->second;
+    }
+
+    if (put_key)
+    {
+        ChipLogProgress(DeviceLayer, "KVS, put key [%s] with PDM key: %i", key, key_id);
+
+        g_kvs_map.insert(std::make_pair(std::string(key), key_id));
+        err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueBin(
+            chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id), (uint8_t *) value, value_size);
+
+        /* save the 'key' in flash such that it can be retrieved later on */
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(DeviceLayer, "KVS, save in flash key [%s] with PDM key: %i", key, key_id + MAX_NO_OF_KEYS);
+            err = chip::DeviceLayer::Internal::K32WConfig::WriteConfigValueStr(
+                chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + MAX_NO_OF_KEYS), key, strlen(key));
+        }
+    }
 
 exit:
     return err;
@@ -83,17 +181,31 @@ exit:
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    std::hash<std::string> hash_fn;
-    uint16_t key_id;
+    CHIP_ERROR err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    std::unordered_map<std::string, uint8_t>::const_iterator it;
     uint8_t pdm_id_kvs = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVS;
+    uint8_t key_id     = 0;
 
-    VerifyOrExit(key != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
-    key_id = hash_fn(key) % MAX_NO_OF_KEYS;
+    VerifyOrExit((key != NULL) && (RestoreFromFlash() == CHIP_NO_ERROR), err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    ChipLogProgress(DeviceLayer, "KVS, deleting key id:: %i", key_id);
+    if ((it = g_kvs_map.find(key)) != g_kvs_map.end())
+    {
+        key_id = it->second;
+        g_key_ids_list.remove(key_id);
+        g_kvs_map.erase(it);
 
-    err = chip::DeviceLayer::Internal::K32WConfig::ClearConfigValue(chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id));
+        ChipLogProgress(DeviceLayer, "KVS, delete key [%s] with PDM key: %i", key, key_id);
+        err = chip::DeviceLayer::Internal::K32WConfig::ClearConfigValue(
+            chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id));
+
+        /* also delete the 'key string' from flash */
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(DeviceLayer, "KVS, delete key [%s] with PDM key: %i", key, key_id + MAX_NO_OF_KEYS);
+            err = chip::DeviceLayer::Internal::K32WConfig::ClearConfigValue(
+                chip::DeviceLayer::Internal::K32WConfigKey(pdm_id_kvs, key_id + MAX_NO_OF_KEYS));
+        }
+    }
 
 exit:
     return err;


### PR DESCRIPTION
#### Problem
* Old implementation was not taking into account collisions.

#### Change overview
* The new implementation keeps an unordered hash having as keys the matter keys and as values the key ids used as NVM identifiers. Used key ids are saved in a list which is updated at each Put/Delete operation.

#### Testing
* manual testing