### PR TITLE
Update PASE state machine to match the latest specifications

### DIFF
--- a/src/messaging/ApplicationExchangeDispatch.cpp
+++ b/src/messaging/ApplicationExchangeDispatch.cpp
@@ -49,10 +49,10 @@ bool ApplicationExchangeDispatch::MessagePermitted(uint16_t protocol, uint8_t ty
         {
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PBKDFParamRequest):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PBKDFParamResponse):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p1):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p2):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p3):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2pError):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake1):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake2):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake3):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_PakeError):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR1):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR2):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR3):

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -72,7 +72,12 @@ enum class MsgType : uint8_t
 };
 
 // Placeholder value for the ProtocolCode field when the GeneralCode is Success or Continue.
-constexpr uint16_t kProtocolCodeSuccess = 0x0000;
+constexpr uint16_t kProtocolCodeSuccess         = 0x0000;
+constexpr uint16_t kProtocolCodeNoSharedRoot    = 0x0001;
+constexpr uint16_t kProtocolCodeInvalidParam    = 0x0002;
+constexpr uint16_t kProtocolCodeCloseSession    = 0x0003;
+constexpr uint16_t kProtocolCodeBusy            = 0x0004;
+constexpr uint16_t kProtocolCodeSessionNotFound = 0x0005;
 
 // Placeholder value for the ProtocolCode field when there is no additional protocol-specific code to provide more information.
 constexpr uint16_t kProtocolCodeGeneralFailure = 0xFFFF;

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -57,10 +57,10 @@ enum class MsgType : uint8_t
     // Password-based session establishment Message Types
     PBKDFParamRequest  = 0x20,
     PBKDFParamResponse = 0x21,
-    PASE_Spake2p1      = 0x22,
-    PASE_Spake2p2      = 0x23,
-    PASE_Spake2p3      = 0x24,
-    PASE_Spake2pError  = 0x2F,
+    PASE_Pake1         = 0x22,
+    PASE_Pake2         = 0x23,
+    PASE_Pake3         = 0x24,
+    PASE_PakeError     = 0x2F,
 
     // Certificate-based session establishment Message Types
     CASE_SigmaR1  = 0x30,

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -582,7 +582,8 @@ CHIP_ERROR PASESession::SendMsg1()
     ReturnErrorOnFailure(
         mSpake2p.BeginProver(nullptr, 0, nullptr, 0, mPASEVerifier.mW0, kSpake2p_WS_Length, mPASEVerifier.mL, kSpake2p_WS_Length));
     ReturnErrorOnFailure(mSpake2p.ComputeRoundOne(NULL, 0, X, &X_len));
-    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kPake1_pA), ByteSpan(X, X_len)));
+    VerifyOrReturnError(X_len == sizeof(X), CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kPake1_pA), ByteSpan(X)));
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize(&msg));
 
@@ -625,6 +626,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
         err = mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, mPASEVerifier.mW0, kSpake2p_WS_Length, mPoint, sizeof(mPoint)));
 
     SuccessOrExit(err = mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len));
+    VerifyOrReturnError(Y_len == sizeof(Y), CHIP_ERROR_INTERNAL);
     SuccessOrExit(err = mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len));
     msg1 = nullptr;
 
@@ -641,7 +643,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(System::PacketBufferHandle && ms
 
         TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
-        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake2_pB), ByteSpan(Y, Y_len)));
+        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake2_pB), ByteSpan(Y)));
         SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kPake2_cB), ByteSpan(verifier, verifier_len)));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));
         SuccessOrExit(err = tlvWriter.Finalize(&msg2));

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -256,19 +256,21 @@ private:
     CHIP_ERROR SetupSpake2p(uint32_t pbkdf2IterCount, const ByteSpan & salt);
 
     CHIP_ERROR SendPBKDFParamRequest();
-    CHIP_ERROR HandlePBKDFParamRequest(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandlePBKDFParamRequest(System::PacketBufferHandle && msg);
 
-    CHIP_ERROR SendPBKDFParamResponse();
-    CHIP_ERROR HandlePBKDFParamResponse(const System::PacketBufferHandle & msg);
+    CHIP_ERROR SendPBKDFParamResponse(ByteSpan initiatorRandom, bool initiatorHasPBKDFParams);
+    CHIP_ERROR HandlePBKDFParamResponse(System::PacketBufferHandle && msg);
 
     CHIP_ERROR SendMsg1();
 
-    CHIP_ERROR HandleMsg1_and_SendMsg2(const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleMsg2_and_SendMsg3(const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleMsg3(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleMsg1_and_SendMsg2(System::PacketBufferHandle && msg);
+    CHIP_ERROR HandleMsg2_and_SendMsg3(System::PacketBufferHandle && msg);
+    CHIP_ERROR HandleMsg3(System::PacketBufferHandle && msg);
 
-    void SendErrorMsg(Spake2pErrorType errorCode);
-    CHIP_ERROR HandleErrorMsg(const System::PacketBufferHandle & msg);
+    void SendStatusReport(uint16_t protocolCode);
+    CHIP_ERROR HandleStatusReport(System::PacketBufferHandle && msg);
+
+    constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields) { return dataLen + (sizeof(uint64_t) * nFields); }
 
     void CloseExchange();
 
@@ -291,6 +293,8 @@ private:
     uint32_t mSetupPINCode;
 
     bool mComputeVerifier = true;
+
+    bool mHavePBKDFParameters = false;
 
     Hash_SHA256_stream mCommissioningHash;
     uint32_t mIterationCount = 0;

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -270,6 +270,7 @@ private:
     void SendStatusReport(uint16_t protocolCode);
     CHIP_ERROR HandleStatusReport(System::PacketBufferHandle && msg);
 
+    // TODO - Move EstimateTLVStructOverhead to CHIPTLV header file
     constexpr size_t EstimateTLVStructOverhead(size_t dataLen, size_t nFields) { return dataLen + (sizeof(uint64_t) * nFields); }
 
     void CloseExchange();

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -276,7 +276,7 @@ private:
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 
-    Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
+    Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_PakeError;
 
 #ifdef ENABLE_HSM_SPAKE
     Spake2pHSM_P256_SHA256_HKDF_HMAC mSpake2p;
@@ -295,6 +295,8 @@ private:
     bool mComputeVerifier = true;
 
     bool mHavePBKDFParameters = false;
+
+    uint8_t mPBKDFLocalRandomData[kPBKDFParamRandomNumberSize];
 
     Hash_SHA256_stream mCommissioningHash;
     uint32_t mIterationCount = 0;

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -68,10 +68,10 @@ bool SessionEstablishmentExchangeDispatch::MessagePermitted(uint16_t protocol, u
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PBKDFParamRequest):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PBKDFParamResponse):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p1):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p2):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2p3):
-        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Spake2pError):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake1):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake2):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_Pake3):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::PASE_PakeError):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR1):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR2):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR3):

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -76,6 +76,7 @@ bool SessionEstablishmentExchangeDispatch::MessagePermitted(uint16_t protocol, u
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR2):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaR3):
         case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::CASE_SigmaErr):
+        case static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StatusReport):
             return true;
 
         default:


### PR DESCRIPTION
#### Problem
PASE state machine code is out of date compared to latest specifications.

#### Change overview
Update the code to match the specifications.
* Use TLV formatted messages
* Use StatusReport to indicate errors and completion

#### Testing
`TestPASESession` unit test.
Tested PASE flow using all-cluster app and chip-tool commissioner.
