### PR TITLE
[TE6] Read Ethernet Network Diagnostic attributes from platform at run-time

### DIFF
--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -2810,7 +2810,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2825,7 +2825,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2840,7 +2840,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2855,7 +2855,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2870,7 +2870,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "RAM",
+              "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -5490,5 +5490,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 259
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -19,6 +19,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
 
+#include <app-common/zap-generated/attribute-id.h>
+#include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/chip-zcl-zpro-codec.h>
@@ -85,6 +87,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
     // TODO: implement any additional Cluster Server init actions
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %d", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %d", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 int main(int argc, char * argv[])

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -826,6 +826,18 @@
 #define CHIP_DEVICE_CONFIG_DEFAULT_TELEMETRY_INTERVAL_MS 90000
 #endif
 
+/**
+ * @def CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
+ *
+ * @brief
+ *   Default ethernet network interface name used to centralize all metrics that are
+ *   relevant to a potential Ethernet connection to a Node.
+ *
+ */
+#ifndef CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
+#define CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME "enp0s25"
+#endif
+
 // -------------------- Event Logging Configuration --------------------
 
 /**

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -170,6 +170,13 @@ public:
     // Service connectivity methods
     bool HaveServiceConnectivity();
 
+    // Ethernet network diagnostics methods
+    CHIP_ERROR GetEthPacketRxCount(uint64_t & packetRxCount);
+    CHIP_ERROR GetEthPacketTxCount(uint64_t & packetTxCount);
+    CHIP_ERROR GetEthTxErrCount(uint64_t & txErrCount);
+    CHIP_ERROR GetEthCollisionCount(uint64_t & collisionCount);
+    CHIP_ERROR GetEthOverrunCount(uint64_t & overrunCount);
+
     // CHIPoBLE service methods
     Ble::BleLayer * GetBleLayer();
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
@@ -379,6 +386,31 @@ inline bool ConnectivityManager::HaveIPv6InternetConnectivity()
 inline bool ConnectivityManager::HaveServiceConnectivity()
 {
     return static_cast<ImplClass *>(this)->_HaveServiceConnectivity();
+}
+
+inline CHIP_ERROR ConnectivityManager::GetEthPacketRxCount(uint64_t & packetRxCount)
+{
+    return static_cast<ImplClass *>(this)->_GetEthPacketRxCount(packetRxCount);
+}
+
+inline CHIP_ERROR ConnectivityManager::GetEthPacketTxCount(uint64_t & packetTxCount)
+{
+    return static_cast<ImplClass *>(this)->_GetEthPacketTxCount(packetTxCount);
+}
+
+inline CHIP_ERROR ConnectivityManager::GetEthTxErrCount(uint64_t & txErrCount)
+{
+    return static_cast<ImplClass *>(this)->_GetEthTxErrCount(txErrCount);
+}
+
+inline CHIP_ERROR ConnectivityManager::GetEthCollisionCount(uint64_t & collisionCount)
+{
+    return static_cast<ImplClass *>(this)->_GetEthCollisionCount(collisionCount);
+}
+
+inline CHIP_ERROR ConnectivityManager::GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return static_cast<ImplClass *>(this)->_GetEthOverrunCount(overrunCount);
 }
 
 inline ConnectivityManager::ThreadMode ConnectivityManager::GetThreadMode()

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -73,6 +73,11 @@ public:
     uint32_t _GetWiFiAPIdleTimeoutMS(void);
     void _SetWiFiAPIdleTimeoutMS(uint32_t val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
+    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
+    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
+    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
+    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
+    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
@@ -233,6 +238,36 @@ template <class ImplClass>
 inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPStateToStr(ConnectivityManager::WiFiAPState state)
 {
     return NULL;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthPacketRxCount(uint64_t & packetRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthPacketTxCount(uint64_t & packetTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthTxErrCount(uint64_t & txErrCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthCollisionCount(uint64_t & collisionCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -73,6 +73,11 @@ public:
     uint32_t _GetWiFiAPIdleTimeoutMS();
     void _SetWiFiAPIdleTimeoutMS(uint32_t val);
     CHIP_ERROR _GetAndLogWifiStatsCounters();
+    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
+    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
+    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
+    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
+    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
@@ -180,6 +185,36 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiScanDone()
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiStationProvisionChange()
 {}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthPacketRxCount(uint64_t & packetRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthPacketTxCount(uint64_t & packetTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthTxErrCount(uint64_t & txErrCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthCollisionCount(uint64_t & collisionCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -24,6 +24,10 @@
 #include <cstdlib>
 #include <new>
 
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <linux/if_link.h>
+
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -47,8 +51,18 @@ using namespace ::chip;
 using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
 namespace {
+
+enum class EthernetStatsCountType
+{
+    kEthPacketRxCount,
+    kEthPacketTxCount,
+    kEthTxErrCount,
+    kEthCollisionCount,
+    kEthOverrunCount
+};
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
 const char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
 const char kWpaSupplicantObjectPath[]  = "/fi/w1/wpa_supplicant1";
 
@@ -224,8 +238,70 @@ static uint16_t MapFrequency(const uint16_t inBand, const uint8_t inChannel)
 
     return frequency;
 }
-} // namespace
 #endif
+
+CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
+{
+    CHIP_ERROR ret          = CHIP_ERROR_READ_FAILED;
+    struct ifaddrs * ifaddr = nullptr;
+
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+    }
+    else
+    {
+        struct ifaddrs * ifa = nullptr;
+
+        /* Walk through linked list, maintaining head pointer so we
+          can free list later */
+        for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+        {
+            if (strcmp(ifa->ifa_name, CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME) == 0)
+                break;
+        }
+
+        if (ifa != nullptr)
+        {
+            if (ifa->ifa_addr->sa_family == AF_PACKET && ifa->ifa_data != nullptr)
+            {
+                struct rtnl_link_stats * stats = (struct rtnl_link_stats *) ifa->ifa_data;
+                switch (type)
+                {
+                case EthernetStatsCountType::kEthPacketRxCount:
+                    count = stats->rx_packets;
+                    ret   = CHIP_NO_ERROR;
+                    break;
+                case EthernetStatsCountType::kEthPacketTxCount:
+                    count = stats->tx_packets;
+                    ret   = CHIP_NO_ERROR;
+                    break;
+                case EthernetStatsCountType::kEthTxErrCount:
+                    count = stats->tx_errors;
+                    ret   = CHIP_NO_ERROR;
+                    break;
+                case EthernetStatsCountType::kEthCollisionCount:
+                    count = stats->collisions;
+                    ret   = CHIP_NO_ERROR;
+                    break;
+                case EthernetStatsCountType::kEthOverrunCount:
+                    count = stats->rx_over_errors;
+                    ret   = CHIP_NO_ERROR;
+                    break;
+                default:
+                    ChipLogError(DeviceLayer, "Unknown Ethernet statistic metric type");
+                    break;
+                }
+            }
+        }
+
+        freeifaddrs(ifaddr);
+    }
+
+    return ret;
+}
+
+} // namespace
 
 namespace chip {
 namespace DeviceLayer {
@@ -454,6 +530,31 @@ void ConnectivityManagerImpl::_SetWiFiAPIdleTimeoutMS(uint32_t val)
 {
     mWiFiAPIdleTimeoutMS = val;
     DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, NULL);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetEthPacketRxCount(uint64_t & packetRxCount)
+{
+    return GetEthernetStatsCount(EthernetStatsCountType::kEthPacketRxCount, packetRxCount);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetEthPacketTxCount(uint64_t & packetTxCount)
+{
+    return GetEthernetStatsCount(EthernetStatsCountType::kEthPacketTxCount, packetTxCount);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetEthTxErrCount(uint64_t & txErrCount)
+{
+    return GetEthernetStatsCount(EthernetStatsCountType::kEthTxErrCount, txErrCount);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetEthCollisionCount(uint64_t & collisionCount)
+{
+    return GetEthernetStatsCount(EthernetStatsCountType::kEthCollisionCount, collisionCount);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return GetEthernetStatsCount(EthernetStatsCountType::kEthOverrunCount, overrunCount);
 }
 
 void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -142,6 +142,12 @@ private:
     uint32_t _GetWiFiAPIdleTimeoutMS();
     void _SetWiFiAPIdleTimeoutMS(uint32_t val);
 
+    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
+    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
+    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
+    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
+    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
+
     static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
                                        gpointer user_data);

--- a/zzz_generated/lighting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/lighting-app/zap-generated/endpoint_config.h
@@ -849,12 +849,16 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Ethernet Network Diagnostics (server) */                                                      \
-            { 0x0002, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1891) }, /* PacketRxCount */                                 \
-            { 0x0003, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1899) }, /* PacketTxCount */                                 \
-            { 0x0004, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1907) }, /* TxErrCount */                                    \
-            { 0x0005, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1915) }, /* CollisionCount */                                \
-            { 0x0006, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1923) }, /* OverrunCount */                                  \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                               \
+            { 0x0002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
+              ZAP_LONG_DEFAULTS_INDEX(1891) }, /* PacketRxCount */                                                                 \
+            { 0x0003, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
+              ZAP_LONG_DEFAULTS_INDEX(1899) }, /* PacketTxCount */                                                                 \
+            { 0x0004, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_LONG_DEFAULTS_INDEX(1907) }, /* TxErrCount */ \
+            { 0x0005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
+              ZAP_LONG_DEFAULTS_INDEX(1915) }, /* CollisionCount */                                                                \
+            { 0x0006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
+              ZAP_LONG_DEFAULTS_INDEX(1923) },                              /* OverrunCount */                                     \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                                  \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: AdministratorCommissioning (server) */                                                        \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                                  \


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the Ethernet Network Diagnostic attributes are fully managed by the attribute store, we can only specify the default values in its xml definitions. We need to populate those attributes with the actual value from platform in run-time.

#### Change overview
* Change Ethernet Network Diagnostic to 'External' in lighting-app.
* Read Ethernet Network Diagnostic attributes from platform at run-time.

#### Testing
How was this tested? (at least one bullet point required)
* ./chip-tool ethernetnetworkdiagnostics read packet-rx-count 0

```
[1631236896.763861][1715471:1715478] CHIP:EM: Removed CHIP MsgId:00000000 from RetransTable
[1631236896.763876][1715471:1715478] CHIP:DMG: ReportData =
[1631236896.763883][1715471:1715478] CHIP:DMG: {
[1631236896.763888][1715471:1715478] CHIP:DMG: 	AttributeDataList =
[1631236896.763894][1715471:1715478] CHIP:DMG: 	[
[1631236896.763902][1715471:1715478] CHIP:DMG: 		AttributeDataElement =
[1631236896.763910][1715471:1715478] CHIP:DMG: 		{
[1631236896.763917][1715471:1715478] CHIP:DMG: 			AttributePath =
[1631236896.763924][1715471:1715478] CHIP:DMG: 			{
[1631236896.763932][1715471:1715478] CHIP:DMG: 				NodeId = 0x47a899eac0fe5bfa,
[1631236896.763941][1715471:1715478] CHIP:DMG: 				EndpointId = 0x0,
[1631236896.763950][1715471:1715478] CHIP:DMG: 				ClusterId = 0x37,
[1631236896.763958][1715471:1715478] CHIP:DMG: 				FieldTag = 0x2,
[1631236896.763966][1715471:1715478] CHIP:DMG: 			}
[1631236896.763976][1715471:1715478] CHIP:DMG: 				
[1631236896.763985][1715471:1715478] CHIP:DMG: 			Data = 4346, 
[1631236896.763992][1715471:1715478] CHIP:DMG: 			DataElementVersion = 0x0,
[1631236896.764000][1715471:1715478] CHIP:DMG: 		},
[1631236896.764010][1715471:1715478] CHIP:DMG: 		
[1631236896.764017][1715471:1715478] CHIP:DMG: 	],
[1631236896.764027][1715471:1715478] CHIP:DMG: 	
[1631236896.764033][1715471:1715478] CHIP:DMG: }
[1631236896.764042][1715471:1715478] CHIP:DMG: ProcessReportData handles the initial report
[1631236896.764069][1715471:1715478] CHIP:ZCL: ReadAttributesResponse:
[1631236896.764075][1715471:1715478] CHIP:ZCL:   ClusterId: 0x0000_0037
[1631236896.764083][1715471:1715478] CHIP:ZCL:   attributeId: 0x0000_0002
[1631236896.764089][1715471:1715478] CHIP:ZCL:   status: Success                (0x0000)
[1631236896.764096][1715471:1715478] CHIP:ZCL:   attribute TLV Type: 0x04
[1631236896.764103][1715471:1715478] CHIP:TOO: Int64u attribute Response: 4346
```
