### PR TITLE
Lock concurrent access to mWpaSupplicant

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -157,6 +157,8 @@ private:
 
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
+    static std::mutex mWpaSupplicantLock;
+
 #endif
 
     // ==================== ConnectivityManager Private Methods ====================

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -157,7 +157,7 @@ private:
 
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
-    static std::mutex mWpaSupplicantLock;
+    static std::mutex mWpaSupplicantMutex;
 
 #endif
 


### PR DESCRIPTION
Lock concurrent access to mWpaSupplicant.

#### Problem
state in GDBusWpaSupplicant may be concurrently accessed by multiples threads leading to race condition.

#### Change overview
Lock concurrent access to mWpaSupplicant.

#### Testing
Tested using a custom embedded linux system with all-clusters-app example, and macOS chip-tool for provisioning.