### PR TITLE
[Darwin]:Enable heap based pool configuration

### DIFF
--- a/src/platform/Darwin/SystemPlatformConfig.h
+++ b/src/platform/Darwin/SystemPlatformConfig.h
@@ -38,8 +38,8 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_NO_LOCKING 1
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 0
-
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
+#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1
 
 // ========== Platform-specific Configuration Overrides =========
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Heap based pool configuration has been tested on Linux for a while and no side effect found until now. Instead of always reserve memory for static pool base on worse case. This feature allow the SystemPool allocates memory based on its actual usage and release back to system after usage.

We should enable this feature on more platforms which has large heap support.

#### Change overview
Enable heap based pool configuration on Darwin

#### Testing
How was this tested? (at least one bullet point required)
* Covered by Darwin CI
