### PR TITLE
[Tizen] Add ChipMdnsShutdown() 

### DIFF
--- a/src/platform/Tizen/MdnsImpl.cpp
+++ b/src/platform/Tizen/MdnsImpl.cpp
@@ -31,6 +31,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback successCallback, MdnsAsyncReturn
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ChipMdnsSetHostname(const char * hostname)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
#### Problem
Issue #8001 MdnsAvahi destructor segfault; require separate shutdown

MdnsAvahi can cause a crash on exit due to a static instance running
code in its destructor after dependent components have shut down.

#### Change overview
- Add `ChipMdnsShutdown()`. This is a narrow fix, which does not attempt
to address other potential problems with singleton mDNS state.

