### PR TITLE
[Android] Stop using destroyed fragment in pairing complete callback

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -158,6 +158,13 @@ class DeviceProvisioningFragment : Fragment() {
     override fun onPairingComplete(code: Int) {
       Log.d(TAG, "onPairingComplete: $code")
 
+      // In IP commissioning, commissioning complete will already be called at this point, and the
+      // next fragment will be shown. As a result, this fragment will be in a destroyed state and
+      // should not be operated on.
+      if (deviceInfo.ipAddress != null) {
+        return
+      }
+
       if (code == STATUS_PAIRING_SUCCESS) {
         childFragmentManager.beginTransaction()
             .add(R.id.fragment_container, EnterNetworkFragment.newInstance(networkType))


### PR DESCRIPTION
#### Problem
* In `DeviceProvisioningFragment`, if pairing complete is called after commissioning complete, it will try to access the already-destroyed DeviceProvisioningFragment's fragmentManager.
* This case happens for IP commissioning -> on/off control without restarting the app.

#### Change overview
* Skip the pairing complete logic if commissioning complete was called.

#### Testing
* Perform IP commissioning and on/off control in one setup flow.