### PR TITLE
Add mDNS shutdown

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -267,6 +267,10 @@ CHIP_ERROR DeviceController::Shutdown()
     // manager.
     app::InteractionModelEngine::GetInstance()->Shutdown();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    Mdns::Resolver::Instance().ShutdownResolver();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
     // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
     // if (mExchangeMgr != nullptr)
     // {

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -33,6 +33,7 @@ class MockResolver : public Resolver
 public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return SetResolverDelegateStatus; }
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return StartResolverStatus; }
+    void ShutdownResolver() override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -43,6 +43,7 @@ public:
 
     /// Starts the service resolver if not yet started
     CHIP_ERROR StartResolver(Inet::InetLayer * inetLayer, uint16_t port) override { return Init(); }
+    void ShutdownResolver() override { ChipMdnsShutdown(); }
 
     /// Advertises the CHIP node as an operational node
     CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override;

--- a/src/lib/mdns/MinimalMdnsServer.cpp
+++ b/src/lib/mdns/MinimalMdnsServer.cpp
@@ -107,5 +107,10 @@ CHIP_ERROR GlobalMinimalMdnsServer::StartServer(chip::Inet::InetLayer * inetLaye
     return GlobalMinimalMdnsServer::Server().Listen(inetLayer, &allInterfaces, port);
 }
 
+void GlobalMinimalMdnsServer::ShutdownServer()
+{
+    GlobalMinimalMdnsServer::Server().Shutdown();
+}
+
 } // namespace Mdns
 } // namespace chip

--- a/src/lib/mdns/MinimalMdnsServer.h
+++ b/src/lib/mdns/MinimalMdnsServer.h
@@ -90,6 +90,7 @@ public:
 
     /// Calls Server().Listen() on all available interfaces
     CHIP_ERROR StartServer(chip::Inet::InetLayer * inetLayer, uint16_t port);
+    void ShutdownServer();
 
     void SetQueryDelegate(MdnsPacketDelegate * delegate) { mQueryDelegate = delegate; }
     void SetResponseDelegate(MdnsPacketDelegate * delegate) { mResponseDelegate = delegate; }

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -260,6 +260,7 @@ public:
     ///
     /// Unsual name to allow base MDNS classes to implement both Advertiser and Resolver interfaces.
     virtual CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
+    virtual void ShutdownResolver()                                                    = 0;
 
     /// Registers a resolver delegate if none has been registered before
     virtual CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) = 0;

--- a/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Resolver_ImplMinimalMdns.cpp
@@ -335,6 +335,7 @@ public:
 
     ///// Resolver implementation
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override;
+    void ShutdownResolver() override;
     CHIP_ERROR SetResolverDelegate(ResolverDelegate * delegate) override;
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
@@ -392,6 +393,11 @@ CHIP_ERROR MinMdnsResolver::StartResolver(chip::Inet::InetLayer * inetLayer, uin
     }
 
     return GlobalMinimalMdnsServer::Instance().StartServer(inetLayer, port);
+}
+
+void MinMdnsResolver::ShutdownResolver()
+{
+    GlobalMinimalMdnsServer::Instance().ShutdownServer();
 }
 
 CHIP_ERROR MinMdnsResolver::SetResolverDelegate(ResolverDelegate * delegate)

--- a/src/lib/mdns/Resolver_ImplNone.cpp
+++ b/src/lib/mdns/Resolver_ImplNone.cpp
@@ -29,6 +29,7 @@ public:
     CHIP_ERROR SetResolverDelegate(ResolverDelegate *) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR StartResolver(chip::Inet::InetLayer * inetLayer, uint16_t port) override { return CHIP_NO_ERROR; }
+    void ShutdownResolver() override {}
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
     {

--- a/src/platform/Tizen/MdnsImpl.cpp
+++ b/src/platform/Tizen/MdnsImpl.cpp
@@ -31,6 +31,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback successCallback, MdnsAsyncReturn
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipMdnsSetHostname(const char * hostname)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -95,6 +95,11 @@ CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCal
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipMdnsShutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
     return test::CheckExpected(test::CallType::kStart, service);


### PR DESCRIPTION
*Re-submit of #9621*

#### Problem
Hit a CI problem due to that udp endpoint in mDNS is used after udp pool has been freed.


#### Change overview
Add shutdown of mDNS service, shutdown the mDNS server and close udp endpoint before release udp endpoint pool

#### Testing
