### PR TITLE
Use pythonic way in Chip Bluez Manager and Utility

### DIFF
--- a/src/controller/python/chip/ChipBluezMgr.py
+++ b/src/controller/python/chip/ChipBluezMgr.py
@@ -844,9 +844,9 @@ class BluezManager(ChipBleBase):
                     self.bluez, self.bus, ADAPTER_INTERFACE, "/org/bluez"
                 )
             ]
-            for i in range(len(adapters)):
+            for adapter in adapters:
                 self.logger.info("AdapterName: %s   AdapterAddress: %s" % (
-                    adapters[i].path.replace("/org/bluez/", ""), adapters[i].Address))
+                    adapter.path.replace("/org/bluez/", ""), adapter.Address))
         except dbus.exceptions.DBusException as ex:
             self.logger.debug(str(ex))
 

--- a/src/controller/python/chip/ChipUtility.py
+++ b/src/controller/python/chip/ChipUtility.py
@@ -38,8 +38,7 @@ class ChipUtility(object):
             v = bytearray(len)
             memmove((c_byte * len).from_buffer(v), ptr, len)
             return v
-        else:
-            return None
+        return None
 
     @staticmethod
     def ByteArrayToVoidPtr(array):
@@ -47,13 +46,12 @@ class ChipUtility(object):
             if not (isinstance(array, bytes) or isinstance(array, bytearray)):
                 raise TypeError("Array must be an str or a bytearray")
             return cast((c_byte * len(array)).from_buffer_copy(array), c_void_p)
-        else:
-            return c_void_p(0)
+        return c_void_p(0)
 
     @staticmethod
     def IsByteArrayAllZeros(array):
-        for i in range(len(array)):
-            if array[i] != 0:
+        for i in array:
+            if i != 0:
                 return False
         return True
 


### PR DESCRIPTION
#### Problem
Python allows to iterate over arrays without the need to use an index.

#### Change overview
This change replaced the usage of `range(len(` functions and remove the need for else statement where is not needed.

#### Testing
This change will be tested by the current CI jobs.
