### PR TITLE
Add manifest to esp32 flashing script build

### DIFF
--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -64,6 +64,9 @@ class Esp32App(Enum):
         else:
             raise Exception('Unknown app type: %r' % self)
 
+    def FlashBundleName(self):
+        return self.AppNamePrefix + '.flashbundle.txt'
+
 
 def DefaultsFileName(board: Esp32Board, app: Esp32App):
     if app != Esp32App.ALL_CLUSTERS:
@@ -129,3 +132,9 @@ class Esp32Builder(Builder):
             self.app.AppNamePrefix + '.map':
                 os.path.join(self.output_dir, self.app.AppNamePrefix + '.map'),
         }
+
+    def flashbundle(self):
+        with open(os.path.join(self.output_dir, self.app.FlashBundleName()), 'r') as fp:
+            return {
+                l.strip(): os.path.join(self.output_dir, l.strip()) for l in fp.readlines() if l.strip()
+            }


### PR DESCRIPTION
#### Problem

For our interop testing we use packaged firmware from infrastructure
rather than building locally. Currently ESP32 can produce the script but
since it does not generate a list of the files the script requires, we
cannot package it.

#### Change overview

Add the missing manifest and enable packaged flashable firmware for
ESP32.

#### Testing

scripts/build/build_examples.py --board m5stack --app all-clusters --enable-flashbundle build --create-archives /tmp