### PR TITLE
TLV Reader error handling test should not read uninitialized data.

### DIFF
--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -3021,7 +3021,7 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 void TestCHIPTLVReaderErrorHandling(nlTestSuite * inSuite)
 {
     CHIP_ERROR err;
-    uint8_t buf[2048];
+    uint8_t buf[2048] = { 0 };
     TLVReader reader;
 
     reader.Init(buf);


### PR DESCRIPTION
We should just zero the data out, so it's known-bad.

#### Problem
Test is making assertions about the contents of uninitialized data.

#### Change overview
Initialize the data.

#### Testing
Ran CI, the test passes.  Now should be consistent, too.