### PR TITLE
Turned On Wconversion for ASN1 Library and Coding Style Updates.

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -787,18 +787,15 @@ CHIP_ERROR ConvertIntegerDERToRaw(ByteSpan derInt, uint8_t * rawInt, const uint1
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, uint8_t * derSig, const uint16_t derSigBufSize,
-                                         uint16_t & derSigLen)
+CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, MutableByteSpan & derSig)
 {
     ASN1Writer writer;
 
-    VerifyOrReturnError(derSig != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    writer.Init(derSig, derSigBufSize);
+    writer.Init(derSig);
 
     ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(rawSig, writer));
 
-    derSigLen = writer.GetLengthWritten();
+    derSig.reduce_size(writer.GetLengthWritten());
 
     return CHIP_NO_ERROR;
 }

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -740,8 +740,10 @@ CHIP_ERROR ConvertIntegerDERToRaw(ByteSpan derInt, uint8_t * rawInt, const uint1
 /**
  * @brief Convert a raw CHIP signature to an ASN.1 DER encoded signature structure.
  *
- * @param rawSig        P256 ECDSA signature in raw form.
- * @param derSig        Buffer to store converted ASN.1 DER encoded signature.
+ * @param[in]     rawSig  P256 ECDSA signature in raw form.
+ * @param[in,out] derSig  Output buffer to receive the converted ASN.1 DER encoded signature.
+ *                        `derSig` must be at least `kMax_ECDSA_Signature_Length_Der` bytes long.
+ *                        The `derSig` size will be set to the actual DER encoded signature length on success.
  *
  * @retval  #CHIP_NO_ERROR  If the signature value was successfully converted.
  */

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -742,13 +742,10 @@ CHIP_ERROR ConvertIntegerDERToRaw(ByteSpan derInt, uint8_t * rawInt, const uint1
  *
  * @param rawSig        P256 ECDSA signature in raw form.
  * @param derSig        Buffer to store converted ASN.1 DER encoded signature.
- * @param derSigBufSize The size of the buffer to store ASN.1 DER encoded signature.
- * @param derSigLen     The length of the ASN.1 DER encoded signature.
  *
  * @retval  #CHIP_NO_ERROR  If the signature value was successfully converted.
  */
-CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, uint8_t * derSig, const uint16_t derSigBufSize,
-                                         uint16_t & derSigLen);
+CHIP_ERROR ConvertECDSASignatureRawToDER(P256ECDSASignatureSpan rawSig, MutableByteSpan & derSig);
 
 /**
  * @brief Convert a raw CHIP ECDSA signature to an ASN.1 DER encoded signature structure.

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -58,7 +58,7 @@ static CHIP_ERROR DecodeConvertDN(TLVReader & reader, ASN1Writer & writer, ChipD
     uint64_t tlvTag;
     uint32_t tlvTagNum;
     OID attrOID;
-    uint32_t asn1Tag;
+    uint8_t asn1Tag;
     const uint8_t * asn1AttrVal;
     uint32_t asn1AttrValLen;
     uint8_t chipAttrStr[17];

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -320,12 +320,8 @@ CHIP_ERROR EncodeChipECDSASignature(Crypto::P256ECDSASignature & signature, ASN1
     ASN1_START_BIT_STRING_ENCAPSULATED
     {
         // Convert RAW signature to DER when generating X509 certs.
-        uint8_t sig_der[Crypto::kMax_ECDSA_Signature_Length_Der];
-        uint16_t sig_der_size = 0;
         P256ECDSASignatureSpan raw_sig(signature.Bytes());
-
-        ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(raw_sig, &sig_der[0], sizeof(sig_der), sig_der_size));
-        ReturnErrorOnFailure(writer.PutConstructedType(&sig_der[0], static_cast<uint16_t>(sig_der_size)));
+        ReturnErrorOnFailure(ConvertECDSASignatureRawToDER(raw_sig, writer));
     }
     ASN1_END_ENCAPSULATED;
 

--- a/src/lib/asn1/ASN1.h
+++ b/src/lib/asn1/ASN1.h
@@ -61,7 +61,7 @@ enum ASN1TagClasses
     kASN1TagClass_Private         = 0xC0
 };
 
-enum ASN1UniversalTags
+enum ASN1UniversalTags : uint8_t
 {
     kASN1UniversalTag_Boolean         = 1,
     kASN1UniversalTag_Integer         = 2,
@@ -111,7 +111,7 @@ public:
     }
 
     uint8_t GetClass(void) const { return Class; };
-    uint32_t GetTag(void) const { return Tag; };
+    uint8_t GetTag(void) const { return Tag; };
     const uint8_t * GetValue(void) const { return Value; };
     uint32_t GetValueLen(void) const { return ValueLen; };
     bool IsConstructed(void) const { return Constructed; };
@@ -145,7 +145,7 @@ private:
     };
 
     uint8_t Class;
-    uint32_t Tag;
+    uint8_t Tag;
     const uint8_t * Value;
     uint32_t ValueLen;
     bool Constructed;
@@ -177,28 +177,28 @@ public:
         Init(data, N);
     }
     void InitNullWriter(void);
-    uint16_t GetLengthWritten(void) const;
+    size_t GetLengthWritten(void) const;
 
     CHIP_ERROR PutInteger(int64_t val);
     CHIP_ERROR PutBoolean(bool val);
     CHIP_ERROR PutObjectId(const uint8_t * val, uint16_t valLen);
     CHIP_ERROR PutObjectId(OID oid);
-    CHIP_ERROR PutString(uint32_t tag, const char * val, uint16_t valLen);
+    CHIP_ERROR PutString(uint8_t tag, const char * val, uint16_t valLen);
     CHIP_ERROR PutOctetString(const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutOctetString(uint8_t cls, uint32_t tag, const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & tlvReader);
+    CHIP_ERROR PutOctetString(uint8_t cls, uint8_t tag, const uint8_t * val, uint16_t valLen);
+    CHIP_ERROR PutOctetString(uint8_t cls, uint8_t tag, chip::TLV::TLVReader & tlvReader);
     CHIP_ERROR PutBitString(uint32_t val);
     CHIP_ERROR PutBitString(uint8_t unusedBits, const uint8_t * val, uint16_t valLen);
     CHIP_ERROR PutBitString(uint8_t unusedBits, chip::TLV::TLVReader & tlvReader);
     CHIP_ERROR PutTime(const ASN1UniversalTime & val);
     CHIP_ERROR PutNull(void);
     CHIP_ERROR PutConstructedType(const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR StartConstructedType(uint8_t cls, uint32_t tag);
+    CHIP_ERROR StartConstructedType(uint8_t cls, uint8_t tag);
     CHIP_ERROR EndConstructedType(void);
-    CHIP_ERROR StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding);
+    CHIP_ERROR StartEncapsulatedType(uint8_t cls, uint8_t tag, bool bitStringEncoding);
     CHIP_ERROR EndEncapsulatedType(void);
-    CHIP_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen);
-    CHIP_ERROR PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader);
+    CHIP_ERROR PutValue(uint8_t cls, uint8_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen);
+    CHIP_ERROR PutValue(uint8_t cls, uint8_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader);
 
 private:
     static constexpr size_t kMaxDeferredLengthDepth = kMaxConstructedAndEncapsulatedTypesDepth;
@@ -209,7 +209,7 @@ private:
     uint8_t * mDeferredLengthLocations[kMaxDeferredLengthDepth];
     uint8_t mDeferredLengthCount;
 
-    CHIP_ERROR EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed, int32_t len);
+    CHIP_ERROR EncodeHead(uint8_t cls, uint8_t tag, bool isConstructed, int32_t len);
     CHIP_ERROR WriteDeferredLength(void);
     static uint8_t BytesForLength(int32_t len);
     static void EncodeLength(uint8_t * buf, uint8_t bytesForLen, int32_t lenToEncode);

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -144,6 +144,7 @@ CHIP_ERROR ASN1Reader::GetInteger(int64_t & val)
 {
     ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
     ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(ValueLen > sizeof(int64_t), ASN1_ERROR_VALUE_OVERFLOW);
     ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
 
     const uint8_t * p = Value;

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -163,7 +163,7 @@ CHIP_ERROR ASN1Reader::GetBoolean(bool & val)
     ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
     VerifyOrReturnError(Value[0] == 0 || Value[0] == 0xFF, ASN1_ERROR_INVALID_ENCODING);
 
-    val = (Value[0] == 0) ? false : true;
+    val = (Value[0] != 0);
 
     return CHIP_NO_ERROR;
 }

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -254,16 +254,18 @@ CHIP_ERROR ASN1Reader::GetBitString(uint32_t & outVal)
 CHIP_ERROR ASN1Reader::DecodeHead()
 {
     const uint8_t * p = mElemStart;
-    ReturnErrorCodeIf(p + 1 >= mBufEnd, ASN1_ERROR_UNDERRUN);
+    ReturnErrorCodeIf(p >= mBufEnd, ASN1_ERROR_UNDERRUN);
 
     Class       = *p & 0xC0;
     Constructed = (*p & 0x20) != 0;
     Tag         = *p & 0x1F;
 
-    // Only tags <= 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
-    ReturnErrorCodeIf(Tag == 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
+    // Only tags < 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
+    VerifyOrReturnError(Tag < 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
     p++;
+    ReturnErrorCodeIf(p >= mBufEnd, ASN1_ERROR_UNDERRUN);
+
     if ((*p & 0x80) == 0)
     {
         ValueLen      = *p & 0x7F;

--- a/src/lib/asn1/ASN1Reader.cpp
+++ b/src/lib/asn1/ASN1Reader.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include <lib/asn1/ASN1.h>
+#include <lib/support/SafeInt.h>
 
 namespace chip {
 namespace ASN1 {
@@ -46,28 +47,21 @@ void ASN1Reader::Init(const uint8_t * buf, size_t len)
 
 CHIP_ERROR ASN1Reader::Next()
 {
-    if (EndOfContents)
-        return ASN1_END;
+    ReturnErrorCodeIf(EndOfContents, ASN1_END);
+    ReturnErrorCodeIf(IndefiniteLen, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
-    if (IndefiniteLen)
-    {
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
-    }
-    else
-        mElemStart += (mHeadLen + ValueLen);
+    mElemStart += (mHeadLen + ValueLen);
 
     ResetElementState();
 
-    if (mElemStart == mContainerEnd)
-        return ASN1_END;
+    ReturnErrorCodeIf(mElemStart == mContainerEnd, ASN1_END);
 
     return DecodeHead();
 }
 
 CHIP_ERROR ASN1Reader::EnterConstructedType()
 {
-    if (!Constructed)
-        return ASN1_ERROR_INVALID_STATE;
+    ReturnErrorCodeIf(!Constructed, ASN1_ERROR_INVALID_STATE);
 
     return EnterContainer(0);
 }
@@ -79,8 +73,7 @@ CHIP_ERROR ASN1Reader::ExitConstructedType()
 
 CHIP_ERROR ASN1Reader::GetConstructedType(const uint8_t *& val, uint32_t & valLen)
 {
-    if (!Constructed)
-        return ASN1_ERROR_INVALID_STATE;
+    ReturnErrorCodeIf(!Constructed, ASN1_ERROR_INVALID_STATE);
 
     val    = mElemStart;
     valLen = mHeadLen + ValueLen;
@@ -89,11 +82,11 @@ CHIP_ERROR ASN1Reader::GetConstructedType(const uint8_t *& val, uint32_t & valLe
 }
 CHIP_ERROR ASN1Reader::EnterEncapsulatedType()
 {
-    if (Class != kASN1TagClass_Universal || (Tag != kASN1UniversalTag_OctetString && Tag != kASN1UniversalTag_BitString))
-        return ASN1_ERROR_INVALID_STATE;
+    VerifyOrReturnError(Class == kASN1TagClass_Universal &&
+                            (Tag == kASN1UniversalTag_OctetString || Tag == kASN1UniversalTag_BitString),
+                        ASN1_ERROR_INVALID_STATE);
 
-    if (Constructed)
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
+    ReturnErrorCodeIf(Constructed, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
     return EnterContainer((Tag == kASN1UniversalTag_BitString) ? 1 : 0);
 }
@@ -105,8 +98,7 @@ CHIP_ERROR ASN1Reader::ExitEncapsulatedType()
 
 CHIP_ERROR ASN1Reader::EnterContainer(uint32_t offset)
 {
-    if (mNumSavedContexts == kMaxContextDepth)
-        return ASN1_ERROR_MAX_DEPTH_EXCEEDED;
+    ReturnErrorCodeIf(mNumSavedContexts == kMaxContextDepth, ASN1_ERROR_MAX_DEPTH_EXCEEDED);
 
     mSavedContexts[mNumSavedContexts].ElemStart     = mElemStart;
     mSavedContexts[mNumSavedContexts].HeadLen       = mHeadLen;
@@ -117,7 +109,9 @@ CHIP_ERROR ASN1Reader::EnterContainer(uint32_t offset)
 
     mElemStart = Value + offset;
     if (!IndefiniteLen)
+    {
         mContainerEnd = Value + ValueLen;
+    }
 
     ResetElementState();
 
@@ -126,17 +120,13 @@ CHIP_ERROR ASN1Reader::EnterContainer(uint32_t offset)
 
 CHIP_ERROR ASN1Reader::ExitContainer()
 {
-    if (mNumSavedContexts == 0)
-        return ASN1_ERROR_INVALID_STATE;
+    ReturnErrorCodeIf(mNumSavedContexts == 0, ASN1_ERROR_INVALID_STATE);
 
     ASN1ParseContext & prevContext = mSavedContexts[--mNumSavedContexts];
 
-    if (prevContext.IndefiniteLen)
-    {
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
-    }
-    else
-        mElemStart = prevContext.ElemStart + prevContext.HeadLen + prevContext.ValueLen;
+    ReturnErrorCodeIf(prevContext.IndefiniteLen, ASN1_ERROR_UNSUPPORTED_ENCODING);
+
+    mElemStart = prevContext.ElemStart + prevContext.HeadLen + prevContext.ValueLen;
 
     mContainerEnd = prevContext.ContainerEnd;
 
@@ -152,67 +142,52 @@ bool ASN1Reader::IsContained() const
 
 CHIP_ERROR ASN1Reader::GetInteger(int64_t & val)
 {
-    if (Value == nullptr)
-        return ASN1_ERROR_INVALID_STATE;
-    if (ValueLen < 1)
-        return ASN1_ERROR_INVALID_ENCODING;
-    if (ValueLen > sizeof(int64_t))
-        return ASN1_ERROR_VALUE_OVERFLOW;
-    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
-        return ASN1_ERROR_UNDERRUN;
+    ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
+    ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
+
     const uint8_t * p = Value;
     val               = ((*p & 0x80) == 0) ? 0 : -1;
     for (uint32_t i = ValueLen; i > 0; i--, p++)
+    {
         val = (val << 8) | *p;
+    }
+
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ASN1Reader::GetBoolean(bool & val)
 {
-    if (Value == nullptr)
-        return ASN1_ERROR_INVALID_STATE;
-    if (ValueLen != 1)
-        return ASN1_ERROR_INVALID_ENCODING;
-    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
-        return ASN1_ERROR_UNDERRUN;
-    if (*Value == 0)
-        val = false;
-    else if (*Value == 0xFF)
-        val = true;
-    else
-        return ASN1_ERROR_INVALID_ENCODING;
+    ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
+    ReturnErrorCodeIf(ValueLen != 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
+    VerifyOrReturnError(Value[0] == 0 || Value[0] == 0xFF, ASN1_ERROR_INVALID_ENCODING);
+
+    val = (Value[0] == 0) ? false : true;
+
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ASN1Reader::GetUTCTime(ASN1UniversalTime & outTime)
 {
     // Supported Encoding: YYMMDDHHMMSSZ
-
-    if (Value == nullptr)
-        return ASN1_ERROR_INVALID_STATE;
-    if (ValueLen < 1)
-        return ASN1_ERROR_INVALID_ENCODING;
-    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
-        return ASN1_ERROR_UNDERRUN;
-
-    if (ValueLen != 13 || Value[12] != 'Z')
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
-
+    ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
+    ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
+    VerifyOrReturnError(ValueLen == 13 && Value[12] == 'Z', ASN1_ERROR_UNSUPPORTED_ENCODING);
     for (int i = 0; i < 12; i++)
-        if (!isdigit(Value[i]))
-            return ASN1_ERROR_INVALID_ENCODING;
+    {
+        VerifyOrReturnError(isdigit(Value[i]), ASN1_ERROR_INVALID_ENCODING);
+    }
 
-    outTime.Year   = (Value[0] - '0') * 10 + (Value[1] - '0');
-    outTime.Month  = (Value[2] - '0') * 10 + (Value[3] - '0');
-    outTime.Day    = (Value[4] - '0') * 10 + (Value[5] - '0');
-    outTime.Hour   = (Value[6] - '0') * 10 + (Value[7] - '0');
-    outTime.Minute = (Value[8] - '0') * 10 + (Value[9] - '0');
-    outTime.Second = (Value[10] - '0') * 10 + (Value[11] - '0');
+    outTime.Year   = static_cast<uint16_t>((Value[0] - '0') * 10 + (Value[1] - '0'));
+    outTime.Month  = static_cast<uint8_t>((Value[2] - '0') * 10 + (Value[3] - '0'));
+    outTime.Day    = static_cast<uint8_t>((Value[4] - '0') * 10 + (Value[5] - '0'));
+    outTime.Hour   = static_cast<uint8_t>((Value[6] - '0') * 10 + (Value[7] - '0'));
+    outTime.Minute = static_cast<uint8_t>((Value[8] - '0') * 10 + (Value[9] - '0'));
+    outTime.Second = static_cast<uint8_t>((Value[10] - '0') * 10 + (Value[11] - '0'));
 
-    if (outTime.Year >= 50)
-        outTime.Year += 1900;
-    else
-        outTime.Year += 2000;
+    outTime.Year = static_cast<uint16_t>(outTime.Year + ((outTime.Year >= 50) ? 1900 : 2000));
 
     return CHIP_NO_ERROR;
 }
@@ -220,27 +195,22 @@ CHIP_ERROR ASN1Reader::GetUTCTime(ASN1UniversalTime & outTime)
 CHIP_ERROR ASN1Reader::GetGeneralizedTime(ASN1UniversalTime & outTime)
 {
     // Supported Encoding: YYYYMMDDHHMMSSZ
-
-    if (Value == nullptr)
-        return ASN1_ERROR_INVALID_STATE;
-    if (ValueLen < 1)
-        return ASN1_ERROR_INVALID_ENCODING;
-    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
-        return ASN1_ERROR_UNDERRUN;
-
-    if (ValueLen != 15 || Value[14] != 'Z')
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
-
+    ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
+    ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
+    VerifyOrReturnError(ValueLen == 15 && Value[14] == 'Z', ASN1_ERROR_UNSUPPORTED_ENCODING);
     for (int i = 0; i < 14; i++)
-        if (!isdigit(Value[i]))
-            return ASN1_ERROR_INVALID_ENCODING;
+    {
+        VerifyOrReturnError(isdigit(Value[i]), ASN1_ERROR_INVALID_ENCODING);
+    }
 
-    outTime.Year   = (Value[0] - '0') * 1000 + (Value[1] - '0') * 100 + (Value[2] - '0') * 10 + (Value[3] - '0');
-    outTime.Month  = (Value[4] - '0') * 10 + (Value[5] - '0');
-    outTime.Day    = (Value[6] - '0') * 10 + (Value[7] - '0');
-    outTime.Hour   = (Value[8] - '0') * 10 + (Value[9] - '0');
-    outTime.Minute = (Value[10] - '0') * 10 + (Value[11] - '0');
-    outTime.Second = (Value[12] - '0') * 10 + (Value[13] - '0');
+    outTime.Year =
+        static_cast<uint16_t>((Value[0] - '0') * 1000 + (Value[1] - '0') * 100 + (Value[2] - '0') * 10 + (Value[3] - '0'));
+    outTime.Month  = static_cast<uint8_t>((Value[4] - '0') * 10 + (Value[5] - '0'));
+    outTime.Day    = static_cast<uint8_t>((Value[6] - '0') * 10 + (Value[7] - '0'));
+    outTime.Hour   = static_cast<uint8_t>((Value[8] - '0') * 10 + (Value[9] - '0'));
+    outTime.Minute = static_cast<uint8_t>((Value[10] - '0') * 10 + (Value[11] - '0'));
+    outTime.Second = static_cast<uint8_t>((Value[12] - '0') * 10 + (Value[13] - '0'));
 
     return CHIP_NO_ERROR;
 }
@@ -248,35 +218,34 @@ CHIP_ERROR ASN1Reader::GetGeneralizedTime(ASN1UniversalTime & outTime)
 static uint8_t ReverseBits(uint8_t v)
 {
     // swap adjacent bits
-    v = ((v >> 1) & 0x55) | ((v & 0x55) << 1);
+    v = static_cast<uint8_t>((v >> 1) & 0x55) | static_cast<uint8_t>((v & 0x55) << 1);
     // swap adjacent bit pairs
-    v = ((v >> 2) & 0x33) | ((v & 0x33) << 2);
+    v = static_cast<uint8_t>((v >> 2) & 0x33) | static_cast<uint8_t>((v & 0x33) << 2);
     // swap nibbles
-    v = (v >> 4) | (v << 4);
+    v = static_cast<uint8_t>(v >> 4) | static_cast<uint8_t>(v << 4);
     return v;
 }
 
 CHIP_ERROR ASN1Reader::GetBitString(uint32_t & outVal)
 {
     // NOTE: only supports DER encoding.
-
-    if (Value == nullptr)
-        return ASN1_ERROR_INVALID_STATE;
-    if (ValueLen < 1)
-        return ASN1_ERROR_INVALID_ENCODING;
-    if (ValueLen > 5)
-        return ASN1_ERROR_UNSUPPORTED_ENCODING;
-    if (mElemStart + mHeadLen + ValueLen > mContainerEnd)
-        return ASN1_ERROR_UNDERRUN;
+    ReturnErrorCodeIf(Value == nullptr, ASN1_ERROR_INVALID_STATE);
+    ReturnErrorCodeIf(ValueLen < 1, ASN1_ERROR_INVALID_ENCODING);
+    ReturnErrorCodeIf(ValueLen > 5, ASN1_ERROR_UNSUPPORTED_ENCODING);
+    ReturnErrorCodeIf(mElemStart + mHeadLen + ValueLen > mContainerEnd, ASN1_ERROR_UNDERRUN);
 
     if (ValueLen == 1)
+    {
         outVal = 0;
+    }
     else
     {
         outVal    = ReverseBits(Value[1]);
         int shift = 8;
         for (uint32_t i = 2; i < ValueLen; i++, shift += 8)
-            outVal |= (ReverseBits(Value[i]) << shift);
+        {
+            outVal |= static_cast<uint32_t>(ReverseBits(Value[i]) << shift);
+        }
     }
 
     return CHIP_NO_ERROR;
@@ -285,32 +254,16 @@ CHIP_ERROR ASN1Reader::GetBitString(uint32_t & outVal)
 CHIP_ERROR ASN1Reader::DecodeHead()
 {
     const uint8_t * p = mElemStart;
-
-    if (p >= mBufEnd)
-        return ASN1_ERROR_UNDERRUN;
+    ReturnErrorCodeIf(p + 1 >= mBufEnd, ASN1_ERROR_UNDERRUN);
 
     Class       = *p & 0xC0;
     Constructed = (*p & 0x20) != 0;
+    Tag         = *p & 0x1F;
 
-    Tag = *p & 0x1F;
+    // Only tags <= 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
+    ReturnErrorCodeIf(Tag == 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
+
     p++;
-    if (Tag == 0x1F)
-    {
-        Tag = 0;
-        do
-        {
-            if (p >= mBufEnd)
-                return ASN1_ERROR_UNDERRUN;
-            if ((Tag & 0xFE000000) != 0)
-                return ASN1_ERROR_TAG_OVERFLOW;
-            Tag = (Tag << 7) | (*p & 0x7F);
-            p++;
-        } while ((*p & 0x80) != 0);
-    }
-
-    if (p >= mBufEnd)
-        return ASN1_ERROR_UNDERRUN;
-
     if ((*p & 0x80) == 0)
     {
         ValueLen      = *p & 0x7F;
@@ -330,16 +283,16 @@ CHIP_ERROR ASN1Reader::DecodeHead()
         p++;
         for (; lenLen > 0; lenLen--, p++)
         {
-            if (p >= mBufEnd)
-                return ASN1_ERROR_UNDERRUN;
-            if ((ValueLen & 0xFF000000) != 0)
-                return ASN1_ERROR_LENGTH_OVERFLOW;
+            ReturnErrorCodeIf(p >= mBufEnd, ASN1_ERROR_UNDERRUN);
+            ReturnErrorCodeIf((ValueLen & 0xFF000000) != 0, ASN1_ERROR_LENGTH_OVERFLOW);
             ValueLen = (ValueLen << 8) | *p;
         }
         IndefiniteLen = false;
     }
 
-    mHeadLen = p - mElemStart;
+    VerifyOrReturnError(CanCastTo<uint32_t>(p - mElemStart), ASN1_ERROR_VALUE_OVERFLOW);
+
+    mHeadLen = static_cast<uint32_t>(p - mElemStart);
 
     EndOfContents = (Class == kASN1TagClass_Universal && Tag == 0 && Constructed == false && ValueLen == 0);
 

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -387,7 +387,7 @@ CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint8_t tag, bool isConstructed, 
 
     // Make sure there's enough space to encode the entire value.
     // Note that the calculated total length doesn't overflow because `len` is a signed value (int32_t).
-    // Note that if `len` is not kUnknownLength then it is positive (`len` >= 0).
+    // Note that if `len` is not kUnknownLength then it is non-negative (`len` >= 0).
     totalLen = 1 + bytesForLen + static_cast<uint32_t>(len != kUnknownLength ? len : 0);
     VerifyOrReturnError((mWritePoint + totalLen) <= mBufEnd, ASN1_ERROR_OVERFLOW);
 

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -68,9 +68,9 @@ void ASN1Writer::InitNullWriter(void)
     mDeferredLengthCount = 0;
 }
 
-uint16_t ASN1Writer::GetLengthWritten() const
+size_t ASN1Writer::GetLengthWritten() const
 {
-    return (mBuf != nullptr) ? mWritePoint - mBuf : 0;
+    return (mBuf != nullptr) ? static_cast<size_t>(mWritePoint - mBuf) : 0;
 }
 
 CHIP_ERROR ASN1Writer::PutInteger(int64_t val)
@@ -88,7 +88,7 @@ CHIP_ERROR ASN1Writer::PutInteger(int64_t val)
             continue;
         break;
     }
-    valLen = 8 - valStart;
+    valLen = static_cast<uint8_t>(8 - valStart);
 
     return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_Integer, false, encodedVal + valStart, valLen);
 }
@@ -110,7 +110,7 @@ CHIP_ERROR ASN1Writer::PutObjectId(const uint8_t * val, uint16_t valLen)
     return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_ObjectId, false, val, valLen);
 }
 
-CHIP_ERROR ASN1Writer::PutString(uint32_t tag, const char * val, uint16_t valLen)
+CHIP_ERROR ASN1Writer::PutString(uint8_t tag, const char * val, uint16_t valLen)
 {
     return PutValue(kASN1TagClass_Universal, tag, false, (const uint8_t *) val, valLen);
 }
@@ -120,12 +120,12 @@ CHIP_ERROR ASN1Writer::PutOctetString(const uint8_t * val, uint16_t valLen)
     return PutValue(kASN1TagClass_Universal, kASN1UniversalTag_OctetString, false, val, valLen);
 }
 
-CHIP_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint32_t tag, const uint8_t * val, uint16_t valLen)
+CHIP_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint8_t tag, const uint8_t * val, uint16_t valLen)
 {
     return PutValue(cls, tag, false, val, valLen);
 }
 
-CHIP_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVReader & tlvReader)
+CHIP_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint8_t tag, chip::TLV::TLVReader & tlvReader)
 {
     return PutValue(cls, tag, false, tlvReader);
 }
@@ -133,11 +133,11 @@ CHIP_ERROR ASN1Writer::PutOctetString(uint8_t cls, uint32_t tag, chip::TLV::TLVR
 static uint8_t ReverseBits(uint8_t v)
 {
     // swap adjacent bits
-    v = ((v >> 1) & 0x55) | ((v & 0x55) << 1);
+    v = static_cast<uint8_t>((v >> 1) & 0x55) | static_cast<uint8_t>((v & 0x55) << 1);
     // swap adjacent bit pairs
-    v = ((v >> 2) & 0x33) | ((v & 0x33) << 2);
+    v = static_cast<uint8_t>((v >> 2) & 0x33) | static_cast<uint8_t>((v & 0x33) << 2);
     // swap nibbles
-    v = (v >> 4) | (v << 4);
+    v = static_cast<uint8_t>(v >> 4) | static_cast<uint8_t>(v << 4);
     return v;
 }
 
@@ -167,7 +167,7 @@ static uint8_t HighestBit(uint32_t v)
     }
     highestBit |= (v >> 1);
 
-    return highestBit;
+    return static_cast<uint8_t>(highestBit);
 }
 
 CHIP_ERROR ASN1Writer::PutBitString(uint32_t val)
@@ -212,7 +212,7 @@ CHIP_ERROR ASN1Writer::PutBitString(uint32_t val)
                 }
             }
         }
-        mWritePoint[0] = 7 - HighestBit(val);
+        mWritePoint[0] = static_cast<uint8_t>(7 - HighestBit(val));
     }
 
     mWritePoint += len;
@@ -245,7 +245,8 @@ CHIP_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, chip::TLV::TLVReader
 
     VerifyOrReturnError(CanCastTo<int32_t>(encodedBits.size() + 1), ASN1_ERROR_LENGTH_OVERFLOW);
 
-    ReturnErrorOnFailure(EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBits.size() + 1));
+    ReturnErrorOnFailure(
+        EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, static_cast<int32_t>(encodedBits.size() + 1)));
 
     *mWritePoint++ = unusedBitCount;
 
@@ -256,9 +257,9 @@ CHIP_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, chip::TLV::TLVReader
 
 static void itoa2(uint32_t val, uint8_t * buf)
 {
-    buf[1] = '0' + (val % 10);
+    buf[1] = static_cast<uint8_t>('0' + (val % 10));
     val /= 10;
-    buf[0] = '0' + (val % 10);
+    buf[0] = static_cast<uint8_t>('0' + (val % 10));
 }
 
 CHIP_ERROR ASN1Writer::PutTime(const ASN1UniversalTime & val)
@@ -303,7 +304,7 @@ CHIP_ERROR ASN1Writer::PutConstructedType(const uint8_t * val, uint16_t valLen)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ASN1Writer::StartConstructedType(uint8_t cls, uint32_t tag)
+CHIP_ERROR ASN1Writer::StartConstructedType(uint8_t cls, uint8_t tag)
 {
     return EncodeHead(cls, tag, true, kUnknownLength);
 }
@@ -313,7 +314,7 @@ CHIP_ERROR ASN1Writer::EndConstructedType()
     return WriteDeferredLength();
 }
 
-CHIP_ERROR ASN1Writer::StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding)
+CHIP_ERROR ASN1Writer::StartEncapsulatedType(uint8_t cls, uint8_t tag, bool bitStringEncoding)
 {
     // Do nothing for a null writer.
     VerifyOrReturnError(mBuf != nullptr, CHIP_NO_ERROR);
@@ -337,7 +338,7 @@ CHIP_ERROR ASN1Writer::EndEncapsulatedType()
     return WriteDeferredLength();
 }
 
-CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen)
+CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint8_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen)
 {
     // Do nothing for a null writer.
     VerifyOrReturnError(mBuf != nullptr, CHIP_NO_ERROR);
@@ -349,7 +350,7 @@ CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, c
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader)
+CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint8_t tag, bool isConstructed, chip::TLV::TLVReader & tlvReader)
 {
     ByteSpan val;
 
@@ -360,14 +361,14 @@ CHIP_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, c
 
     VerifyOrReturnError(CanCastTo<int32_t>(val.size()), ASN1_ERROR_LENGTH_OVERFLOW);
 
-    ReturnErrorOnFailure(EncodeHead(cls, tag, isConstructed, val.size()));
+    ReturnErrorOnFailure(EncodeHead(cls, tag, isConstructed, static_cast<int32_t>(val.size())));
 
     WriteData(val.data(), val.size());
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed, int32_t len)
+CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint8_t tag, bool isConstructed, int32_t len)
 {
     uint8_t bytesForLen;
     uint32_t totalLen;
@@ -386,11 +387,11 @@ CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed,
 
     // Make sure there's enough space to encode the entire value.
     // Note that the calculated total length doesn't overflow because `len` is a signed value (int32_t).
-    totalLen = 1 + bytesForLen + (len != kUnknownLength ? len : 0);
+    totalLen = 1 + bytesForLen + static_cast<uint32_t>(len != kUnknownLength ? len : 0);
     VerifyOrReturnError((mWritePoint + totalLen) <= mBufEnd, ASN1_ERROR_OVERFLOW);
 
     // Write the tag byte.
-    *mWritePoint++ = cls | (isConstructed ? 0x20 : 0) | tag;
+    *mWritePoint++ = cls | static_cast<uint8_t>(isConstructed ? 0x20 : 0) | tag;
 
     // Encode the length if it is known.
     if (len != kUnknownLength)
@@ -430,7 +431,7 @@ CHIP_ERROR ASN1Writer::WriteDeferredLength()
     VerifyOrReturnError(*lenField == kUnknownLengthMarker, ASN1_ERROR_INVALID_STATE);
 
     // Compute the length of the element's value.
-    uint32_t elemLen = (mWritePoint - lenField) - kLengthFieldReserveSize;
+    size_t elemLen = static_cast<size_t>((mWritePoint - lenField) - kLengthFieldReserveSize);
 
     VerifyOrReturnError(CanCastTo<int32_t>(elemLen), ASN1_ERROR_LENGTH_OVERFLOW);
 
@@ -449,7 +450,7 @@ CHIP_ERROR ASN1Writer::WriteDeferredLength()
 
     // Encode the final length of the element, overwriting the unknown length marker
     // in the process.
-    EncodeLength(lenField, bytesForLen, elemLen);
+    EncodeLength(lenField, bytesForLen, static_cast<int32_t>(elemLen));
 
     mDeferredLengthCount--;
 

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -376,8 +376,8 @@ CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint8_t tag, bool isConstructed, 
     // Do nothing for a null writer.
     VerifyOrReturnError(mBuf != nullptr, CHIP_NO_ERROR);
 
-    // Only tags <= 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
-    VerifyOrReturnError(tag <= 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
+    // Only tags < 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
+    VerifyOrReturnError(tag < 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
     // Only positive and kUnknownLength values are supported for len input.
     VerifyOrReturnError(len >= 0 || len == kUnknownLength, ASN1_ERROR_UNSUPPORTED_ENCODING);
@@ -387,6 +387,7 @@ CHIP_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint8_t tag, bool isConstructed, 
 
     // Make sure there's enough space to encode the entire value.
     // Note that the calculated total length doesn't overflow because `len` is a signed value (int32_t).
+    // Note that if `len` is not kUnknownLength then it is positive (`len` >= 0).
     totalLen = 1 + bytesForLen + static_cast<uint32_t>(len != kUnknownLength ? len : 0);
     VerifyOrReturnError((mWritePoint + totalLen) <= mBufEnd, ASN1_ERROR_OVERFLOW);
 

--- a/src/lib/asn1/BUILD.gn
+++ b/src/lib/asn1/BUILD.gn
@@ -42,6 +42,8 @@ static_library("asn1") {
     "ASN1Writer.cpp",
   ]
 
+  cflags = [ "-Wconversion" ]
+
   public_deps = [
     ":asn1oid_header",
     "${chip_root}/src/lib/core",


### PR DESCRIPTION
#### Problem
ASN1 library doesn't enable -Wconversion checks.

#### Change overview
  -- Turned on -Wconversion in src/lib/asn1/BUILD.gn
  -- Added required SafeCast checks.
  -- Update code to support only short (uint8_t) ASN1 Tags.
  -- Updated ASN1 library conding style to use ReturnErrorCodeIf() and VerifyOrReturnError() macros.
  -- Other minor updates.

#### Testing
Unittesting