### PR TITLE
[msg] Update message version and session id fields to match spec.

### DIFF
--- a/src/channel/Channel.h
+++ b/src/channel/Channel.h
@@ -91,9 +91,9 @@ public:
     TransportPreference GetTransportPreference() const { return mTransportPreference; }
 
     uint16_t GetPeerSessionId() const { return mCaseParameters.mPeerSessionId; }
-    ChannelBuilder & SetPeerSessionId(uint16_t keyId)
+    ChannelBuilder & SetPeerSessionId(uint16_t sessionId)
     {
-        mCaseParameters.mPeerSessionId = keyId;
+        mCaseParameters.mPeerSessionId = sessionId;
         return *this;
     }
 

--- a/src/channel/Channel.h
+++ b/src/channel/Channel.h
@@ -90,10 +90,10 @@ public:
     }
     TransportPreference GetTransportPreference() const { return mTransportPreference; }
 
-    uint16_t GetPeerKeyID() const { return mCaseParameters.mPeerKeyId; }
-    ChannelBuilder & SetPeerKeyID(uint16_t keyId)
+    uint16_t GetPeerSessionId() const { return mCaseParameters.mPeerSessionId; }
+    ChannelBuilder & SetPeerSessionId(uint16_t keyId)
     {
-        mCaseParameters.mPeerKeyId = keyId;
+        mCaseParameters.mPeerSessionId = keyId;
         return *this;
     }
 
@@ -126,7 +126,7 @@ private:
     TransportPreference mTransportPreference = TransportPreference::kDefault;
     struct
     {
-        uint16_t mPeerKeyId;
+        uint16_t mPeerSessionId;
         Credentials::OperationalCredentialSet * mOperationalCredentialSet;
         uint8_t mOperationalCredentialSetIndex;
     } mCaseParameters;

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -131,7 +131,7 @@ bool ChannelContext::MatchesSession(SessionHandle session, SecureSessionMgr * ss
         case PrepareState::kCasePairing: {
             auto state = ssm->GetPeerConnectionState(session);
             return (state->GetPeerNodeId() == GetPrepareVars().mBuilder.GetPeerNodeId() &&
-                    state->GetPeerKeyID() == GetPrepareVars().mBuilder.GetPeerKeyID());
+                    state->GetPeerSessionId() == GetPrepareVars().mBuilder.GetPeerSessionId());
         }
         default:
             return false;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -591,7 +591,7 @@ CHIP_ERROR Device::WarmupCASESession()
 void Device::OnSessionEstablishmentError(CHIP_ERROR error)
 {
     mState = ConnectionState::NotConnected;
-    mIDAllocator->Free(mCASESession.GetLocalKeyId());
+    mIDAllocator->Free(mCASESession.GetLocalSessionId());
 
     Cancelable ready;
     mConnectionFailure.DequeueAll(ready);

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -379,7 +379,7 @@ struct ChipDeviceEvent final
         {
             uint64_t PeerNodeId;
             uint16_t SessionKeyId;
-            uint8_t EncType;
+            uint8_t SessionType;
             bool IsCommissioner;
         } SessionEstablished;
         struct

--- a/src/lib/core/CHIPKeyIds.cpp
+++ b/src/lib/core/CHIPKeyIds.cpp
@@ -244,7 +244,7 @@ bool ChipKeyId::IsValidKeyId(uint32_t keyId)
  *  @return      true                  If the identified key can be used to encrypt CHIP messages.
  *
  */
-bool ChipKeyId::IsMessageEncryptionKeyId(uint32_t keyId, bool allowLogicalKeys)
+bool ChipKeyId::IsMessageSessionId(uint32_t keyId, bool allowLogicalKeys)
 {
     switch (GetType(keyId))
     {

--- a/src/lib/core/CHIPKeyIds.h
+++ b/src/lib/core/CHIPKeyIds.h
@@ -357,7 +357,7 @@ public:
     static uint32_t UpdateEpochKeyId(uint32_t keyId, uint32_t epochKeyId);
 
     static bool IsValidKeyId(uint32_t keyId);
-    static bool IsMessageEncryptionKeyId(uint32_t keyId, bool allowLogicalKeys = true);
+    static bool IsMessageSessionId(uint32_t keyId, bool allowLogicalKeys = true);
     static bool IsSameKeyOrGroup(uint32_t keyId1, uint32_t keyId2);
     static const char * DescribeKey(uint32_t keyId);
 };

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -191,7 +191,7 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     // TODO: Right now, platform impl doesn't stop commissionable node before starting a new one. Add stop call here once that is
     // fixed.
     test::Reset();
-    commissionableLarge.callType = test::CallType::kStart;
+    commissionableLargeBasic.callType = test::CallType::kStart;
     NL_TEST_ASSERT(inSuite,
                    mdnsPlatform.GetCommissionableInstanceName(commissionableLargeBasic.instanceName,
                                                               sizeof(commissionableLargeBasic.instanceName)) == CHIP_NO_ERROR);
@@ -199,7 +199,7 @@ void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLargeBasic) == CHIP_NO_ERROR);
 
     test::Reset();
-    commissionableLarge.callType = test::CallType::kStart;
+    commissionableLargeEnhanced.callType = test::CallType::kStart;
     NL_TEST_ASSERT(inSuite,
                    mdnsPlatform.GetCommissionableInstanceName(commissionableLargeEnhanced.instanceName,
                                                               sizeof(commissionableLargeEnhanced.instanceName)) == CHIP_NO_ERROR);

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -101,7 +101,7 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, ec1->GetExchangeId() != 0);
     auto sessionPeerToLocal = ctx.GetSecureSessionManager().GetPeerConnectionState(ec1->GetSecureSession());
     NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerNodeId() == ctx.GetBobNodeId());
-    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerKeyID() == ctx.GetBobKeyId());
+    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerSessionId() == ctx.GetBobKeyId());
     NL_TEST_ASSERT(inSuite, ec1->GetDelegate() == &mockAppDelegate);
 
     ExchangeContext * ec2 = ctx.NewExchangeToAlice(&mockAppDelegate);
@@ -109,7 +109,7 @@ void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, ec2->GetExchangeId() > ec1->GetExchangeId());
     auto sessionLocalToPeer = ctx.GetSecureSessionManager().GetPeerConnectionState(ec2->GetSecureSession());
     NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerNodeId() == ctx.GetAliceNodeId());
-    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerKeyID() == ctx.GetAliceKeyId());
+    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerSessionId() == ctx.GetAliceKeyId());
 
     ec1->Close();
     ec2->Close();

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -159,7 +159,7 @@ CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
     serializable.mPairingComplete  = (mPairingComplete) ? 1 : 0;
     serializable.mPeerNodeId       = peerNodeId;
     serializable.mLocalKeyId       = GetLocalKeyId();
-    serializable.mPeerKeyId        = GetPeerKeyId();
+    serializable.mPeerSessionId        = GetPeerSessionId();
 
     memcpy(serializable.mSharedSecret, mSharedSecret, mSharedSecret.Length());
     memcpy(serializable.mMessageDigest, mMessageDigest, sizeof(mMessageDigest));
@@ -183,7 +183,7 @@ CHIP_ERROR CASESession::FromSerializable(const CASESessionSerializable & seriali
 
     SetPeerNodeId(serializable.mPeerNodeId);
     SetLocalKeyId(serializable.mLocalKeyId);
-    SetPeerKeyId(serializable.mPeerKeyId);
+    SetPeerSessionId(serializable.mPeerSessionId);
 
     return CHIP_NO_ERROR;
 }
@@ -395,7 +395,7 @@ CHIP_ERROR CASESession::HandleSigmaR1(System::PacketBufferHandle && msg)
     SuccessOrExit(err = tlvReader.Get(initiatorSessionId));
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", initiatorSessionId);
-    SetPeerKeyId(initiatorSessionId);
+    SetPeerSessionId(initiatorSessionId);
 
     SuccessOrExit(err = tlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(tlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
@@ -649,7 +649,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle && msg)
     SuccessOrExit(err = tlvReader.Get(responderSessionId));
 
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", responderSessionId);
-    SetPeerKeyId(responderSessionId);
+    SetPeerSessionId(responderSessionId);
 
     // Retrieve Responder's Ephemeral Pubkey
     SuccessOrExit(err = tlvReader.Next());

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -158,7 +158,7 @@ CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
     serializable.mIPKLen           = static_cast<uint16_t>(sizeof(mIPK));
     serializable.mPairingComplete  = (mPairingComplete) ? 1 : 0;
     serializable.mPeerNodeId       = peerNodeId;
-    serializable.mLocalKeyId       = GetLocalKeyId();
+    serializable.mLocalSessionId       = GetLocalSessionId();
     serializable.mPeerSessionId    = GetPeerSessionId();
 
     memcpy(serializable.mSharedSecret, mSharedSecret, mSharedSecret.Length());
@@ -182,7 +182,7 @@ CHIP_ERROR CASESession::FromSerializable(const CASESessionSerializable & seriali
     memcpy(mIPK, serializable.mIPK, serializable.mIPKLen);
 
     SetPeerNodeId(serializable.mPeerNodeId);
-    SetLocalKeyId(serializable.mLocalKeyId);
+    SetLocalSessionId(serializable.mLocalSessionId);
     SetPeerSessionId(serializable.mPeerSessionId);
 
     return CHIP_NO_ERROR;
@@ -197,7 +197,7 @@ CHIP_ERROR CASESession::Init(uint16_t myKeyId, SessionEstablishmentDelegate * de
     ReturnErrorOnFailure(mCommissioningHash.Begin());
 
     mDelegate = delegate;
-    SetLocalKeyId(myKeyId);
+    SetLocalSessionId(myKeyId);
 
     mValidContext.Reset();
     mValidContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
@@ -329,7 +329,7 @@ CHIP_ERROR CASESession::SendSigmaR1()
     ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(1), initiatorRandom, sizeof(initiatorRandom)));
     // Retrieve Session Identifier
-    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId(), true));
     // Generate a Destination Identifier
     {
         MutableByteSpan destinationIdSpan(destinationIdentifier);
@@ -558,7 +558,7 @@ CHIP_ERROR CASESession::SendSigmaR2()
         tlvWriter.Init(std::move(msg_R2));
         SuccessOrExit(err = tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(1), &msg_rand[0], sizeof(msg_rand)));
-        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
+        SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId(), true));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(3), mEphemeralKey.Pubkey(),
                                                static_cast<uint32_t>(mEphemeralKey.Pubkey().Length())));
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(4), msg_R2_Encrypted.Get(),

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -159,7 +159,7 @@ CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
     serializable.mPairingComplete  = (mPairingComplete) ? 1 : 0;
     serializable.mPeerNodeId       = peerNodeId;
     serializable.mLocalKeyId       = GetLocalKeyId();
-    serializable.mPeerSessionId        = GetPeerSessionId();
+    serializable.mPeerSessionId    = GetPeerSessionId();
 
     memcpy(serializable.mSharedSecret, mSharedSecret, mSharedSecret.Length());
     memcpy(serializable.mMessageDigest, mMessageDigest, sizeof(mMessageDigest));

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -372,7 +372,7 @@ CHIP_ERROR CASESession::HandleSigmaR1(System::PacketBufferHandle && msg)
     System::PacketBufferTLVReader tlvReader;
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
-    uint16_t initiatorSessionId = 0;
+    uint16_t initiatorSessionId;
     uint8_t destinationIdentifier[kSHA256_Hash_Length];
     uint8_t initiatorRandom[kSigmaParamRandomNumberSize];
 
@@ -626,7 +626,7 @@ CHIP_ERROR CASESession::HandleSigmaR2(System::PacketBufferHandle && msg)
     uint8_t responderOpCert[EstimateTLVStructOverhead(kMaxCHIPOpCertArrayLength, 2)];
     size_t responderOpCertLen;
 
-    uint16_t responderSessionId = 0;
+    uint16_t responderSessionId;
 
     uint32_t decodeTagIdSeq = 0;
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -158,7 +158,7 @@ CHIP_ERROR CASESession::ToSerializable(CASESessionSerializable & serializable)
     serializable.mIPKLen           = static_cast<uint16_t>(sizeof(mIPK));
     serializable.mPairingComplete  = (mPairingComplete) ? 1 : 0;
     serializable.mPeerNodeId       = peerNodeId;
-    serializable.mLocalSessionId       = GetLocalSessionId();
+    serializable.mLocalSessionId   = GetLocalSessionId();
     serializable.mPeerSessionId    = GetPeerSessionId();
 
     memcpy(serializable.mSharedSecret, mSharedSecret, mSharedSecret.Length());

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -72,7 +72,7 @@ struct CASESessionSerializable
     uint8_t mPairingComplete;
     NodeId mPeerNodeId;
     uint16_t mLocalKeyId;
-    uint16_t mPeerKeyId;
+    uint16_t mPeerSessionId;
 };
 
 class DLL_EXPORT CASESession : public Messaging::ExchangeDelegate, public PairingSession

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -71,7 +71,7 @@ struct CASESessionSerializable
     uint8_t mIPK[kIPKSize];
     uint8_t mPairingComplete;
     NodeId mPeerNodeId;
-    uint16_t mLocalKeyId;
+    uint16_t mLocalSessionId;
     uint16_t mPeerSessionId;
 };
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -389,7 +389,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
     System::PacketBufferTLVReader tlvReader;
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
-    uint16_t initiatorSessionId = 0;
+    uint16_t initiatorSessionId;
     uint8_t initiatorRandom[kPBKDFParamRandomNumberSize];
 
     uint32_t decodeTagIdSeq = 0;
@@ -492,7 +492,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     System::PacketBufferTLVReader tlvReader;
     TLV::TLVType containerType = TLV::kTLVType_Structure;
 
-    uint16_t responderSessionId = 0;
+    uint16_t responderSessionId;
     uint8_t random[kPBKDFParamRandomNumberSize];
 
     uint32_t decodeTagIdSeq = 0;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -158,7 +158,7 @@ CHIP_ERROR PASESession::ToSerializable(PASESessionSerializable & serializable)
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
     serializable.mLocalKeyId      = GetLocalKeyId();
-    serializable.mPeerSessionId       = GetPeerSessionId();
+    serializable.mPeerSessionId   = GetPeerSessionId();
 
     memcpy(serializable.mKe, mKe, mKeLen);
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR PASESession::ToSerializable(PASESessionSerializable & serializable)
     memset(&serializable, 0, sizeof(serializable));
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
-    serializable.mLocalKeyId      = GetLocalKeyId();
+    serializable.mLocalSessionId      = GetLocalSessionId();
     serializable.mPeerSessionId   = GetPeerSessionId();
 
     memcpy(serializable.mKe, mKe, mKeLen);
@@ -174,7 +174,7 @@ CHIP_ERROR PASESession::FromSerializable(const PASESessionSerializable & seriali
     memset(mKe, 0, sizeof(mKe));
     memcpy(mKe, serializable.mKe, mKeLen);
 
-    SetLocalKeyId(serializable.mLocalKeyId);
+    SetLocalSessionId(serializable.mLocalSessionId);
     SetPeerSessionId(serializable.mPeerSessionId);
 
     return CHIP_NO_ERROR;
@@ -193,7 +193,7 @@ CHIP_ERROR PASESession::Init(uint16_t myKeyId, uint32_t setupCode, SessionEstabl
     mDelegate = delegate;
 
     ChipLogDetail(SecureChannel, "Assigned local session key ID %d", myKeyId);
-    SetLocalKeyId(myKeyId);
+    SetLocalSessionId(myKeyId);
     mSetupPINCode    = setupCode;
     mComputeVerifier = true;
 
@@ -362,7 +362,7 @@ CHIP_ERROR PASESession::SendPBKDFParamRequest()
     TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
     ReturnErrorOnFailure(tlvWriter.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, outerContainerType));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(1), mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
-    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalKeyId(), true));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(2), GetLocalSessionId(), true));
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), mPasscodeID, true));
     ReturnErrorOnFailure(tlvWriter.PutBoolean(TLV::ContextTag(4), mHavePBKDFParameters));
     // TODO - Add optional MRP parameter support to PASE
@@ -454,7 +454,7 @@ CHIP_ERROR PASESession::SendPBKDFParamResponse(ByteSpan initiatorRandom, bool in
     // The initiator random value is being sent back in the response as required by the specifications
     ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(1), initiatorRandom));
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(2), mPBKDFLocalRandomData, sizeof(mPBKDFLocalRandomData)));
-    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), GetLocalKeyId(), true));
+    ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(3), GetLocalSessionId(), true));
 
     if (!initiatorHasPBKDFParams)
     {

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR PASESession::ToSerializable(PASESessionSerializable & serializable)
     memset(&serializable, 0, sizeof(serializable));
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
-    serializable.mLocalSessionId      = GetLocalSessionId();
+    serializable.mLocalSessionId  = GetLocalSessionId();
     serializable.mPeerSessionId   = GetPeerSessionId();
 
     memcpy(serializable.mKe, mKe, mKeLen);

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -158,7 +158,7 @@ CHIP_ERROR PASESession::ToSerializable(PASESessionSerializable & serializable)
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
     serializable.mLocalKeyId      = GetLocalKeyId();
-    serializable.mPeerKeyId       = GetPeerKeyId();
+    serializable.mPeerSessionId       = GetPeerSessionId();
 
     memcpy(serializable.mKe, mKe, mKeLen);
 
@@ -175,7 +175,7 @@ CHIP_ERROR PASESession::FromSerializable(const PASESessionSerializable & seriali
     memcpy(mKe, serializable.mKe, mKeLen);
 
     SetLocalKeyId(serializable.mLocalKeyId);
-    SetPeerKeyId(serializable.mPeerKeyId);
+    SetPeerSessionId(serializable.mPeerSessionId);
 
     return CHIP_NO_ERROR;
 }
@@ -413,7 +413,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
 
     ChipLogDetail(SecureChannel, "Peer assigned session ID %d", initiatorSessionId);
     // TODO - Update <Set/Get><Local/Peer>KeyId() functions to <Set/Get><Local/Peer>SessionId()
-    SetPeerKeyId(initiatorSessionId);
+    SetPeerSessionId(initiatorSessionId);
 
     SuccessOrExit(err = tlvReader.Next());
     VerifyOrExit(TLV::TagNumFromTag(tlvReader.GetTag()) == ++decodeTagIdSeq, err = CHIP_ERROR_INVALID_TLV_TAG);
@@ -524,7 +524,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     SuccessOrExit(err = tlvReader.Get(responderSessionId));
 
     ChipLogDetail(SecureChannel, "Peer assigned session ID %d", responderSessionId);
-    SetPeerKeyId(responderSessionId);
+    SetPeerSessionId(responderSessionId);
 
     if (mHavePBKDFParameters)
     {

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -343,10 +343,10 @@ public:
         SetPeerSessionId(0);
     }
 
-    SecurePairingUsingTestSecret(uint16_t PeerSessionId, uint16_t LocalSessionId)
+    SecurePairingUsingTestSecret(uint16_t peerSessionId, uint16_t localSessionId)
     {
-        SetLocalSessionId(LocalSessionId);
-        SetPeerSessionId(PeerSessionId);
+        SetLocalSessionId(localSessionId);
+        SetPeerSessionId(peerSessionId);
     }
 
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -69,7 +69,7 @@ struct PASESessionSerializable
     uint16_t mKeLen;
     uint8_t mKe[kMAX_Hash_Length];
     uint8_t mPairingComplete;
-    uint16_t mLocalKeyId;
+    uint16_t mLocalSessionId;
     uint16_t mPeerSessionId;
 };
 
@@ -339,13 +339,13 @@ class SecurePairingUsingTestSecret : public PairingSession
 public:
     SecurePairingUsingTestSecret()
     {
-        SetLocalKeyId(0);
+        SetLocalSessionId(0);
         SetPeerSessionId(0);
     }
 
-    SecurePairingUsingTestSecret(uint16_t PeerSessionId, uint16_t localKeyId)
+    SecurePairingUsingTestSecret(uint16_t PeerSessionId, uint16_t LocalSessionId)
     {
-        SetLocalKeyId(localKeyId);
+        SetLocalSessionId(LocalSessionId);
         SetPeerSessionId(PeerSessionId);
     }
 
@@ -363,7 +363,7 @@ public:
         memset(&serializable, 0, sizeof(serializable));
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
-        serializable.mLocalKeyId      = GetLocalKeyId();
+        serializable.mLocalSessionId      = GetLocalSessionId();
         serializable.mPeerSessionId   = GetPeerSessionId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -364,7 +364,7 @@ public:
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
         serializable.mLocalKeyId      = GetLocalKeyId();
-        serializable.mPeerSessionId       = GetPeerSessionId();
+        serializable.mPeerSessionId   = GetPeerSessionId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);
         return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -363,7 +363,7 @@ public:
         memset(&serializable, 0, sizeof(serializable));
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
-        serializable.mLocalSessionId      = GetLocalSessionId();
+        serializable.mLocalSessionId  = GetLocalSessionId();
         serializable.mPeerSessionId   = GetPeerSessionId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -70,7 +70,7 @@ struct PASESessionSerializable
     uint8_t mKe[kMAX_Hash_Length];
     uint8_t mPairingComplete;
     uint16_t mLocalKeyId;
-    uint16_t mPeerKeyId;
+    uint16_t mPeerSessionId;
 };
 
 struct PASEVerifier
@@ -340,13 +340,13 @@ public:
     SecurePairingUsingTestSecret()
     {
         SetLocalKeyId(0);
-        SetPeerKeyId(0);
+        SetPeerSessionId(0);
     }
 
-    SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId)
+    SecurePairingUsingTestSecret(uint16_t PeerSessionId, uint16_t localKeyId)
     {
         SetLocalKeyId(localKeyId);
-        SetPeerKeyId(peerKeyId);
+        SetPeerSessionId(PeerSessionId);
     }
 
     CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override
@@ -364,7 +364,7 @@ public:
         serializable.mKeLen           = static_cast<uint16_t>(secretLen);
         serializable.mPairingComplete = 1;
         serializable.mLocalKeyId      = GetLocalKeyId();
-        serializable.mPeerKeyId       = GetPeerKeyId();
+        serializable.mPeerSessionId       = GetPeerSessionId();
 
         memcpy(serializable.mKe, kTestSecret, secretLen);
         return CHIP_NO_ERROR;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR UserDirectedCommissioningClient::EncodeUDCMessage(System::PacketBuffe
 
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(payload));
 
-    packetHeader.SetEncryptionType(Header::EncryptionType::kEncryptionTypeNone);
+    packetHeader.SetSessionType(Header::SessionType::kSessionTypeNone);
 
     ReturnErrorOnFailure(packetHeader.EncodeBeforeData(payload));
 

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -47,12 +47,12 @@ public:
     uint16_t GetLocalKeyId() const { return mLocalKeyId; }
     bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
 
-    uint16_t GetPeerKeyId() const
+    uint16_t GetPeerSessionId() const
     {
-        VerifyOrDie(mPeerKeyId.HasValue());
-        return mPeerKeyId.Value();
+        VerifyOrDie(mPeerSessionId.HasValue());
+        return mPeerSessionId.Value();
     }
-    bool IsValidPeerKeyId() const { return mPeerKeyId.HasValue(); }
+    bool IsValidPeerSessionId() const { return mPeerSessionId.HasValue(); }
 
     // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
@@ -86,7 +86,7 @@ public:
 
 protected:
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
-    void SetPeerKeyId(uint16_t id) { mPeerKeyId.SetValue(id); }
+    void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
     void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
     void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
 
@@ -95,7 +95,7 @@ protected:
     {
         mPeerNodeId  = kUndefinedNodeId;
         mPeerAddress = Transport::PeerAddress::Uninitialized();
-        mPeerKeyId.ClearValue();
+        mPeerSessionId.ClearValue();
         mLocalKeyId = kInvalidKeyId;
     }
 
@@ -110,7 +110,7 @@ private:
     // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();
 
-    Optional<uint16_t> mPeerKeyId;
+    Optional<uint16_t> mPeerSessionId;
 };
 
 } // namespace chip

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -42,8 +42,8 @@ public:
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
 
     // TODO: the local key id should be allocateed at start
-    // mLocalSessionId should be const and assigned at the construction, such that GetLocalSessionId will always return a valid key id , and
-    // SetLocalSessionId is not necessary.
+    // mLocalSessionId should be const and assigned at the construction, such that GetLocalSessionId will always return a valid key
+    // id , and SetLocalSessionId is not necessary.
     uint16_t GetLocalSessionId() const { return mLocalSessionId; }
     bool IsValidLocalSessionId() const { return mLocalSessionId != kInvalidKeyId; }
 
@@ -105,7 +105,7 @@ private:
     // TODO: the local key id should be allocateed at start
     // then we can remove kInvalidKeyId
     static constexpr uint16_t kInvalidKeyId = UINT16_MAX;
-    uint16_t mLocalSessionId                    = kInvalidKeyId;
+    uint16_t mLocalSessionId                = kInvalidKeyId;
 
     // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -42,10 +42,10 @@ public:
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
 
     // TODO: the local key id should be allocateed at start
-    // mLocalKeyId should be const and assigned at the construction, such that GetLocalKeyId will always return a valid key id , and
-    // SetLocalKeyId is not necessary.
-    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
-    bool IsValidLocalKeyId() const { return mLocalKeyId != kInvalidKeyId; }
+    // mLocalSessionId should be const and assigned at the construction, such that GetLocalSessionId will always return a valid key id , and
+    // SetLocalSessionId is not necessary.
+    uint16_t GetLocalSessionId() const { return mLocalSessionId; }
+    bool IsValidLocalSessionId() const { return mLocalSessionId != kInvalidKeyId; }
 
     uint16_t GetPeerSessionId() const
     {
@@ -87,7 +87,7 @@ public:
 protected:
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
-    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
+    void SetLocalSessionId(uint16_t id) { mLocalSessionId = id; }
     void SetPeerAddress(const Transport::PeerAddress & address) { mPeerAddress = address; }
 
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
@@ -96,7 +96,7 @@ protected:
         mPeerNodeId  = kUndefinedNodeId;
         mPeerAddress = Transport::PeerAddress::Uninitialized();
         mPeerSessionId.ClearValue();
-        mLocalKeyId = kInvalidKeyId;
+        mLocalSessionId = kInvalidKeyId;
     }
 
 private:
@@ -105,7 +105,7 @@ private:
     // TODO: the local key id should be allocateed at start
     // then we can remove kInvalidKeyId
     static constexpr uint16_t kInvalidKeyId = UINT16_MAX;
-    uint16_t mLocalKeyId                    = kInvalidKeyId;
+    uint16_t mLocalSessionId                    = kInvalidKeyId;
 
     // TODO: decouple peer address into transport, such that pairing session do not need to handle peer address
     Transport::PeerAddress mPeerAddress = Transport::PeerAddress::Uninitialized();

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -103,7 +103,7 @@ public:
 private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId           = kUndefinedNodeId;
-    uint16_t mPeerSessionId          = UINT16_MAX;
+    uint16_t mPeerSessionId      = UINT16_MAX;
     uint16_t mLocalKeyID         = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     SecureSession mSecureSession;

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -104,7 +104,7 @@ private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId           = kUndefinedNodeId;
     uint16_t mPeerSessionId      = UINT16_MAX;
-    uint16_t mLocalSessionId         = UINT16_MAX;
+    uint16_t mLocalSessionId     = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     SecureSession mSecureSession;
     SessionMessageCounter mSessionMessageCounter;

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -69,8 +69,8 @@ public:
     void SetPeerSessionId(uint16_t id) { mPeerSessionId = id; }
 
     // TODO: Rename KeyID to SessionID
-    uint16_t GetLocalKeyID() const { return mLocalKeyID; }
-    void SetLocalKeyID(uint16_t id) { mLocalKeyID = id; }
+    uint16_t GetLocalSessionId() const { return mLocalSessionId; }
+    void SetLocalSessionId(uint16_t id) { mLocalSessionId = id; }
 
     uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
@@ -83,7 +83,7 @@ public:
     bool IsInitialized()
     {
         return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerSessionId != UINT16_MAX ||
-                mLocalKeyID != UINT16_MAX);
+                mLocalSessionId != UINT16_MAX);
     }
 
     CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
@@ -104,7 +104,7 @@ private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId           = kUndefinedNodeId;
     uint16_t mPeerSessionId      = UINT16_MAX;
-    uint16_t mLocalKeyID         = UINT16_MAX;
+    uint16_t mLocalSessionId         = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     SecureSession mSecureSession;
     SessionMessageCounter mSessionMessageCounter;

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -65,8 +65,8 @@ public:
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
 
-    uint16_t GetPeerKeyID() const { return mPeerKeyID; }
-    void SetPeerKeyID(uint16_t id) { mPeerKeyID = id; }
+    uint16_t GetPeerSessionId() const { return mPeerSessionId; }
+    void SetPeerSessionId(uint16_t id) { mPeerSessionId = id; }
 
     // TODO: Rename KeyID to SessionID
     uint16_t GetLocalKeyID() const { return mLocalKeyID; }
@@ -82,7 +82,7 @@ public:
 
     bool IsInitialized()
     {
-        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerKeyID != UINT16_MAX ||
+        return (mPeerAddress.IsInitialized() || mPeerNodeId != kUndefinedNodeId || mPeerSessionId != UINT16_MAX ||
                 mLocalKeyID != UINT16_MAX);
     }
 
@@ -103,7 +103,7 @@ public:
 private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId           = kUndefinedNodeId;
-    uint16_t mPeerKeyID          = UINT16_MAX;
+    uint16_t mPeerSessionId          = UINT16_MAX;
     uint16_t mLocalKeyID         = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     SecureSession mSecureSession;

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -86,7 +86,7 @@ public:
      * Allocates a new peer connection state state object out of the internal resource pool.
      *
      * @param peerNode represents optional peer Node's ID
-     * @param peerKeyId represents the encryption key ID assigned by peer node
+     * @param PeerSessionId represents the encryption key ID assigned by peer node
      * @param localKeyId represents the encryption key ID assigned by local node
      * @param state [out] will contain the connection state if one was available. May be null if no return value is desired.
      *
@@ -96,7 +96,7 @@ public:
      *          has been reached (with CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t peerKeyId, uint16_t localKeyId,
+    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t PeerSessionId, uint16_t localKeyId,
                                             PeerConnectionState ** state)
     {
         CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
@@ -111,7 +111,7 @@ public:
             if (!mStates[i].IsInitialized())
             {
                 mStates[i] = PeerConnectionState();
-                mStates[i].SetPeerKeyID(peerKeyId);
+                mStates[i].SetPeerSessionId(PeerSessionId);
                 mStates[i].SetLocalKeyID(localKeyId);
                 mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
 
@@ -203,13 +203,13 @@ public:
      *
      * @param nodeId is the connection to find (based on nodeId). Note that initial connections
      *        do not have a node id set. Use this if you know the node id should be set.
-     * @param peerKeyId Encryption key ID used by the peer node.
+     * @param PeerSessionId Encryption key ID used by the peer node.
      * @param begin If a member of the pool, will start search from the next item. Can be nullptr to search from start.
      *
      * @return the state found, nullptr if not found
      */
     CHECK_RETURN_VALUE
-    PeerConnectionState * FindPeerConnectionState(Optional<NodeId> nodeId, uint16_t peerKeyId, PeerConnectionState * begin)
+    PeerConnectionState * FindPeerConnectionState(Optional<NodeId> nodeId, uint16_t PeerSessionId, PeerConnectionState * begin)
     {
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
@@ -225,7 +225,7 @@ public:
             {
                 continue;
             }
-            if (peerKeyId == kAnyKeyId || iter->GetPeerKeyID() == peerKeyId)
+            if (PeerSessionId == kAnyKeyId || iter->GetPeerSessionId() == PeerSessionId)
             {
                 if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
                     iter->GetPeerNodeId() == nodeId.Value())

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -86,8 +86,8 @@ public:
      * Allocates a new peer connection state state object out of the internal resource pool.
      *
      * @param peerNode represents optional peer Node's ID
-     * @param PeerSessionId represents the encryption key ID assigned by peer node
-     * @param LocalSessionId represents the encryption key ID assigned by local node
+     * @param peerSessionId represents the encryption key ID assigned by peer node
+     * @param localSessionId represents the encryption key ID assigned by local node
      * @param state [out] will contain the connection state if one was available. May be null if no return value is desired.
      *
      * @note the newly created state will have an 'active' time set based on the current time source.
@@ -96,7 +96,7 @@ public:
      *          has been reached (with CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t PeerSessionId, uint16_t LocalSessionId,
+    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t peerSessionId, uint16_t localSessionId,
                                             PeerConnectionState ** state)
     {
         CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
@@ -111,8 +111,8 @@ public:
             if (!mStates[i].IsInitialized())
             {
                 mStates[i] = PeerConnectionState();
-                mStates[i].SetPeerSessionId(PeerSessionId);
-                mStates[i].SetLocalSessionId(LocalSessionId);
+                mStates[i].SetPeerSessionId(peerSessionId);
+                mStates[i].SetLocalSessionId(localSessionId);
                 mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
 
                 if (peerNode.ValueOr(kUndefinedNodeId) != kUndefinedNodeId)
@@ -203,13 +203,13 @@ public:
      *
      * @param nodeId is the connection to find (based on nodeId). Note that initial connections
      *        do not have a node id set. Use this if you know the node id should be set.
-     * @param PeerSessionId Encryption key ID used by the peer node.
+     * @param peerSessionId Encryption key ID used by the peer node.
      * @param begin If a member of the pool, will start search from the next item. Can be nullptr to search from start.
      *
      * @return the state found, nullptr if not found
      */
     CHECK_RETURN_VALUE
-    PeerConnectionState * FindPeerConnectionState(Optional<NodeId> nodeId, uint16_t PeerSessionId, PeerConnectionState * begin)
+    PeerConnectionState * FindPeerConnectionState(Optional<NodeId> nodeId, uint16_t peerSessionId, PeerConnectionState * begin)
     {
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
@@ -225,7 +225,7 @@ public:
             {
                 continue;
             }
-            if (PeerSessionId == kAnyKeyId || iter->GetPeerSessionId() == PeerSessionId)
+            if (peerSessionId == kAnyKeyId || iter->GetPeerSessionId() == peerSessionId)
             {
                 if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
                     iter->GetPeerNodeId() == nodeId.Value())
@@ -280,13 +280,13 @@ public:
      *
      * @param nodeId is the connection to find (based on peer nodeId). Note that initial connections
      *        do not have a node id set. Use this if you know the node id should be set.
-     * @param LocalSessionId Encryption key ID used by the local node.
+     * @param localSessionId Encryption key ID used by the local node.
      * @param begin If a member of the pool, will start search from the next item. Can be nullptr to search from start.
      *
      * @return the state found, nullptr if not found
      */
     CHECK_RETURN_VALUE
-    PeerConnectionState * FindPeerConnectionStateByLocalKey(Optional<NodeId> nodeId, uint16_t LocalSessionId,
+    PeerConnectionState * FindPeerConnectionStateByLocalKey(Optional<NodeId> nodeId, uint16_t localSessionId,
                                                             PeerConnectionState * begin)
     {
         PeerConnectionState * state = nullptr;
@@ -303,7 +303,7 @@ public:
             {
                 continue;
             }
-            if (iter->GetLocalSessionId() == LocalSessionId)
+            if (iter->GetLocalSessionId() == localSessionId)
             {
                 if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
                     iter->GetPeerNodeId() == nodeId.Value())

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -87,7 +87,7 @@ public:
      *
      * @param peerNode represents optional peer Node's ID
      * @param PeerSessionId represents the encryption key ID assigned by peer node
-     * @param localKeyId represents the encryption key ID assigned by local node
+     * @param LocalSessionId represents the encryption key ID assigned by local node
      * @param state [out] will contain the connection state if one was available. May be null if no return value is desired.
      *
      * @note the newly created state will have an 'active' time set based on the current time source.
@@ -96,7 +96,7 @@ public:
      *          has been reached (with CHIP_ERROR_NO_MEMORY).
      */
     CHECK_RETURN_VALUE
-    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t PeerSessionId, uint16_t localKeyId,
+    CHIP_ERROR CreateNewPeerConnectionState(const Optional<NodeId> & peerNode, uint16_t PeerSessionId, uint16_t LocalSessionId,
                                             PeerConnectionState ** state)
     {
         CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
@@ -112,7 +112,7 @@ public:
             {
                 mStates[i] = PeerConnectionState();
                 mStates[i].SetPeerSessionId(PeerSessionId);
-                mStates[i].SetLocalKeyID(localKeyId);
+                mStates[i].SetLocalSessionId(LocalSessionId);
                 mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
 
                 if (peerNode.ValueOr(kUndefinedNodeId) != kUndefinedNodeId)
@@ -266,7 +266,7 @@ public:
                 continue;
             }
 
-            if (iter->GetLocalKeyID() == keyId)
+            if (iter->GetLocalSessionId() == keyId)
             {
                 state = iter;
                 break;
@@ -280,13 +280,13 @@ public:
      *
      * @param nodeId is the connection to find (based on peer nodeId). Note that initial connections
      *        do not have a node id set. Use this if you know the node id should be set.
-     * @param localKeyId Encryption key ID used by the local node.
+     * @param LocalSessionId Encryption key ID used by the local node.
      * @param begin If a member of the pool, will start search from the next item. Can be nullptr to search from start.
      *
      * @return the state found, nullptr if not found
      */
     CHECK_RETURN_VALUE
-    PeerConnectionState * FindPeerConnectionStateByLocalKey(Optional<NodeId> nodeId, uint16_t localKeyId,
+    PeerConnectionState * FindPeerConnectionStateByLocalKey(Optional<NodeId> nodeId, uint16_t LocalSessionId,
                                                             PeerConnectionState * begin)
     {
         PeerConnectionState * state = nullptr;
@@ -303,7 +303,7 @@ public:
             {
                 continue;
             }
-            if (iter->GetLocalKeyID() == localKeyId)
+            if (iter->GetLocalSessionId() == LocalSessionId)
             {
                 if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
                     iter->GetPeerNodeId() == nodeId.Value())

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -49,8 +49,8 @@ CHIP_ERROR Encode(Transport::PeerConnectionState * state, PayloadHeader & payloa
                   "Addition to generate payloadLength might overflow");
 
     packetHeader
-        .SetMessageCounter(messageCounter) //
-        .SetEncryptionKeyID(state->GetPeerKeyID());
+        .SetMessageId(messageCounter) //
+        .SetSessionId(state->GetPeerSessionId());
 
     packetHeader.GetFlags().Set(Header::FlagValues::kEncryptedMessage);
 

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -49,7 +49,7 @@ CHIP_ERROR Encode(Transport::PeerConnectionState * state, PayloadHeader & payloa
                   "Addition to generate payloadLength might overflow");
 
     packetHeader
-        .SetMessageId(messageCounter) //
+        .SetMessageCounter(messageCounter) //
         .SetSessionId(state->GetPeerSessionId());
 
     packetHeader.GetFlags().Set(Header::FlagValues::kEncryptedMessage);
@@ -92,7 +92,7 @@ CHIP_ERROR Decode(Transport::PeerConnectionState * state, PayloadHeader & payloa
     msg->SetDataLength(len);
 #endif
 
-    uint16_t footerLen = MessageAuthenticationCode::TagLenForEncryptionType(packetHeader.GetEncryptionType());
+    uint16_t footerLen = MessageAuthenticationCode::TagLenForSessionType(packetHeader.GetSessionType());
     VerifyOrReturnError(footerLen <= len, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     uint16_t taglen = 0;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -127,9 +127,9 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
                                   MessageAuthenticationCode & mac) const
 {
 
-    constexpr Header::EncryptionType encType = Header::EncryptionType::kAESCCMTagLen16;
+    constexpr Header::SessionType encType = Header::SessionType::kAESCCMTagLen16;
 
-    const size_t taglen = MessageAuthenticationCode::TagLenForEncryptionType(encType);
+    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(encType);
     VerifyOrDie(taglen <= kMaxTagLen);
 
     VerifyOrReturnError(mKeyAvailable, CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
@@ -166,7 +166,7 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
 CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
                                   const MessageAuthenticationCode & mac) const
 {
-    const size_t taglen = MessageAuthenticationCode::TagLenForEncryptionType(header.GetEncryptionType());
+    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(header.GetSessionType());
     const uint8_t * tag = mac.GetTag();
     uint8_t IV[kAESCCMIVLen];
     uint8_t AAD[kMaxAADLen];

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -127,9 +127,9 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
                                   MessageAuthenticationCode & mac) const
 {
 
-    constexpr Header::SessionType encType = Header::SessionType::kAESCCMTagLen16;
+    constexpr Header::SessionType sessionType = Header::SessionType::kAESCCMTagLen16;
 
-    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(encType);
+    const size_t taglen = MessageAuthenticationCode::TagLenForSessionType(sessionType);
     VerifyOrDie(taglen <= kMaxTagLen);
 
     VerifyOrReturnError(mKeyAvailable, CHIP_ERROR_INVALID_USE_OF_SESSION_KEY);
@@ -158,7 +158,7 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
     ReturnErrorOnFailure(AES_CCM_encrypt(input, input_length, AAD, aadLen, mKeys[usage], kAES_CCM128_Key_Length, IV, sizeof(IV),
                                          output, tag, taglen));
 
-    mac.SetTag(&header, encType, tag, taglen);
+    mac.SetTag(&header, sessionType, tag, taglen);
 
     return CHIP_NO_ERROR;
 }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -247,10 +247,10 @@ void SecureSessionMgr::ExpireAllPairingsForFabric(FabricIndex fabric)
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
 {
-    uint16_t PeerSessionId  = pairing->GetPeerSessionId();
-    uint16_t LocalSessionId = pairing->GetLocalSessionId();
+    uint16_t peerSessionId  = pairing->GetPeerSessionId();
+    uint16_t localSessionId = pairing->GetLocalSessionId();
     PeerConnectionState * state =
-        mPeerConnections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(peerNodeId), LocalSessionId, nullptr);
+        mPeerConnections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(peerNodeId), localSessionId, nullptr);
 
     // Find any existing connection with the same local key ID
     if (state)
@@ -260,10 +260,10 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     }
 
     ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
-                  PeerSessionId);
+                  peerSessionId);
     state = nullptr;
     ReturnErrorOnFailure(
-        mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), PeerSessionId, LocalSessionId, &state));
+        mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerSessionId, localSessionId, &state));
     ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
     state->SetFabricIndex(fabric);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -247,8 +247,8 @@ void SecureSessionMgr::ExpireAllPairingsForFabric(FabricIndex fabric)
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
 {
-    uint16_t PeerSessionId  = pairing->GetPeerSessionId();
-    uint16_t localKeyId = pairing->GetLocalKeyId();
+    uint16_t PeerSessionId = pairing->GetPeerSessionId();
+    uint16_t localKeyId    = pairing->GetLocalKeyId();
     PeerConnectionState * state =
         mPeerConnections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(peerNodeId), localKeyId, nullptr);
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -247,8 +247,8 @@ void SecureSessionMgr::ExpireAllPairingsForFabric(FabricIndex fabric)
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
 {
-    uint16_t PeerSessionId = pairing->GetPeerSessionId();
-    uint16_t LocalSessionId    = pairing->GetLocalSessionId();
+    uint16_t PeerSessionId  = pairing->GetPeerSessionId();
+    uint16_t LocalSessionId = pairing->GetLocalSessionId();
     PeerConnectionState * state =
         mPeerConnections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(peerNodeId), LocalSessionId, nullptr);
 
@@ -393,7 +393,8 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
             // Queue and start message sync procedure
             err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
                 packetHeader,
-                SessionHandle(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(), state->GetFabricIndex()),
+                SessionHandle(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(),
+                              state->GetFabricIndex()),
                 state, peerAddress, std::move(msg));
 
             if (err != CHIP_NO_ERROR)
@@ -457,7 +458,8 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (mCB != nullptr)
     {
-        SessionHandle session(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(), state->GetFabricIndex());
+        SessionHandle session(state->GetPeerNodeId(), state->GetLocalSessionId(), state->GetPeerSessionId(),
+                              state->GetFabricIndex());
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
     }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -247,7 +247,7 @@ void SecureSessionMgr::ExpireAllPairingsForFabric(FabricIndex fabric)
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
                                         PairingSession * pairing, SecureSession::SessionRole direction, FabricIndex fabric)
 {
-    uint16_t peerKeyId  = pairing->GetPeerKeyId();
+    uint16_t PeerSessionId  = pairing->GetPeerSessionId();
     uint16_t localKeyId = pairing->GetLocalKeyId();
     PeerConnectionState * state =
         mPeerConnections.FindPeerConnectionStateByLocalKey(Optional<NodeId>::Value(peerNodeId), localKeyId, nullptr);
@@ -260,10 +260,10 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     }
 
     ChipLogDetail(Inet, "New secure session created for device 0x" ChipLogFormatX64 ", key %d!!", ChipLogValueX64(peerNodeId),
-                  peerKeyId);
+                  PeerSessionId);
     state = nullptr;
     ReturnErrorOnFailure(
-        mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
+        mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), PeerSessionId, localKeyId, &state));
     ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
     state->SetFabricIndex(fabric);
@@ -288,7 +288,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     if (mCB != nullptr)
     {
         state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(pairing->GetPeerCounter());
-        mCB->OnNewConnection(SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), fabric));
+        mCB->OnNewConnection(SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerSessionId(), fabric));
     }
 
     return CHIP_NO_ERROR;
@@ -367,7 +367,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetEncryptionKeyID(), nullptr);
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetSessionId(), nullptr);
 
     PayloadHeader payloadHeader;
 
@@ -377,7 +377,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (state == nullptr)
     {
-        ChipLogError(Inet, "Data received on an unknown connection (%d). Dropping it!!", packetHeader.GetEncryptionKeyID());
+        ChipLogError(Inet, "Data received on an unknown connection (%d). Dropping it!!", packetHeader.GetSessionId());
         ExitNow(err = CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
     }
 
@@ -393,7 +393,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
             // Queue and start message sync procedure
             err = mMessageCounterManager->QueueReceivedMessageAndStartSync(
                 packetHeader,
-                SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), state->GetFabricIndex()),
+                SessionHandle(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerSessionId(), state->GetFabricIndex()),
                 state, peerAddress, std::move(msg));
 
             if (err != CHIP_NO_ERROR)
@@ -457,7 +457,7 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (mCB != nullptr)
     {
-        SessionHandle session(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerKeyID(), state->GetFabricIndex());
+        SessionHandle session(state->GetPeerNodeId(), state->GetLocalKeyID(), state->GetPeerSessionId(), state->GetFabricIndex());
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, peerAddress, isDuplicate, std::move(msg));
     }
 
@@ -476,7 +476,7 @@ void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionSt
     if (mCB != nullptr)
     {
         mCB->OnConnectionExpired(
-            SessionHandle(state.GetPeerNodeId(), state.GetLocalKeyID(), state.GetPeerKeyID(), state.GetFabricIndex()));
+            SessionHandle(state.GetPeerNodeId(), state.GetLocalKeyID(), state.GetPeerSessionId(), state.GetFabricIndex()));
     }
 
     mTransportMgr->Disconnect(state.GetPeerAddress());

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -32,11 +32,11 @@ public:
         mPeerNodeId(kPlaceholderNodeId), mFabric(Transport::kUndefinedFabricIndex), mUnauthenticatedSessionHandle(session)
     {}
 
-    SessionHandle(NodeId peerNodeId, uint16_t localKeyId, uint16_t peerKeyId, FabricIndex fabric) :
+    SessionHandle(NodeId peerNodeId, uint16_t localSessionId, uint16_t peerSessionId, FabricIndex fabric) :
         mPeerNodeId(peerNodeId), mFabric(fabric)
     {
-        mLocalKeyId.SetValue(localKeyId);
-        mPeerKeyId.SetValue(peerKeyId);
+        mLocalSessionId.SetValue(localSessionId);
+        mPeerSessionId.SetValue(peerSessionId);
     }
 
     bool IsSecure() const { return !mUnauthenticatedSessionHandle.HasValue(); }
@@ -48,14 +48,14 @@ public:
     bool operator==(const SessionHandle & that) const
     {
         // TODO: Temporarily keep the old logic, check why only those two fields are used in comparison.
-        return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId;
+        return mPeerNodeId == that.mPeerNodeId && mPeerSessionId == that.mPeerSessionId;
     }
 
     bool MatchIncomingSession(const SessionHandle & that) const
     {
         if (IsSecure())
         {
-            return that.IsSecure() && mLocalKeyId.Value() == that.mLocalKeyId.Value();
+            return that.IsSecure() && mLocalSessionId.Value() == that.mLocalSessionId.Value();
         }
         else
         {
@@ -64,8 +64,8 @@ public:
     }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
-    const Optional<uint16_t> & GetPeerKeyId() const { return mPeerKeyId; }
-    const Optional<uint16_t> & GetLocalKeyId() const { return mLocalKeyId; }
+    const Optional<uint16_t> & GetPeerSessionId() const { return mPeerSessionId; }
+    const Optional<uint16_t> & GetLocalSessionId() const { return mLocalSessionId; }
 
     Transport::UnauthenticatedSessionHandle GetUnauthenticatedSession() { return mUnauthenticatedSessionHandle.Value(); }
 
@@ -74,8 +74,8 @@ private:
 
     // Fields for secure session
     NodeId mPeerNodeId;
-    Optional<uint16_t> mLocalKeyId;
-    Optional<uint16_t> mPeerKeyId;
+    Optional<uint16_t> mLocalSessionId;
+    Optional<uint16_t> mPeerSessionId;
     // TODO: Re-evaluate the storing of Fabric ID in SessionHandle
     //       The Fabric ID will not be available for PASE and group sessions. So need
     //       to identify an approach that'll allow looking up the corresponding information for

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -151,7 +151,7 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     err = reader.Read16(&header).StatusCode();
     SuccessOrExit(err);
     version = ((header & kVersionMask) >> kVersionShift);
-    VerifyOrExit(version == kHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
+    VerifyOrExit(version == kMsgHeaderVersion, err = CHIP_ERROR_VERSION_MISMATCH);
 
     mFlags.SetRaw(header);
     mEncryptionType = static_cast<Header::EncryptionType>((header & kEncryptionTypeMask) >> kEncryptionTypeShift);
@@ -271,7 +271,7 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
     encodeFlags.Set(Header::FlagValues::kSourceNodeIdPresent, mSourceNodeId.HasValue())
         .Set(Header::FlagValues::kDestinationNodeIdPresent, mDestinationNodeId.HasValue());
 
-    uint16_t header = (kHeaderVersion << kVersionShift) | encodeFlags.Raw();
+    uint16_t header = (kMsgHeaderVersion << kVersionShift) | encodeFlags.Raw();
     header |= (static_cast<uint16_t>(static_cast<uint16_t>(mEncryptionType) << kEncryptionTypeShift) & kEncryptionTypeMask);
 
     uint8_t * p = data;

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -156,6 +156,9 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     mFlags.SetRaw(header);
     mSessionType = static_cast<Header::SessionType>((header & kSessionTypeMask) >> kSessionTypeShift);
 
+    err = reader.Read16(&mSessionId).StatusCode();
+    SuccessOrExit(err);
+
     err = reader.Read32(&mMessageCounter).StatusCode();
     SuccessOrExit(err);
 
@@ -182,9 +185,6 @@ CHIP_ERROR PacketHeader::Decode(const uint8_t * const data, uint16_t size, uint1
     {
         mDestinationNodeId.ClearValue();
     }
-
-    err = reader.Read16(&mSessionId).StatusCode();
-    SuccessOrExit(err);
 
     octets_read = static_cast<uint16_t>(reader.OctetsRead());
     VerifyOrExit(octets_read == EncodeSizeBytes(), err = CHIP_ERROR_INTERNAL);
@@ -276,6 +276,7 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
 
     uint8_t * p = data;
     LittleEndian::Write16(p, header);
+    LittleEndian::Write16(p, mSessionId);
     LittleEndian::Write32(p, mMessageCounter);
     if (mSourceNodeId.HasValue())
     {
@@ -285,8 +286,6 @@ CHIP_ERROR PacketHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode
     {
         LittleEndian::Write64(p, mDestinationNodeId.Value());
     }
-
-    LittleEndian::Write16(p, mSessionId);
 
     // Written data size provided to caller on success
     VerifyOrReturnError(p - data == EncodeSizeBytes(), CHIP_ERROR_INTERNAL);

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -42,12 +42,14 @@
  *  16 bit: | Session ID                                                           |
  *  32 bit: | Message Counter                                                      |
  *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
- *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      | |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |
  * -------- Encrypted header -------------------------------------------------------
- *  8 bit:  | Exchange Flags: RESERVED: 3 bit | V: 1 bit | SX: 1 bit | R: 1 bit | A: 1 bit | I: 1 bit | | 8 bit:  | Protocol Opcode
- *| 16 bit: | Exchange ID                                                          | 16 bit: | Protocol ID 16 bit: | Optional Vendor
- *ID                                                   |                                                        | 32 bit: |
- *Acknowledged Message Counter (if A flag in the Header is set)        |
+ *  8 bit:  | Exchange Flags: RESERVED: 3 bit | V: 1 bit | SX: 1 bit | R: 1 bit | A: 1 bit | I: 1 bit |
+ *  8 bit:  | Protocol Opcode                                                      |
+ * 16 bit:  | Exchange ID                                                          |
+ * 16 bit:  | Protocol ID                                                          |
+ * 16 bit:  | Optional Vendor ID                                                   |
+ * 32 bit:  | Acknowledged Message Counter (if A flag in the Header is set)        |
  * -------- Encrypted Application Data Start ---------------------------------------
  *  <var>:  | Encrypted Data                                                       |
  * -------- Encrypted Application Data End -----------------------------------------
@@ -125,9 +127,9 @@ uint16_t PayloadHeader::EncodeSizeBytes() const
     return static_cast<uint16_t>(size);
 }
 
-uint16_t MessageAuthenticationCode::TagLenForSessionType(Header::SessionType encType)
+uint16_t MessageAuthenticationCode::TagLenForSessionType(Header::SessionType sessionType)
 {
-    switch (encType)
+    switch (sessionType)
     {
     case Header::SessionType::kAESCCMTagLen16:
         return 16;

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -37,18 +37,18 @@
  * Header format (little endian):
  *
  * -------- Unencrypted header -----------------------------------------------------
- *  16 bit: | VERSION: 4 bit | FLAGS: 4 bit | ENCRYPTTYPE: 4 bit | RESERVED: 4 bit |
- *  32 bit: | MESSAGE_ID                                                           |
+ *  8 bit:  | Message Flags: VERSION: 4 bit | S: 1 bit | RESERVED: 1 bit | DSIZ: 2 bit |
+ *  8 bit:  | Security Flags: P: 1 bit | C: 1 bit | MX: 1 bit | RESERVED: 3 bit | Session Type: 2 bit |
+ *  16 bit: | Session ID                                                           |
+ *  32 bit: | Message Counter                                                      |
  *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
- *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |
- *  16 bit: | Encryption Key ID                                                    |
- *  16 bit: | Payload Length                                                       |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |                                                    |
  * -------- Encrypted header -------------------------------------------------------
- *  8 bit:  | Exchange Header                                                      |
- *  8 bit:  | Message Type                                                         |
+ *  8 bit:  | Exchange Flags: RESERVED: 3 bit | V: 1 bit | SX: 1 bit | R: 1 bit | A: 1 bit | I: 1 bit |                                                       |
+ *  8 bit:  | Protocol Opcode                                                         |
  *  16 bit: | Exchange ID                                                          |
- *  16 bit: | Optional Vendor ID                                                   |
- *  16 bit: | Protocol ID                                                          |
+ *  16 bit: | Protocol ID
+ *  16 bit: | Optional Vendor ID                                                   |                                                        |
  *  32 bit: | Acknowledged Message Counter (if A flag in the Header is set)        |
  * -------- Encrypted Application Data Start ---------------------------------------
  *  <var>:  | Encrypted Data                                                       |

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -42,14 +42,12 @@
  *  16 bit: | Session ID                                                           |
  *  32 bit: | Message Counter                                                      |
  *  64 bit: | SOURCE_NODE_ID (iff source node flag is set)                         |
- *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      |                                                    |
+ *  64 bit: | DEST_NODE_ID (iff destination node flag is set)                      | |
  * -------- Encrypted header -------------------------------------------------------
- *  8 bit:  | Exchange Flags: RESERVED: 3 bit | V: 1 bit | SX: 1 bit | R: 1 bit | A: 1 bit | I: 1 bit |                                                       |
- *  8 bit:  | Protocol Opcode                                                         |
- *  16 bit: | Exchange ID                                                          |
- *  16 bit: | Protocol ID
- *  16 bit: | Optional Vendor ID                                                   |                                                        |
- *  32 bit: | Acknowledged Message Counter (if A flag in the Header is set)        |
+ *  8 bit:  | Exchange Flags: RESERVED: 3 bit | V: 1 bit | SX: 1 bit | R: 1 bit | A: 1 bit | I: 1 bit | | 8 bit:  | Protocol Opcode
+ *| 16 bit: | Exchange ID                                                          | 16 bit: | Protocol ID 16 bit: | Optional Vendor
+ *ID                                                   |                                                        | 32 bit: |
+ *Acknowledged Message Counter (if A flag in the Header is set)        |
  * -------- Encrypted Application Data Start ---------------------------------------
  *  <var>:  | Encrypted Data                                                       |
  * -------- Encrypted Application Data End -----------------------------------------

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -42,6 +42,8 @@ static constexpr size_t kMaxTagLen = 16;
 
 static constexpr size_t kMaxAppMessageLen = 1200;
 
+static constexpr size_t kMsgSessionIdUnsecured = 0x0000;
+
 typedef int PacketHeaderFlags;
 
 namespace Header {
@@ -303,13 +305,13 @@ private:
     /// Intended recipient of the message.
     Optional<NodeId> mDestinationNodeId;
 
-    /// Encryption Key ID
-    uint16_t mSessionId = 0;
+    /// Session ID
+    uint16_t mSessionId = kMsgSessionIdUnsecured;
 
     /// Message flags read from the message.
     Header::Flags mFlags;
 
-    /// Represents encryption type used for encrypting current packet
+    /// Represents session type used for encrypting current packet
     Header::SessionType mSessionType = Header::SessionType::kAESCCMTagLen16;
 };
 

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -550,12 +550,12 @@ public:
     const uint8_t * GetTag() const { return &mTag[0]; }
 
     /** Set the message auth tag for this header. */
-    MessageAuthenticationCode & SetTag(PacketHeader * header, Header::SessionType encType, uint8_t * tag, size_t len)
+    MessageAuthenticationCode & SetTag(PacketHeader * header, Header::SessionType sessionType, uint8_t * tag, size_t len)
     {
-        const size_t tagLen = TagLenForSessionType(encType);
+        const size_t tagLen = TagLenForSessionType(sessionType);
         if (tagLen > 0 && tagLen <= kMaxTagLen && len == tagLen)
         {
-            header->SetSessionType(encType);
+            header->SetSessionType(sessionType);
             memcpy(&mTag, tag, tagLen);
         }
 
@@ -594,7 +594,7 @@ public:
      */
     CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, uint16_t size, uint16_t * encode_size) const;
 
-    static uint16_t TagLenForSessionType(Header::SessionType encType);
+    static uint16_t TagLenForSessionType(Header::SessionType sessionType);
 
 private:
     /// Message authentication tag generated at encryption of the message.

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -46,9 +46,9 @@ typedef int PacketHeaderFlags;
 
 namespace Header {
 
-enum class EncryptionType
+enum class SessionType
 {
-    kEncryptionTypeNone = 0,
+    kSessionTypeNone = 0,
     kAESCCMTagLen16     = 1,
 };
 
@@ -134,7 +134,7 @@ public:
      */
     const Optional<NodeId> & GetDestinationNodeId() const { return mDestinationNodeId; }
 
-    uint16_t GetEncryptionKeyID() const { return mEncryptionKeyID; }
+    uint16_t GetSessionId() const { return mSessionId; }
 
     Header::Flags & GetFlags() { return mFlags; }
     const Header::Flags & GetFlags() const { return mFlags; }
@@ -142,7 +142,7 @@ public:
     /** Check if it's a secure session control message. */
     bool IsSecureSessionControlMsg() const { return mFlags.Has(Header::FlagValues::kSecureSessionControlMessage); }
 
-    Header::EncryptionType GetEncryptionType() const { return mEncryptionType; }
+    Header::SessionType GetSessionType() const { return mSessionType; }
 
     PacketHeader & SetSecureSessionControlMsg(bool value)
     {
@@ -192,9 +192,9 @@ public:
         return *this;
     }
 
-    PacketHeader & SetEncryptionKeyID(uint16_t id)
+    PacketHeader & SetSessionId(uint16_t id)
     {
-        mEncryptionKeyID = id;
+        mSessionId = id;
         return *this;
     }
 
@@ -204,9 +204,9 @@ public:
         return *this;
     }
 
-    PacketHeader & SetEncryptionType(Header::EncryptionType type)
+    PacketHeader & SetSessionType(Header::SessionType type)
     {
-        mEncryptionType = type;
+        mSessionType = type;
         return *this;
     }
 
@@ -304,13 +304,13 @@ private:
     Optional<NodeId> mDestinationNodeId;
 
     /// Encryption Key ID
-    uint16_t mEncryptionKeyID = 0;
+    uint16_t mSessionId = 0;
 
     /// Message flags read from the message.
     Header::Flags mFlags;
 
     /// Represents encryption type used for encrypting current packet
-    Header::EncryptionType mEncryptionType = Header::EncryptionType::kAESCCMTagLen16;
+    Header::SessionType mSessionType = Header::SessionType::kAESCCMTagLen16;
 };
 
 /**
@@ -550,12 +550,12 @@ public:
     const uint8_t * GetTag() const { return &mTag[0]; }
 
     /** Set the message auth tag for this header. */
-    MessageAuthenticationCode & SetTag(PacketHeader * header, Header::EncryptionType encType, uint8_t * tag, size_t len)
+    MessageAuthenticationCode & SetTag(PacketHeader * header, Header::SessionType encType, uint8_t * tag, size_t len)
     {
-        const size_t tagLen = TagLenForEncryptionType(encType);
+        const size_t tagLen = TagLenForSessionType(encType);
         if (tagLen > 0 && tagLen <= kMaxTagLen && len == tagLen)
         {
-            header->SetEncryptionType(encType);
+            header->SetSessionType(encType);
             memcpy(&mTag, tag, tagLen);
         }
 
@@ -594,7 +594,7 @@ public:
      */
     CHIP_ERROR Encode(const PacketHeader & packetHeader, uint8_t * data, uint16_t size, uint16_t * encode_size) const;
 
-    static uint16_t TagLenForEncryptionType(Header::EncryptionType encType);
+    static uint16_t TagLenForSessionType(Header::SessionType encType);
 
 private:
     /// Message authentication tag generated at encryption of the message.

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -292,7 +292,7 @@ public:
 
 private:
     /// Represents the current encode/decode header version
-    static constexpr int kHeaderVersion = 2;
+    static constexpr int kMsgHeaderVersion = 0;
 
     /// Value expected to be incremented for each message sent.
     uint32_t mMessageCounter = 0;

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -49,7 +49,7 @@ namespace Header {
 enum class SessionType
 {
     kSessionTypeNone = 0,
-    kAESCCMTagLen16     = 1,
+    kAESCCMTagLen16  = 1,
 };
 
 /**

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -41,7 +41,6 @@ chip_test_suite("tests") {
 
   test_sources = [
     "TestMessageHeader.cpp",
-    "TestUDP.cpp",
   ]
 
   if (current_os != "mac") {

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -39,9 +39,7 @@ static_library("helpers") {
 chip_test_suite("tests") {
   output_name = "libRawTransportTests"
 
-  test_sources = [
-    "TestMessageHeader.cpp",
-  ]
+  test_sources = [ "TestMessageHeader.cpp" ]
 
   if (current_os != "mac") {
     test_sources += [ "TestTCP.cpp" ]

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -126,7 +126,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 234);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(88ull));
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
-    NL_TEST_ASSERT(inSuite, header.GetEncryptionKeyID() == 2);
+    NL_TEST_ASSERT(inSuite, header.GetSessionId() == 2);
 
     header.SetMessageCounter(234).SetSourceNodeId(77).SetDestinationNodeId(88);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -40,7 +40,7 @@ void TestPacketHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, !header.IsSecureSessionControlMsg());
     NL_TEST_ASSERT(inSuite, header.GetMessageCounter() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetEncryptionKeyID() == 0);
+    NL_TEST_ASSERT(inSuite, header.GetSessionId() == 0);
     NL_TEST_ASSERT(inSuite, !header.GetDestinationNodeId().HasValue());
     NL_TEST_ASSERT(inSuite, !header.GetSourceNodeId().HasValue());
 }
@@ -117,7 +117,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<uint64_t>::Value(77ull));
     NL_TEST_ASSERT(inSuite, header.IsSecureSessionControlMsg());
 
-    header.SetMessageCounter(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetEncryptionKeyID(2);
+    header.SetMessageCounter(234).SetSourceNodeId(77).SetDestinationNodeId(88).SetSessionId(2);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
     // change it to verify decoding

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -382,7 +382,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, badKeyIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     // the secure channel is setup to use key ID 1, and 2. So let's use 3 here.
-    packetHeader.SetEncryptionKeyID(3);
+    packetHeader.SetSessionId(3);
     NL_TEST_ASSERT(inSuite, badKeyIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     err = secureSessionMgr.SendPreparedMessage(localToRemoteSession, badKeyIdMsg);


### PR DESCRIPTION
#### Problem
The message format does not fully match what is described in the specification.

#### Change overview
* Update message version field from `2` to `0` to match spec.
* Rename KeyId to SessionId
* Move SessionId field up to fixed portion of header
* Rename EncryptionType to SessionType
* Remapping of auth tag length based on SessionId rather than EncryptionType deferred to follow-on.

#### Testing
Standard CI unit test suite.
Ran echo-request / responder locally.