### PR TITLE
Fix EventHandlerDelegate crash on LwIP platforms

### DIFF
--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR LayerImplLwIP::HandleSystemLayerEvent(Object & aTarget, EventType aEv
 
 CHIP_ERROR LayerImplLwIP::AddEventHandlerDelegate(EventHandlerDelegate & aDelegate)
 {
-    LwIPEventHandlerDelegate lDelegate = static_cast<LwIPEventHandlerDelegate &>(aDelegate);
+    LwIPEventHandlerDelegate & lDelegate = static_cast<LwIPEventHandlerDelegate &>(aDelegate);
     VerifyOrReturnError(lDelegate.GetFunction() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     lDelegate.Prepend(mEventDelegateList);
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem

3a505010973c #9366 caused a crash. In `AddEventHandlerDelegate()`,
`lDelegate` was accidentally a stack variable instead of a reference to
the caller-supplied storage.

This affects all platforms using LwIP.

#### Change overview

Add one small but important `&`.

Fixes #9563 _ESP32&ESP32C3 crash on system layer_

#### Testing

all-clusters-app on M5Stack
