### PR TITLE
Increase ESP32 build time to 10min instead of 5m

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -26,7 +26,7 @@ jobs:
     # TODO ESP32 https://github.com/project-chip/connectedhomeip/issues/1510
     esp32:
         name: ESP32
-        timeout-minutes: 60
+        timeout-minutes: 70
 
         env:
             BUILD_TYPE: esp32
@@ -84,89 +84,26 @@ jobs:
                      example_binaries/$BUILD_TYPE-build/chip-all-clusters-app.elf \
                      /tmp/bloat_reports/
             - name: Build example Pigweed App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh pigweed-app sdkconfig.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/pigweed-app/esp32/build/chip-pigweed-app.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-pigweed-app.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default pigweed-app \
-                     example_binaries/$BUILD_TYPE-build/chip-pigweed-app.elf \
-                     /tmp/bloat_reports/
             - name: Build example Lock App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh lock-app sdkconfig.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/lock-app/esp32/build/chip-lock-app.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-lock-app.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default lock-app \
-                     example_binaries/$BUILD_TYPE-build/chip-lock-app.elf \
-                     /tmp/bloat_reports/
             - name: Build example Bridge App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh bridge-app
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/bridge-app/esp32/build/chip-bridge-app.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-bridge-app.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default bridge-app \
-                     example_binaries/$BUILD_TYPE-build/chip-bridge-app.elf \
-                     /tmp/bloat_reports/
             - name: Build example Persistent Storage App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh persistent-storage sdkconfig.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/persistent-storage/esp32/build/chip-persistent-storage.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-persistent-storage.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default persistent-storage \
-                     example_binaries/$BUILD_TYPE-build/chip-persistent-storage.elf \
-                     /tmp/bloat_reports/
             - name: Build example Shell App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh shell sdkconfig.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/shell/esp32/build/chip-shell.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-shell.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default shell \
-                     example_binaries/$BUILD_TYPE-build/chip-shell.elf \
-                     /tmp/bloat_reports/
             - name: Build example Temperature Measurement App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh temperature-measurement-app sdkconfig.optimize.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/temperature-measurement-app/esp32/build/chip-temperature-measurement-app.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-temperature-measurement-app.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 optimize temperature-measurement-app \
-                     example_binaries/$BUILD_TYPE-build/chip-temperature-measurement-app.elf \
-                     /tmp/bloat_reports/
             - name: Build example IPv6 Only App
-              timeout-minutes: 5
+              timeout-minutes: 10
               run: scripts/examples/esp_example.sh ipv6only-app sdkconfig.defaults
-            - name: Copy aside build products
-              run: |
-                  mkdir -p example_binaries/$BUILD_TYPE-build
-                  cp examples/ipv6only-app/esp32/build/chip-ipv6only-app.elf \
-                     example_binaries/$BUILD_TYPE-build/chip-ipv6only-app.elf
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                     esp32 default ipv6only-app \
-                     example_binaries/$BUILD_TYPE-build/chip-ipv6only-app.elf \
-                     /tmp/bloat_reports/
             - name: Binary artifact suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0


### PR DESCRIPTION
Also remove some extra 'Copy build artifacts'. Bloat check should be
sufficient on the all-clusters-app only.

#### Problem
ESP32 builds timeout in master

#### Change overview
Increase timeouts

#### Testing
CI build will validate this.