### PR TITLE
Remove incorrect "open enhanced commissioning window" UI on M5Stack.

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -330,14 +330,12 @@ class SetupListModel : public ListScreen::Model
 public:
     SetupListModel()
     {
-        std::string resetWiFi                      = "Reset WiFi";
-        std::string resetToFactory                 = "Reset to factory";
-        std::string forceWifiCommissioningBasic    = "Force WiFi commissioning (basic)";
-        std::string forceWifiCommissioningEnhanced = "Force WiFi commissioning (enhanced)";
+        std::string resetWiFi                   = "Reset WiFi";
+        std::string resetToFactory              = "Reset to factory";
+        std::string forceWifiCommissioningBasic = "Force WiFi commissioning (basic)";
         options.emplace_back(resetWiFi);
         options.emplace_back(resetToFactory);
         options.emplace_back(forceWifiCommissioningBasic);
-        options.emplace_back(forceWifiCommissioningEnhanced);
     }
     virtual std::string GetTitle() { return "Setup"; }
     virtual int GetItemCount() { return options.size(); }
@@ -357,11 +355,6 @@ public:
         else if (i == 2)
         {
             app::Mdns::AdvertiseCommissionableNode(app::Mdns::CommissioningMode::kEnabledBasic);
-            OpenBasicCommissioningWindow(ResetFabrics::kYes, kNoCommissioningTimeout, PairingWindowAdvertisement::kMdns);
-        }
-        else if (i == 3)
-        {
-            app::Mdns::AdvertiseCommissionableNode(app::Mdns::CommissioningMode::kEnabledEnhanced);
             OpenBasicCommissioningWindow(ResetFabrics::kYes, kNoCommissioningTimeout, PairingWindowAdvertisement::kMdns);
         }
     }


### PR DESCRIPTION
The option doesn't actually open an enhanced commissioning window.  It
opens a basic one, but then advertises as if it opened an enhanced
one, sort of.  This is not actually usable/useful, as far as I can
tell.

#### Problem
UI was accidentally added as part of a build fix in #9114 that does not do what it says it does.

#### Change overview
Just remove the new UI.

#### Testing
Looked at M5Stack screen, option is gone.