### PR TITLE
Fix mbedos docker build (fixes "ERROR: Cannot uninstall PyYAML. It is…

### DIFF
--- a/integrations/docker/images/chip-build-mbed-os/Dockerfile
+++ b/integrations/docker/images/chip-build-mbed-os/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x \
 # Install Python modules
 RUN set -x \
     && pip3 install --no-cache-dir -U mbed-cli mbed-tools \
-    && pip3 install --no-cache-dir -r /opt/mbed-os/requirements.txt \
+    && pip3 install --no-cache-dir --ignore-installed -r /opt/mbed-os/requirements.txt \
     && : # last line
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
… a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.")

#### Problem
MbedOS docker build does not work (PyYAML fails to be installed/upgraded)

#### Change overview
Pass in `--ignore-installed` to pip install when adding mbedos dependencies

#### Testing
Docker file builds.
