### PR TITLE
Fix naming of public key param of ExampleOperationalCredentialsIssuer

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -89,7 +89,7 @@ public:
      * This method is expected to be called once all the checks (e.g. device attestation, CSR verification etc)
      * have been completed, or not required (e.g. for self trusted devices such as commissioner apps).
      */
-    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & ephemeralKey,
+    CHIP_ERROR GenerateNOCChainAfterValidation(NodeId nodeId, FabricId fabricId, const Crypto::P256PublicKey & pubkey,
                                                MutableByteSpan & rcac, MutableByteSpan & icac, MutableByteSpan & noc);
 
 private:


### PR DESCRIPTION
#### Problem

The public key field is named "ephemeralKey" which is presumably a copy
paste error from chip-tool which generates a new credential every time
it runs.

#### Change overview

Fix it to "pubkey" which matches the definition.

#### Testing

Compile.