### PR TITLE
Fix compilation with CHIP_CONFIG_SECURITY_TEST_MODE by updating OpenThread API usage

### DIFF
--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -131,10 +131,15 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
         }
 #if CHIP_CONFIG_SECURITY_TEST_MODE
         {
+#if OPENTHREAD_API_VERSION >= 126
+            const otNetworkKey * otKey = otThreadGetNetworkKey(otInst);
+            for (int i = 0; i < OT_NETWORK_KEY_SIZE; i++)
+#else
             const otMasterKey * otKey = otThreadGetMasterKey(otInst);
             for (int i = 0; i < OT_MASTER_KEY_SIZE; i++)
+#endif
                 snprintf(&strBuf[i * 2], 3, "%02X", otKey->m8[i]);
-            ChipLogDetail(DeviceLayer, "   Master Key: %s", strBuf);
+            ChipLogDetail(DeviceLayer, "   Network Key: %s", strBuf);
         }
 #endif // CHIP_CONFIG_SECURITY_TEST_MODE
     }


### PR DESCRIPTION
#### Problem
* Fix compilation when `CHIP_CONFIG_SECURITY_TEST_MODE` is set.
* Fixes #9084

#### Change overview
I changed the code to replace `otMasterKey` usage with  `otNetworkKey` if the OpenThread version is >= 126. The log message will always output `Network Key: ` for consistency.

#### Testing
* I successfully compiled the [lock-app example for the cc13x2x7_26x2x7 platform](https://github.com/project-chip/connectedhomeip/tree/master/examples/lock-app/cc13x2x7_26x2x7), which has `CHIP_CONFIG_SECURITY_TEST_MODE` set. (With hardware-accelerated sha256 disabled to circumvent #9176)