### PR TITLE
fix unknown argument: '-ffile-prefix-map' error by only build default target

### DIFF
--- a/src/android/CHIPTool/app/build.gradle
+++ b/src/android/CHIPTool/app/build.gradle
@@ -17,6 +17,12 @@ android {
         // NOTE: This build assumes CHIP was configured and built for armeabi-v7a. Deal with
         // other archs later when build is sane.
         //  ndk {abiFilters 'armeabi-v7a'}
+
+        externalNativeBuild {
+            cmake {
+                targets "default"
+            }
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
#### Problem
Android IDE mode build failed with error
clang++: error: unknown argument: '-ffile-prefix-map=/Users/austinhsieh/repos/connectedhomeip/out/android_arm64=out'

#### Change overview
Only build 'default' target in IDE mode, same as script mode

#### Testing
How was this tested? (at least one bullet point required)
* Build and run basic test in CHIPTools
