### PR TITLE
Make System::Layer mockable

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -217,7 +217,7 @@ void IdentifyTimerHandler(Layer * systemLayer, void * appState)
 
     if (identifyTimerCount)
     {
-        SystemLayer.StartTimer(kIdentifyTimerDelayMS, IdentifyTimerHandler, appState);
+        systemLayer->StartTimer(kIdentifyTimerDelayMS, IdentifyTimerHandler, appState);
         // Decrement the timer count.
         identifyTimerCount--;
     }
@@ -235,8 +235,8 @@ void DeviceCallbacks::OnIdentifyPostAttributeChangeCallback(EndpointId endpointI
     // Also, we want timerCount to be odd number, so the ligth state ends in the same state it starts.
     identifyTimerCount = (*value) * 4;
 
-    SystemLayer.CancelTimer(IdentifyTimerHandler, this);
-    SystemLayer.StartTimer(kIdentifyTimerDelayMS, IdentifyTimerHandler, this);
+    DeviceLayer::SystemLayer().CancelTimer(IdentifyTimerHandler, this);
+    DeviceLayer::SystemLayer().StartTimer(kIdentifyTimerDelayMS, IdentifyTimerHandler, this);
 
 exit:
     return;

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -423,7 +423,7 @@ static void OnResponseTimeout(chip::System::Layer *, void *)
 
 CHIP_ERROR Command::ScheduleWaitForResponse(uint16_t seconds)
 {
-    CHIP_ERROR err = chip::DeviceLayer::SystemLayer.StartTimer(seconds * 1000, OnResponseTimeout, this);
+    CHIP_ERROR err = chip::DeviceLayer::SystemLayer().StartTimer(seconds * 1000, OnResponseTimeout, this);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(chipTool, "Failed to allocate timer %" CHIP_ERROR_FORMAT, err.Format());

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -54,5 +54,5 @@ void TestCommand::OnWaitForMsFn(chip::System::Layer * systemLayer, void * contex
 
 CHIP_ERROR TestCommand::WaitForMs(uint32_t ms)
 {
-    return chip::DeviceLayer::SystemLayer.StartTimer(ms, OnWaitForMsFn, this);
+    return chip::DeviceLayer::SystemLayer().StartTimer(ms, OnWaitForMsFn, this);
 }

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -374,7 +374,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
 
 void AppTask::CancelTimer()
 {
-    SystemLayer.CancelTimer(TimerEventHandler, this);
+    SystemLayer().CancelTimer(TimerEventHandler, this);
     mFunctionTimerActive = false;
 }
 
@@ -382,7 +382,7 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 {
     CHIP_ERROR err;
 
-    err = SystemLayer.StartTimer(aTimeoutInMs, TimerEventHandler, this);
+    err = SystemLayer().StartTimer(aTimeoutInMs, TimerEventHandler, this);
     SuccessOrExit(err);
 
     mFunctionTimerActive = true;

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -389,7 +389,7 @@ void AppTask::FunctionHandler(AppEvent * aEvent)
 
 void AppTask::CancelTimer()
 {
-    SystemLayer.CancelTimer(TimerEventHandler, this);
+    chip::DeviceLayer::SystemLayer().CancelTimer(TimerEventHandler, this);
     mFunctionTimerActive = false;
 }
 
@@ -397,8 +397,8 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 {
     CHIP_ERROR err;
 
-    SystemLayer.CancelTimer(TimerEventHandler, this);
-    err = SystemLayer.StartTimer(aTimeoutInMs, TimerEventHandler, this);
+    chip::DeviceLayer::SystemLayer().CancelTimer(TimerEventHandler, this);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(aTimeoutInMs, TimerEventHandler, this);
     SuccessOrExit(err);
 
     mFunctionTimerActive = true;

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -326,9 +326,9 @@ int main(int argc, char ** args)
 
     BroadcastPacket(&mdnsServer);
 
-    CHIP_ERROR err = DeviceLayer::SystemLayer.StartTimer(
+    CHIP_ERROR err = DeviceLayer::SystemLayer().StartTimer(
         gOptions.runtimeMs,
-        [](System::Layer *, void *, CHIP_ERROR err) {
+        [](System::Layer *, void *) {
             DeviceLayer::PlatformMgr().StopEventLoopTask();
             DeviceLayer::PlatformMgr().Shutdown();
         },

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char * argv[])
 
     BitFlags<TransferControlFlags> bdxFlags;
     bdxFlags.Set(TransferControlFlags::kReceiverDrive);
-    err = bdxServer.PrepareForTransfer(&chip::DeviceLayer::SystemLayer, chip::bdx::TransferRole::kSender, bdxFlags,
+    err = bdxServer.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender, bdxFlags,
                                        kMaxBdxBlockSize, kBdxTimeoutMs, kBdxPollFreqMs);
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -151,7 +151,7 @@ Transport::PeerAddress GetEchoPeerAddress()
 
 void Shutdown()
 {
-    chip::DeviceLayer::SystemLayer.CancelTimer(EchoTimerHandler, NULL);
+    chip::DeviceLayer::SystemLayer().CancelTimer(EchoTimerHandler, NULL);
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
@@ -212,7 +212,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
     }
 
     gPingArguments.SetLastEchoTime(System::Clock::GetMonotonicMilliseconds());
-    SuccessOrExit(chip::DeviceLayer::SystemLayer.StartTimer(gPingArguments.GetEchoInterval(), EchoTimerHandler, NULL));
+    SuccessOrExit(chip::DeviceLayer::SystemLayer().StartTimer(gPingArguments.GetEchoInterval(), EchoTimerHandler, NULL));
 
     streamer_printf(stream, "\nSend echo request message with payload size: %d bytes to Node: %" PRIu64 "\n", payloadSize,
                     kTestDeviceNodeId);
@@ -226,7 +226,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
     }
     else
     {
-        chip::DeviceLayer::SystemLayer.CancelTimer(EchoTimerHandler, NULL);
+        chip::DeviceLayer::SystemLayer().CancelTimer(EchoTimerHandler, NULL);
     }
 
 exit:
@@ -306,7 +306,7 @@ void StartPinging(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer, &gTCPManager, &gFabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &gFabrics, &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);
@@ -315,7 +315,7 @@ void StartPinging(streamer_t * stream, char * destination)
     else
 #endif
     {
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer, &gUDPManager, &gFabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &gFabrics, &gMessageCounterManager);
         SuccessOrExit(err);
 
         err = gExchangeManager.Init(&gSessionManager);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -227,7 +227,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer, &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -235,7 +235,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
     {
         peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
 
-        err = gSessionManager.Init(&DeviceLayer::SystemLayer, &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -73,7 +73,7 @@ void RequestUserDirectedCommissioning(System::SocketEvents events, intptr_t data
     int selectedCommissionerNumber = CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES;
     scanf("%d", &selectedCommissionerNumber);
     printf("%d\n", selectedCommissionerNumber);
-    chip::DeviceLayer::SystemLayer.StopWatchingSocket(&token);
+    chip::DeviceLayer::SystemLayerSockets().StopWatchingSocket(&token);
 
     const Mdns::DiscoveredNodeData * selectedCommissioner =
         commissionableNodeController.GetDiscoveredCommissioner(selectedCommissionerNumber - 1);
@@ -105,9 +105,10 @@ void InitCommissioningFlow(intptr_t commandArg)
         int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
         VerifyOrReturn(fcntl(0, F_SETFL, flags | O_NONBLOCK) == 0,
                        ChipLogError(Zcl, "Could not set non-blocking mode for user input!"));
-        ReturnOnFailure(chip::DeviceLayer::SystemLayer.StartWatchingSocket(STDIN_FILENO, &token));
-        ReturnOnFailure(chip::DeviceLayer::SystemLayer.SetCallback(token, RequestUserDirectedCommissioning, (intptr_t) NULL));
-        ReturnOnFailure(chip::DeviceLayer::SystemLayer.RequestCallbackOnPendingRead(token));
+        ReturnOnFailure(chip::DeviceLayer::SystemLayerSockets().StartWatchingSocket(STDIN_FILENO, &token));
+        ReturnOnFailure(
+            chip::DeviceLayer::SystemLayerSockets().SetCallback(token, RequestUserDirectedCommissioning, (intptr_t) NULL));
+        ReturnOnFailure(chip::DeviceLayer::SystemLayerSockets().RequestCallbackOnPendingRead(token));
     }
     else
     {
@@ -127,7 +128,7 @@ int main(int argc, char * argv[])
                       Mdns::DiscoveryFilter(Mdns::DiscoveryFilterType::kDeviceType, kTvDeviceType)));
 
     // Give commissioners some time to respond and then ScheduleWork to initiate commissioning
-    DeviceLayer::SystemLayer.StartTimer(
+    DeviceLayer::SystemLayer().StartTimer(
         commissionerDiscoveryTimeoutInMs,
         [](System::Layer *, void *) { chip::DeviceLayer::PlatformMgr().ScheduleWork(InitCommissioningFlow); }, nullptr);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -286,7 +286,7 @@ CHIP_ERROR OpenBasicCommissioningWindow(ResetFabrics resetFabrics, uint16_t comm
     if (commissioningTimeoutSeconds != kNoCommissioningTimeout)
     {
         ReturnErrorOnFailure(
-            DeviceLayer::SystemLayer.StartTimer(commissioningTimeoutSeconds * 1000, HandlePairingWindowTimeout, nullptr));
+            DeviceLayer::SystemLayer().StartTimer(commissioningTimeoutSeconds * 1000, HandlePairingWindowTimeout, nullptr));
     }
 
     return CHIP_NO_ERROR;
@@ -313,7 +313,7 @@ CHIP_ERROR OpenEnhancedCommissioningWindow(uint16_t commissioningTimeoutSeconds,
     if (commissioningTimeoutSeconds != kNoCommissioningTimeout)
     {
         ReturnErrorOnFailure(
-            DeviceLayer::SystemLayer.StartTimer(commissioningTimeoutSeconds * 1000, HandlePairingWindowTimeout, nullptr));
+            DeviceLayer::SystemLayer().StartTimer(commissioningTimeoutSeconds * 1000, HandlePairingWindowTimeout, nullptr));
     }
 
     return CHIP_NO_ERROR;
@@ -384,7 +384,7 @@ void InitServer(AppDelegate * delegate)
 
     SuccessOrExit(err);
 
-    err = gSessions.Init(&DeviceLayer::SystemLayer, &gTransports, &gFabrics, &gMessageCounterManager);
+    err = gSessions.Init(&DeviceLayer::SystemLayer(), &gTransports, &gFabrics, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeMgr.Init(&gSessions);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -325,12 +325,12 @@ void CommandRequestTimerHandler(chip::System::Layer * systemLayer, void * appSta
         err = SendCommandRequest(commandSender);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to send command request with error: %s\n", chip::ErrorStr(err)));
 
-        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, CommandRequestTimerHandler, NULL);
+        err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, CommandRequestTimerHandler, NULL);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
     }
     else
     {
-        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, BadCommandRequestTimerHandler, NULL);
+        err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, BadCommandRequestTimerHandler, NULL);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
     }
 
@@ -351,7 +351,7 @@ void BadCommandRequestTimerHandler(chip::System::Layer * systemLayer, void * app
     err = SendBadCommandRequest(commandSender);
     VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to send bad command request with error: %s\n", chip::ErrorStr(err)));
 
-    err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, ReadRequestTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, ReadRequestTimerHandler, NULL);
     VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
 
 exit:
@@ -378,12 +378,12 @@ void ReadRequestTimerHandler(chip::System::Layer * systemLayer, void * appState)
         err = SendReadRequest();
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to send read request with error: %s\n", chip::ErrorStr(err)));
 
-        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, ReadRequestTimerHandler, NULL);
+        err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, ReadRequestTimerHandler, NULL);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
     }
     else
     {
-        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, WriteRequestTimerHandler, NULL);
+        err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, WriteRequestTimerHandler, NULL);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
     }
 
@@ -415,7 +415,7 @@ void WriteRequestTimerHandler(chip::System::Layer * systemLayer, void * appState
         err = SendWriteRequest(writeClient);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to send write request with error: %s\n", chip::ErrorStr(err)));
 
-        err = chip::DeviceLayer::SystemLayer.StartTimer(gMessageIntervalMsec, WriteRequestTimerHandler, NULL);
+        err = chip::DeviceLayer::SystemLayer().StartTimer(gMessageIntervalMsec, WriteRequestTimerHandler, NULL);
         VerifyOrExit(err == CHIP_NO_ERROR, printf("Failed to schedule timer with error: %s\n", chip::ErrorStr(err)));
     }
     else
@@ -583,7 +583,7 @@ int main(int argc, char * argv[])
                                      .SetListenPort(IM_CLIENT_PORT));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &fabrics, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);
@@ -599,7 +599,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = chip::DeviceLayer::SystemLayer.StartTimer(0, CommandRequestTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(0, CommandRequestTimerHandler, NULL);
     SuccessOrExit(err);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -177,7 +177,7 @@ int main(int argc, char * argv[])
         chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gTransportManager, &fabrics, &gMessageCounterManager);
+    err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTransportManager, &fabrics, &gMessageCounterManager);
     SuccessOrExit(err);
 
     err = gExchangeManager.Init(&gSessionManager);

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -148,7 +148,7 @@ EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t de
     {
         control->status = EMBER_EVENT_MS_TIME;
 #if !CHIP_DEVICE_LAYER_NONE
-        chip::DeviceLayer::SystemLayer.StartTimer(delayMs, EventControlHandler, control);
+        chip::DeviceLayer::SystemLayer().StartTimer(delayMs, EventControlHandler, control);
 #endif
     }
     else
@@ -164,7 +164,7 @@ void emberEventControlSetInactive(EmberEventControl * control)
     {
         control->status = EMBER_EVENT_INACTIVE;
 #if !CHIP_DEVICE_LAYER_NONE
-        chip::DeviceLayer::SystemLayer.CancelTimer(EventControlHandler, control);
+        chip::DeviceLayer::SystemLayer().CancelTimer(EventControlHandler, control);
 #endif
     }
 }
@@ -178,7 +178,7 @@ void emberEventControlSetActive(EmberEventControl * control)
 {
     control->status = EMBER_EVENT_ZERO_DELAY;
 #if !CHIP_DEVICE_LAYER_NONE
-    chip::DeviceLayer::SystemLayer.ScheduleWork(EventControlHandler, control);
+    chip::DeviceLayer::SystemLayer().ScheduleWork(EventControlHandler, control);
 #endif
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 #if CONFIG_DEVICE_LAYER
         ReturnErrorOnFailure(DeviceLayer::PlatformMgr().InitChipStack());
 
-        mSystemLayer = &DeviceLayer::SystemLayer;
+        mSystemLayer = &DeviceLayer::SystemLayer();
         mInetLayer   = &DeviceLayer::InetLayer;
 #endif // CONFIG_DEVICE_LAYER
     }

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -98,7 +98,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         chip::Controller::CommissionerInitParams params;
 
         params.storageDelegate = &gServerStorage;
-        params.systemLayer     = &chip::DeviceLayer::SystemLayer;
+        params.systemLayer     = &chip::DeviceLayer::SystemLayer();
         params.inetLayer       = &chip::DeviceLayer::InetLayer;
         params.pairingDelegate = &gPairingDelegate;
 

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -45,8 +45,27 @@ namespace chip {
 namespace DeviceLayer {
 
 struct ChipDeviceEvent;
-extern chip::System::LayerImpl SystemLayer;
 extern Inet::InetLayer InetLayer;
+
+inline chip::System::Layer & SystemLayer()
+{
+    extern chip::System::Layer * globalSystemLayer;
+    return *globalSystemLayer;
+}
+
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+inline chip::System::LayerSockets & SystemLayerSockets()
+{
+    extern chip::System::Layer * globalSystemLayer;
+    return *static_cast<chip::System::LayerSockets *>(globalSystemLayer);
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
+
+inline void SetSystemLayerForTesting(System::Layer * layer)
+{
+    extern chip::System::Layer * globalSystemLayer;
+    globalSystemLayer = layer;
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/CHIPDeviceLayer.h
+++ b/src/include/platform/CHIPDeviceLayer.h
@@ -44,27 +44,28 @@
 namespace chip {
 namespace DeviceLayer {
 
+namespace Internal {
+extern chip::System::Layer * gSystemLayer;
+} // namespace Internal
+
 struct ChipDeviceEvent;
 extern Inet::InetLayer InetLayer;
 
 inline chip::System::Layer & SystemLayer()
 {
-    extern chip::System::Layer * globalSystemLayer;
-    return *globalSystemLayer;
+    return *Internal::gSystemLayer;
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 inline chip::System::LayerSockets & SystemLayerSockets()
 {
-    extern chip::System::Layer * globalSystemLayer;
-    return *static_cast<chip::System::LayerSockets *>(globalSystemLayer);
+    return *static_cast<chip::System::LayerSockets *>(Internal::gSystemLayer);
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 inline void SetSystemLayerForTesting(System::Layer * layer)
 {
-    extern chip::System::Layer * globalSystemLayer;
-    globalSystemLayer = layer;
+    Internal::gSystemLayer = layer;
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -40,11 +40,10 @@
 namespace chip {
 namespace DeviceLayer {
 
-extern chip::System::Layer * globalSystemLayer;
-
 namespace Internal {
 
-extern chip::System::LayerImpl staticSystemLayer;
+extern chip::System::Layer * gSystemLayer;
+extern chip::System::LayerImpl gSystemLayerImpl;
 
 extern CHIP_ERROR InitEntropy();
 
@@ -76,11 +75,11 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     SuccessOrExit(err);
 
     // Initialize the CHIP system layer.
-    if (globalSystemLayer == nullptr)
+    if (gSystemLayer == nullptr)
     {
-        globalSystemLayer = &staticSystemLayer;
+        gSystemLayer = &gSystemLayerImpl;
     }
-    err = globalSystemLayer->Init();
+    err = gSystemLayer->Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
@@ -88,7 +87,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     SuccessOrExit(err);
 
     // Initialize the CHIP Inet layer.
-    err = InetLayer.Init(*globalSystemLayer, nullptr);
+    err = InetLayer.Init(*gSystemLayer, nullptr);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "InetLayer initialization failed: %s", ErrorStr(err));
@@ -146,7 +145,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 #endif
 
     ChipLogError(DeviceLayer, "System Layer shutdown");
-    err = globalSystemLayer->Shutdown();
+    err = gSystemLayer->Shutdown();
 
     return err;
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
@@ -138,7 +138,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
 
                 // Call into the system layer to dispatch the callback functions for all timers
                 // that have expired.
-                err = SystemLayer.HandlePlatformTimer();
+                err = static_cast<System::LayerImplLwIP &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
                 if (err != CHIP_NO_ERROR)
                 {
                     ChipLogError(DeviceLayer, "Error handling CHIP timers: %s", ErrorStr(err));

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -43,9 +43,15 @@
 #include <unistd.h>
 
 namespace chip {
-
 namespace DeviceLayer {
 namespace Internal {
+
+namespace {
+System::LayerSocketsLoop & SystemLayerSocketsLoop()
+{
+    return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer());
+}
+} // anonymous namespace
 
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
@@ -116,7 +122,7 @@ bool GenericPlatformManagerImpl_POSIX<ImplClass>::_IsChipStackLockedByCurrentThr
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartChipTimer(int64_t aMilliseconds)
 {
-    // Let SystemLayer.PrepareEvents() handle timers.
+    // Let System::LayerSocketsLoop.PrepareEvents() handle timers.
     return CHIP_NO_ERROR;
 }
 
@@ -125,7 +131,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_PostEvent(const ChipDeviceEve
 {
     mChipEventQueue.Push(*event);
 
-    SystemLayer.Signal(); // Trigger wake select on CHIP thread
+    SystemLayerSocketsLoop().Signal(); // Trigger wake select on CHIP thread
 }
 
 template <class ImplClass>
@@ -160,20 +166,20 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_RunEventLoop()
 
     Impl()->LockChipStack();
 
-    SystemLayer.EventLoopBegins();
+    SystemLayerSocketsLoop().EventLoopBegins();
     do
     {
-        SystemLayer.PrepareEvents();
+        SystemLayerSocketsLoop().PrepareEvents();
 
         Impl()->UnlockChipStack();
-        SystemLayer.WaitForEvents();
+        SystemLayerSocketsLoop().WaitForEvents();
         Impl()->LockChipStack();
 
-        SystemLayer.HandleEvents();
+        SystemLayerSocketsLoop().HandleEvents();
 
         ProcessDeviceEvents();
     } while (mShouldRunEventLoop.load(std::memory_order_relaxed));
-    SystemLayer.EventLoopEnds();
+    SystemLayerSocketsLoop().EventLoopEnds();
 
     Impl()->UnlockChipStack();
 
@@ -251,10 +257,10 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
 
         //
         // We need to grab the lock to protect critical sections accessed by the WakeSelect() call within
-        // SystemLayer.
+        // System::Layer.
         //
         Impl()->LockChipStack();
-        SystemLayer.Signal();
+        SystemLayerSocketsLoop().Signal();
         Impl()->UnlockChipStack();
 
         pthread_mutex_lock(&mStateLock);

--- a/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.cpp
+++ b/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.cpp
@@ -265,7 +265,7 @@ CHIP_ERROR GenericSoftwareUpdateManagerImpl<ImplClass>::_CheckNow(void)
         if (mState == SoftwareUpdateManager::kState_ScheduledHoldoff)
         {
             // Cancel scheduled hold off and trigger software update prepare.
-            SystemLayer.CancelTimer(HandleHoldOffTimerExpired, NULL);
+            DeviceLayer::SystemLayer().CancelTimer(HandleHoldOffTimerExpired, NULL);
         }
 
         {
@@ -633,7 +633,7 @@ void GenericSoftwareUpdateManagerImpl<ImplClass>::DriveState(SoftwareUpdateManag
             if (timeToNextQueryMS)
             {
                 mState = SoftwareUpdateManager::kState_ScheduledHoldoff;
-                SystemLayer.StartTimer(timeToNextQueryMS, HandleHoldOffTimerExpired, NULL);
+                DeviceLayer::SystemLayer().StartTimer(timeToNextQueryMS, HandleHoldOffTimerExpired, NULL);
             }
         }
     }

--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -44,7 +44,7 @@
 
 /*
  * If the CHIP_SYSTEM_CONFIG_TRANSFER_INETLAYER_PROJECT_CONFIGURATION option is not applicable, then the "InetProjectConfig.h"
- * header was not included by <SystemLayer/SystemConfig.h> and therefore it must be included here.
+ * header was not included by <system/SystemConfig.h> and therefore it must be included here.
  */
 #if !CHIP_SYSTEM_CONFIG_TRANSFER_INETLAYER_PROJECT_CONFIGURATION
 

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -185,7 +185,7 @@ public:
     // Must be called before System::Layer::Shutdown(), since this holds a pointer to that.
     CHIP_ERROR Shutdown();
 
-    chip::System::Layer * SystemLayer() const;
+    chip::System::Layer * SystemLayer() const { return mSystemLayer; }
 
     // End Points
 
@@ -308,11 +308,6 @@ private:
 
     bool IsIdleTimerRunning();
 };
-
-inline chip::System::Layer * InetLayer::SystemLayer() const
-{
-    return mSystemLayer;
-}
 
 /**
  *  @class IPPacketInfo

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -77,7 +77,7 @@ void EchoTimerHandler(chip::System::Layer * systemLayer, void * appState);
 
 void Shutdown()
 {
-    chip::DeviceLayer::SystemLayer.CancelTimer(EchoTimerHandler, NULL);
+    chip::DeviceLayer::SystemLayer().CancelTimer(EchoTimerHandler, NULL);
     gEchoClient.Shutdown();
     ShutdownChip();
 }
@@ -123,7 +123,7 @@ CHIP_ERROR SendEchoRequest()
 
     gLastEchoTime = chip::System::Clock::GetMonotonicMilliseconds();
 
-    err = chip::DeviceLayer::SystemLayer.StartTimer(gEchoInterval, EchoTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(gEchoInterval, EchoTimerHandler, NULL);
     if (err != CHIP_NO_ERROR)
     {
         printf("Unable to schedule timer\n");
@@ -141,7 +141,7 @@ CHIP_ERROR SendEchoRequest()
     else
     {
         printf("Send echo request failed, err: %s\n", chip::ErrorStr(err));
-        chip::DeviceLayer::SystemLayer.CancelTimer(EchoTimerHandler, NULL);
+        chip::DeviceLayer::SystemLayer().CancelTimer(EchoTimerHandler, NULL);
     }
 
     return err;
@@ -234,7 +234,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -244,7 +244,7 @@ int main(int argc, char * argv[])
                                    .SetListenPort(ECHO_CLIENT_PORT));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 
@@ -264,7 +264,7 @@ int main(int argc, char * argv[])
     // Arrange to get a callback whenever an Echo Response is received.
     gEchoClient.SetEchoResponseReceived(HandleEchoResponseReceived);
 
-    err = chip::DeviceLayer::SystemLayer.StartTimer(0, EchoTimerHandler, NULL);
+    err = chip::DeviceLayer::SystemLayer().StartTimer(0, EchoTimerHandler, NULL);
     SuccessOrExit(err);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[])
             chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gTCPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gTCPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
     else
@@ -98,7 +98,7 @@ int main(int argc, char * argv[])
             chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
         SuccessOrExit(err);
 
-        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer, &gUDPManager, &fabrics, &gMessageCounterManager);
+        err = gSessionManager.Init(&chip::DeviceLayer::SystemLayer(), &gUDPManager, &fabrics, &gMessageCounterManager);
         SuccessOrExit(err);
     }
 

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     BleApplicationDelegateImpl * appDelegate   = new BleApplicationDelegateImpl();
     BleConnectionDelegateImpl * connDelegate   = new BleConnectionDelegateImpl();
     BlePlatformDelegateImpl * platformDelegate = new BlePlatformDelegateImpl();
-    err                                        = BleLayer::Init(platformDelegate, connDelegate, appDelegate, &SystemLayer);
+    err = BleLayer::Init(platformDelegate, connDelegate, appDelegate, &DeviceLayer::SystemLayer());
     return err;
 }
 

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     err = Internal::GenericPlatformManagerImpl<PlatformManagerImpl>::_InitChipStack();
     SuccessOrExit(err);
 
-    SystemLayer.SetDispatchQueue(GetWorkQueue());
+    static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()).SetDispatchQueue(GetWorkQueue());
 
 exit:
     return err;

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -52,13 +52,13 @@ void DeviceControlServer::CommissioningFailedTimerComplete()
 CHIP_ERROR DeviceControlServer::ArmFailSafe(uint16_t expiryLengthSeconds)
 {
     uint32_t timerMs = expiryLengthSeconds * 1000;
-    SystemLayer.StartTimer(timerMs, HandleArmFailSafe, this);
+    DeviceLayer::SystemLayer().StartTimer(timerMs, HandleArmFailSafe, this);
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceControlServer::DisarmFailSafe()
 {
-    SystemLayer.CancelTimer(HandleArmFailSafe, this);
+    DeviceLayer::SystemLayer().CancelTimer(HandleArmFailSafe, this);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -159,7 +159,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     sl_status_t ret;
 
     // Initialize the CHIP BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     memset(mBleConnections, 0, sizeof(mBleConnections));

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(WiFiStationMode val)
         err              = Internal::ESP32Utils::SetAPMode(autoConnect);
         SuccessOrExit(err);
 
-        SystemLayer.ScheduleWork(DriveStationState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
     }
 
     if (mWiFiStationMode != val)
@@ -119,8 +119,8 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
         memset(&stationConfig, 0, sizeof(stationConfig));
         esp_wifi_set_config(WIFI_IF_STA, &stationConfig);
 
-        SystemLayer.ScheduleWork(DriveStationState, NULL);
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -137,7 +137,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 
     mWiFiAPMode = val;
 
-    SystemLayer.ScheduleWork(DriveAPState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 
 exit:
     return err;
@@ -148,7 +148,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP(void)
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -157,7 +157,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         mLastAPDemandTime = 0;
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -175,7 +175,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP(void)
 void ConnectivityManagerImpl::_SetWiFiAPIdleTimeoutMS(uint32_t val)
 {
     mWiFiAPIdleTimeoutMS = val;
-    SystemLayer.ScheduleWork(DriveAPState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 }
 
 #define WIFI_BAND_2_4GHZ 2400
@@ -442,8 +442,8 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     ReturnErrorOnFailure(Internal::ESP32Utils::SetAPMode(false));
 
     // Queue work items to bootstrap the AP and station state machines once the Chip event loop is running.
-    ReturnErrorOnFailure(SystemLayer.ScheduleWork(DriveStationState, NULL));
-    ReturnErrorOnFailure(SystemLayer.ScheduleWork(DriveAPState, NULL));
+    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL));
+    ReturnErrorOnFailure(DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL));
 
     return CHIP_NO_ERROR;
 }
@@ -527,13 +527,13 @@ void ConnectivityManagerImpl::_OnWiFiScanDone()
 {
     // Schedule a call to DriveStationState method in case a station connect attempt was
     // deferred because the scan was in progress.
-    SystemLayer.ScheduleWork(DriveStationState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 }
 
 void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
 {
     // Schedule a call to the DriveStationState method to adjust the station state as needed.
-    SystemLayer.ScheduleWork(DriveStationState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 }
 
 // ==================== ConnectivityManager Private Methods ====================
@@ -642,7 +642,7 @@ void ConnectivityManagerImpl::DriveStationState()
 
                 ChipLogProgress(DeviceLayer, "Next WiFi station reconnect in %" PRIu32 " ms", timeToNextConnect);
 
-                ReturnOnFailure(SystemLayer.StartTimer(timeToNextConnect, DriveStationState, NULL));
+                ReturnOnFailure(DeviceLayer::SystemLayer().StartTimer(timeToNextConnect, DriveStationState, NULL));
             }
         }
     }
@@ -765,7 +765,7 @@ void ConnectivityManagerImpl::DriveAPState()
                 // Compute the amount of idle time before the AP should be deactivated and
                 // arm a timer to fire at that time.
                 apTimeout = (uint32_t)((mLastAPDemandTime + mWiFiAPIdleTimeoutMS) - now);
-                err       = SystemLayer.StartTimer(apTimeout, DriveAPState, NULL);
+                err       = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, NULL);
                 SuccessOrExit(err);
                 ChipLogProgress(DeviceLayer, "Next WiFi AP timeout in %" PRIu32 " ms", apTimeout);
             }

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
 
     // Initialize the Chip BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     memset(mCons, 0, sizeof(mCons));
@@ -176,8 +176,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        ReturnErrorOnFailure(SystemLayer.StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
-        ReturnErrorOnFailure(SystemLayer.StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
+        ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
+        ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
     }
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);
     mFlags.Set(Flags::kAdvertisingRefreshNeeded, 1);

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -126,7 +126,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
 
     // Initialize the Chip BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     mRXCharAttrHandle     = 0;
@@ -170,8 +170,8 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
     if (val)
     {
         mAdvertiseStartTime = System::Clock::GetMonotonicMilliseconds();
-        ReturnErrorOnFailure(SystemLayer.StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
-        ReturnErrorOnFailure(SystemLayer.StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
+        ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(kAdvertiseTimeout, HandleAdvertisementTimer, this));
+        ReturnErrorOnFailure(DeviceLayer::SystemLayer().StartTimer(kFastAdvertiseTimeout, HandleFastAdvertisementTimer, this));
     }
 
     mFlags.Set(Flags::kFastAdvertisingEnabled, val);

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -25,11 +25,12 @@
 namespace chip {
 namespace DeviceLayer {
 
-chip::System::LayerImpl SystemLayer;
+chip::System::Layer * globalSystemLayer = nullptr;
 chip::Inet::InetLayer InetLayer;
 
 namespace Internal {
 
+chip::System::LayerImpl staticSystemLayer;
 const char * const TAG = "CHIP[DL]";
 
 } // namespace Internal

--- a/src/platform/Globals.cpp
+++ b/src/platform/Globals.cpp
@@ -25,12 +25,12 @@
 namespace chip {
 namespace DeviceLayer {
 
-chip::System::Layer * globalSystemLayer = nullptr;
 chip::Inet::InetLayer InetLayer;
 
 namespace Internal {
 
-chip::System::LayerImpl staticSystemLayer;
+chip::System::Layer * gSystemLayer = nullptr;
+chip::System::LayerImpl gSystemLayerImpl;
 const char * const TAG = "CHIP[DL]";
 
 } // namespace Internal

--- a/src/platform/K32W/BLEManagerImpl.cpp
+++ b/src/platform/K32W/BLEManagerImpl.cpp
@@ -155,7 +155,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     VerifyOrExit(!mFlags.Has(Flags::kK32WBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
 
     // Initialize the Chip BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     (void) RNG_Init();

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -75,7 +75,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err;
 
-    err = BleLayer::Init(this, this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
@@ -715,7 +715,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
 void BLEManagerImpl::CleanScanConfig()
 {
     if (mBLEScanConfig.mBleScanState == BleScanState::kConnecting)
-        DeviceLayer::SystemLayer.CancelTimer(HandleConnectTimeout, mpEndpoint);
+        DeviceLayer::SystemLayer().CancelTimer(HandleConnectTimeout, mpEndpoint);
 
     mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
 }
@@ -803,7 +803,7 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::Chi
     }
 
     mBLEScanConfig.mBleScanState = BleScanState::kConnecting;
-    DeviceLayer::SystemLayer.StartTimer(kConnectTimeoutMs, HandleConnectTimeout, mpEndpoint);
+    DeviceLayer::SystemLayer().StartTimer(kConnectTimeoutMs, HandleConnectTimeout, mpEndpoint);
     mDeviceScanner->StopScan();
 
     ConnectDevice(device, mpEndpoint);

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -404,7 +404,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
         ChipLogProgress(DeviceLayer, "WiFi AP mode change: %s -> %s", WiFiAPModeToStr(mWiFiAPMode), WiFiAPModeToStr(val));
         mWiFiAPMode = val;
 
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 
 exit:
@@ -417,7 +417,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP()
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand start WiFi AP");
         mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
     else
     {
@@ -431,7 +431,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand stop WiFi AP");
         mLastAPDemandTime = 0;
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
     else
     {
@@ -453,7 +453,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP()
 void ConnectivityManagerImpl::_SetWiFiAPIdleTimeoutMS(uint32_t val)
 {
     mWiFiAPIdleTimeoutMS = val;
-    SystemLayer.ScheduleWork(DriveAPState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
@@ -688,7 +688,7 @@ void ConnectivityManagerImpl::DriveAPState()
                 // Compute the amount of idle time before the AP should be deactivated and
                 // arm a timer to fire at that time.
                 apTimeout = (uint32_t)((mLastAPDemandTime + mWiFiAPIdleTimeoutMS) - now);
-                err       = SystemLayer.StartTimer(apTimeout, DriveAPState, NULL);
+                err       = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, NULL);
                 SuccessOrExit(err);
                 ChipLogProgress(DeviceLayer, "Next WiFi AP timeout in %" PRIu32 " s", apTimeout / 1000);
             }

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -163,9 +163,9 @@ AvahiWatch * Poller::WatchNew(int fd, AvahiWatchEvent event, AvahiWatchCallback 
 
     auto watch     = std::make_unique<AvahiWatch>();
     watch->mSocket = fd;
-    LogErrorOnFailure(DeviceLayer::SystemLayer.StartWatchingSocket(fd, &watch->mSocketWatch));
-    LogErrorOnFailure(DeviceLayer::SystemLayer.SetCallback(watch->mSocketWatch, AvahiWatchCallbackTrampoline,
-                                                           reinterpret_cast<intptr_t>(watch.get())));
+    LogErrorOnFailure(DeviceLayer::SystemLayerSockets().StartWatchingSocket(fd, &watch->mSocketWatch));
+    LogErrorOnFailure(DeviceLayer::SystemLayerSockets().SetCallback(watch->mSocketWatch, AvahiWatchCallbackTrampoline,
+                                                                    reinterpret_cast<intptr_t>(watch.get())));
     WatchUpdate(watch.get(), event);
     watch->mCallback = callback;
     watch->mContext  = context;
@@ -179,19 +179,19 @@ void Poller::WatchUpdate(AvahiWatch * watch, AvahiWatchEvent event)
 {
     if (event & AVAHI_WATCH_IN)
     {
-        LogErrorOnFailure(DeviceLayer::SystemLayer.RequestCallbackOnPendingRead(watch->mSocketWatch));
+        LogErrorOnFailure(DeviceLayer::SystemLayerSockets().RequestCallbackOnPendingRead(watch->mSocketWatch));
     }
     else
     {
-        LogErrorOnFailure(DeviceLayer::SystemLayer.ClearCallbackOnPendingRead(watch->mSocketWatch));
+        LogErrorOnFailure(DeviceLayer::SystemLayerSockets().ClearCallbackOnPendingRead(watch->mSocketWatch));
     }
     if (event & AVAHI_WATCH_OUT)
     {
-        LogErrorOnFailure(DeviceLayer::SystemLayer.RequestCallbackOnPendingWrite(watch->mSocketWatch));
+        LogErrorOnFailure(DeviceLayer::SystemLayerSockets().RequestCallbackOnPendingWrite(watch->mSocketWatch));
     }
     else
     {
-        LogErrorOnFailure(DeviceLayer::SystemLayer.ClearCallbackOnPendingWrite(watch->mSocketWatch));
+        LogErrorOnFailure(DeviceLayer::SystemLayerSockets().ClearCallbackOnPendingWrite(watch->mSocketWatch));
     }
 }
 
@@ -207,7 +207,7 @@ void Poller::WatchFree(AvahiWatch * watch)
 
 void Poller::WatchFree(AvahiWatch & watch)
 {
-    DeviceLayer::SystemLayer.StopWatchingSocket(&watch.mSocketWatch);
+    DeviceLayer::SystemLayerSockets().StopWatchingSocket(&watch.mSocketWatch);
     mWatches.erase(std::remove_if(mWatches.begin(), mWatches.end(),
                                   [&watch](const std::unique_ptr<AvahiWatch> & aValue) { return aValue.get() == &watch; }),
                    mWatches.end());

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -78,7 +78,7 @@ ChipDeviceScanner::~ChipDeviceScanner()
     StopScan();
 
     // In case the timeout timer is still active
-    chip::DeviceLayer::SystemLayer.CancelTimer(TimerExpiredCallback, this);
+    chip::DeviceLayer::SystemLayer().CancelTimer(TimerExpiredCallback, this);
 
     g_object_unref(mManager);
     g_object_unref(mCancellable);
@@ -131,7 +131,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(unsigned timeoutMs)
         return CHIP_ERROR_INTERNAL;
     }
 
-    CHIP_ERROR err = chip::DeviceLayer::SystemLayer.StartTimer(timeoutMs, TimerExpiredCallback, static_cast<void *>(this));
+    CHIP_ERROR err = chip::DeviceLayer::SystemLayer().StartTimer(timeoutMs, TimerExpiredCallback, static_cast<void *>(this));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/platform/P6/BLEManagerImpl.cpp
+++ b/src/platform/P6/BLEManagerImpl.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
 
     // Initialize the CHIP BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     // Configure platform specific settings for Bluetooth

--- a/src/platform/P6/ConnectivityManagerImpl.cpp
+++ b/src/platform/P6/ConnectivityManagerImpl.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(WiFiStationMode val)
     if (val != kWiFiStationMode_ApplicationControlled)
     {
         mWiFiStationMode = val;
-        SystemLayer.ScheduleWork(DriveStationState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
     }
     if (mWiFiStationMode != val)
     {
@@ -101,8 +101,8 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
         memset(&stationConfig, 0, sizeof(stationConfig));
         Internal::P6Utils::p6_wifi_set_config(WIFI_IF_STA, &stationConfig);
 
-        SystemLayer.ScheduleWork(DriveStationState, NULL);
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -117,7 +117,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
         ChipLogProgress(DeviceLayer, "WiFi AP mode change: %s -> %s", WiFiAPModeToStr(mWiFiAPMode), WiFiAPModeToStr(val));
     }
     mWiFiAPMode = val;
-    SystemLayer.ScheduleWork(DriveAPState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 exit:
     return err;
 }
@@ -127,7 +127,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP(void)
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         mLastAPDemandTime = System::Clock::GetMonotonicMilliseconds();
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -136,7 +136,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP(void)
     if (mWiFiAPMode == kWiFiAPMode_OnDemand || mWiFiAPMode == kWiFiAPMode_OnDemand_NoStationProvision)
     {
         mLastAPDemandTime = 0;
-        SystemLayer.ScheduleWork(DriveAPState, NULL);
+        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
     }
 }
 
@@ -154,7 +154,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP(void)
 void ConnectivityManagerImpl::_SetWiFiAPIdleTimeoutMS(uint32_t val)
 {
     mWiFiAPIdleTimeoutMS = val;
-    SystemLayer.ScheduleWork(DriveAPState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
@@ -225,7 +225,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     SuccessOrExit(err);
 
     // Queue work items to bootstrap the station state machines once the Chip event loop is running.
-    err = SystemLayer.ScheduleWork(DriveStationState, NULL);
+    err = DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
     SuccessOrExit(err);
 
 exit:
@@ -278,12 +278,12 @@ void ConnectivityManagerImpl::wlan_event_cb(cy_wcm_event_t event, cy_wcm_event_d
 }
 void ConnectivityManagerImpl::_OnWiFiScanDone()
 {
-    SystemLayer.ScheduleWork(DriveStationState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 }
 
 void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
 {
-    SystemLayer.ScheduleWork(DriveStationState, NULL);
+    DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);
 }
 
 void ConnectivityManagerImpl::DriveStationState(::chip::System::Layer * aLayer, void * aAppState)
@@ -417,7 +417,7 @@ void ConnectivityManagerImpl::DriveAPState()
                 // Compute the amount of idle time before the AP should be deactivated and
                 // arm a timer to fire at that time.
                 apTimeout = (uint32_t)((mLastAPDemandTime + mWiFiAPIdleTimeoutMS) - now);
-                err       = SystemLayer.StartTimer(apTimeout, DriveAPState, NULL);
+                err       = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, NULL);
                 SuccessOrExit(err);
                 ChipLogProgress(DeviceLayer, "Next WiFi AP timeout in %" PRIu32 " ms", apTimeout);
             }
@@ -574,7 +574,7 @@ void ConnectivityManagerImpl::DriveStationState()
                 uint32_t timeToNextConnect = (uint32_t)((mLastStationConnectFailTime + mWiFiStationReconnectIntervalMS) - now);
                 ChipLogProgress(DeviceLayer, "Next WiFi station reconnect in %" PRId32 " ms ", timeToNextConnect);
 
-                err = SystemLayer.StartTimer(timeToNextConnect, DriveStationState, NULL);
+                err = DeviceLayer::SystemLayer().StartTimer(timeToNextConnect, DriveStationState, NULL);
                 SuccessOrExit(err);
             }
         }

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     bt_conn_cb_register(&mConnCallbacks);
 
     // Initialize the CHIP BleLayer.
-    ReturnErrorOnFailure(BleLayer::Init(this, this, &SystemLayer));
+    ReturnErrorOnFailure(BleLayer::Init(this, this, &DeviceLayer::SystemLayer()));
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
@@ -291,15 +291,15 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         if (mFlags.Has(Flags::kFastAdvertisingEnabled))
         {
             // Start timer to change advertising interval.
-            SystemLayer.StartTimer(CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME, HandleBLEAdvertisementIntervalChange,
-                                   this);
+            DeviceLayer::SystemLayer().StartTimer(CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME,
+                                                  HandleBLEAdvertisementIntervalChange, this);
         }
 
         // Start timer to disable CHIPoBLE advertisement after timeout expiration only if it isn't advertising rerun (in that case
         // timer is already running).
         if (!isAdvertisingRerun)
         {
-            SystemLayer.StartTimer(CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT, HandleBLEAdvertisementTimeout, this);
+            DeviceLayer::SystemLayer().StartTimer(CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT, HandleBLEAdvertisementTimeout, this);
         }
     }
 
@@ -328,10 +328,10 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
         }
 
         // Cancel timer event disabling CHIPoBLE advertisement after timeout expiration
-        SystemLayer.CancelTimer(HandleBLEAdvertisementTimeout, this);
+        DeviceLayer::SystemLayer().CancelTimer(HandleBLEAdvertisementTimeout, this);
 
         // Cancel timer event changing CHIPoBLE advertisement interval
-        SystemLayer.CancelTimer(HandleBLEAdvertisementIntervalChange, this);
+        DeviceLayer::SystemLayer().CancelTimer(HandleBLEAdvertisementIntervalChange, this);
     }
 
     return CHIP_NO_ERROR;

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
 
     BLEMGR_LOG("BLEMGR: BLE Initialization Start");
     // Initialize the CHIP BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     if (err != CHIP_NO_ERROR)
     {
         return err;

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -627,7 +627,7 @@ void BLEManagerImpl::HandleInitComplete(bool no_error)
     VerifyOrExit(mbed_err == BLE_ERROR_NONE, err = CHIP_ERROR(chip::ChipError::Range::kOS, mbed_err));
     security_mgr.setSecurityManagerEventHandler(&sSecurityManagerEventHandler);
 
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 #if _BLEMGRIMPL_USE_LEDS

--- a/src/platform/qpg/BLEManagerImpl.cpp
+++ b/src/platform/qpg/BLEManagerImpl.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     }
 
     // Initialize the CHIP BleLayer.
-    err = BleLayer::Init(this, this, &SystemLayer);
+    err = BleLayer::Init(this, this, &DeviceLayer::SystemLayer());
     SuccessOrExit(err);
 
     appCbacks.stackCback    = ExternalCbHandler;

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -68,7 +68,7 @@
 #include CHIP_PLATFORM_CONFIG_INCLUDE
 #endif
 
-/* Include a SystemLayer project-specific configuration file, if defined.
+/* Include a System::Layer project-specific configuration file, if defined.
  *
  * An application or module that incorporates CHIP can define a project configuration
  * file to override standard System Layer configuration with application-specific values.
@@ -79,7 +79,7 @@
 #include SYSTEM_PROJECT_CONFIG_INCLUDE
 #endif // SYSTEM_PROJECT_CONFIG_INCLUDE
 
-/* Include a SystemLayer platform-specific configuration file, if defined.
+/* Include a System::Layer platform-specific configuration file, if defined.
  *
  * A platform configuration file contains overrides to standard System Layer configuration
  * that are specific to the platform or OS on which CHIP is running.  It is typically

--- a/src/system/SystemEvent.h
+++ b/src/system/SystemEvent.h
@@ -62,7 +62,7 @@ typedef CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE Event;
  */
 enum
 {
-    kEvent_ReleaseObj   = _CHIP_SYSTEM_CONFIG_LWIP_EVENT(0), /**< The event for the drop of a SystemLayer object */
+    kEvent_ReleaseObj   = _CHIP_SYSTEM_CONFIG_LWIP_EVENT(0), /**< The event for the drop of a System::Layer object */
     kEvent_ScheduleWork = _CHIP_SYSTEM_CONFIG_LWIP_EVENT(1), /**< The event for scheduling work on the System Layer's thread. */
 };
 

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -127,24 +127,17 @@ public:
      * @note
      *   This function could, in principle, be implemented as `StartTimer`. The specification for `SystemTimer` however
      *   permits certain optimizations that might make that implementation impossible. Specifically, `SystemTimer`
-     *   API may only be called from the thread owning the particular `SystemLayer`, whereas the `ScheduleWork` may be
+     *   API may only be called from the thread owning the particular `System::Layer`, whereas the `ScheduleWork` may be
      *   called from any thread. Additionally, whereas the `SystemTimer` API permits the invocation of the already
      *   expired handler in line, `ScheduleWork` guarantees that the handler function will be called only after the
      *   current CHIP event completes.
      *
-     * @param[in] aComplete A pointer to a callback function to be called
-     *                      when this timer fires.
+     * @param[in] aComplete     A pointer to a callback function to be called when this timer fires.
+     * @param[in] aAppState     A pointer to an application state object to be passed to the callback function as argument.
      *
-     * @param[in] aAppState A pointer to an application state object to be
-     *                      passed to the callback function as argument.
-     *
-     * @retval CHIP_ERROR_INCORRECT_STATE If the SystemLayer has
-     *                      not been initialized.
-     *
-     * @retval CHIP_ERROR_NO_MEMORY If the SystemLayer cannot
-     *                      allocate a new timer.
-     *
-     * @retval CHIP_NO_ERROR On success.
+     * @retval CHIP_ERROR_INCORRECT_STATE   If the System::Layer has not been initialized.
+     * @retval CHIP_ERROR_NO_MEMORY         If the SystemLayer cannot allocate a new timer.
+     * @retval CHIP_NO_ERROR                On success.
      */
     virtual CHIP_ERROR ScheduleWork(TimerCompleteCallback aComplete, void * aAppState) = 0;
 


### PR DESCRIPTION
#### Problem

System::Layer is now an abstract base class, but in normal builds is
still accessed through a static global variable.

#### Change overview

Replace the direct global access `DeviceLayer::SystemLayer` with
a function indirecting through a pointer. In the normal case, the
pointer is initialized by `InitChipStack()` with the global, but
it can be set with a mock implementation before that.

#### Testing

Added a unit test case to TestPlatformMgr.
