### PR TITLE
Don't clobber chip-tool error

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -121,6 +121,10 @@ int Commands::Run(int argc, char ** argv)
 #endif // !CONFIG_USE_SEPARATE_EVENTLOOP
 
 exit:
+#if CONFIG_USE_SEPARATE_EVENTLOOP
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+#endif // CONFIG_USE_SEPARATE_EVENTLOOP
+
     if ((err == CHIP_NO_ERROR) && (command != nullptr))
     {
         err = command->GetCommandExitStatus();
@@ -129,10 +133,6 @@ exit:
     {
         ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err));
     }
-
-#if CONFIG_USE_SEPARATE_EVENTLOOP
-    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
-#endif // CONFIG_USE_SEPARATE_EVENTLOOP
 
     if (command)
     {

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -121,6 +121,10 @@ int Commands::Run(int argc, char ** argv)
 #endif // !CONFIG_USE_SEPARATE_EVENTLOOP
 
 exit:
+    if ((err == CHIP_NO_ERROR) && (command != nullptr))
+    {
+        err = command->GetCommandExitStatus();
+    }
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err));
@@ -129,15 +133,6 @@ exit:
 #if CONFIG_USE_SEPARATE_EVENTLOOP
     chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
 #endif // CONFIG_USE_SEPARATE_EVENTLOOP
-
-    if (command)
-    {
-        err = command->GetCommandExitStatus();
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(chipTool, "Run command failure: %s", chip::ErrorStr(err));
-        }
-    }
 
     if (command)
     {


### PR DESCRIPTION
#### Problem

82cf1b132f22 (PR #9086) could clobber a returned error code with a
different value `GetCommandExitStatus()`, which could lead to `chip-tool`
exiting successfully when it shouldn't. (This doesn't actually happen
at present because nothing sets `err` after `RunCommand()`, but could
be triggered by otherwise innocuous code changes.)

#### Change overview

Check for an existing error in preference to `GetCommandExitStatus()`.

#### Testing

Manual run of `chip-tool` with edits.
