### PR TITLE
Making py chip-device-ctrl discoverable over DNS-SD as a commissioner

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -48,6 +48,7 @@
 
 #include <app/CommandSender.h>
 #include <app/InteractionModelEngine.h>
+#include <app/server/Mdns.h>
 #include <controller/CHIPDevice.h>
 #include <controller/CHIPDeviceController.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
@@ -214,6 +215,9 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
     (*outDevCtrl)->SetUdpListenPort(0);
     err = (*outDevCtrl)->Init(initParams);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+    chip::app::MdnsServer::Instance().StartServer(chip::Mdns::CommissioningMode::kDisabled);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     return CHIP_NO_ERROR.AsInteger();
 }


### PR DESCRIPTION
#### Problem
For a Matter Test event, we need to run the python chip-device-ctrl tool on a raspi and test the tv-casting-app against it. For this the tool needs to be discoverable over DNS-SD as a commissioner (It already accepts UDC requests and has the connect command to do onnetwork commissioning)

#### Change overview
With this change, the python chip-device-ctrl tool will start advertising itself as a commissioner on start-up behind a feature flag: CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY.
TBD: Code to set the flag CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY to 1 for just the python chip-device-ctrl tool will follow separately.

#### Testing
Tested with the CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY set to 1. Used the minimal-mdns client to ensure the python chip-device-ctrl tool is discoverable as a commissioner device