### PR TITLE
Python controller do not exit when resolve command fails

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -111,7 +111,7 @@ class ChipDeviceController(object):
             if err != 0:
                 print("Failed to update node address: {}".format(err))
                 # Failed update address, don't wait for HandleCommissioningComplete
-                self.state = DCState.IDLEHandleCommissioningComplete
+                self.state = DCState.IDLE
                 self._ChipStack.callbackRes = err
                 self._ChipStack.completeEvent.set()
             else:


### PR DESCRIPTION
#### Problem
* When `resolve` command fails in the python controller then the controller does not exit.
* Undefined enum is used in `HandleAdressComplete` API which was throwing an error.

#### Change overview
Used appropriate API.

#### Testing
* Build and flash the all-cluster app and carried out the commissioning.
