### PR TITLE
Allow create object with non-default constructor in SystemPool

### DIFF
--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -65,7 +65,7 @@ DLL_EXPORT void Object::Release()
     }
 }
 
-DLL_EXPORT bool Object::TryCreate(size_t aOctets)
+DLL_EXPORT bool Object::TryCreate()
 {
     if (!__sync_bool_compare_and_swap(&this->mRefCount, 0, 1))
     {
@@ -73,7 +73,6 @@ DLL_EXPORT bool Object::TryCreate(size_t aOctets)
     }
 
     this->AppState = nullptr;
-    memset(reinterpret_cast<char *>(this) + sizeof(*this), 0, aOctets - sizeof(*this));
 
     return true;
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, there are some limitations to put an Object into the SystemPool, the Object need to have a default constructor defined, also a separate init function to initialize the Object. This limits the usage of SystemPool to only those classes which meets those pre-conditions.

* We need to Allow create object with non-default constructor in SystemPool,  so  a typical usage will look like:

```
     *           class Foo: public Object {
     *              Foo(int a, int b, int c)
     *           ...}
     *           ....
     *           Foo foo;
     *           foo.TryCreate(a, b, c);
```

#### Change overview
Allow create object with non-default constructor in SystemPool

#### Testing
How was this tested? (at least one bullet point required)
* covered by unit tests added
