### PR TITLE
support different dhcp client in Linux

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -39,6 +39,10 @@
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.cpp>
 #endif
 
+#ifndef CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD
+#define CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD "dhclient -nw %s"
+#endif
+
 using namespace ::chip;
 using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
@@ -945,7 +949,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
             // Run dhclient for IP on WiFi.
             // TODO: The wifi can be managed by networkmanager on linux so we don't have to care about this.
             char cmdBuffer[128];
-            sprintf(cmdBuffer, "dhclient -nw %s", CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
+            sprintf(cmdBuffer, CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
             int dhclientSystemRet = system(cmdBuffer);
             if (dhclientSystemRet != 0)
             {


### PR DESCRIPTION
Some Linux environment like Yocto has no dhclient tool set.
So add a macro named CHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD to config
the command which used to query the IP address from the DHCP server.

The macro didn't added into CHIPDeviceConfig.h due it is only used for Linux and by default the command is reset to using "dhclient".

For example in Yocto arm64 cross compile :
#Yocto using udhcpc to fetch IP and DNS info
PLATFORM_CFLAGS='-DCHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME=\"mlan0\"", "-DCHIP_DEVICE_CONFIG_LINUX_DHCPC_CMD=\"udhcpc -b -i %s & \"'
PKG_CONFIG_SYSROOT_DIR=${PKG_CONFIG_SYSROOT_DIR} \
            PKG_CONFIG_LIBDIR=${PKG_CONFIG_PATH} \
            gn gen out/aarch64 --args="target_os=\"linux\" target_cpu=\"arm64\" arm_arch=\"armv8-a\"
                import(\"//build_overrides/build.gni\")
                target_cflags=[ \"--sysroot=${SDKTARGETSYSROOT}\", \"${PLATFORM_CFLAGS}\" ]
                target_ldflags = [ \"--sysroot=${SDKTARGETSYSROOT}\" ]
                custom_toolchain=\"\${build_root}/toolchain/custom\"
                target_cc=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc\"
                target_cxx=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++\"
                target_ar=\"${OECORE_NATIVE_SYSROOT}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-ar\""

Signed-off-by: Haoran Wang <elven.wang@nxp.com>

