### PR TITLE
CHIPDevice: add access to ExchangeManager, fix SessionHandle getter

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -743,7 +743,8 @@ CHIP_ERROR Device::SendSubscribeAttributeRequest(app::AttributePathParams aPath,
 
     // The application context is used to identify different requests from client application the type of it is intptr_t, here we
     // use the seqNum.
-    app::ReadPrepareParams params(GetSecureSession());
+    VerifyOrReturnError(GetSecureSession().HasValue(), CHIP_ERROR_INCORRECT_STATE);
+    app::ReadPrepareParams params(GetSecureSession().Value());
     params.mpAttributePathParamsList    = path;
     params.mAttributePathParamsListSize = 1;
     params.mMinIntervalFloorSeconds     = mMinIntervalFloorSeconds;

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -374,7 +374,9 @@ public:
 
     bool MatchesSession(SessionHandle session) const { return mSecureSession.HasValue() && mSecureSession.Value() == session; }
 
-    SessionHandle GetSecureSession() const { return mSecureSession.Value(); }
+    chip::Optional<SessionHandle> GetSecureSession() const { return mSecureSession; }
+
+    Messaging::ExchangeManager * GetExchangeManager() const { return mExchangeMgr; }
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddress.SetIPAddress(deviceAddr); }
 


### PR DESCRIPTION
#### Problem
* When using the `Device` and `DeviceController` APIs, there is no way to get a new `ExchangeContext` for use with other protocols like BDX.
* To do this, the caller needs access to both a `SessionHandle` and the `ExchangeManager`
* `GetSecureSession()` could cause process to abort if `mSecureSession` (`Optional` type) did not contain a value

#### Change overview
* Add `GetExchangeManager()`
* fix `GetSecureSession()` to return an `Optional` type

#### Testing
* tested manually with `ota-requestor-app` and `ota-provider-app` (see #9733)
