### PR TITLE
Make CRI/CRA txt fields optional and move to base.

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -256,8 +256,7 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
                     .SetPeerId(fabricInfo.GetPeerId())
                     .SetMac(FillMAC(mac))
                     .SetPort(GetSecuredPort())
-                    // TODO: This uses active twice, but we don't have an idle default. Is this as-intended?
-                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL),
+                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
                                           Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
                     .EnableIpV4(true);
 
@@ -334,8 +333,7 @@ CHIP_ERROR MdnsServer::Advertise(bool commissionableNode, chip::Mdns::Commission
     advertiseParameters.SetRotatingId(chip::Optional<const char *>::Value(rotatingDeviceIdHexBuffer));
 #endif
 
-    // TODO: Set same as operational - this uses active twice, but we don't have an idle default. Is this as-intended?
-    advertiseParameters.SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL),
+    advertiseParameters.SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
                                              Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL));
 
     if (mode != chip::Mdns::CommissioningMode::kEnabledEnhanced)

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -251,13 +251,15 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
         {
             uint8_t mac[8];
 
-            const auto advertiseParameters = chip::Mdns::OperationalAdvertisingParameters()
-                                                 .SetPeerId(fabricInfo.GetPeerId())
-                                                 .SetMac(FillMAC(mac))
-                                                 .SetPort(GetSecuredPort())
-                                                 .SetMRPRetryIntervals(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL,
-                                                                       CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL)
-                                                 .EnableIpV4(true);
+            const auto advertiseParameters =
+                chip::Mdns::OperationalAdvertisingParameters()
+                    .SetPeerId(fabricInfo.GetPeerId())
+                    .SetMac(FillMAC(mac))
+                    .SetPort(GetSecuredPort())
+                    // TODO: This uses active twice, but we don't have an idle default. Is this as-intended?
+                    .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL),
+                                          Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
+                    .EnableIpV4(true);
 
             auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
 
@@ -331,6 +333,10 @@ CHIP_ERROR MdnsServer::Advertise(bool commissionableNode, chip::Mdns::Commission
     ReturnErrorOnFailure(GenerateRotatingDeviceId(rotatingDeviceIdHexBuffer, ArraySize(rotatingDeviceIdHexBuffer)));
     advertiseParameters.SetRotatingId(chip::Optional<const char *>::Value(rotatingDeviceIdHexBuffer));
 #endif
+
+    // TODO: Set same as operational - this uses active twice, but we don't have an idle default. Is this as-intended?
+    advertiseParameters.SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL),
+                                             Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL));
 
     if (mode != chip::Mdns::CommissioningMode::kEnabledEnhanced)
     {

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -163,8 +163,14 @@ private:
             ReturnErrorOnFailure(chip::DeviceLayer::ThreadStackMgr().GetPollPeriod(sedPollPeriod));
             // Increment default MRP retry intervals by SED poll period to be on the safe side
             // and avoid unnecessary retransmissions.
-            mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollPeriod);
-            mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollPeriod);
+            if (mrpRetryIntervalIdle.HasValue())
+            {
+                mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollPeriod);
+            }
+            if (mrpRetryIntervalActive.HasValue())
+            {
+                mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollPeriod);
+            }
         }
 #endif
         if (mrpRetryIntervalIdle.HasValue())

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -144,8 +144,9 @@ private:
 
     struct CommonTxtEntryStorage
     {
-        char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 1];
-        char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 1];
+        // CRA and CRI are both 3 chars + '=' = 4 + 1 for nullchar
+        char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 4 + 1];
+        char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 4 + 1];
     };
     template <class Derived>
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -139,7 +139,65 @@ private:
     /// interfaces on which the mDNS server is listening
     bool ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr);
 
-    FullQName GetCommisioningTextEntries(const CommissionAdvertisingParameters & params);
+    FullQName GetCommissioningTxtEntries(const CommissionAdvertisingParameters & params);
+    FullQName GetOperationalTxtEntries(const OperationalAdvertisingParameters & params);
+
+    struct CommonTxtEntryStorage
+    {
+        char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 1];
+        char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 1];
+    };
+    template <class Derived>
+    CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
+                                   char ** txtFields, size_t & numTxtFields)
+    {
+        Optional<uint32_t> mrpRetryIntervalIdle, mrpRetryIntervalActive;
+        params.GetMRPRetryIntervals(mrpRetryIntervalIdle, mrpRetryIntervalActive);
+        // TODO: Issue #5833 - MRP retry intervals should be updated on the poll period value change or device type change.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+        if (chip::DeviceLayer::ConnectivityMgr().GetThreadDeviceType() ==
+            chip::DeviceLayer::ConnectivityManager::kThreadDeviceType_SleepyEndDevice)
+        {
+            uint32_t sedPollPeriod;
+            ReturnErrorOnFailure(chip::DeviceLayer::ThreadStackMgr().GetPollPeriod(sedPollPeriod));
+            // Increment default MRP retry intervals by SED poll period to be on the safe side
+            // and avoid unnecessary retransmissions.
+            mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollPeriod);
+            mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollPeriod);
+        }
+#endif
+        if (mrpRetryIntervalIdle.HasValue())
+        {
+            if (mrpRetryIntervalIdle.Value() > kMaxRetryInterval)
+            {
+                ChipLogProgress(Discovery,
+                                "MRP retry interval idle value exceeds allowed range of 1 hour, using maximum available");
+                mrpRetryIntervalIdle.SetValue(kMaxRetryInterval);
+            }
+            size_t writtenCharactersNumber = snprintf(storage.mrpRetryIntervalIdleBuf, sizeof(storage.mrpRetryIntervalIdleBuf),
+                                                      "CRI=%" PRIu32, mrpRetryIntervalIdle.Value());
+            VerifyOrReturnError((writtenCharactersNumber > 0) &&
+                                    (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalIdleBuf)),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtFields[numTxtFields++] = storage.mrpRetryIntervalIdleBuf;
+        }
+        if (mrpRetryIntervalActive.HasValue())
+        {
+            if (mrpRetryIntervalActive.Value() > kMaxRetryInterval)
+            {
+                ChipLogProgress(Discovery,
+                                "MRP retry interval active value exceeds allowed range of 1 hour, using maximum available");
+                mrpRetryIntervalActive.SetValue(kMaxRetryInterval);
+            }
+            size_t writtenCharactersNumber = snprintf(storage.mrpRetryIntervalActiveBuf, sizeof(storage.mrpRetryIntervalActiveBuf),
+                                                      "CRA=%" PRIu32, mrpRetryIntervalActive.Value());
+            VerifyOrReturnError((writtenCharactersNumber > 0) &&
+                                    (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalActiveBuf)),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtFields[numTxtFields++] = storage.mrpRetryIntervalActiveBuf;
+        }
+        return CHIP_NO_ERROR;
+    }
 
     // Max number of records for operational = PTR, SRV, TXT, A, AAAA, no subtypes.
     static constexpr size_t kMaxOperationalRecords  = 5;
@@ -307,7 +365,9 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         ChipLogError(Discovery, "Failed to add SRV record mDNS responder");
         return CHIP_ERROR_NO_MEMORY;
     }
-    if (!operationalAllocator->AddResponder<TxtResponder>(TxtResourceRecord(operationalServerName, mEmptyTextEntries))
+
+    if (!operationalAllocator
+             ->AddResponder<TxtResponder>(TxtResourceRecord(operationalServerName, GetOperationalTxtEntries(params)))
              .SetReportAdditional(serverName)
              .IsValid())
     {
@@ -503,7 +563,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
         }
     }
 
-    if (!allocator->AddResponder<TxtResponder>(TxtResourceRecord(instanceName, GetCommisioningTextEntries(params)))
+    if (!allocator->AddResponder<TxtResponder>(TxtResourceRecord(instanceName, GetCommissioningTxtEntries(params)))
              .SetReportAdditional(hostName)
              .IsValid())
     {
@@ -523,11 +583,26 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
     return CHIP_NO_ERROR;
 }
 
-FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertisingParameters & params)
+FullQName AdvertiserMinMdns::GetOperationalTxtEntries(const OperationalAdvertisingParameters & params)
 {
-    // Max number of TXT fields from the spec is 8: D, VP, CM, DT, DN, RI, PI, PH.
-    constexpr size_t kMaxTxtFields = 8;
-    const char * txtFields[kMaxTxtFields];
+    char * txtFields[OperationalAdvertisingParameters::kTxtMaxNumber];
+    size_t numTxtFields = 0;
+    auto * allocator    = mQueryResponderAllocatorOperational;
+    struct CommonTxtEntryStorage commonStorage;
+    AddCommonTxtEntries<OperationalAdvertisingParameters>(params, commonStorage, txtFields, numTxtFields);
+    if (numTxtFields == 0)
+    {
+        return allocator->AllocateQNameFromArray(mEmptyTextEntries, 1);
+    }
+    else
+    {
+        return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
+    }
+}
+
+FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertisingParameters & params)
+{
+    char * txtFields[CommissionAdvertisingParameters::kTxtMaxNumber];
     size_t numTxtFields = 0;
 
     QueryResponderAllocator<kMaxCommissionRecords> * allocator =
@@ -559,6 +634,8 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
         snprintf(txtDeviceName, sizeof(txtDeviceName), "DN=%s", params.GetDeviceName().Value());
         txtFields[numTxtFields++] = txtDeviceName;
     }
+    CommonTxtEntryStorage commonStorage;
+    AddCommonTxtEntries<CommissionAdvertisingParameters>(params, commonStorage, txtFields, numTxtFields);
 
     // the following sub types only apply to commissionable node advertisements
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
@@ -601,7 +678,7 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
     {
         return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
     }
-} // namespace
+}
 
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)
 {

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
             snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32, mrpRetryIntervalIdle.Value());
         VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRI", reinterpret_cast<const uint8_t *>(mrpRetryIdleStorage),
+        txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage),
                                            strlen(mrpRetryIdleStorage) };
     }
     if (mrpRetryIntervalActive.HasValue())

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -142,8 +142,14 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
         ReturnErrorOnFailure(chip::DeviceLayer::ThreadStackMgr().GetPollPeriod(sedPollPeriod));
         // Increment default MRP retry intervals by SED poll period to be on the safe side
         // and avoid unnecessary retransmissions.
-        mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollPeriod);
-        mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollPeriod);
+        if (mrpRetryIntervalIdle.HasValue())
+        {
+            mrpRetryIntervalIdle.SetValue(mrpRetryIntervalIdle.Value() + sedPollPeriod);
+        }
+        if (mrpRetryIntervalActive.HasValue())
+        {
+            mrpRetryIntervalActive.SetValue(mrpRetryIntervalActive.Value() + sedPollPeriod);
+        }
     }
 #endif
     if (mrpRetryIntervalIdle.HasValue())
@@ -157,8 +163,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
             snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32, mrpRetryIntervalIdle.Value());
         VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage),
-                                           strlen(mrpRetryIdleStorage) };
+        txtEntryStorage[txtEntryIdx++] = { "CRI", Uint8::from_const_char(mrpRetryIdleStorage), strlen(mrpRetryIdleStorage) };
     }
     if (mrpRetryIntervalActive.HasValue())
     {
@@ -171,8 +176,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
             snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32, mrpRetryIntervalActive.Value());
         VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage),
-                                           strlen(mrpRetryActiveStorage) };
+        txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage), strlen(mrpRetryActiveStorage) };
     }
     return CHIP_NO_ERROR;
 }

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -155,7 +155,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
         }
         size_t writtenCharactersNumber =
             snprintf(mrpRetryIdleStorage, sizeof(mrpRetryIdleStorage), "%" PRIu32, mrpRetryIntervalIdle.Value());
-        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kTxtRetryIntervalIdleMaxLength),
+        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalIdleMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
         txtEntryStorage[txtEntryIdx++] = { "CRI", reinterpret_cast<const uint8_t *>(mrpRetryIdleStorage),
                                            strlen(mrpRetryIdleStorage) };
@@ -169,7 +169,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
         }
         size_t writtenCharactersNumber =
             snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32, mrpRetryIntervalActive.Value());
-        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < kTxtRetryIntervalActiveMaxLength),
+        VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
         txtEntryStorage[txtEntryIdx++] = { "CRA", reinterpret_cast<const uint8_t *>(mrpRetryActiveStorage),
                                            strlen(mrpRetryActiveStorage) };

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -171,7 +171,7 @@ CHIP_ERROR AddCommonTxtElements(const BaseAdvertisingParams<Derived> & params, c
             snprintf(mrpRetryActiveStorage, sizeof(mrpRetryActiveStorage), "%" PRIu32, mrpRetryIntervalActive.Value());
         VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber <= kTxtRetryIntervalActiveMaxLength),
                             CHIP_ERROR_INVALID_STRING_LENGTH);
-        txtEntryStorage[txtEntryIdx++] = { "CRA", reinterpret_cast<const uint8_t *>(mrpRetryActiveStorage),
+        txtEntryStorage[txtEntryIdx++] = { "CRA", Uint8::from_const_char(mrpRetryActiveStorage),
                                            strlen(mrpRetryActiveStorage) };
     }
     return CHIP_NO_ERROR;

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -65,7 +65,12 @@ const FullQName kInstanceName2                  = FullQName(kInstanceNameParts2)
 const QNamePart kTxtRecordEmptyParts[]          = { "=" };
 const FullQName kTxtRecordEmptyName             = FullQName(kTxtRecordEmptyParts);
 OperationalAdvertisingParameters operationalParams1 =
-    OperationalAdvertisingParameters().SetPeerId(kPeerId1).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+    OperationalAdvertisingParameters()
+        .SetPeerId(kPeerId1)
+        .SetMac(ByteSpan(kMac))
+        .SetPort(CHIP_PORT)
+        .EnableIpV4(true)
+        .SetMRPRetryIntervals(chip::Optional<uint32_t>(32), chip::Optional<uint32_t>(33));
 OperationalAdvertisingParameters operationalParams2 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId2).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams3 =
@@ -76,10 +81,11 @@ OperationalAdvertisingParameters operationalParams5 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId5).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams6 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId6).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
+const QNamePart txtOperational1Parts[]  = { "CRI=32", "CRA=33" };
 PtrResourceRecord ptrOperationalService = PtrResourceRecord(kDnsSdQueryName, kMatterOperationalQueryName);
 PtrResourceRecord ptrOperational1       = PtrResourceRecord(kMatterOperationalQueryName, kInstanceName1);
 SrvResourceRecord srvOperational1       = SrvResourceRecord(kInstanceName1, kHostnameName, CHIP_PORT);
-TxtResourceRecord txtOperational1       = TxtResourceRecord(kInstanceName1, kTxtRecordEmptyName);
+TxtResourceRecord txtOperational1       = TxtResourceRecord(kInstanceName1, txtOperational1Parts);
 PtrResourceRecord ptrOperational2       = PtrResourceRecord(kMatterOperationalQueryName, kInstanceName2);
 SrvResourceRecord srvOperational2       = SrvResourceRecord(kInstanceName2, kHostnameName, CHIP_PORT);
 TxtResourceRecord txtOperational2       = TxtResourceRecord(kInstanceName2, kTxtRecordEmptyName);

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -168,9 +168,12 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetPairingHint(chip::Optional<uint16_t>(3))
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"));
+        .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetMRPRetryIntervals(chip::Optional<uint32_t>(3600000),
+                              chip::Optional<uint32_t>(3600005)); // 3600005 is more than the max so should be adjusted down
 QNamePart txtCommissionableNodeParamsLargeEnhancedParts[] = { "D=22",          "VP=555+897",       "CM=2",       "DT=25",
-                                                              "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3" };
+                                                              "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3",
+                                                              "CRA=3600000",   "CRI=3600000" };
 FullQName txtCommissionableNodeParamsLargeEnhancedName    = FullQName(txtCommissionableNodeParamsLargeEnhancedParts);
 TxtResourceRecord txtCommissionableNodeParamsLargeEnhanced =
     TxtResourceRecord(instanceName, txtCommissionableNodeParamsLargeEnhancedName);

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -87,7 +87,8 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetPairingHint(chip::Optional<uint16_t>(3))
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
-        .SetRotatingId(chip::Optional<const char *>("id_that_spins"));
+        .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetMRPRetryIntervals(chip::Optional<uint32_t>(32), chip::Optional<uint32_t>(33));
 
 test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .SetProtocol(MdnsServiceProtocol::kMdnsProtocolUdp)
@@ -101,6 +102,8 @@ test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .AddTxt("RI", "id_that_spins")
                                                   .AddTxt("PI", "Pair me")
                                                   .AddTxt("PH", "3")
+                                                  .AddTxt("CRI", "32")
+                                                  .AddTxt("CRA", "33")
                                                   .AddSubtype("_S2")
                                                   .AddSubtype("_L22")
                                                   .AddSubtype("_V555")

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -37,25 +37,19 @@ const char host[]               = "0102030405060708";
 
 const PeerId kPeerId1 = PeerId().SetCompressedFabricId(0xBEEFBEEFF00DF00D).SetNodeId(0x1111222233334444);
 const PeerId kPeerId2 = PeerId().SetCompressedFabricId(0x5555666677778888).SetNodeId(0x1212343456567878);
-OperationalAdvertisingParameters operationalParams1 = OperationalAdvertisingParameters()
-                                                          .SetPeerId(kPeerId1)
-                                                          .SetMac(ByteSpan(kMac))
-                                                          .SetPort(CHIP_PORT)
-                                                          .EnableIpV4(true)
-                                                          .SetMRPRetryIntervals(32, 33);
+OperationalAdvertisingParameters operationalParams1 =
+    OperationalAdvertisingParameters().SetPeerId(kPeerId1).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 test::ExpectedCall operationalCall1 = test::ExpectedCall()
                                           .SetProtocol(MdnsServiceProtocol::kMdnsProtocolTcp)
                                           .SetServiceName("_matter")
                                           .SetInstanceName("BEEFBEEFF00DF00D-1111222233334444")
-                                          .SetHostName(host)
-                                          .AddTxt("CRI", "32")
-                                          .AddTxt("CRA", "33");
+                                          .SetHostName(host);
 OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingParameters()
                                                           .SetPeerId(kPeerId2)
                                                           .SetMac(ByteSpan(kMac))
                                                           .SetPort(CHIP_PORT)
                                                           .EnableIpV4(true)
-                                                          .SetMRPRetryIntervals(32, 33);
+                                                          .SetMRPRetryIntervals(Optional<uint32_t>(32), Optional<uint32_t>(33));
 test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetProtocol(MdnsServiceProtocol::kMdnsProtocolTcp)
                                           .SetServiceName("_matter")

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -88,7 +88,9 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
-        .SetMRPRetryIntervals(chip::Optional<uint32_t>(32), chip::Optional<uint32_t>(33));
+        .SetMRPRetryIntervals(
+            chip::Optional<uint32_t>(3600000),
+            chip::Optional<uint32_t>(3600005)); // 3600005 is over the max, so this should be adjusted by the platform
 
 test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .SetProtocol(MdnsServiceProtocol::kMdnsProtocolUdp)
@@ -102,8 +104,8 @@ test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .AddTxt("RI", "id_that_spins")
                                                   .AddTxt("PI", "Pair me")
                                                   .AddTxt("PH", "3")
-                                                  .AddTxt("CRI", "32")
-                                                  .AddTxt("CRA", "33")
+                                                  .AddTxt("CRI", "3600000")
+                                                  .AddTxt("CRA", "3600000")
                                                   .AddSubtype("_S2")
                                                   .AddSubtype("_L22")
                                                   .AddSubtype("_V555")


### PR DESCRIPTION
These are optional in the spec and common to all adverts
(Please see section 4.3.3.2.).  Also added CRI/CRA to
operational for minimal mdns and added to commissionable
for both.

T txt values will be added in an upcoming PR.

A general cleanup of the duplication between minimal and
platform txt is expected likely after TE6.

Fixes #8880
Fixes #9712

#### Problem
CRA and CRI are optional in the spec and common to all adverts
(Please see section 4.3.3.2.).

T txt values will be added in an upcoming PR.

A general cleanup of the duplication between minimal and
platform txt is expected likely after TE6.

#### Change overview
Made CRI/CRA optional, separated them into their own functions and added to operational adverts for platform and 
operational for minimal mdns and added to commissionable
for both.

#### Testing
Unit tests cover minimal and platform for txt record formatting - updated in this PR.
Tested minimal on linux using avahi-discovery and saw CRA / CRI on both
Due to #9695, platfom (avahi) is broken on ToT, so platform was only tested with unit tests.
