### PR TITLE
add build instructions to ota-provider-app

### DIFF
--- a/examples/ota-provider-app/linux/README.md
+++ b/examples/ota-provider-app/linux/README.md
@@ -3,6 +3,11 @@
 This is a reference application that implements an example of an OTA Provider
 Cluster Server.
 
+## Building
+
+Suggest doing the following:
+`scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false`
+
 ## Usage
 
 `./ota-provider-app [--filepath \<filepath\>]`


### PR DESCRIPTION
#### Problem
It is not obvious how to `build ota-provider-app`.

#### Change overview
Add build instructions to README.md

#### Testing
n/a
