### PR TITLE
Sync sdkconfig_m5stack.defaults from sdkconfig.defaults

### DIFF
--- a/examples/all-clusters-app/esp32/sdkconfig_m5stack.defaults
+++ b/examples/all-clusters-app/esp32/sdkconfig_m5stack.defaults
@@ -40,7 +40,13 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
 
-# Main task needs a bit more stack than the default
-# default is 3584, bump this up to 4k.
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=4096
+# Vendor and product id
+CONFIG_DEVICE_VENDOR_ID=0x235A
+CONFIG_DEVICE_PRODUCT_ID=0x4541
 
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 5k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
+
+#enable debug shell
+CONFIG_ENABLE_CHIP_SHELL=y


### PR DESCRIPTION
#### Problem

The continuous builds for m5stack crash due to stack overflow on
startup.

#### Change overview

Sync the stack size increase from https://github.com/project-chip/connectedhomeip/pull/9263 to the main sdkconfig.default to fix this. Also sync the other configuration discrepancies.

#### Testing

```
scripts/build/build_examples.py --board m5stack --app all-clusters --enable-flashbundle build --create-archives /tmp
chip-all-clusters-app.flash.py --erase
```