### PR TITLE
linux: Filter ble/matter only

### DIFF
--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -273,12 +273,20 @@ int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
         self->RemoveDevice(bluez_object_get_device1(&object));
     }
 
+    /* Search for matter/chip UUID only */
+    GVariantBuilder uuidsBuilder;
+    GVariant * uuids;
+    g_variant_builder_init(&uuidsBuilder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&uuidsBuilder, "s", CHIP_BLE_UUID_SERVICE_STRING);
+    uuids = g_variant_builder_end(&uuidsBuilder);
+
     /* Search for LE only: Advertises */
     GVariantBuilder filterBuilder;
     GVariant * filter;
 
     g_variant_builder_init(&filterBuilder, G_VARIANT_TYPE("a{sv}"));
     g_variant_builder_add(&filterBuilder, "{sv}", "Transport", g_variant_new_string("le"));
+    g_variant_builder_add(&filterBuilder, "{sv}", "UUIDs", uuids);
     filter = g_variant_builder_end(&filterBuilder);
 
     if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter, filter, self->mCancellable, &error))

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -273,6 +273,21 @@ int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
         self->RemoveDevice(bluez_object_get_device1(&object));
     }
 
+    /* Search for LE only: Advertises */
+    GVariantBuilder filterBuilder;
+    GVariant * filter;
+
+    g_variant_builder_init(&filterBuilder, G_VARIANT_TYPE("a{sv}"));
+    g_variant_builder_add(&filterBuilder, "{sv}", "Transport", g_variant_new_string("le"));
+    filter = g_variant_builder_end(&filterBuilder);
+
+    if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter, filter, self->mCancellable, &error))
+    {
+        /* Not critical: ignore if fails */
+        ChipLogError(Ble, "Failed to set discovery filters: %s", error->message);
+        g_error_free(error);
+    }
+
     ChipLogProgress(Ble, "BLE initiating scan.");
     if (!bluez_adapter1_call_start_discovery_sync(self->mAdapter, self->mCancellable, &error))
     {


### PR DESCRIPTION
#### Problem
* Running interleaved discovery instead of BLE only. It is not necessary inquiry for traditional Bluetooth devices.
* Getting all BLE devices. For chip/matter, devices can be filtered at bt stack level instead of after getting reported devices.


#### Change overview
* Add filters to linux BlueZ StartDiscovery method to be notified of BLE chip/matter devices only

#### Testing
How was this tested? (at least one bullet point required)
See btmon logs:
@ MGMT Command: Start Service Discovery (0x003a) plen 20                      {0x0001} [hci0] 2.689705
        Address type: 0x06
          LE Public
          LE Random
        RSSI: invalid (0x7f)
        UUIDs: 1
        UUID: 0000fff6-0000-1000-8000-00805f9b34fb

Executed chip-tool pairing ble-wifi 
