### PR TITLE
Fix sleep signature (Add extern "C")

### DIFF
--- a/examples/shell/efr32/src/main.cpp
+++ b/examples/shell/efr32/src/main.cpp
@@ -82,7 +82,7 @@ void appError(int err)
         ;
 }
 
-unsigned int sleep(unsigned int seconds)
+extern "C" unsigned int sleep(unsigned int seconds)
 {
     const TickType_t xDelay = 1000 * seconds / portTICK_PERIOD_MS;
     vTaskDelay(xDelay);

--- a/examples/shell/k32w/main/main.cpp
+++ b/examples/shell/k32w/main/main.cpp
@@ -55,7 +55,7 @@ extern InitFunc __init_array_end;
 /* needed for FreeRtos Heap 4 */
 uint8_t __attribute__((section(".heap"))) ucHeap[0xF000];
 
-unsigned int sleep(unsigned int seconds)
+extern "C" unsigned int sleep(unsigned int seconds)
 {
     const TickType_t xDelay = 1000 * seconds / portTICK_PERIOD_MS;
     vTaskDelay(xDelay);


### PR DESCRIPTION
#### Problem
Encountered an link error of `sleep` is not defined.

#### Change overview
Change signature of `sleep`, make it complaint with `unistd.h`

#### Testing
Verified by unit-tests.