### PR TITLE
Add mDNS shutdown

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -266,6 +266,10 @@ CHIP_ERROR DeviceController::Shutdown()
     // manager.
     app::InteractionModelEngine::GetInstance()->Shutdown();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    Mdns::Resolver::Instance().ShutdownResolver();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
     // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
     // if (mExchangeMgr != nullptr)
     // {

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -33,6 +33,7 @@ class MockResolver : public Resolver
 public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return SetResolverDelegateStatus; }
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return StartResolverStatus; }
+    void ShutdownResolver() override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -43,6 +43,7 @@ public:
 
     /// Starts the service resolver if not yet started
     CHIP_ERROR StartResolver(Inet::InetLayer * inetLayer, uint16_t port) override { return Init(); }
+    void ShutdownResolver() override { ChipMdnsShutdown(); }
 
     /// Advertises the CHIP node as an operational node
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;

--- a/src/lib/mdns/MinimalMdnsServer.cpp
+++ b/src/lib/mdns/MinimalMdnsServer.cpp
@@ -107,5 +107,10 @@ CHIP_ERROR GlobalMinimalMdnsServer::StartServer(chip::Inet::InetLayer * inetLaye
     return GlobalMinimalMdnsServer::Server().Listen(inetLayer, &allInterfaces, port);
 }
 
+void GlobalMinimalMdnsServer::ShutdownServer()
+{
+    GlobalMinimalMdnsServer::Server().Shutdown();
+}
+
 } // namespace Mdns
 } // namespace chip

--- a/src/lib/mdns/MinimalMdnsServer.h
+++ b/src/lib/mdns/MinimalMdnsServer.h
@@ -90,6 +90,7 @@ public:
 
     /// Calls Server().Listen() on all available interfaces
     CHIP_ERROR StartServer(chip::Inet::InetLayer * inetLayer, uint16_t port);
+    void ShutdownServer();
 
     void SetQueryDelegate(MdnsPacketDelegate * delegate) { mQueryDelegate = delegate; }
     void SetResponseDelegate(MdnsPacketDelegate * delegate) { mResponseDelegate = delegate; }

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -260,6 +260,7 @@ public:
     ///
     /// Unsual name to allow base MDNS classes to implement both Advertiser and Resolver interfaces.
     virtual CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
+    virtual void ShutdownResolver()                                                    = 0;
 
     /// Registers a resolver delegate if none has been registered before
     virtual CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) = 0;

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -335,6 +335,7 @@ public:
 
     ///// Resolver implementation
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    void ShutdownResolver() override;
     CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -392,6 +393,11 @@ CHIP_ERROR MinMdnsResolver::StartResolver(chip::Inet::InetLayer * inetLayer, uin
     }
 
     return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port);
+}
+
+void MinMdnsResolver::ShutdownResolver()
+{
+    GlobalMinimalMdnsServer::Instance().ShutdownServer();
 }
 
 CHIP_ERROR MinMdnsResolver::SetResolverDelegate(ResolverDelegate * delegate)

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -29,6 +29,7 @@ public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return CHIP_NO_ERROR; }
+    void ShutdownResolver() override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
     {

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -95,6 +95,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     return test::CheckExpected(test::CallType::kStart, service);


### PR DESCRIPTION
#### Problem
Hit a CI problem due to that udp endpoint in mDNS is used after udp pool has been freed.

#### Change overview
Add shutdown of mDNS service, shutdown the mDNS server and close udp endpoint before release udp endpoint pool

#### Testing
Verified using unit-tests


Triggered a CI failure in PR #9590
```
WARNING: ThreadSanitizer: heap-use-after-free (pid=29980)
  Read of size 8 at 0x7b0c000020c0 by main thread (mutexes: write M79):
    #0 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::_M_lower_bound(std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*, std::_Rb_tree_node_base*, chip::Inet::UDPEndPoint* const&) /usr/include/c++/9/bits/stl_tree.h:1929 (chip-tool+0x341066)
    #1 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::find(chip::Inet::UDPEndPoint* const&) /usr/include/c++/9/bits/stl_tree.h:2557 (chip-tool+0x340e83)
    #2 std::set<chip::Inet::UDPEndPoint*, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::find(chip::Inet::UDPEndPoint* const&) /usr/include/c++/9/bits/stl_set.h:795 (chip-tool+0x340d04)
    #3 chip::System::ObjectPoolHeap<chip::Inet::UDPEndPoint, 32u>::ReleaseObject(chip::Inet::UDPEndPoint*) ../../../examples/chip-tool/third_party/connectedhomeip/src/system/SystemPoolHeap.h:55 (chip-tool+0x340b70)
    #4 chip::Inet::UDPEndPointDeletor::Release(chip::Inet::UDPEndPoint*) ../../../examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPoint.h:113 (chip-tool+0x33fd67)
    #5 chip::AtomicReferenceCounted<chip::Inet::UDPEndPoint, chip::Inet::UDPEndPointDeletor, 1>::Release() ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/core/ReferenceCounted.h:115 (chip-tool+0x340cb8)
    #6 chip::Inet::UDPEndPoint::Free() ../../../examples/chip-tool/third_party/connectedhomeip/src/inet/UDPEndPoint.cpp:437 (chip-tool+0x3405e5)
    #7 ShutdownEndpoint ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/mdns/minimal/Server.cpp:118 (chip-tool+0x2fa127)
    #8 mdns::Minimal::ServerBase::Shutdown() ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/mdns/minimal/Server.cpp:135 (chip-tool+0x2fa28a)
    #9 mdns::Minimal::ServerBase::~ServerBase() ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/mdns/minimal/Server.cpp:126 (chip-tool+0x2fa195)
    #10 mdns::Minimal::Server<30ul>::~Server() ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/mdns/minimal/Server.h:161 (chip-tool+0x349aa7)
    #11 chip::Mdns::GlobalMinimalMdnsServer::~GlobalMinimalMdnsServer() ../../../examples/chip-tool/third_party/connectedhomeip/src/lib/mdns/MinimalMdnsServer.h:69 (chip-tool+0x349d0d)
    #12 cxa_at_exit_wrapper ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:393 (libtsan.so.0+0x2bc24)

  Previous write of size 8 at 0x7b0c000020c0 by main thread:
    #0 operator delete(void*) ../../../../src/libsanitizer/tsan/tsan_new_delete.cpp:126 (libtsan.so.0+0x8b2c8)
    #1 __gnu_cxx::new_allocator<std::_Rb_tree_node<chip::Inet::UDPEndPoint*> >::deallocate(std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*, unsigned long) /usr/include/c++/9/ext/new_allocator.h:128 (chip-tool+0x33e1f1)
    #2 std::allocator_traits<std::allocator<std::_Rb_tree_node<chip::Inet::UDPEndPoint*> > >::deallocate(std::allocator<std::_Rb_tree_node<chip::Inet::UDPEndPoint*> >&, std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*, unsigned long) /usr/include/c++/9/bits/alloc_traits.h:470 (chip-tool+0x33e002)
    #3 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::_M_put_node(std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*) /usr/include/c++/9/bits/stl_tree.h:584 (chip-tool+0x33d98c)
    #4 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::_M_drop_node(std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*) /usr/include/c++/9/bits/stl_tree.h:651 (chip-tool+0x33cb99)
    #5 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::_M_erase(std::_Rb_tree_node<chip::Inet::UDPEndPoint*>*) /usr/include/c++/9/bits/stl_tree.h:1915 (chip-tool+0x33c0af)
    #6 std::_Rb_tree<chip::Inet::UDPEndPoint*, chip::Inet::UDPEndPoint*, std::_Identity<chip::Inet::UDPEndPoint*>, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::~_Rb_tree() /usr/include/c++/9/bits/stl_tree.h:995 (chip-tool+0x33b83d)
    #7 std::set<chip::Inet::UDPEndPoint*, std::less<chip::Inet::UDPEndPoint*>, std::allocator<chip::Inet::UDPEndPoint*> >::~set() /usr/include/c++/9/bits/stl_set.h:281 (chip-tool+0x33b167)
    #8 chip::System::ObjectPoolHeap<chip::Inet::UDPEndPoint, 32u>::~ObjectPoolHeap() ../../../examples/chip-tool/third_party/connectedhomeip/src/system/SystemPoolHeap.h:37 (chip-tool+0x3412a9)
    #9 cxa_at_exit_wrapper ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:393 (libtsan.so.0+0x2bc24)
```