### PR TITLE
Revert "Add mDNS shutdown (#9621)"

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -266,10 +266,6 @@ CHIP_ERROR DeviceController::Shutdown()
     // manager.
     app::InteractionModelEngine::GetInstance()->Shutdown();
 
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    Mdns::Resolver::Instance().ShutdownResolver();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
-
     // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
     // if (mExchangeMgr != nullptr)
     // {

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -33,7 +33,6 @@ class MockResolver : public Resolver
 public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return SetResolverDelegateStatus; }
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return StartResolverStatus; }
-    void ShutdownResolver() override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -43,7 +43,6 @@ public:
 
     /// Starts the service resolver if not yet started
     CHIP_ERROR StartResolver(Inet::InetLayer * inetLayer, uint16_t port) override { return Init(); }
-    void ShutdownResolver() override { ChipMdnsShutdown(); }
 
     /// Advertises the CHIP node as an operational node
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;

--- a/src/lib/mdns/MinimalMdnsServer.cpp
+++ b/src/lib/mdns/MinimalMdnsServer.cpp
@@ -107,10 +107,5 @@ CHIP_ERROR GlobalMinimalMdnsServer::StartServer(chip::Inet::InetLayer * inetLaye
     return GlobalMinimalMdnsServer::Server().Listen(inetLayer, &allInterfaces, port);
 }
 
-void GlobalMinimalMdnsServer::ShutdownServer()
-{
-    GlobalMinimalMdnsServer::Server().Shutdown();
-}
-
 } // namespace Mdns
 } // namespace chip

--- a/src/lib/mdns/MinimalMdnsServer.h
+++ b/src/lib/mdns/MinimalMdnsServer.h
@@ -90,7 +90,6 @@ public:
 
     /// Calls Server().Listen() on all available interfaces
     CHIP_ERROR StartServer(chip::Inet::InetLayer * inetLayer, uint16_t port);
-    void ShutdownServer();
 
     void SetQueryDelegate(MdnsPacketDelegate * delegate) { mQueryDelegate = delegate; }
     void SetResponseDelegate(MdnsPacketDelegate * delegate) { mResponseDelegate = delegate; }

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -260,7 +260,6 @@ public:
     ///
     /// Unsual name to allow base MDNS classes to implement both Advertiser and Resolver interfaces.
     virtual CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
-    virtual void ShutdownResolver()                                                    = 0;
 
     /// Registers a resolver delegate if none has been registered before
     virtual CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) = 0;

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -335,7 +335,6 @@ public:
 
     ///// Resolver implementation
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
-    void ShutdownResolver() override;
     CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -393,11 +392,6 @@ CHIP_ERROR MinMdnsResolver::StartResolver(chip::Inet::InetLayer * inetLayer, uin
     }
 
     return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port);
-}
-
-void MinMdnsResolver::ShutdownResolver()
-{
-    GlobalMinimalMdnsServer::Instance().ShutdownServer();
 }
 
 CHIP_ERROR MinMdnsResolver::SetResolverDelegate(ResolverDelegate * delegate)

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -29,7 +29,6 @@ public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return CHIP_NO_ERROR; }
-    void ShutdownResolver() override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
     {

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -95,11 +95,6 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipMdnsShutdown()
-{
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     return test::CheckExpected(test::CallType::kStart, service);


### PR DESCRIPTION
This reverts commit 3da26cfa879282c06fea97b7c98db371d0d018a7.

Tizen builds seem broken since this change:

```
2021-09-13 15:22:31 INFO
/__w/connectedhomeip/connectedhomeip/out/tizen-arm-light/../../examples/lighting-app/linux/third_party/connectedhomeip/src/lib/mdns/Discovery_ImplPlatform.h:46:
undefined reference to `chip::Mdns::ChipMdnsShutdown()'
409
2021-09-13 15:22:31 INFO    collect2: error: ld returned 1 exit status
```
