### PR TITLE
Invoke python3.8 directly for for add-repository since python3.9 does not work

### DIFF
--- a/integrations/docker/images/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/chip-build-cirque/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
        curl gnupg-agent apt-transport-https ca-certificates \
        software-properties-common \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && add-apt-repository \
+    && python3.8 `which add-apt-repository` \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \


### PR DESCRIPTION
#### Problem
Python 3.9 is selected as the default python, however `apt-add-repository` does not work with 3.9.

#### Change overview
Invoke python 3.8 explicitly instead of relying in the `#!/usr/bin/python3` in the script

#### Testing
Docker file builds.
