### PR TITLE
Enable act tool for running CI jobs locally

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -48,7 +48,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -129,7 +129,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -270,7 +270,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -115,7 +115,7 @@ jobs:
                      --volume /dev/pts:/dev/pts \
                      -- scripts/tests/cirque_tests.sh run_all_tests
             - name: Uploading Binaries
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name:

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -116,7 +116,7 @@ jobs:
                      -- scripts/tests/cirque_tests.sh run_all_tests
             - name: Uploading Binaries
               uses: actions/upload-artifact@v1
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name:
                       cirque_log-${{steps.outsuffix.outputs.value}}-logs

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -51,7 +51,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -49,7 +49,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -85,6 +85,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
               uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -139,7 +139,7 @@ jobs:
               run: |
                   cp -r example_binaries/$BUILD_TYPE-build /tmp/output_binaries/
             - name: Uploading Binaries
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}
               with:
                   name:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -50,7 +50,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -140,6 +140,7 @@ jobs:
                   cp -r example_binaries/$BUILD_TYPE-build /tmp/output_binaries/
             - name: Uploading Binaries
               uses: actions/upload-artifact@v1
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -44,7 +44,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -48,7 +48,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -75,6 +75,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
               uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -49,7 +49,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -96,6 +96,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
               uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -85,7 +85,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
 
             - name: Uploading binaries as artifacts
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}
               with:
                   name:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -53,7 +53,7 @@ jobs:
 
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -86,6 +86,7 @@ jobs:
 
             - name: Uploading binaries as artifacts
               uses: actions/upload-artifact@v1
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-binaries-${{env.APP_TARGET}}-${{ env.APP_PROFILE}}-build-${{

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -107,7 +107,7 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}
               with:
                   name:

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -102,6 +102,7 @@ jobs:
             - name: Binary artifact suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0
+              if: ${{ !env.ACT }}
               with:
                   cond: ${{ github.event.pull_request.number == '' }}
                   if_true: "${{ github.sha }}"

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -49,7 +49,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -108,6 +108,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
               uses: actions/upload-artifact@v1
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -48,7 +48,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -75,6 +75,7 @@ jobs:
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Uploading Binaries
               uses: actions/upload-artifact@v2
+              if: ${{ !env.ACT }}
               with:
                   name:
                       ${{ env.BUILD_TYPE }}-example-build-${{

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -61,7 +61,7 @@ jobs:
               timeout-minutes: 35
               run: scripts/tests/esp32_qemu_tests.sh /tmp/test_logs
             - name: Uploading Logs
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}
               with:
                   name: qemu-esp32-logs

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -48,7 +48,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -62,6 +62,7 @@ jobs:
               run: scripts/tests/esp32_qemu_tests.sh /tmp/test_logs
             - name: Uploading Logs
               uses: actions/upload-artifact@v1
+              if: ${{ !env.ACT }}
               with:
                   name: qemu-esp32-logs
                   path: /tmp/log_output

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -42,7 +42,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -82,7 +82,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs-linux-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: |
@@ -94,7 +94,7 @@ jobs:
                   scripts/tests/test_suites.sh  -a tv
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: crash-core-linux-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: /tmp/cores/
@@ -102,7 +102,7 @@ jobs:
                   retention-days: 5
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: crash-objdir-linux-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: objdir-clone/
@@ -149,7 +149,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs-darwin-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: |
@@ -175,7 +175,7 @@ jobs:
                   scripts/tests/test_suites.sh
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: crash-core-darwin-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: /cores/
@@ -183,13 +183,13 @@ jobs:
                   retention-days: 5
             - name: Uploading diagnostic logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: crash-log-darwin-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: ~/Library/Logs/DiagnosticReports/
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }}
+              if: ${{ failure() }} && ${{ !env.ACT }}
               with:
                   name: crash-objdir-darwin-${{ matrix.type }}-${{ matrix.eventloop }}
                   path: objdir-clone/

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -60,7 +60,7 @@ jobs:
                   scripts/build/gn_bootstrap.sh ;
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -91,7 +91,7 @@ jobs:
               run: RUN_HAPPY_TESTS=1 scripts/tests/gn_tests.sh
             - name: Uploading Happy Test Log
               uses: actions/upload-artifact@v1
-              if: ${{ always() }}
+              if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name:
                       happy_log-${{ steps.outsuffix.outputs.value }}-${{ matrix.type }}

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -90,7 +90,7 @@ jobs:
               timeout-minutes: 5
               run: RUN_HAPPY_TESTS=1 scripts/tests/gn_tests.sh
             - name: Uploading Happy Test Log
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v2
               if: ${{ always() }} && ${{ !env.ACT }}
               with:
                   name:


### PR DESCRIPTION
#### Problem
[act](https://github.com/nektos/act) tool allows to execute GitHub actions locally.  [Actions like upload-artifact and cache use third-party services configured defined through  ACTIONS_RUNTIME_URL, ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL environment variables](https://github.com/nektos/act/issues/329#issuecomment-766341018), this dependency limits the execution of act tool.

#### Change overview
This change allows the execution of act tool locally for development and validation of GitHub jobs.

It also upgrade the upload-artifact GH action version to v2.

#### Testing
To run this locally it's necessary to install act and its dependencies described [here](https://github.com/nektos/act#installation). Once it's installed, CI jobs can be tested executing the following command:

```bash
$ act
```
> The previous command will execute all jobs currently defined, resulting in downloading ~55 GB and consuming + 210 GB in HDD (/var/lib/docker) therefore, it's highly recommended to select the jobs to test.

```bash
$ act --list
ID                      Stage  Name                                          
android                 0      Build Android                                 
build_darwin            0      Build on Darwin (clang, python_lib)           
build_linux_gcc_debug   0      Build on Linux (gcc_debug)                    
build_linux             0      Build on Linux (gcc_release, clang, mbedtls)  
build_linux_python_lib  0      Build on Linux (python_lib)                   
cirque                  0      Cirque                                        
darwin                  0      Build Darwin                                  
doxygen                 0      Build Doxygen                                 
efr32                   0      EFR32                                         
esp32                   0      ESP32                                         
infineon                0      Infineon examples building                    
k32w                    0      K32W                                          
linux_standalone        0      Linux Standalone                              
mbedos                  0      Mbed OS examples building                     
nrfconnect              0      nRF Connect SDK                               
qpg                     0      QPG                                           
telink                  0      Telink                                        
tizen                   0      Tizen                                         
qemu                    0      ESP32                                         
test_suites_darwin      0      Test Suites - Darwin                          
test_suites_linux       0      Test Suites - Linux                           
unit_tests              0      Unit / Interation Tests                       
zap_templates           0      ZAP templates generation                   
$ act --job nrfconnect
[Build example - nRF Connect SDK/nRF Connect SDK] 🚀  Start image=connectedhomeip/chip-build-nrf-platform:latest
[Build example - nRF Connect SDK/nRF Connect SDK]   🐳  docker run image=connectedhomeip/chip-build-nrf-platform:latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Build example - nRF Connect SDK/nRF Connect SDK]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root
...
```