### PR TITLE
Use the primary Ethernet interface diagnostically for Ethernet diagnostic cluster

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -826,18 +826,6 @@
 #define CHIP_DEVICE_CONFIG_DEFAULT_TELEMETRY_INTERVAL_MS 90000
 #endif
 
-/**
- * @def CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
- *
- * @brief
- *   Default ethernet network interface name used to centralize all metrics that are
- *   relevant to a potential Ethernet connection to a Node.
- *
- */
-#ifndef CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME
-#define CHIP_DEVICE_CONFIG_ETHERNET_IF_NAME "enp0s25"
-#endif
-
 // -------------------- Event Logging Configuration --------------------
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, the vendor need to statically config the Ethernet interface for Ethernet diagnostic cluster.  We should choose the primary Ethernet interface diagnostically instead of static config.   

#### Change overview
Use the primary Ethernet interface diagnostically for Ethernet diagnostic cluster.

#### Testing
How was this tested? (at least one bullet point required)
* On client
   ./chip-tool ethernetnetworkdiagnostics read packet-rx-count 0

* On server
   ./chip-tool ethernetnetworkdiagnostics read packet-rx-count 0
   
```
[1631738094.421989][31236:31236] CHIP:DMG: Received Cluster Command: Cluster=0x0000_0037 NodeId=0x5B5C0FD11C39B86F Endpoint=0 AttributeId=2 ListIndex=0
[1631738094.422020][31236:31236] CHIP:ZCL: emberAfExternalAttributeReadCallback - Cluster ID: '0x0037', EndPoint ID: '0x00', Attribute ID: '0x0002'
[1631738094.422375][31236:31236] CHIP:DL: Found the primary Ethernet interface:enp0s25
```
