### PR TITLE
Simplify telink build

### DIFF
--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -61,7 +61,7 @@ class TelinkBuilder(Builder):
 
     def generate(self):
         if os.path.exists(self.output_dir):
-           return
+            return
 
         if not self._runner.dry_run:
             # Zephyr base
@@ -78,12 +78,13 @@ export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {outdir} -b {board} {sourcedir}
         '''.format(
-                outdir=shlex.quote(
-                    self.output_dir), board=self.board.GnArgName(), sourcedir=shlex.quote(
-                    os.path.join(
-                        self.root, 'examples', self.app.ExampleName(), 'telink'))).strip()
+            outdir=shlex.quote(
+                self.output_dir), board=self.board.GnArgName(), sourcedir=shlex.quote(
+                os.path.join(
+                    self.root, 'examples', self.app.ExampleName(), 'telink'))).strip()
 
-        self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
+        self._Execute(['bash', '-c', cmd],
+                      title='Generating ' + self.identifier)
 
     def _build(self):
         logging.info('Compiling Telink at %s', self.output_dir)

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -60,25 +60,21 @@ class TelinkBuilder(Builder):
         self.board = board
 
     def generate(self):
+        if os.path.exists(self.output_dir):
+           return
 
-        if not os.path.exists(self.output_dir):
-            cmd = 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"\n'
+        if not self._runner.dry_run:
+            # Zephyr base
+            if 'TELINK_ZEPHYR_BASE' not in os.environ:
+                raise Exception("Telink builds require TELINK_ZEPHYR_BASE")
 
-            if not self._runner.dry_run:
+        cmd = 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"\n'
 
-                # Zephyr base
-                if 'TELINK_ZEPHYR_BASE' not in os.environ:
-                    # TODO: remove once variable in all images
-                    cmd = ''
-                    if 'ZEPHYR_BASE' not in os.environ:
-                        raise Exception(
-                            "Telink builds require TELINK_ZEPHYR_BASE or ZEPHYR_BASE to be set")
+        if 'TELINK_ZEPHYR_SDK_DIR' in os.environ:
+            cmd += 'export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"\n'
 
-            # TODO: TELINK_ZEPHYR_SDK_DIR should be used for compilation and
-            # NOT hardcoding of zephyr-sdk-0.13.0
-            cmd += '''
+        cmd += '''
 export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-export ZEPHYR_SDK_INSTALL_DIR="$ZEPHYR_BASE/../../zephyr-sdk-0.13.0"
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {outdir} -b {board} {sourcedir}
         '''.format(
@@ -87,8 +83,7 @@ west build --cmake-only -d {outdir} -b {board} {sourcedir}
                     os.path.join(
                         self.root, 'examples', self.app.ExampleName(), 'telink'))).strip()
 
-            self._Execute(['bash', '-c', cmd],
-                          title='Generating ' + self.identifier)
+        self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
 
     def _build(self):
         logging.info('Compiling Telink at %s', self.output_dir)

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -127,8 +127,8 @@ gn gen --check --fail-on-unused-args --root={root}/examples/lock-app/p6 '--args=
 
 # Generating telink-tlsr9518adk80d-light
 bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
 export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-export ZEPHYR_SDK_INSTALL_DIR="$ZEPHYR_BASE/../../zephyr-sdk-0.13.0"
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting-app/telink'
 

--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -47,6 +47,7 @@ def build_actual_output(root: str, out: str) -> List[str]:
         'ANDROID_NDK_HOME': 'TEST_ANDROID_NDK_HOME',
         'ANDROID_HOME': 'TEST_ANDROID_HOME',
         'TIZEN_HOME': 'TEST_TIZEN_HOME',
+        'TELINK_ZEPHYR_SDK_DIR': 'TELINK_ZEPHYR_SDK_DIR',
     })
 
     retval = subprocess.run([


### PR DESCRIPTION
#### Problem
Previous vscode images were missing required build environment variables so build script hardcoded zephyr SDK paths

#### Change overview
After #9535 we can use environment variables.

#### Testing
Local build, CI build.