### PR TITLE
Fix error copying artifacts for tizen platform (invalid app name)

### DIFF
--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -29,9 +29,9 @@ class TizenApp(Enum):
         else:
             raise Exception('Unknown app type: %r' % self)
 
-    def AppNamePrefix(self):
+    def AppName(self):
         if self == TizenApp.LIGHT:
-            return 'chip-tizen-lighting-example'
+            return 'chip-lighting-app'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -91,12 +91,10 @@ gn gen --check --fail-on-unused-args --root=%s '--args=''' % self.root
 
     def build_outputs(self):
         items = {
-            '%s.out' % self.app.AppNamePrefix():
-                os.path.join(self.output_dir, '%s.out' %
-                             self.app.AppNamePrefix()),
-            '%s.out.map' % self.app.AppNamePrefix():
-                os.path.join(self.output_dir,
-                             '%s.out.map' % self.app.AppNamePrefix()),
+            '%s' % self.app.AppName():
+                os.path.join(self.output_dir, self.app.AppName()),
+            '%s.map' % self.app.AppName():
+                os.path.join(self.output_dir, '%s.map' % self.app.AppName()),
         }
 
         return items


### PR DESCRIPTION
#### Problem

This fixes errors like:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/workspaces/connectedhomeip/out/tizen-arm-light/chip-tizen-lighting-example.out'
```

When trying to copy artifacts.

#### Change overview

Correct the application name (use a correct name and no out prefix).


#### Testing

```
./scripts/build/build_examples.py --platform tizen build --copy-artifacts-to /tmp
```
