### PR TITLE
Make dynamic endpoint lifetime more similar to that of fixed endpoints.

### DIFF
--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -131,13 +131,13 @@ void emberAfPluginDescriptorServerInitCallback(void)
 
     for (uint16_t index = 0; index < emberAfEndpointCount(); index++)
     {
-        EndpointId endpoint = emberAfEndpointFromIndex(index);
-        if (!emberAfContainsCluster(endpoint, Descriptor::Id))
+        if (!emberAfEndpointIndexIsEnabled(index))
         {
             continue;
         }
 
-        if (!emberAfEndpointIndexIsEnabled(index))
+        EndpointId endpoint = emberAfEndpointFromIndex(index);
+        if (!emberAfContainsCluster(endpoint, Descriptor::Id))
         {
             continue;
         }


### PR DESCRIPTION
Specific changes:

1) Ensure that dynamic endpoints land in initializeEndpoint (via
   emberAfEndpointEnableDisable) like fixed ones do (via emAfCallInits).

2) Ensure that clearing an dynamic endpoint properly disables it.
   This makes sure we call emberAfDeactivateClusterTick as needed and
   we can add other cleanup inside emberAfEndpointEnableDisable as it
   becomes useful.

3) Move the emberAfPluginDescriptorServerInitCallback calls for
   dynamic endpoints to the one choke-point in
   emberAfEndpointEnableDisable.  This also fixes a pre-existing issue
   where disabling a fixed endpoint would not correctly update the
   descriptor bits.

4) In descriptor, check for enabled state before trying to actually
   touch the endpoint's data, not after we have tried to touch some of
   it.

#### Testing
I'm not sure how to test this.  Right now nothing except bridge-app exercises dynamic endpoints, and I don't know how to go about testing that.