### PR TITLE
Fix ChipError scope resolution

### DIFF
--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -146,9 +146,9 @@ public:
      * (In C++20 this could be replaced by a consteval constructor.)
      */
 #if CHIP_CONFIG_ERROR_SOURCE
-#define CHIP_SDK_ERROR(part, code) (::chip::ChipError(chip::ChipError::SdkErrorConstant<(part), (code)>::value, __FILE__, __LINE__))
+#define CHIP_SDK_ERROR(part, code) (::chip::ChipError(::chip::ChipError::SdkErrorConstant<(part), (code)>::value, __FILE__, __LINE__))
 #else // CHIP_CONFIG_ERROR_SOURCE
-#define CHIP_SDK_ERROR(part, code) (::chip::ChipError(chip::ChipError::SdkErrorConstant<(part), (code)>::value))
+#define CHIP_SDK_ERROR(part, code) (::chip::ChipError(::chip::ChipError::SdkErrorConstant<(part), (code)>::value))
 #endif // CHIP_CONFIG_ERROR_SOURCE
 
     /**


### PR DESCRIPTION
#### Problem

The CHIP error macros result in compile errors in contexts where the 'chip' identifier resolve to the wrong namespace.

#### Change overview

Use qualified name lookup for chip namespace in error macros.

#### Testing
Compile.