### PR TITLE
SystemLayer::PostEvent add API to post a lambda event

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -228,6 +228,7 @@ enum InternalEventTypes
     kEventTypeNotSet = kRange_Internal,
     kNoOp,
     kCallWorkFunct,
+    kChipLambdaEvent,
     kChipSystemLayerEvent,
     kCHIPoBLESubscribe,
     kCHIPoBLEUnsubscribe,
@@ -302,6 +303,7 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 #include <ble/BleConfig.h>
 #include <inet/InetLayer.h>
 #include <system/SystemEvent.h>
+#include <system/SystemLayer.h>
 #include <system/SystemObject.h>
 #include <system/SystemPacketBuffer.h>
 
@@ -318,6 +320,7 @@ struct ChipDeviceEvent final
     union
     {
         ChipDevicePlatformEvent Platform;
+        System::LambdaBridge LambdaEvent;
         struct
         {
             ::chip::System::EventType Type;

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -232,6 +232,10 @@ void GenericPlatformManagerImpl<ImplClass>::_DispatchEvent(const ChipDeviceEvent
         Impl()->DispatchEventToSystemLayer(event);
         break;
 
+    case DeviceEventType::kChipLambdaEvent:
+        event->LambdaEvent.LambdaProxy(static_cast<const void *>(event->LambdaEvent.LambdaBody));
+        break;
+
     case DeviceEventType::kCallWorkFunct:
         // If the event is a "call work function" event, call the specified function.
         event->CallWorkFunct.WorkFunct(event->CallWorkFunct.Arg);

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2471,5 +2471,23 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_LAMBDA_EVENT_SIZE
+ *
+ * @brief The maximum size of the lambda which can be post into system event queue.
+ */
+#ifndef CHIP_CONFIG_LAMBDA_EVENT_SIZE
+#define CHIP_CONFIG_LAMBDA_EVENT_SIZE (16)
+#endif
+
+/**
+ * @def CHIP_CONFIG_LAMBDA_EVENT_ALIGN
+ *
+ * @brief The maximum alignment of the lambda which can be post into system event queue.
+ */
+#ifndef CHIP_CONFIG_LAMBDA_EVENT_ALIGN
+#define CHIP_CONFIG_LAMBDA_EVENT_ALIGN (sizeof(void *))
+#endif
+
+/**
  * @}
  */

--- a/src/platform/LwIPEventSupport.cpp
+++ b/src/platform/LwIPEventSupport.cpp
@@ -34,6 +34,15 @@ namespace System {
 
 using namespace ::chip::DeviceLayer;
 
+CHIP_ERROR PlatformEventing::ScheduleLambdaBridge(System::Layer & aLayer, const LambdaBridge & bridge)
+{
+    ChipDeviceEvent event;
+    event.Type        = DeviceEventType::kChipLambdaEvent;
+    event.LambdaEvent = bridge;
+
+    return PlatformMgr().PostEvent(&event);
+}
+
 CHIP_ERROR PlatformEventing::PostEvent(System::Layer & aLayer, System::Object & aTarget, System::EventType aType,
                                        uintptr_t aArgument)
 {

--- a/src/system/LwIPEventSupport.h
+++ b/src/system/LwIPEventSupport.h
@@ -18,6 +18,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <system/SystemEvent.h>
+#include <system/SystemLayer.h>
 
 namespace chip {
 namespace System {
@@ -28,6 +29,7 @@ class Object;
 class PlatformEventing
 {
 public:
+    static CHIP_ERROR ScheduleLambdaBridge(System::Layer & aLayer, const LambdaBridge & bridge);
     static CHIP_ERROR PostEvent(System::Layer & aLayer, Object & aTarget, EventType aType, uintptr_t aArgument);
     static CHIP_ERROR DispatchEvents(System::Layer & aLayer);
     static CHIP_ERROR DispatchEvent(System::Layer & aLayer, Event aEvent);

--- a/src/system/SystemEvent.h
+++ b/src/system/SystemEvent.h
@@ -56,16 +56,6 @@ typedef CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE Event;
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-/**
- *   The Inet layer event type definitions.
- *
- */
-enum
-{
-    kEvent_ReleaseObj   = _CHIP_SYSTEM_CONFIG_LWIP_EVENT(0), /**< The event for the drop of a System::Layer object */
-    kEvent_ScheduleWork = _CHIP_SYSTEM_CONFIG_LWIP_EVENT(1), /**< The event for scheduling work on the System Layer's thread. */
-};
-
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 } // namespace System

--- a/src/system/SystemLayerImplLwIP.cpp
+++ b/src/system/SystemLayerImplLwIP.cpp
@@ -30,13 +30,7 @@
 namespace chip {
 namespace System {
 
-LayerLwIP::EventHandlerDelegate LayerImplLwIP::sSystemEventHandlerDelegate;
-
-LayerImplLwIP::LayerImplLwIP() : mHandlingTimerComplete(false), mEventDelegateList(nullptr)
-{
-    if (!sSystemEventHandlerDelegate.IsInitialized())
-        sSystemEventHandlerDelegate.Init(HandleSystemLayerEvent);
-}
+LayerImplLwIP::LayerImplLwIP() : mHandlingTimerComplete(false), mEventDelegateList(nullptr) {}
 
 CHIP_ERROR LayerImplLwIP::Init()
 {
@@ -44,7 +38,6 @@ CHIP_ERROR LayerImplLwIP::Init()
 
     RegisterLwIPErrorFormatter();
 
-    AddEventHandlerDelegate(sSystemEventHandlerDelegate);
     ReturnErrorOnFailure(mTimerList.Init());
 
     VerifyOrReturnError(mLayerState.Init(), CHIP_ERROR_INCORRECT_STATE);
@@ -100,7 +93,7 @@ CHIP_ERROR LayerImplLwIP::ScheduleWork(TimerCompleteCallback onComplete, void * 
     Timer * timer = Timer::New(*this, 0, onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    return PostEvent(*timer, chip::System::kEvent_ScheduleWork, 0);
+    return ScheduleLambda([timer] { timer->HandleComplete(); });
 }
 
 bool LayerLwIP::EventHandlerDelegate::IsInitialized() const
@@ -120,37 +113,24 @@ void LayerLwIP::EventHandlerDelegate::Prepend(const LayerLwIP::EventHandlerDeleg
     aDelegateList = this;
 }
 
-/**
- * This is the dispatch handler for system layer events.
- *
- *  @param[in,out]  aTarget     A pointer to the CHIP System Layer object making the post request.
- *  @param[in]      aEventType  The type of event to post.
- *  @param[in,out]  aArgument   The argument associated with the event to post.
- */
-CHIP_ERROR LayerImplLwIP::HandleSystemLayerEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)
-{
-    // Dispatch logic specific to the event type
-    switch (aEventType)
-    {
-    case kEvent_ReleaseObj:
-        aTarget.Release();
-        return CHIP_NO_ERROR;
-
-    case kEvent_ScheduleWork:
-        static_cast<Timer &>(aTarget).HandleComplete();
-        return CHIP_NO_ERROR;
-
-    default:
-        return CHIP_ERROR_UNEXPECTED_EVENT;
-    }
-}
-
 CHIP_ERROR LayerImplLwIP::AddEventHandlerDelegate(EventHandlerDelegate & aDelegate)
 {
     LwIPEventHandlerDelegate & lDelegate = static_cast<LwIPEventHandlerDelegate &>(aDelegate);
     VerifyOrReturnError(lDelegate.GetFunction() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     lDelegate.Prepend(mEventDelegateList);
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR LayerImplLwIP::ScheduleLambdaBridge(const LambdaBridge & bridge)
+{
+    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+
+    CHIP_ERROR lReturn = PlatformEventing::ScheduleLambdaBridge(*this, bridge);
+    if (lReturn != CHIP_NO_ERROR)
+    {
+        ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer lambda event: %s", ErrorStr(lReturn));
+    }
+    return lReturn;
 }
 
 CHIP_ERROR LayerImplLwIP::PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument)

--- a/src/system/SystemLayerImplLwIP.h
+++ b/src/system/SystemLayerImplLwIP.h
@@ -44,6 +44,7 @@ public:
 
     // LayerLwIP overrides.
     CHIP_ERROR AddEventHandlerDelegate(EventHandlerDelegate & aDelegate);
+    CHIP_ERROR ScheduleLambdaBridge(const LambdaBridge & bridge) override;
     CHIP_ERROR PostEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument);
 
 public:
@@ -55,12 +56,8 @@ public:
 private:
     friend class PlatformEventing;
 
-    static CHIP_ERROR HandleSystemLayerEvent(Object & aTarget, EventType aEventType, uintptr_t aArgument);
-
     CHIP_ERROR DispatchEvent(Event aEvent);
     CHIP_ERROR StartPlatformTimer(uint32_t aDelayMilliseconds);
-
-    static EventHandlerDelegate sSystemEventHandlerDelegate;
 
     Timer::MutexedList mTimerList;
     bool mHandlingTimerComplete; // true while handling any timer completion

--- a/src/system/SystemObject.cpp
+++ b/src/system/SystemObject.cpp
@@ -83,7 +83,7 @@ void Object::DeferredRelease(LayerLwIP * aSystemLayer, Object::ReleaseDeferralEr
 {
     VerifyOrReturn(aSystemLayer != nullptr, ChipLogError(chipSystemLayer, "aSystemLayer is nullptr"));
 
-    CHIP_ERROR lError = aSystemLayer->PostEvent(*this, chip::System::kEvent_ReleaseObj, 0);
+    CHIP_ERROR lError = aSystemLayer->ScheduleLambda([this] { this->Release(); });
 
     if (lError != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
#### Problem
Provides a most flexible API to run a deferred function.

This will decouple system object from network endpoints (TCPEndpoint, UDPEndpoint). It helps implementing the system object pool in PR #9590

#### Change overview
Add a `PostLambda` to post a generic lambda into system event queue.

There is several limitation of the lambda

* The lambda must be trivially copyable. Because the lambda is `memcpy` into the queue. It means that the lambda can only capture pod data (Including pointers).
* The size of the lambda must less than the queue element size. The size of the lambda is the sum of all captured fields. The body of the lambda is encoded in the type info of the lambda, which is captured by a static function `LambdaProxy<Lambda>::Call`, and resolved into a function pointer at compile time, assigned to `LambdaBridge::LambdaProxy` into the queue element.

#### Testing
Verified by unit tests.