### PR TITLE
Mbed optimize debug

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -20,7 +20,7 @@ declare_args() {
   optimize_for_size = true
 
   # Optimize debug builds with -Og.
-  optimize_debug = current_os == "freertos" || current_os == "zephyr"
+  optimize_debug = current_os == "freertos" || current_os == "zephyr" || current_os == "mbed"
 
   # Symbol level for debugging.
   symbol_level = 2

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -20,7 +20,8 @@ declare_args() {
   optimize_for_size = true
 
   # Optimize debug builds with -Og.
-  optimize_debug = current_os == "freertos" || current_os == "zephyr" || current_os == "mbed"
+  optimize_debug =
+      current_os == "freertos" || current_os == "zephyr" || current_os == "mbed"
 
   # Symbol level for debugging.
   symbol_level = 2


### PR DESCRIPTION
#### Problem
Now, Mbed debug profile use the -O0 (no optimization for building application). We want to use more debug-specific optimization with -Og option. The best way will be to set the optimize_debug flag for the Mbed platform.

#### Change overview
Add optimize debug builds with -Og for Mbed platform

#### Testing
Build and run Mbed examples with debug profile
