### PR TITLE
Rename System::Clock globals (followup from #9547 review)

### DIFF
--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -33,7 +33,9 @@
 namespace chip {
 namespace System {
 
-ClockImpl staticClock;
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
 
 Clock::MonotonicMicroseconds ClockImpl::GetMonotonicMicroseconds(void)
 {

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -32,7 +32,9 @@
 namespace chip {
 namespace System {
 
-ClockImpl staticClock;
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
 
 namespace {
 

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -35,7 +35,9 @@
 namespace chip {
 namespace System {
 
-ClockImpl staticClock;
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
 
 Clock::MonotonicMicroseconds ClockImpl::GetMonotonicMicroseconds()
 {

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -33,7 +33,9 @@
 namespace chip {
 namespace System {
 
-ClockImpl staticClock;
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
 
 Clock::MonotonicMicroseconds ClockImpl::GetMonotonicMicroseconds(void)
 {

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -35,7 +35,9 @@
 namespace chip {
 namespace System {
 
-ClockImpl staticClock;
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
 
 // Platform-specific function for getting monotonic system time in microseconds.
 // Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.

--- a/src/system/SystemClock.cpp
+++ b/src/system/SystemClock.cpp
@@ -50,11 +50,17 @@
 namespace chip {
 namespace System {
 
-ClockBase * globalClock = &staticClock;
+namespace Internal {
+
+ClockBase * gClockBase = &gClockImpl;
 
 #if !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
+ClockImpl gClockImpl;
+#endif // !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
 
-ClockImpl staticClock;
+} // namespace Internal
+
+#if !CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS
 

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -89,8 +89,11 @@ public:
     MonotonicMilliseconds GetMonotonicMilliseconds() override;
 };
 
-extern ClockImpl staticClock;
-extern ClockBase * globalClock;
+namespace Internal {
+// These should only be used via the public Clock:: functions below.
+extern ClockImpl gClockImpl;
+extern ClockBase * gClockBase;
+} // namespace Internal
 
 namespace Clock {
 using MonotonicMicroseconds = ClockBase::MonotonicMicroseconds;
@@ -99,12 +102,12 @@ using UnixTimeMicroseconds  = ClockBase::MonotonicMicroseconds;
 
 inline MonotonicMicroseconds GetMonotonicMicroseconds()
 {
-    return globalClock->GetMonotonicMicroseconds();
+    return Internal::gClockBase->GetMonotonicMicroseconds();
 }
 
 inline MonotonicMilliseconds GetMonotonicMilliseconds()
 {
-    return globalClock->GetMonotonicMilliseconds();
+    return Internal::gClockBase->GetMonotonicMilliseconds();
 }
 
 /**

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -91,8 +91,8 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     };
     MockClock clock;
 
-    ClockBase * savedRealClock = globalClock;
-    globalClock                = &clock;
+    ClockBase * savedRealClock = Internal::gClockBase;
+    Internal::gClockBase       = &clock;
 
     NL_TEST_ASSERT(inSuite, Clock::GetMonotonicMilliseconds() == 0);
     NL_TEST_ASSERT(inSuite, Clock::GetMonotonicMicroseconds() == 0);
@@ -101,7 +101,7 @@ void TestMockClock(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, Clock::GetMonotonicMilliseconds() == 1234);
     NL_TEST_ASSERT(inSuite, Clock::GetMonotonicMicroseconds() == 1234 * chip::kMicrosecondsPerMillisecond);
 
-    globalClock = savedRealClock;
+    Internal::gClockBase = savedRealClock;
 }
 
 } // namespace


### PR DESCRIPTION
#### Problem

Review comments in #9547 recommended renaming `globalClock` and `staticClock`.

#### Change overview

Renamed to `gClockImpl` and `gClockBase` in an `Internal` namespace.

#### Testing

CI — no expected change to functionality.
