### PR TITLE
[ota-provider-app] fix location parsing and BDX sender

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -30,12 +30,6 @@ using chip::bdx::StatusCode;
 using chip::bdx::TransferControlFlags;
 using chip::bdx::TransferSession;
 
-bool IsStatusReportMessage(const TransferSession::MessageTypeData & msgTypeData)
-{
-    return (msgTypeData.ProtocolId == chip::Protocols::SecureChannel::Id) &&
-        (msgTypeData.MessageType == static_cast<uint8_t>(chip::Protocols::SecureChannel::MsgType::StatusReport));
-}
-
 BdxOtaSender::BdxOtaSender()
 {
     memset(mFilepath, 0, kFilepathMaxLength);
@@ -68,7 +62,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         break;
     case TransferSession::OutputEventType::kMsgToSend: {
         chip::Messaging::SendFlags sendFlags;
-        if (!IsStatusReportMessage(event.msgTypeData))
+        if (!event.msgTypeData.HasMessageType(chip::Protocols::SecureChannel::MsgType::StatusReport))
         {
             // All messages sent from the Sender expect a response, except for a StatusReport which would indicate an error and the
             // end of the transfer.

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -168,10 +168,12 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
     ChipLogDetail(Zcl, "OTA Provider received QueryImage");
 
     // TODO: (#7112) change location size checking once CHAR_STRING is supported
-    const uint8_t locationLen = emberAfStringLength(location);
+    // The following commented code does not work because location is being treated as uint8_t* and this leads to always sending a
+    // failure response message.
+    const size_t locationLen = strlen(reinterpret_cast<char *>(location));
     if (locationLen != kLocationParamLength)
     {
-        ChipLogError(Zcl, "expected location length %" PRIu8 ", got %" PRIu8, locationLen, kLocationParamLength);
+        ChipLogError(Zcl, "expected location length %" PRIu8 ", got %zu", kLocationParamLength, locationLen);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
     else if (metadataForProvider.size() > kMaxMetadataLen)

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -168,8 +168,6 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
     ChipLogDetail(Zcl, "OTA Provider received QueryImage");
 
     // TODO: (#7112) change location size checking once CHAR_STRING is supported
-    // The following commented code does not work because location is being treated as uint8_t* and this leads to always sending a
-    // failure response message.
     const size_t locationLen = strlen(reinterpret_cast<char *>(location));
     if (locationLen != kLocationParamLength)
     {

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -12,6 +12,8 @@
 #include <system/SystemPacketBuffer.h>
 #include <transport/raw/MessageHeader.h>
 
+#include <type_traits>
+
 namespace chip {
 namespace bdx {
 
@@ -86,6 +88,14 @@ public:
         uint8_t MessageType;
 
         MessageTypeData() : ProtocolId(Protocols::NotSpecified), MessageType(0) {}
+
+        bool HasProtocol(Protocols::Id protocol) const { return ProtocolId == protocol; }
+        bool HasMessageType(uint8_t type) const { return MessageType == type; }
+        template <typename TMessageType, typename = std::enable_if_t<std::is_enum<TMessageType>::value>>
+        bool HasMessageType(TMessageType type) const
+        {
+            return HasProtocol(Protocols::MessageTypeTraits<TMessageType>::ProtocolId()) && HasMessageType(to_underlying(type));
+        }
     };
 
     /**


### PR DESCRIPTION
#### Problem
This PR contains necessary changes for completing an OTA BDX transfer with an ota-requestor-app (which will also require changes submitted in another PR).
* file I/O for BDX sending was erroring out on EOF instead of sending the last block
* code that verified `QueryImage` parameters was using `emberAfStringLength()` which is incompatible with CHIP TLV format
* The BDX `ExchangeContext` was closing after every message send
* Fixes #9703 

#### Change overview
* don't consider EOF as an error condition when reading blocks for BDX transfer
* don't keep calling `gcount()` to get the number of bytes read
* add `kExpectResponse` for all BDX messages except StatusReport in order to keep exchange open
* use `strlen()` to parse location string instead of `emberAfStringLength()`
* fix message for printing location string length

#### Testing
* tested again modified `ota-requestor-app` (PR will be submitted soon)
