### PR TITLE
 Move Ethernet Diagnostic APIs to GenericConnectivityManagerImpl

### DIFF
--- a/src/include/platform/internal/GenericConnectivityManagerImpl.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl.h
@@ -47,6 +47,12 @@ public:
     uint16_t _GetUserSelectedModeTimeout();
     void _SetUserSelectedModeTimeout(uint16_t val);
 
+    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
+    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
+    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
+    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
+    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
+
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
@@ -70,6 +76,36 @@ inline uint16_t GenericConnectivityManagerImpl<ImplClass>::_GetUserSelectedModeT
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedModeTimeout(uint16_t val)
 {}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthPacketRxCount(uint64_t & packetRxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthPacketTxCount(uint64_t & packetTxCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthTxErrCount(uint64_t & txErrCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthCollisionCount(uint64_t & collisionCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ImplClass>
+inline CHIP_ERROR GenericConnectivityManagerImpl<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -73,11 +73,6 @@ public:
     uint32_t _GetWiFiAPIdleTimeoutMS(void);
     void _SetWiFiAPIdleTimeoutMS(uint32_t val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
-    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
-    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
-    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
-    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
-    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
@@ -238,36 +233,6 @@ template <class ImplClass>
 inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPStateToStr(ConnectivityManager::WiFiAPState state)
 {
     return NULL;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthPacketRxCount(uint64_t & packetRxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthPacketTxCount(uint64_t & packetTxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthTxErrCount(uint64_t & txErrCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthCollisionCount(uint64_t & collisionCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -73,11 +73,6 @@ public:
     uint32_t _GetWiFiAPIdleTimeoutMS();
     void _SetWiFiAPIdleTimeoutMS(uint32_t val);
     CHIP_ERROR _GetAndLogWifiStatsCounters();
-    CHIP_ERROR _GetEthPacketRxCount(uint64_t & packetRxCount);
-    CHIP_ERROR _GetEthPacketTxCount(uint64_t & packetTxCount);
-    CHIP_ERROR _GetEthTxErrCount(uint64_t & txErrCount);
-    CHIP_ERROR _GetEthCollisionCount(uint64_t & collisionCount);
-    CHIP_ERROR _GetEthOverrunCount(uint64_t & overrunCount);
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
@@ -185,36 +180,6 @@ inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiScanDone()
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_WiFi<ImplClass>::_OnWiFiStationProvisionChange()
 {}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthPacketRxCount(uint64_t & packetRxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthPacketTxCount(uint64_t & packetTxCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthTxErrCount(uint64_t & txErrCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthCollisionCount(uint64_t & collisionCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetEthOverrunCount(uint64_t & overrunCount)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
 
 } // namespace Internal
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* There is no difference between GenericConnectivityManagerImpl_WiFi and GenericConnectivityManagerImpl_NoWiFi for Ethernet Diagnostic APIs default implementation. We can move those APIs implementation to GenericConnectivityManagerImpl

#### Change overview
 Move Ethernet Diagnostic APIs to GenericConnectivityManagerImpl

#### Testing
How was this tested? (at least one bullet point required)
* No change in Ethernet Diagnostic APIs default implementation, compile is covered by CI.

