### PR TITLE
[TE6]: Enable Network Diagnostic attributes on missing platforms

### DIFF
--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -22,6 +22,8 @@
 
 #include "AppConfig.h"
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
 
 #include "LightingManager.h"
 
@@ -31,6 +33,7 @@
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
+using namespace ::chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
@@ -71,6 +74,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
 
         // WIP Apply attribute change to Light
     }
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %ld", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04lx', EndPoint ID: '0x%02x', Attribute ID: '0x%04lx'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %ld", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 /** @brief OnOff Cluster Init

--- a/examples/lighting-app/mbed/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/mbed/main/ZclCallbacks.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
 
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/cluster-id.h>
@@ -28,6 +30,8 @@
 #include "LightingManager.h"
 
 using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
@@ -68,6 +72,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
         return;
     }
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %ld", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04lx', EndPoint ID: '0x%02x', Attribute ID: '0x%04lx'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %ld", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 /** @brief OnOff Cluster Init

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -29,6 +31,7 @@
 
 using namespace chip;
 using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
@@ -44,6 +47,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %" PRIu8, *value);
         LightingMgr().InitiateAction(LightingManager::LEVEL_ACTION, AppEvent::kEventType_Lighting, size, value);
     }
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %ld", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04lx', EndPoint ID: '0x%02x', Attribute ID: '0x%04lx'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %ld", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 /** @brief OnOff Cluster Init

--- a/examples/lighting-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg/src/ZclCallbacks.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
 
 #include "AppTask.h"
 #include "LightingManager.h"
@@ -30,8 +32,9 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 
-using namespace ::chip;
+using namespace chip;
 using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
@@ -133,6 +136,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         ChipLogProgress(Zcl, "Unknown cluster ID: %" PRIx32, clusterId);
         return;
     }
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %ld", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04lx', EndPoint ID: '0x%02x', Attribute ID: '0x%04lx'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %ld", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 /** @brief OnOff Cluster Init

--- a/examples/lighting-app/telink/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/telink/src/ZclCallbacks.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -29,6 +31,7 @@
 
 using namespace chip;
 using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
@@ -69,6 +72,103 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
         ChipLogProgress(Zcl, "Unknown cluster ID: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
         return;
     }
+}
+
+EmberAfStatus HandleReadEthernetNetworkDiagnosticsAttribute(chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    switch (attributeId)
+    {
+    case ZCL_PACKET_RX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetRxCount;
+
+            if (ConnectivityMgr().GetEthPacketRxCount(packetRxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetRxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_PACKET_TX_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t packetTxCount;
+
+            if (ConnectivityMgr().GetEthPacketTxCount(packetTxCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &packetTxCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_TX_ERR_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t txErrCount;
+
+            if (ConnectivityMgr().GetEthTxErrCount(txErrCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &txErrCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_COLLISION_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t collisionCount;
+
+            if (ConnectivityMgr().GetEthCollisionCount(collisionCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &collisionCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    case ZCL_ETHERNET_OVERRUN_COUNT_ATTRIBUTE_ID:
+        if (maxReadLength == sizeof(uint64_t))
+        {
+            uint64_t overrunCount;
+
+            if (ConnectivityMgr().GetEthOverrunCount(overrunCount) == CHIP_NO_ERROR)
+            {
+                memcpy(buffer, &overrunCount, maxReadLength);
+                ret = EMBER_ZCL_STATUS_SUCCESS;
+            }
+        }
+        break;
+    default:
+        ChipLogProgress(Zcl, "Unhandled attribute ID: %ld", attributeId);
+        break;
+    }
+
+    return ret;
+}
+
+EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                   EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
+                                                   uint8_t * buffer, uint16_t maxReadLength, int32_t index)
+{
+    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+
+    ChipLogProgress(Zcl,
+                    "emberAfExternalAttributeReadCallback - Cluster ID: '0x%04lx', EndPoint ID: '0x%02x', Attribute ID: '0x%04lx'",
+                    clusterId, endpoint, attributeMetadata->attributeId);
+
+    switch (clusterId)
+    {
+    case ZCL_ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER_ID:
+        ret = HandleReadEthernetNetworkDiagnosticsAttribute(attributeMetadata->attributeId, buffer, maxReadLength);
+        break;
+    default:
+        ChipLogError(Zcl, "Unhandled cluster ID: %ld", clusterId);
+        break;
+    }
+
+    return ret;
 }
 
 /** @brief OnOff Cluster Init

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -826,18 +826,6 @@
 #define CHIP_DEVICE_CONFIG_DEFAULT_TELEMETRY_INTERVAL_MS 90000
 #endif
 
-/**
- * @def CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
- *
- * @brief
- *   Default ethernet network interface name used to centralize all metrics that are
- *   relevant to a potential Ethernet connection to a Node.
- *
- */
-#ifndef CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
-#define CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME "enp0s25"
-#endif
-
 // -------------------- Event Logging Configuration --------------------
 
 /**

--- a/src/platform/Linux/CHIPDevicePlatformConfig.h
+++ b/src/platform/Linux/CHIPDevicePlatformConfig.h
@@ -86,3 +86,15 @@
 
 // TODO: CHIP has redesigned the crypto interface, pending on the final version of CHIP HASH APIs
 #define CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH 0
+
+/**
+ * @def CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
+ *
+ * @brief
+ *   Default ethernet network interface name used to centralize all metrics that are
+ *   relevant to a potential Ethernet connection to a Node.
+ *
+ */
+#ifndef CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
+#define CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME "enp0s25"
+#endif


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We have enabled Network Diagnostic attributes as 'External' in zap, but we only implemented the attribute read callbacks for Linux platform. Currently, the zap file is platform independent, so we need to implement those callbacks for all platforms that implement the server.


#### Change overview
* Enable Network Diagnostic attributes on missing platforms
* Move config CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME  from platform/CHIPDeviceConfig.h to CHIPDeviceBuildConfig.h since this config is platform specific.

#### Testing
How was this tested? (at least one bullet point required)
* Same callback implementations are added to missing platforms, we only need to confirm they can compile. 
