### PR TITLE
TestUDP: use ephemeral port

### DIFF
--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -61,6 +61,8 @@ CHIP_ERROR UDP::Init(UdpListenParameters & params)
 
     mState = State::kInitialized;
 
+    ChipLogDetail(Inet, "UDP::Init bound to port=%d", mUDPEndPoint->GetBoundPort());
+
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -73,6 +75,12 @@ exit:
     }
 
     return err;
+}
+
+uint16_t UDP::GetBoundPort()
+{
+    VerifyOrDie(mUDPEndPoint != nullptr);
+    return mUDPEndPoint->GetBoundPort();
 }
 
 void UDP::Close()

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -105,6 +105,8 @@ public:
      */
     CHIP_ERROR Init(UdpListenParameters & params);
 
+    uint16_t GetBoundPort();
+
     /**
      * Close the open endpoint without destroying the object
      */

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -90,7 +90,7 @@ void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext, Inet::IPAddres
 
     Transport::UDP udp;
 
-    CHIP_ERROR err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(type));
+    CHIP_ERROR err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(type).SetListenPort(0));
 
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
@@ -122,7 +122,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
 
     Transport::UDP udp;
 
-    err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(addr.Type()));
+    err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(addr.Type()).SetListenPort(0));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     MockTransportMgrDelegate gMockTransportMgrDelegate(inSuite);
@@ -139,7 +139,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Should be able to send a message to itself by just calling send.
-    err = udp.SendMessage(Transport::PeerAddress::UDP(addr), std::move(buffer));
+    err = udp.SendMessage(Transport::PeerAddress::UDP(addr, udp.GetBoundPort()), std::move(buffer));
     if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
     {
         // TODO(#2698): the underlying system does not support IPV6. This early return


### PR DESCRIPTION
#### Problem
Fix TestUDP failure. The problem is triggered when multiple TestUDP (gcc/clang/mbedtls variant) is running concurrently, then their UDP port may conflict.

#### Change overview
In TestUDP, use ephemeral port instead of CHIP_PORT (5540)

#### Testing
Verified by unit-tests

```
[228/251] ACTION //src/transport/raw/t...//build/toolchain/linux:linux_x64_gcc)
FAILED: gen/src/transport/raw/tests/TestUDP_run.pw_pystamp 
python3 ../../third_party/pigweed/repo/pw_build/py/pw_build/python_runner.py --gn-root ../../ --current-path ../../src/transport/raw/tests --default-toolchain=//build/toolchain/linux:linux_x64_gcc --current-toolchain=//build/toolchain/linux:linux_x64_gcc --touch gen/src/transport/raw/tests/TestUDP_run.pw_pystamp --capture-output -- ../../third_party/pigweed/repo/pw_unit_test/py/pw_unit_test/test_runner.py --runner ../../third_party/pigweed/repo/targets/host/run_test --test tests/TestUDP
INF Test 1/1: [ RUN] TestUDP
ERR ../../third_party/pigweed/repo/targets/host/run_test exited with status 255
OUT [3685167]
'#0:','Test-CHIP-Udp'
'#2:','Setup                 ','PASSED'
[1631567899.867510][3685169:3685169] CHIP:IN: UDP::Init bind&listen port=5540
'#3:','Simple Init Test IPV4 ','PASSED'
[1631567899.867611][3685169:3685169] CHIP:IN: UDP::Init bind&listen port=5540
[1631567899.867640][3685169:3685169] CHIP:IN: TransportMgr initialized
CHIP node ready to service events
../../src/transport/raw/tests/TestUDP.cpp:155: assertion failed: "ReceiveHandlerCallCount == 1"
'#3:','Message Self Test IPV4','FAILED'
[1631567900.867263][3685169:3685169] CHIP:IN: UDP::Init bind&listen port=5540
'#3:','Simple Init Test IPV6 ','PASSED'
[1631567900.867330][3685169:3685169] CHIP:IN: UDP::Init bind&listen port=5540
[1631567900.867354][3685169:3685169] CHIP:IN: TransportMgr initialized
'#3:','Message Self Test IPV6','PASSED'
[1631567900.867482][3685169:3685175] CHIP:IN: Async DNS worker thread woke up.
[1631567900.867524][3685169:3685175] CHIP:IN: Async DNS worker thread exiting.
[1631567900.867531][3685169:3685174] CHIP:IN: Async DNS worker thread woke up.
[1631567900.867581][3685169:3685174] CHIP:IN: Async DNS worker thread exiting.
'#4:','Teardown              ','PASSED'
'#6:','1','4'
'#7:','1','17'
INF Test 1/1: [FAIL] TestUDP
[233/251] ACTION //src/app/tests:TestC...//build/toolchain/linux:linux_x64_gcc)
ninja: build stopped: subcommand failed.
```