### PR TITLE
Updated ASN1Writer Methods to Use Safe Methods on TLVReader.

### DIFF
--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -711,7 +711,7 @@ CHIP_ERROR ConvertX509CertToChipCert(const ByteSpan x509Cert, MutableByteSpan & 
     VerifyOrReturnError(!x509Cert.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(CanCastTo<uint32_t>(x509Cert.size()), CHIP_ERROR_INVALID_ARGUMENT);
 
-    reader.Init(x509Cert.data(), static_cast<uint32_t>(x509Cert.size()));
+    reader.Init(x509Cert);
 
     writer.Init(chipCert);
 
@@ -737,8 +737,8 @@ CHIP_ERROR ConvertX509CertsToChipCertArray(const ByteSpan & x509NOC, const ByteS
     ReturnErrorOnFailure(writer.StartContainer(AnonymousTag, kTLVType_Array, outerContainer));
 
     ASN1Reader reader;
-    VerifyOrReturnError(CanCastTo<uint32_t>(x509NOC.size()), CHIP_ERROR_INVALID_ARGUMENT);
-    reader.Init(x509NOC.data(), static_cast<uint32_t>(x509NOC.size()));
+    reader.Init(x509NOC);
+
     uint64_t nocIssuer, nocSubject;
     Optional<uint64_t> nocFabric;
     ReturnErrorOnFailure(ConvertCertificate(reader, writer, AnonymousTag, nocIssuer, nocSubject, nocFabric));

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -842,7 +842,7 @@ DLL_EXPORT CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, Mutable
 
     reader.Init(chipCert);
 
-    writer.Init(x509Cert.data(), static_cast<uint32_t>(x509Cert.size()));
+    writer.Init(x509Cert);
 
     certData.Clear();
 

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -415,15 +415,14 @@ CHIP_ERROR NewChipX509Cert(const X509CertRequestParams & requestParams, Certific
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     ASN1Writer writer;
-    uint32_t size = static_cast<uint32_t>(std::min(static_cast<size_t>(UINT32_MAX), x509Cert.size()));
-    writer.Init(x509Cert.data(), size);
+    writer.Init(x509Cert);
 
     ReturnErrorOnFailure(EncodeTBSCert(requestParams, issuerLevel, subject, subjectPubkey, issuerKeypair.Pubkey(), writer));
 
     Crypto::P256ECDSASignature signature;
     ReturnErrorOnFailure(issuerKeypair.ECDSA_sign_msg(x509Cert.data(), writer.GetLengthWritten(), signature));
 
-    writer.Init(x509Cert.data(), size);
+    writer.Init(x509Cert);
 
     ASN1_START_SEQUENCE
     {

--- a/src/lib/asn1/ASN1.h
+++ b/src/lib/asn1/ASN1.h
@@ -32,6 +32,7 @@
 
 #include <lib/asn1/ASN1Error.h>
 #include <lib/support/DLLUtil.h>
+#include <lib/support/Span.h>
 
 namespace chip {
 namespace TLV {
@@ -101,7 +102,13 @@ struct ASN1UniversalTime
 class DLL_EXPORT ASN1Reader
 {
 public:
-    void Init(const uint8_t * buf, uint32_t len);
+    void Init(const uint8_t * buf, size_t len);
+    void Init(const ByteSpan & data) { Init(data.data(), data.size()); }
+    template <size_t N>
+    void Init(const uint8_t (&data)[N])
+    {
+        Init(data, N);
+    }
 
     uint8_t GetClass(void) const { return Class; };
     uint32_t GetTag(void) const { return Tag; };
@@ -162,7 +169,13 @@ private:
 class DLL_EXPORT ASN1Writer
 {
 public:
-    void Init(uint8_t * buf, uint32_t maxLen);
+    void Init(uint8_t * buf, size_t maxLen);
+    void Init(const MutableByteSpan & data) { Init(data.data(), data.size()); }
+    template <size_t N>
+    void Init(uint8_t (&data)[N])
+    {
+        Init(data, N);
+    }
     void InitNullWriter(void);
     uint16_t GetLengthWritten(void) const;
 
@@ -173,10 +186,10 @@ public:
     CHIP_ERROR PutString(uint32_t tag, const char * val, uint16_t valLen);
     CHIP_ERROR PutOctetString(const uint8_t * val, uint16_t valLen);
     CHIP_ERROR PutOctetString(uint8_t cls, uint32_t tag, const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & val);
+    CHIP_ERROR PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & tlvReader);
     CHIP_ERROR PutBitString(uint32_t val);
     CHIP_ERROR PutBitString(uint8_t unusedBits, const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutBitString(uint8_t unusedBits, chip::TLV::TLVReader & val);
+    CHIP_ERROR PutBitString(uint8_t unusedBits, chip::TLV::TLVReader & tlvReader);
     CHIP_ERROR PutTime(const ASN1UniversalTime & val);
     CHIP_ERROR PutNull(void);
     CHIP_ERROR PutConstructedType(const uint8_t * val, uint16_t valLen);
@@ -185,7 +198,7 @@ public:
     CHIP_ERROR StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding);
     CHIP_ERROR EndEncapsulatedType(void);
     CHIP_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & val);
+    CHIP_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader);
 
 private:
     static constexpr size_t kMaxDeferredLengthDepth = kMaxConstructedAndEncapsulatedTypesDepth;
@@ -200,6 +213,7 @@ private:
     CHIP_ERROR WriteDeferredLength(void);
     static uint8_t BytesForLength(int32_t len);
     static void EncodeLength(uint8_t * buf, uint8_t bytesForLen, int32_t lenToEncode);
+    void WriteData(const uint8_t * p, size_t len);
 };
 
 OID ParseObjectID(const uint8_t * encodedOID, uint16_t encodedOIDLen);

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -34,7 +34,7 @@
 namespace chip {
 namespace ASN1 {
 
-void ASN1Reader::Init(const uint8_t * buf, uint32_t len)
+void ASN1Reader::Init(const uint8_t * buf, size_t len)
 {
     ResetElementState();
     mBuf              = buf;

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -32,10 +32,12 @@
 
 #include <lib/asn1/ASN1.h>
 #include <lib/asn1/ASN1Macros.h>
+#include <lib/core/CHIPTLV.h>
 #include <lib/support/UnitTestRegistration.h>
 
 using namespace chip;
 using namespace chip::ASN1;
+using namespace chip::TLV;
 
 enum
 {
@@ -63,6 +65,7 @@ enum
 };
 
 // clang-format off
+static uint8_t kTestVal_09_BitString_AsOctetString[] = { 0xE7, 0xC0 };
 static uint8_t kTestVal_20_OctetString[]        = { 0x01, 0x03, 0x05, 0x07, 0x10, 0x30, 0x50, 0x70, 0x00 };
 static const char * kTestVal_21_PrintableString = "Sudden death in Venice";
 static const char * kTestVal_22_UTFString       = "Ond bra\xCC\x8A""d do\xCC\x88""d i Venedig";
@@ -154,11 +157,11 @@ exit:
 static void TestASN1_Encode(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
-    uint8_t buf[2048];
+    static uint8_t buf[2048];
     ASN1Writer writer;
     uint16_t encodedLen;
 
-    writer.Init(buf, sizeof(buf));
+    writer.Init(buf);
 
     err = EncodeASN1TestData(writer);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -188,7 +191,7 @@ static void TestASN1_Decode(nlTestSuite * inSuite, void * inContext)
     int64_t intVal;
     OID oidVal;
 
-    reader.Init(TestASN1_EncodedData, sizeof(TestASN1_EncodedData));
+    reader.Init(TestASN1_EncodedData);
 
     ASN1_PARSE_ENTER_SEQUENCE
     {
@@ -301,7 +304,7 @@ static void TestASN1_NullWriter(nlTestSuite * inSuite, void * inContext)
 static void TestASN1_ObjectID(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
-    uint8_t buf[2048];
+    static uint8_t buf[2048];
     ASN1Writer writer;
     ASN1Reader reader;
     uint16_t encodedLen;
@@ -362,6 +365,122 @@ exit:
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+static void TestASN1_FromTLVReader(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    static uint8_t tlvBuf[128];
+    static uint8_t asn1Buf1[128];
+    static uint8_t asn1Buf2[128];
+    TLVWriter tlvWriter;
+    TLVReader tlvReader;
+    ASN1Writer writer;
+    ASN1Reader reader;
+    MutableByteSpan tlvEncodedData(tlvBuf);
+    MutableByteSpan asn1EncodedData1(asn1Buf1);
+    MutableByteSpan asn1EncodedData2(asn1Buf2);
+    TLVType outerContainerType;
+
+    // Construct TLV Encoded Structure.
+    {
+        tlvWriter.Init(tlvEncodedData);
+
+        err = tlvWriter.StartContainer(AnonymousTag, kTLVType_Structure, outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvWriter.PutBytes(TLV::ContextTag(1), kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvWriter.PutBytes(TLV::ContextTag(2), kTestVal_09_BitString_AsOctetString,
+                                 sizeof(kTestVal_09_BitString_AsOctetString));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvWriter.PutString(TLV::ContextTag(3), kTestVal_21_PrintableString);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvWriter.EndContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvWriter.Finalize();
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+
+    // Construct first ASN1 SEQUESNCE using values.
+    writer.Init(asn1EncodedData1);
+    ASN1_START_SEQUENCE
+    {
+        ASN1_ENCODE_OCTET_STRING(kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString));
+
+        ASN1_ENCODE_BIT_STRING(kTestVal_09_BitString);
+
+        err = writer.PutValue(kASN1TagClass_Universal, kASN1UniversalTag_PrintableString, false,
+                              reinterpret_cast<const uint8_t *>(kTestVal_21_PrintableString), strlen(kTestVal_21_PrintableString));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+    ASN1_END_SEQUENCE;
+    asn1EncodedData1.reduce_size(writer.GetLengthWritten());
+
+    // Construct second ASN1 SEQUENCE from TLVReader.
+    tlvReader.Init(tlvEncodedData);
+    writer.Init(asn1EncodedData2);
+    ASN1_START_SEQUENCE
+    {
+        err = tlvReader.Next(kTLVType_Structure, AnonymousTag);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvReader.EnterContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvReader.Next(kTLVType_ByteString, ContextTag(1));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.PutOctetString(kASN1TagClass_Universal, kASN1UniversalTag_OctetString, tlvReader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvReader.Next(kTLVType_ByteString, ContextTag(2));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.PutBitString(6, tlvReader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvReader.Next(kTLVType_UTF8String, ContextTag(3));
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = writer.PutValue(kASN1TagClass_Universal, kASN1UniversalTag_PrintableString, false, tlvReader);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        err = tlvReader.ExitContainer(outerContainerType);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    }
+    ASN1_END_SEQUENCE;
+    asn1EncodedData2.reduce_size(writer.GetLengthWritten());
+
+    // Compare two ASN1 SEQUENCEs.
+    NL_TEST_ASSERT(inSuite, asn1EncodedData2.data_equal(asn1EncodedData1));
+
+    // Initialize ASN1Reader and test data.
+    reader.Init(asn1EncodedData2);
+    ASN1_PARSE_ENTER_SEQUENCE
+    {
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_OctetString);
+        NL_TEST_ASSERT(inSuite, reader.GetValue() != nullptr);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == sizeof(kTestVal_20_OctetString));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), kTestVal_20_OctetString, sizeof(kTestVal_20_OctetString)) == 0);
+
+        uint32_t val;
+        ASN1_PARSE_BIT_STRING(val);
+        NL_TEST_ASSERT(inSuite, val == kTestVal_09_BitString);
+
+        ASN1_PARSE_ELEMENT(kASN1TagClass_Universal, kASN1UniversalTag_PrintableString);
+        NL_TEST_ASSERT(inSuite, reader.GetValue() != nullptr);
+        NL_TEST_ASSERT(inSuite, reader.GetValueLen() == strlen(kTestVal_21_PrintableString));
+        NL_TEST_ASSERT(inSuite, memcmp(reader.GetValue(), kTestVal_21_PrintableString, strlen(kTestVal_21_PrintableString)) == 0);
+    }
+    ASN1_EXIT_SEQUENCE;
+
+exit:
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -373,6 +492,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Test ASN1 decoding macros", TestASN1_Decode),
     NL_TEST_DEF("Test ASN1 NULL writer", TestASN1_NullWriter),
     NL_TEST_DEF("Test ASN1 Object IDs", TestASN1_ObjectID),
+    NL_TEST_DEF("Test ASN1 Init with ByteSpan", TestASN1_FromTLVReader),
     NL_TEST_SENTINEL()
 };
 // clang-format on


### PR DESCRIPTION
 #### Problem
ASN1Writer uses unsafe methods on TLVReader.

Ticket: #9299 

#### Change overview
-- Replaced unsafe GetLength() and GetBytes() methods on TLVReader with
    safe Get(ByteSpan & v), which performs length/data sanity checks.
 -- Added new ASN1 methods to initialize ASN1Writer and ASN1Reader
    from ByteSpan and arrays.

#### Testing
Unit tests