### PR TITLE
[codegen] Update template for generating TestOnlyClusters

### DIFF
--- a/examples/chip-tool/templates/partials/simulated_cluster/WaitForMs.zapt
+++ b/examples/chip-tool/templates/partials/simulated_cluster/WaitForMs.zapt
@@ -1,0 +1,6 @@
+CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
+{
+    ChipLogProgress(chipTool, "{{cluster}} - {{asUpperCamelCase command}} - {{label}}");
+
+    return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{definedValue}}{{/chip_tests_item_parameters}});
+}

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -46,12 +46,7 @@ class {{filename}}: public TestCommand
 
     {{#chip_tests_items}}
     {{#if (isTestOnlyCluster cluster)}}
-    CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
-    {
-        ChipLogProgress(chipTool, "{{cluster}} - {{label}}");
-
-        return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{definedValue}}{{/chip_tests_item_parameters}});
-    }
+    {{> (asSimulatedClusterCommandPartial command) }}
     {{else}}
     // Test {{label}}
     using SuccessCallback_{{index}} = void (*)(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});

--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -26,6 +26,10 @@
         {
             "name": "test_cluster",
             "path": "partials/test_cluster.zapt"
+        },
+        {
+            "name": "SimulatedCluster_WaitForMs",
+            "path": "partials/simulated_cluster/WaitForMs.zapt"
         }
     ],
     "templates": [

--- a/src/app/tests/suites/TestDelayCommands.yaml
+++ b/src/app/tests/suites/TestDelayCommands.yaml
@@ -20,7 +20,7 @@ config:
 
 tests:
     - label: "Wait 100ms"
-      cluster: "DelayCommands"
+      cluster: "SimulatedCluster"
       command: "WaitForMs"
       arguments:
           values:

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -26,7 +26,9 @@ const path              = require('path');
 // Import helpers from zap core
 const templateUtil = require(zapPath + 'dist/src-electron/generator/template-util.js')
 
-const { DelayCommands }                 = require('./simulated-clusters/TestDelayCommands.js');
+const chipTemplateHelper = require(basePath + 'src/app/zap-templates/templates/app/helper.js')
+
+const { SimulatedCluster }              = require('./SimulatedCluster.js');
 const { Clusters, asBlocks, asPromise } = require('./ClustersHelper.js');
 
 const kClusterName       = 'cluster';
@@ -214,18 +216,19 @@ function getClusters()
 {
   // Create a new array to merge the configured clusters list and test
   // simulated clusters.
-  return Clusters.getClusters().then(clusters => clusters.concat(DelayCommands));
+  return Clusters.getClusters().then(clusters => clusters.concat(SimulatedCluster));
 }
 
 function getCommands(clusterName)
 {
-  return (clusterName == DelayCommands.name) ? Promise.resolve(DelayCommands.commands) : Clusters.getClientCommands(clusterName);
+  return (clusterName == SimulatedCluster.name) ? Promise.resolve(SimulatedCluster.commands)
+                                                : Clusters.getClientCommands(clusterName);
 }
 
 function getAttributes(clusterName)
 {
-  return (clusterName == DelayCommands.name) ? Promise.resolve(DelayCommands.attributes)
-                                             : Clusters.getServerAttributes(clusterName);
+  return (clusterName == SimulatedCluster.name) ? Promise.resolve(SimulatedCluster.attributes)
+                                                : Clusters.getServerAttributes(clusterName);
 }
 
 function assertCommandOrAttribute(context)
@@ -291,7 +294,7 @@ function chip_tests_items(options)
 
 function isTestOnlyCluster(name)
 {
-  return name == DelayCommands.name;
+  return name == SimulatedCluster.name;
 }
 
 function chip_tests_item_parameters(options)
@@ -360,6 +363,11 @@ function chip_tests_item_response_parameters(options)
   return asBlocks.call(this, promise, options);
 }
 
+function asSimulatedClusterCommandPartial(label)
+{
+  return "SimulatedCluster_" + chipTemplateHelper.asUpperCamelCase(label)
+}
+
 //
 // Module exports
 //
@@ -368,3 +376,4 @@ exports.chip_tests_items                    = chip_tests_items;
 exports.chip_tests_item_parameters          = chip_tests_item_parameters;
 exports.chip_tests_item_response_parameters = chip_tests_item_response_parameters;
 exports.isTestOnlyCluster                   = isTestOnlyCluster;
+exports.asSimulatedClusterCommandPartial    = asSimulatedClusterCommandPartial;

--- a/src/app/zap-templates/common/SimulatedCluster.js
+++ b/src/app/zap-templates/common/SimulatedCluster.js
@@ -16,7 +16,7 @@
  */
 
 /*
- * This file declare test suites utilities methods for delayed commands.
+ * This file declare utilities methods for test suite in (simulated) cluster interface.
  *
  * Each method declared in this file needs to be implemented on a per-language
  * basis and permits to exposes methods to the test suites that are not part
@@ -30,12 +30,12 @@ const WaitForMs = {
   response : { arguments : [] }
 };
 
-const DelayCommands = {
-  name : 'DelayCommands',
+const SimulatedCluster = {
+  name : 'SimulatedCluster',
   commands : [ WaitForMs ],
 };
 
 //
 // Module exports
 //
-exports.DelayCommands = DelayCommands;
+exports.SimulatedCluster = SimulatedCluster;

--- a/src/darwin/Framework/CHIP/templates/partials/simulated_cluster/WaitForMs.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/simulated_cluster/WaitForMs.zapt
@@ -1,0 +1,2 @@
+dispatch_queue_t queue = dispatch_get_main_queue();
+{{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -4,8 +4,7 @@
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"{{label}}"];
 {{#if (isTestOnlyCluster cluster)}}
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});
+{{> (asSimulatedClusterCommandPartial command)}}
 {{else}}
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -22,6 +22,10 @@
         {
             "name": "CHIPCallbackBridge",
             "path": "partials/CHIPCallbackBridge.zapt"
+        },
+        {
+            "name": "SimulatedCluster_WaitForMs",
+            "path": "partials/simulated_cluster/WaitForMs.zapt"
         }
     ],
     "templates": [

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -10426,7 +10426,7 @@ public:
         switch (mTestIndex++)
         {
         case 0:
-            err = TestSendClusterDelayCommandsCommandWaitForMs_0();
+            err = TestSendClusterSimulatedClusterCommandWaitForMs_0();
             break;
         }
 
@@ -10445,9 +10445,9 @@ private:
     // Tests methods
     //
 
-    CHIP_ERROR TestSendClusterDelayCommandsCommandWaitForMs_0()
+    CHIP_ERROR TestSendClusterSimulatedClusterCommandWaitForMs_0()
     {
-        ChipLogProgress(chipTool, "DelayCommands - Wait 100ms");
+        ChipLogProgress(chipTool, "SimulatedCluster - WaitForMs - Wait 100ms");
 
         return WaitForMs(100);
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

Current codegen for test only clusters limits the codegen for complex context.

#### Change overview

- Rename `DelayCommands` to `TestSuite`
- Create seperate partical for test suite commands for more complex template rules.

#### Testing
- Codegen pass, no (meaningful) code change found.
