### PR TITLE
[Telink]: Fix entropy source failed crash on boot

### DIFF
--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -21,7 +21,10 @@
  *          for Zephyr platforms.
  */
 
+#if !CONFIG_NORDIC_SECURITY_BACKEND
 #include <crypto/CHIPCryptoPAL.h>
+#endif // !CONFIG_NORDIC_SECURITY_BACKEND
+
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/PlatformManager.h>

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -22,7 +22,7 @@
  */
 
 #if !CONFIG_NORDIC_SECURITY_BACKEND
-#include <crypto/CHIPCryptoPAL.h>
+#include <crypto/CHIPCryptoPAL.h> // nogncheck
 #endif // !CONFIG_NORDIC_SECURITY_BACKEND
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -23,7 +23,7 @@
 
 #if !CONFIG_NORDIC_SECURITY_BACKEND
 #include <crypto/CHIPCryptoPAL.h> // nogncheck
-#endif // !CONFIG_NORDIC_SECURITY_BACKEND
+#endif                            // !CONFIG_NORDIC_SECURITY_BACKEND
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -21,6 +21,7 @@
  *          for Zephyr platforms.
  */
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/PlatformManager.h>
@@ -37,19 +38,29 @@ static K_THREAD_STACK_DEFINE(sChipThreadStack, CHIP_DEVICE_CONFIG_CHIP_TASK_STAC
 
 PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 
+static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
+{
+    const struct device * entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+
+    SuccessOrExit(entropy_get_entropy(entropy, output, len));
+
+    *olen = len;
+
+exit:
+    return 0;
+}
+
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
-    const struct device * entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-    unsigned int seed;
 
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
 
-    // Get entropy to initialize seed for pseudorandom operations.
-    SuccessOrExit(entropy_get_entropy(entropy, reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
-    srand(seed);
+    // Add entropy source based on Zephyr entropy driver
+    err = chip::Crypto::add_entropy_source(app_entropy_source, NULL, 16);
+    SuccessOrExit(err);
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -38,29 +38,43 @@ static K_THREAD_STACK_DEFINE(sChipThreadStack, CHIP_DEVICE_CONFIG_CHIP_TASK_STAC
 
 PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 
+#if !CONFIG_NORDIC_SECURITY_BACKEND
 static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
 {
     const struct device * entropy = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+    int ret                       = entropy_get_entropy(entropy, output, len);
 
-    SuccessOrExit(entropy_get_entropy(entropy, output, len));
+    if (ret == 0)
+    {
+        *olen = len;
+    }
+    else
+    {
+        *olen = 0;
+    }
 
-    *olen = len;
-
-exit:
-    return 0;
+    return ret;
 }
+#endif // !CONFIG_NORDIC_SECURITY_BACKEND
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
+#if !CONFIG_NORDIC_SECURITY_BACKEND
+    // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
+    const size_t kThreshold = 16;
+#endif // !CONFIG_NORDIC_SECURITY_BACKEND
+
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
 
+#if !CONFIG_NORDIC_SECURITY_BACKEND
     // Add entropy source based on Zephyr entropy driver
-    err = chip::Crypto::add_entropy_source(app_entropy_source, NULL, 16);
+    err = chip::Crypto::add_entropy_source(app_entropy_source, NULL, kThreshold);
     SuccessOrExit(err);
+#endif // !CONFIG_NORDIC_SECURITY_BACKEND
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -46,10 +46,7 @@ static_library("nrfconnect") {
 
   deps = []
 
-  public_deps = [
-    "${chip_root}/src/crypto",
-    "${chip_root}/src/platform:platform_base",
-  ]
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
 
   if (chip_enable_openthread) {
     sources += [

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -46,7 +46,10 @@ static_library("nrfconnect") {
 
   deps = []
 
-  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  public_deps = [ 
+    "${chip_root}/src/platform:platform_base",
+    "${chip_root}/src/crypto"
+  ]
 
   if (chip_enable_openthread) {
     sources += [

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -46,9 +46,9 @@ static_library("nrfconnect") {
 
   deps = []
 
-  public_deps = [ 
+  public_deps = [
+    "${chip_root}/src/crypto",
     "${chip_root}/src/platform:platform_base",
-    "${chip_root}/src/crypto"
   ]
 
   if (chip_enable_openthread) {

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -59,7 +59,5 @@ static_library("telink") {
     }
   }
 
-  public_deps += [
-    "${chip_root}/src/crypto"
-  ]
+  public_deps += [ "${chip_root}/src/crypto" ]
 }

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -58,4 +58,8 @@ static_library("telink") {
       deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
     }
   }
+
+  public_deps += [
+    "${chip_root}/src/crypto"
+  ]
 }


### PR DESCRIPTION
#### Problem
Fix crash on startup for Telink platform with following log:
```
*** Booting Zephyr OS build zephyr-v2.5.0-7511-g083f3065b44a  ***
I: Notifier: StateChanged (0x00000001) [Ip6+]
I: Init CHIP stack
E: 75 [CR]mbedTLS error: CTR_DRBG - The entropy source failed
E: 80 [DL]Entropy initialization failed: Error CHIP:0x000000AC
E: PlatformMgr().InitChipStack() failed
E: Exited with code ac
I: 8 Sectors of 256 bytes
I: alloc wra: 0, e8
I: data wra: 0, 0
I: Notifier: StateChanged (0x00038200) [NetData PanId NetName ExtPanId]

```
Investigation  shows that the issue occurs due to changes made by this https://github.com/project-chip/connectedhomeip/pull/9420 PR

Did previous solution works for nRF platform?

Any way, according to previous solution, **srand()** were called twice. 
First time in ${chip_root}/src/platform/Zephyr/PlatformManagerImpl.cpp in **_InitChipStack**
Second time in ${chip_root}/src/platform/Entropy.cpp in **InitEntropy**

#### Change overview

- Remove srand call from ${chip_root}/src/platform/Zephyr/PlatformManagerImpl.cpp
- Move Zephyr related entropy driver calls to **app_entropy_source** function
- Add **chip::Crypto::add_entropy_source** call in **_InitChipStack** method

#### Testing
Manually. Steps:
1. Build lighting example
2. Flash it on Telink device
3. Check if it does not crash on boot
4. Pair device over chip-tool
5. Send chip-tool onoff on 1 command
6. Check if it works correctly
