### PR TITLE
Fix system layer call: add missing brackets

### DIFF
--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -311,7 +311,7 @@ void Poller::SystemTimerUpdate(AvahiTimeout * timer)
     {
         mEarliestTimeout = timer->mAbsTimeout;
         auto msDelay     = std::chrono::duration_cast<std::chrono::milliseconds>(steady_clock::now() - mEarliestTimeout).count();
-        DeviceLayer::SystemLayer.StartTimer(msDelay, SystemTimerCallback, this);
+        DeviceLayer::SystemLayer().StartTimer(msDelay, SystemTimerCallback, this);
     }
 }
 


### PR DESCRIPTION
Fix master CI build: merge and revert caused a transition from ::SystemLayer to ::SystemLayer() to be missed.

Tested: local build passes after the change.