### PR TITLE
Fix ToT failure on avahi

### DIFF
--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -512,8 +512,10 @@ exit:
 CHIP_ERROR MdnsAvahi::StopPublish()
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-
-    VerifyOrExit(avahi_entry_group_reset(mGroup) == 0, error = CHIP_ERROR_INTERNAL);
+    mPublishedServices.clear();
+    if (mGroup) {
+        VerifyOrExit(avahi_entry_group_reset(mGroup) == 0, error = CHIP_ERROR_INTERNAL);
+    }
 exit:
     return error;
 }


### PR DESCRIPTION
#### Problem
The current ToT code calls PublishService twice in a row during startup - once during a call to open the pairing window, one during the general server startup. There's also a Stop called between them. On ToT this was failing. Root caused to Stop not depopulating the list of services, so we were attempting to update a service that had already been stopped. 

Fixes #9695

#### Change overview
Add a clear to the Stop call in the avahi mdnsImpl

#### Testing
No unit tests for avahi impl - tested on linux lighting-app, can see error no longer prints, can find on avahi-discover.
