### PR TITLE
Revert "[im/test] Fix interaction model subscription test"

### DIFF
--- a/examples/chip-tool/templates/partials/process_response_value.zapt
+++ b/examples/chip-tool/templates/partials/process_response_value.zapt
@@ -1,0 +1,78 @@
+{{#chip_tests_item_response_parameters}}
+{{#if hasExpectedValue}}
+{{#if isList}}
+if (count != {{expectedValue.length}})
+{
+    ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+}
+{{else}}
+{{#if (isString type)}}
+{{chipType}} {{asLowerCamelCase name}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{expectedValue}}"), strlen("{{expectedValue}}"));
+if (!{{asLowerCamelCase name}}.data_equal({{asLowerCamelCase name}}Argument))
+{{else}}
+if ({{asLowerCamelCase name}} != {{expectedValue}}{{asTypeLiteralSuffix chipType}})
+{{/if}}
+{
+    ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+}
+{{/if}}
+{{/if}}
+{{#if hasExpectedConstraints}}
+{{#if expectedConstraints.type}}
+ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} type checking is not implemented yet. Expected type: '%s'", "{{expectedConstraints.type}}");
+{{/if}}
+
+{{#if expectedConstraints.format}}
+ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} format checking is not implemented yet. Expected format: '%s'", "{{expectedConstraints.format}}");
+{{/if}}
+
+{{#if expectedConstraints.minLength}}
+  if ({{asLowerCamelCase name}}.size() < {{expectedConstraints.minLength}})
+  {
+    ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too short. Min size is {{expectedConstraints.minLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+  }
+{{/if}}
+
+{{#if expectedConstraints.maxLength}}
+  if ({{asLowerCamelCase name}}.size() > {{expectedConstraints.maxLength}})
+  {
+    ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too long. Max size is {{expectedConstraints.maxLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+  }
+{{/if}}
+
+{{#if expectedConstraints.minValue}}
+  if ({{asLowerCamelCase name}} < {{expectedConstraints.minValue}})
+  {
+    ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is lower than expected. Min value is {{expectedConstraints.minValue}} but got '%d'", {{asLowerCamelCase name}});
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+  }
+{{/if}}
+
+{{#if expectedConstraints.maxValue}}
+  if ({{asLowerCamelCase name}} > {{expectedConstraints.maxValue}})
+  {
+    ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is higher than expected. Max value is {{expectedConstraints.maxValue}} but got '%d'", {{asLowerCamelCase name}});
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+  }
+{{/if}}
+
+{{#if expectedConstraints.notValue}}
+  if ({{asLowerCamelCase name}} == {{expectedConstraints.notValue}})
+  {
+    ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} was not expected to be '{{expectedConstraints.notValue}}' due to notValue constraint");
+    runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+    return;
+  }
+{{/if}}
+{{/if}}
+{{/chip_tests_item_response_parameters}}

--- a/examples/chip-tool/templates/partials/test_cluster.zapt
+++ b/examples/chip-tool/templates/partials/test_cluster.zapt
@@ -46,21 +46,19 @@ class {{filename}}: public TestCommand
 
     {{#chip_tests_items}}
     {{#if (isTestOnlyCluster cluster)}}
-    CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
-    {
-        ChipLogProgress(chipTool, "{{cluster}} - {{label}}");
-
-        return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{definedValue}}{{/chip_tests_item_parameters}});
-    }
+    {{> (asTestSuiteSimulatedClusterCommandPartial command) }}
     {{else}}
     // Test {{label}}
     using SuccessCallback_{{index}} = void (*)(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
     chip::Callback::Callback<SuccessCallback_{{index}}> mOnSuccessCallback_{{index}} { OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_SuccessResponse, this };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_{{index}} { OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_FailureResponse, this };
+    {{#if isSubscribeAttribute}}
+    chip::Callback::Callback<DefaultSuccessCallback> mOnSubscriptionEstablishedCallback_{{index}} { SubscribeAttribute_{{ index }}_OnSubscriptionEstablishedCallback, this };
+    {{/if}}
 
     bool mIsFailureExpected_{{index}} = {{response.error}};
 
-    {{#if isWaitForReport}}
+    {{#if isSubscribeAttribute}}
     bool mReceivedReport_{{index}} = false;
     {{/if}}
 
@@ -83,9 +81,8 @@ class {{filename}}: public TestCommand
         {{/chip_tests_item_parameters}}
         err = cluster.{{asUpperCamelCase command}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(){{#chip_tests_item_parameters}}, {{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}});
         {{else if isSubscribeAttribute}}
-        err = cluster.ConfigureAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(), {{minInterval}}, {{maxInterval}});
-        {{else if isWaitForReport}}
-        err = cluster.ReportAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel());
+        cluster.ReportAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel());
+        err = cluster.ConfigureAttribute{{asUpperCamelCase attribute}}(mOnSubscriptionEstablishedCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel(), {{minInterval}}, {{maxInterval}});
         {{else if isReadAttribute}}
         err = cluster.ReadAttribute{{asUpperCamelCase attribute}}(mOnSuccessCallback_{{index}}.Cancel(), mOnFailureCallback_{{index}}.Cancel());
         {{else if isWriteAttribute}}
@@ -101,10 +98,21 @@ class {{filename}}: public TestCommand
         err = CHIP_ERROR_NOT_IMPLEMENTED;
         {{/if}}
 
-        {{#if async}}ReturnErrorOnFailure(chip::DeviceLayer::SystemLayer().StartTimer(0, OnWaitForMsFn, this));{{/if}}
-
         return err;
     }
+
+    {{#if isSubscribeAttribute }}
+    static void SubscribeAttribute_{{ index }}_OnSubscriptionEstablishedCallback(void * context)
+    {
+      {{parent.filename}} * runner = reinterpret_cast<{{parent.filename}} *>(context);
+      if (!runner->mReceivedReport_{{index}}) {
+          ChipLogError(chipTool, "Error: Initial report not received!");
+          runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+          return;
+      }
+      runner->NextTest();
+    }
+    {{/if}}
 
     static void OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_FailureResponse(void * context, uint8_t status)
     {
@@ -125,7 +133,7 @@ class {{filename}}: public TestCommand
             return;
         }
 
-        {{#unless async}}runner->NextTest();{{/unless}}
+        runner->NextTest();
     }
 
     static void OnTestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}_SuccessResponse(void * context {{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}})
@@ -141,105 +149,13 @@ class {{filename}}: public TestCommand
             return;
         }
 
-        {{#if isWaitForReport}}
-        if (runner->mReceivedReport_{{index}}) {
-            // Receiving report more than once is not an error since the subscription may be alive for a long time.
-            ChipLogProgress(chipTool, "Note: on report called more than once.");
-            return;
-        }
-        runner->mReceivedReport_{{index}} = true;
-        {{/if}}
+        {{> process_response_value}}
 
         {{#if isSubscribeAttribute}}
-        {{#if hasWaitForReport}}
-        if (!runner->mReceivedReport_{{waitForReport.index}}) {
-            ChipLogError(chipTool, "Error: Initial report not received!");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-        {{/if}}
-        {{/if}}
-
-        {{#chip_tests_item_response_parameters}}
-        {{#if hasExpectedValue}}
-        {{#if isList}}
-        if (count != {{expectedValue.length}})
-        {
-            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
+            runner->mReceivedReport_{{index}} = true;
         {{else}}
-        {{#if (isString type)}}
-        {{chipType}} {{asLowerCamelCase name}}Argument = chip::ByteSpan(chip::Uint8::from_const_char("{{expectedValue}}"), strlen("{{expectedValue}}"));
-        if (!{{asLowerCamelCase name}}.data_equal({{asLowerCamelCase name}}Argument))
-        {{else}}
-        if ({{asLowerCamelCase name}} != {{expectedValue}}{{asTypeLiteralSuffix chipType}})
+            runner->NextTest();
         {{/if}}
-        {
-            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "{{expectedValue}}");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-        {{/if}}
-        {{/if}}
-        {{#if hasExpectedConstraints}}
-        {{#if expectedConstraints.type}}
-        ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} type checking is not implemented yet. Expected type: '%s'", "{{expectedConstraints.type}}");
-        {{/if}}
-
-        {{#if expectedConstraints.format}}
-        ChipLogError(chipTool, "Warning: {{asLowerCamelCase name}} format checking is not implemented yet. Expected format: '%s'", "{{expectedConstraints.format}}");
-        {{/if}}
-
-        {{#if expectedConstraints.minLength}}
-          if ({{asLowerCamelCase name}}.size() < {{expectedConstraints.minLength}})
-          {
-            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too short. Min size is {{expectedConstraints.minLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-          }
-        {{/if}}
-
-        {{#if expectedConstraints.maxLength}}
-          if ({{asLowerCamelCase name}}.size() > {{expectedConstraints.maxLength}})
-          {
-            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is too long. Max size is {{expectedConstraints.maxLength}} but got '%zu'", {{asLowerCamelCase name}}.size());
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-          }
-        {{/if}}
-
-        {{#if expectedConstraints.minValue}}
-          if ({{asLowerCamelCase name}} < {{expectedConstraints.minValue}})
-          {
-            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is lower than expected. Min value is {{expectedConstraints.minValue}} but got '%d'", {{asLowerCamelCase name}});
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-          }
-        {{/if}}
-
-        {{#if expectedConstraints.maxValue}}
-          if ({{asLowerCamelCase name}} > {{expectedConstraints.maxValue}})
-          {
-            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} is higher than expected. Max value is {{expectedConstraints.maxValue}} but got '%d'", {{asLowerCamelCase name}});
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-          }
-        {{/if}}
-
-        {{#if expectedConstraints.notValue}}
-          if ({{asLowerCamelCase name}} == {{expectedConstraints.notValue}})
-          {
-            ChipLogError(chipTool, "Error: {{asLowerCamelCase name}} was not expected to be '{{expectedConstraints.notValue}}' due to notValue constraint");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-          }
-        {{/if}}
-        {{/if}}
-        {{/chip_tests_item_response_parameters}}
-
-        {{#unless async}}runner->NextTest();{{/unless}}
     }
 
     {{/if}}

--- a/examples/chip-tool/templates/partials/testsuite/WaitForAttributeReport.zapt
+++ b/examples/chip-tool/templates/partials/testsuite/WaitForAttributeReport.zapt
@@ -1,0 +1,38 @@
+// The callback should be called atleast once
+{{#chip_tests_WaitForAttributeReport_attribute_info}}
+using OnReportCallback_{{parent.index}} = void (*)(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}});
+chip::Callback::Callback<OnReportCallback_{{ parent.index }}> mOnReportCallback_{{parent.index}} { SubscribeAttribute_{{ parent.index }}_OnReportCallback, this };
+{{/chip_tests_WaitForAttributeReport_attribute_info}}
+
+bool mReceivedReport_{{index}} = false;
+
+CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
+{
+    ChipLogProgress(chipTool, "{{cluster}} - {{asUpperCamelCase command}} - {{label}}");
+{{#chip_tests_WaitForAttributeReport_attribute_info}}
+    chip::Controller::{{asUpperCamelCase cluster}}Cluster cluster;
+    cluster.Associate(mDevice, {{endpoint}});
+    return cluster.ReportAttribute{{asUpperCamelCase attribute}}(mOnReportCallback_{{parent.index}}.Cancel());
+{{/chip_tests_WaitForAttributeReport_attribute_info}}
+}
+
+{{#chip_tests_WaitForAttributeReport_attribute_info}}
+static void SubscribeAttribute_{{ parent.index }}_OnReportCallback(void * context{{#chip_tests_item_response_parameters}}, {{#if isList}}uint16_t count, {{/if}}{{chipType}} {{#if isList}}* {{/if}}{{asLowerCamelCase name}}{{/chip_tests_item_response_parameters}})
+{
+    ChipLogProgress(chipTool, "On/Off - Subscribe {{asUpperCamelCase attribute}} Attribute: Report Data");
+    {{parent.parent.filename}} * runner = reinterpret_cast<{{parent.parent.filename}} *>(context);
+
+    if (runner->mReceivedReport_{{parent.index}})
+    {
+        // Receiving attribute more than once is not an issue, since the following handler will override previous handlers.
+        return;
+    }
+
+    {{> process_response_value}}
+
+    runner->mReceivedReport_{{parent.index}} = true;
+    ChipLogProgress(chipTool, "On/Off - report received.");
+    runner->NextTest();
+}
+
+{{/chip_tests_WaitForAttributeReport_attribute_info}}

--- a/examples/chip-tool/templates/partials/testsuite/WaitForMs.zapt
+++ b/examples/chip-tool/templates/partials/testsuite/WaitForMs.zapt
@@ -1,0 +1,6 @@
+CHIP_ERROR TestSendCluster{{asUpperCamelCase cluster}}Command{{asUpperCamelCase command}}_{{index}}()
+{
+    ChipLogProgress(chipTool, "{{cluster}} - {{asUpperCamelCase command}} - {{label}}");
+
+    return {{command}}({{#chip_tests_item_parameters}}{{#not_first}}, {{/not_first}}{{definedValue}}{{/chip_tests_item_parameters}});
+}

--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -24,8 +24,20 @@
             "path": "../../../src/app/zap-templates/partials/cluster_header.zapt"
         },
         {
+            "name": "process_response_value",
+            "path": "partials/process_response_value.zapt"
+        },
+        {
             "name": "test_cluster",
             "path": "partials/test_cluster.zapt"
+        },
+        {
+            "name": "TestSuiteHelper_WaitForMs",
+            "path": "partials/testsuite/WaitForMs.zapt"
+        },
+        {
+            "name": "TestSuiteHelper_WaitForAttributeReport",
+            "path": "partials/testsuite/WaitForAttributeReport.zapt"
         }
     ],
     "templates": [

--- a/src/app/tests/suites/TestDelayCommands.yaml
+++ b/src/app/tests/suites/TestDelayCommands.yaml
@@ -20,7 +20,7 @@ config:
 
 tests:
     - label: "Wait 100ms"
-      cluster: "DelayCommands"
+      cluster: "TestSuite"
       command: "WaitForMs"
       arguments:
           values:

--- a/src/app/tests/suites/TestSubscribe_OnOff.yaml
+++ b/src/app/tests/suites/TestSubscribe_OnOff.yaml
@@ -21,7 +21,6 @@ config:
 tests:
     - label: "Set OnOff Attribute to false"
       command: "Off"
-
     - label: "Subscribe OnOff Attribute"
       command: "subscribeAttribute"
       attribute: "OnOff"
@@ -29,21 +28,14 @@ tests:
       maxInterval: 10
       response:
           value: false
-
     - label: "Turn On the light to see attribute change"
       command: "On"
-
     - label: "Check for attribute report"
-      command: "waitForReport"
-      attribute: "OnOff"
-      response:
-          value: true
-
-    - label: "Turn Off the light to see attribute change"
-      command: "Off"
-
-    - label: "Check for attribute report"
-      command: "waitForReport"
-      attribute: "OnOff"
-      response:
-          value: false
+      cluster: "TestSuite"
+      command: "WaitForAttributeReport"
+      waitfor:
+          endpoint: 1
+          cluster: "On/Off"
+          attribute: "OnOff"
+          response:
+              value: true

--- a/src/app/zap-templates/common/TestSuiteHelperCluster.js
+++ b/src/app/zap-templates/common/TestSuiteHelperCluster.js
@@ -16,7 +16,7 @@
  */
 
 /*
- * This file declare test suites utilities methods for delayed commands.
+ * This file declare test suites utilities methods for test suite.
  *
  * Each method declared in this file needs to be implemented on a per-language
  * basis and permits to exposes methods to the test suites that are not part
@@ -30,12 +30,21 @@ const WaitForMs = {
   response : { arguments : [] }
 };
 
-const DelayCommands = {
-  name : 'DelayCommands',
-  commands : [ WaitForMs ],
+const WaitForAttributeRepor = {
+  name : 'WaitForAttributeReport',
+  arguments : [],
+  response : { arguments : [ { name : 'value' } ] }
+  /*
+   * 'WaitForAttributeResponse' will take "attribute" parameter for detailed attribute path.
+   */
+};
+
+const TestSuiteHelperCluster = {
+  name : 'TestSuite',
+  commands : [ WaitForMs, WaitForAttributeRepor ],
 };
 
 //
 // Module exports
 //
-exports.DelayCommands = DelayCommands;
+exports.TestSuiteHelperCluster = TestSuiteHelperCluster;

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -335,16 +335,22 @@ function asMEI(prefix, suffix)
   return cHelper.asHex((prefix << 16) + suffix, 8);
 }
 
+function asTestSuiteSimulatedClusterCommandPartial(label)
+{
+  return "TestSuiteHelper_" + asUpperCamelCase(label)
+}
+
 //
 // Module exports
 //
-exports.asPrintFormat                     = asPrintFormat;
-exports.asReadType                        = asReadType;
-exports.asReadTypeLength                  = asReadTypeLength;
-exports.chip_endpoint_generated_functions = chip_endpoint_generated_functions
-exports.chip_endpoint_cluster_list        = chip_endpoint_cluster_list
-exports.asTypeLiteralSuffix               = asTypeLiteralSuffix;
-exports.asLowerCamelCase                  = asLowerCamelCase;
-exports.asUpperCamelCase                  = asUpperCamelCase;
-exports.hasSpecificAttributes             = hasSpecificAttributes;
-exports.asMEI                             = asMEI;
+exports.asPrintFormat                             = asPrintFormat;
+exports.asReadType                                = asReadType;
+exports.asReadTypeLength                          = asReadTypeLength;
+exports.chip_endpoint_generated_functions         = chip_endpoint_generated_functions
+exports.chip_endpoint_cluster_list                = chip_endpoint_cluster_list
+exports.asTypeLiteralSuffix                       = asTypeLiteralSuffix;
+exports.asLowerCamelCase                          = asLowerCamelCase;
+exports.asUpperCamelCase                          = asUpperCamelCase;
+exports.hasSpecificAttributes                     = hasSpecificAttributes;
+exports.asMEI                                     = asMEI;
+exports.asTestSuiteSimulatedClusterCommandPartial = asTestSuiteSimulatedClusterCommandPartial;

--- a/src/darwin/Framework/CHIP/templates/partials/process_response_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/process_response_value.zapt
@@ -1,0 +1,38 @@
+ {{#chip_tests_item_response_parameters}}
+ {{#if hasExpectedValue}}
+ {{#if isList}}
+ XCTAssertEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] count], {{expectedValue.length}});
+ {{else}}
+ {{#if (isString type)}}
+ {{#if (isOctetString type)}}
+ NSString * {{asLowerCamelCase name}}ArgumentString= @"{{expectedValue}}";
+ NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
+ XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToData:{{asLowerCamelCase name}}Argument]);
+ {{else}}
+ NSString * {{asLowerCamelCase name}}Argument= @"{{expectedValue}}";
+ XCTAssertTrue([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToString:{{asLowerCamelCase name}}Argument]);
+ {{/if}}
+ {{else}}
+ XCTAssertEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedValue}}{{asTypeLiteralSuffix}});
+ {{/if}}
+ {{/if}}
+ {{/if}}
+ {{#if hasExpectedConstraints}}
+ {{#if expectedConstraints.minLength}}
+ XCTAssertGreaterThanOrEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] length], {{expectedConstraints.minLength}});
+ {{/if}}
+ {{#if expectedConstraints.maxLength}}
+ XCTAssertLessThanOrEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] length], {{expectedConstraints.maxLength}});
+ {{/if}}
+ {{#if expectedConstraints.minValue}}
+ XCTAssertGreaterThanOrEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.minValue}});
+ {{/if}}
+ {{#if expectedConstraints.maxValue}}
+ XCTAssertLessThanOrEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.maxValue}});
+ {{/if}}
+ {{#if expectedConstraints.notValue}}
+ XCTAssertNotEqual([values[@"{{#if parent.isReadAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.notValue}});
+ {{/if}}
+ {{/if}}
+ {{/chip_tests_item_response_parameters}}
+ 

--- a/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/test_cluster.zapt
@@ -1,23 +1,18 @@
 {{#chip_tests tests}}
 {{#chip_tests_items}}
-{{#if async}}
-bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = false;
-{{/if}}
 - (void)testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}
 {
-    {{#unless async}}
     XCTestExpectation * expectation = [self expectationWithDescription:@"{{label}}"];
-    {{/unless}}
-
 {{#if (isTestOnlyCluster cluster)}}
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    {{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});
+{{> (asTestSuiteSimulatedClusterCommandPartial command)}}
 {{else}}
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTest{{asUpperCamelCase cluster}} * cluster = [[CHIPTest{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:queue];
     XCTAssertNotNil(cluster);
 
+    {{#if isReadAttribute}}
+    {{else}}
     {{#chip_tests_item_parameters}}
     {{#if (isString type)}}
     {{#if (isOctetString type)}}
@@ -30,14 +25,21 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
     {{chipType}} {{asLowerCamelCase name}}Argument = {{definedValue}}{{asTypeLiteralSuffix chipType}};
     {{/if}}
     {{/chip_tests_item_parameters}}
+    {{/if}}
     {{#if isCommand}}
     [cluster {{asLowerCamelCase command}}:{{#chip_tests_item_parameters}}{{#not_first}}{{asLowerCamelCase name}}:{{/not_first}}{{asLowerCamelCase name}}Argument {{#last}}responseHandler:{{/last}}{{/chip_tests_item_parameters}}^(NSError * err, NSDictionary * values) {
     {{else if isSubscribeAttribute}}
+    __block bool initialReportReceived = false;
+    [cluster reportAttribute{{asUpperCamelCase attribute}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
+        NSLog(@"Reporting Test Report: %@", err);
+        XCTAssertEqual(err.code, 0);
+        {{> process_response_value}}
+        initialReportReceived = true;
+    }];
+
     [cluster configureAttribute{{asUpperCamelCase attribute}}WithMinInterval:{{minInterval}}
                                                                  maxInterval:{{maxInterval}}
                                                              responseHandler:^(NSError * err, NSDictionary * values) {
-    {{else if isWaitForReport}}
-    [cluster reportAttribute{{asUpperCamelCase attribute}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
     {{else if isReadAttribute}}
     [cluster readAttribute{{asUpperCamelCase attribute}}WithResponseHandler:^(NSError * err, NSDictionary * values) {
     {{else if isWriteAttribute}}
@@ -57,60 +59,16 @@ bool testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase
         [expectation fulfill];
         {{else}}
         {{#unless isSubscribeAttribute}}
-
-        {{#chip_tests_item_response_parameters}}
-        {{#if hasExpectedValue}}
-        {{#if isList}}
-        XCTAssertEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] count], {{expectedValue.length}});
+        {{> process_response_value}}
         {{else}}
-        {{#if (isString type)}}
-        {{#if (isOctetString type)}}
-        NSString * {{asLowerCamelCase name}}ArgumentString= @"{{expectedValue}}";
-        NSData * {{asLowerCamelCase name}}Argument = [{{asLowerCamelCase name}}ArgumentString dataUsingEncoding:NSUTF8StringEncoding];
-        XCTAssertTrue([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToData:{{asLowerCamelCase name}}Argument]);
-        {{else}}
-        NSString * {{asLowerCamelCase name}}Argument= @"{{expectedValue}}";
-        XCTAssertTrue([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] isEqualToString:{{asLowerCamelCase name}}Argument]);
-        {{/if}}
-        {{else}}
-        XCTAssertEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedValue}}{{asTypeLiteralSuffix}});
-        {{/if}}
-        {{/if}}
-        {{/if}}
-        {{#if hasExpectedConstraints}}
-        {{#if expectedConstraints.minLength}}
-        XCTAssertGreaterThanOrEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] length], {{expectedConstraints.minLength}});
-        {{/if}}
-        {{#if expectedConstraints.maxLength}}
-        XCTAssertLessThanOrEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] length], {{expectedConstraints.maxLength}});
-        {{/if}}
-        {{#if expectedConstraints.minValue}}
-        XCTAssertGreaterThanOrEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.minValue}});
-        {{/if}}
-        {{#if expectedConstraints.maxValue}}
-        XCTAssertLessThanOrEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.maxValue}});
-        {{/if}}
-        {{#if expectedConstraints.notValue}}
-        XCTAssertNotEqual([values[@"{{#if parent.isAttribute}}value{{else}}{{name}}{{/if}}"] {{asObjectiveCNumberType "" type true}}Value], {{expectedConstraints.notValue}});
-        {{/if}}
-        {{/if}}
-        {{/chip_tests_item_response_parameters}}
-
-        {{else}}
-        XCTAssertEqual(testSendCluster{{parent.filename}}_{{asTestIndex waitForReport.index}}_{{asUpperCamelCase waitForReport.command}}_Fulfilled, true);
+        XCTAssertEqual(initialReportReceived, true);
         {{/unless}}
-        {{#unless async}}
         [expectation fulfill];
-        {{else}}
-        testSendCluster{{parent.filename}}_{{asTestIndex index}}_{{asUpperCamelCase command}}_Fulfilled = true;
-        {{/unless}}
         {{/unless}}
     }];
 
 {{/if}}
-    {{#unless async}}
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-    {{/unless}}
 }
 {{/chip_tests_items}}
 

--- a/src/darwin/Framework/CHIP/templates/partials/testsuite/WaitForMs.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/testsuite/WaitForMs.zapt
@@ -1,0 +1,2 @@
+dispatch_queue_t queue = dispatch_get_main_queue();
+{{command}}(expectation, queue{{#chip_tests_item_parameters}}, {{definedValue}}{{/chip_tests_item_parameters}});

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -20,8 +20,20 @@
             "path": "partials/test_cluster.zapt"
         },
         {
+            "name": "process_response_value",
+            "path": "partials/process_response_value.zapt"
+        },
+        {
             "name": "CHIPCallbackBridge",
             "path": "partials/CHIPCallbackBridge.zapt"
+        },
+        {
+            "name": "TestSuiteHelper_WaitForMs",
+            "path": "partials/testsuite/WaitForMs.zapt"
+        },
+        {
+            "name": "TestSuiteHelper_WaitForAttributeReport",
+            "path": "partials/testsuite/WaitForAttributeReport.zapt"
         }
     ],
     "templates": [

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -164,7 +164,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000000_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -174,7 +173,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Send Test Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -183,7 +181,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000001_TestNotHandled
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Not Handled Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -201,7 +198,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000002_TestSpecific
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Specific Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -211,9 +207,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Send Test Specific Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"returnValue"] unsignedCharValue], 7);
-
         [expectation fulfill];
     }];
 
@@ -222,7 +216,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000003_TestAddArguments
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Add Arguments Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -236,9 +229,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                   NSLog(@"Send Test Add Arguments Command Error: %@", err);
 
                   XCTAssertEqual(err.code, 0);
-
                   XCTAssertEqual([values[@"returnValue"] unsignedCharValue], 20);
-
                   [expectation fulfill];
               }];
 
@@ -247,7 +238,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000004_TestAddArguments
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send failing Test Add Arguments Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -269,7 +259,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -279,9 +268,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BOOLEAN Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -290,7 +277,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000006_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BOOLEAN True"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -302,7 +288,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                 NSLog(@"Write attribute BOOLEAN True Error: %@", err);
 
                                 XCTAssertEqual(err.code, 0);
-
                                 [expectation fulfill];
                             }];
 
@@ -311,7 +296,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN True"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -321,9 +305,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BOOLEAN True Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -332,7 +314,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000008_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BOOLEAN False"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -344,7 +325,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                 NSLog(@"Write attribute BOOLEAN False Error: %@", err);
 
                                 XCTAssertEqual(err.code, 0);
-
                                 [expectation fulfill];
                             }];
 
@@ -353,7 +333,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BOOLEAN False"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -363,9 +342,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BOOLEAN False Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -374,7 +351,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -384,9 +360,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP8 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -395,7 +369,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000011_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP8 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -407,7 +380,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                 NSLog(@"Write attribute BITMAP8 Max Value Error: %@", err);
 
                                 XCTAssertEqual(err.code, 0);
-
                                 [expectation fulfill];
                             }];
 
@@ -416,7 +388,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000012_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -426,9 +397,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP8 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 255);
-
         [expectation fulfill];
     }];
 
@@ -437,7 +406,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000013_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP8 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -449,7 +417,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                 NSLog(@"Write attribute BITMAP8 Min Value Error: %@", err);
 
                                 XCTAssertEqual(err.code, 0);
-
                                 [expectation fulfill];
                             }];
 
@@ -458,7 +425,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000014_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP8 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -468,9 +434,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP8 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -479,7 +443,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000015_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -489,9 +452,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP16 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -500,7 +461,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000016_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP16 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -512,7 +472,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP16 Max Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -521,7 +480,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000017_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -531,9 +489,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP16 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 65535);
-
         [expectation fulfill];
     }];
 
@@ -542,7 +498,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000018_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP16 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -554,7 +509,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP16 Min Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -563,7 +517,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000019_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP16 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -573,9 +526,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP16 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -584,7 +535,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000020_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -594,9 +544,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP32 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -605,7 +553,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000021_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP32 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -617,7 +564,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP32 Max Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -626,7 +572,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000022_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -636,9 +581,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP32 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 4294967295);
-
         [expectation fulfill];
     }];
 
@@ -647,7 +590,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000023_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP32 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -659,7 +601,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP32 Min Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -668,7 +609,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000024_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP32 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -678,9 +618,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP32 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -689,7 +627,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000025_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -699,9 +636,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP64 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -710,7 +645,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000026_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP64 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -722,7 +656,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP64 Max Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -731,7 +664,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000027_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -741,9 +673,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP64 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 18446744073709551615);
-
         [expectation fulfill];
     }];
 
@@ -752,7 +682,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000028_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute BITMAP64 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -764,7 +693,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                  NSLog(@"Write attribute BITMAP64 Min Value Error: %@", err);
 
                                  XCTAssertEqual(err.code, 0);
-
                                  [expectation fulfill];
                              }];
 
@@ -773,7 +701,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000029_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute BITMAP64 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -783,9 +710,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute BITMAP64 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -794,7 +719,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000030_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -804,9 +728,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8U Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -815,7 +737,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000031_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -827,7 +748,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute INT8U Max Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -836,7 +756,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000032_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -846,9 +765,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8U Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 255);
-
         [expectation fulfill];
     }];
 
@@ -857,7 +774,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000033_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -869,7 +785,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute INT8U Min Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -878,7 +793,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000034_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -888,9 +802,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8U Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -899,7 +811,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000035_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -909,9 +820,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16U Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -920,7 +829,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000036_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -932,7 +840,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT16U Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -941,7 +848,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000037_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -951,9 +857,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16U Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 65535);
-
         [expectation fulfill];
     }];
 
@@ -962,7 +866,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000038_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -974,7 +877,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT16U Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -983,7 +885,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000039_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -993,9 +894,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16U Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1004,7 +903,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000040_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1014,9 +912,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1025,7 +921,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000041_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1037,7 +932,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32U Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1046,7 +940,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000042_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1056,9 +949,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 4294967295);
-
         [expectation fulfill];
     }];
 
@@ -1067,7 +958,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000043_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1079,7 +969,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32U Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1088,7 +977,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000044_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1098,9 +986,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1109,7 +995,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000045_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1119,9 +1004,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64U Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1130,7 +1013,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000046_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1142,7 +1024,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT64U Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1151,7 +1032,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000047_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1161,9 +1041,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64U Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 18446744073709551615);
-
         [expectation fulfill];
     }];
 
@@ -1172,7 +1050,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000048_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1184,7 +1061,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT64U Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1193,7 +1069,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000049_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64U Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1203,9 +1078,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64U Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1214,7 +1087,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000050_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1224,9 +1096,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] charValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1235,7 +1105,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000051_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1247,7 +1116,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute INT8S Max Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -1256,7 +1124,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000052_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1266,9 +1133,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8S Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] charValue], 127);
-
         [expectation fulfill];
     }];
 
@@ -1277,7 +1142,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000053_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1289,7 +1153,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute INT8S Min Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -1298,7 +1161,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000054_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1308,9 +1170,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8S Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] charValue], -128);
-
         [expectation fulfill];
     }];
 
@@ -1319,7 +1179,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000055_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT8S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1331,7 +1190,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute INT8S Default Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -1340,7 +1198,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000056_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT8S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1350,9 +1207,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT8S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] charValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1361,7 +1216,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000057_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1371,9 +1225,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] shortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1382,7 +1234,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000058_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1394,7 +1245,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT16S Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1403,7 +1253,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000059_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1413,9 +1262,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16S Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] shortValue], 32767);
-
         [expectation fulfill];
     }];
 
@@ -1424,7 +1271,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000060_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1436,7 +1282,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT16S Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1445,7 +1290,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000061_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1455,9 +1299,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16S Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] shortValue], -32768);
-
         [expectation fulfill];
     }];
 
@@ -1466,7 +1308,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000062_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT16S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1478,7 +1319,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT16S Default Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1487,7 +1327,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000063_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT16S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1497,9 +1336,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT16S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] shortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1508,7 +1345,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000064_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1518,9 +1354,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1529,7 +1363,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000065_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1541,7 +1374,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32S Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1550,7 +1382,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000066_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1560,9 +1391,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32S Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longValue], 2147483647);
-
         [expectation fulfill];
     }];
 
@@ -1571,7 +1400,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000067_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1583,7 +1411,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32S Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1592,7 +1419,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000068_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1602,9 +1428,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32S Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longValue], -2147483648);
-
         [expectation fulfill];
     }];
 
@@ -1613,7 +1437,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000069_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1625,7 +1448,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32S Default Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1634,7 +1456,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000070_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1644,9 +1465,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1655,7 +1474,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000071_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1665,9 +1483,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1676,7 +1492,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000072_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1688,7 +1503,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT64S Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1697,7 +1511,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000073_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1707,9 +1520,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64S Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longLongValue], 9223372036854775807);
-
         [expectation fulfill];
     }];
 
@@ -1718,7 +1529,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000074_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1730,7 +1540,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT64S Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1739,7 +1548,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000075_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1749,9 +1557,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64S Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longLongValue], -9223372036854775807);
-
         [expectation fulfill];
     }];
 
@@ -1760,7 +1566,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000076_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT64S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1772,7 +1577,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT64S Default Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1781,7 +1585,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000077_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT64S Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1791,9 +1594,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT64S Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] longLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1802,7 +1603,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000078_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1812,9 +1612,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM8 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1823,7 +1621,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000079_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM8 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1835,7 +1632,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute ENUM8 Max Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -1844,7 +1640,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000080_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1854,9 +1649,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM8 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 255);
-
         [expectation fulfill];
     }];
 
@@ -1865,7 +1658,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000081_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM8 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1877,7 +1669,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                               NSLog(@"Write attribute ENUM8 Min Value Error: %@", err);
 
                               XCTAssertEqual(err.code, 0);
-
                               [expectation fulfill];
                           }];
 
@@ -1886,7 +1677,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000082_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM8 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1896,9 +1686,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM8 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1907,7 +1695,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000083_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1917,9 +1704,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM16 Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -1928,7 +1713,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000084_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM16 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1940,7 +1724,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute ENUM16 Max Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1949,7 +1732,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000085_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Max Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1959,9 +1741,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM16 Max Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 65535);
-
         [expectation fulfill];
     }];
 
@@ -1970,7 +1750,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000086_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute ENUM16 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -1982,7 +1761,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute ENUM16 Min Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -1991,7 +1769,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000087_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute ENUM16 Min Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2001,9 +1778,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute ENUM16 Min Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2012,7 +1787,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000088_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2022,11 +1796,9 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute OCTET_STRING Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * octetStringArgumentString = @"";
         NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2035,7 +1807,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000089_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2048,7 +1819,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
 
                                     XCTAssertEqual(err.code, 0);
-
                                     [expectation fulfill];
                                 }];
 
@@ -2057,7 +1827,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000090_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2067,11 +1836,9 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute OCTET_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * octetStringArgumentString = @"TestValue";
         NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2080,7 +1847,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000091_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2101,7 +1867,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000092_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2111,11 +1876,9 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute OCTET_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * octetStringArgumentString = @"TestValue";
         NSData * octetStringArgument = [octetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
         XCTAssertTrue([values[@"value"] isEqualToData:octetStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2124,7 +1887,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000093_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2137,7 +1899,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                     NSLog(@"Write attribute OCTET_STRING Error: %@", err);
 
                                     XCTAssertEqual(err.code, 0);
-
                                     [expectation fulfill];
                                 }];
 
@@ -2146,7 +1907,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000094_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_OCTET_STRING Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2156,11 +1916,9 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LONG_OCTET_STRING Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * longOctetStringArgumentString = @"";
         NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
         XCTAssertTrue([values[@"value"] isEqualToData:longOctetStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2169,7 +1927,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000095_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2185,7 +1942,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                         NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
 
                                         XCTAssertEqual(err.code, 0);
-
                                         [expectation fulfill];
                                     }];
 
@@ -2194,7 +1950,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000096_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2204,14 +1959,12 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LONG_OCTET_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * longOctetStringArgumentString
             = @"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
               @"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
               @"1111111111111111111111111111111111111111111111111111111111111111111111";
         NSData * longOctetStringArgument = [longOctetStringArgumentString dataUsingEncoding:NSUTF8StringEncoding];
         XCTAssertTrue([values[@"value"] isEqualToData:longOctetStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2220,7 +1973,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000097_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2233,7 +1985,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                         NSLog(@"Write attribute LONG_OCTET_STRING Error: %@", err);
 
                                         XCTAssertEqual(err.code, 0);
-
                                         [expectation fulfill];
                                     }];
 
@@ -2242,7 +1993,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000098_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute CHAR_STRING Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2252,10 +2002,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute CHAR_STRING Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * charStringArgument = @"";
         XCTAssertTrue([values[@"value"] isEqualToString:charStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2264,7 +2012,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000099_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2276,7 +2023,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                    NSLog(@"Write attribute CHAR_STRING Error: %@", err);
 
                                    XCTAssertEqual(err.code, 0);
-
                                    [expectation fulfill];
                                }];
 
@@ -2285,7 +2031,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000100_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING - Value too long"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2305,7 +2050,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000101_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute CHAR_STRING - Empty"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2317,7 +2061,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                    NSLog(@"Write attribute CHAR_STRING - Empty Error: %@", err);
 
                                    XCTAssertEqual(err.code, 0);
-
                                    [expectation fulfill];
                                }];
 
@@ -2326,7 +2069,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000102_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_CHAR_STRING Default Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2336,10 +2078,8 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LONG_CHAR_STRING Default Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * longCharStringArgument = @"";
         XCTAssertTrue([values[@"value"] isEqualToString:longCharStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2348,7 +2088,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000103_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_CHAR_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2363,7 +2102,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                        NSLog(@"Write attribute LONG_CHAR_STRING Error: %@", err);
 
                                        XCTAssertEqual(err.code, 0);
-
                                        [expectation fulfill];
                                    }];
 
@@ -2372,7 +2110,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000104_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LONG_CHAR_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2382,13 +2119,11 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LONG_CHAR_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         NSString * longCharStringArgument
             = @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
               @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉"
               @"☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉☉";
         XCTAssertTrue([values[@"value"] isEqualToString:longCharStringArgument]);
-
         [expectation fulfill];
     }];
 
@@ -2397,7 +2132,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000105_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute LONG_CHAR_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2409,7 +2143,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                        NSLog(@"Write attribute LONG_CHAR_STRING Error: %@", err);
 
                                        XCTAssertEqual(err.code, 0);
-
                                        [expectation fulfill];
                                    }];
 
@@ -2418,7 +2151,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000106_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2428,9 +2160,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LIST Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] count], 4);
-
         [expectation fulfill];
     }];
 
@@ -2439,7 +2169,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000107_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST_OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2449,9 +2178,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LIST_OCTET_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] count], 4);
-
         [expectation fulfill];
     }];
 
@@ -2460,7 +2187,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000108_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute LIST_STRUCT_OCTET_STRING"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2470,9 +2196,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute LIST_STRUCT_OCTET_STRING Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] count], 4);
-
         [expectation fulfill];
     }];
 
@@ -2481,7 +2205,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000109_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute UNSUPPORTED"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2496,9 +2219,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2507,7 +2228,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000110_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Writeattribute UNSUPPORTED"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2524,7 +2244,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                     }
 
                                     XCTAssertEqual(err.code, 0);
-
                                     [expectation fulfill];
                                 }];
 
@@ -2533,7 +2252,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestCluster_000111_Test
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Test Command to unsupported endpoint"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:200 queue:queue];
@@ -2552,7 +2270,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestConstraints_000000_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Write attribute INT32U Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2564,7 +2281,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
                                NSLog(@"Write attribute INT32U Value Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -2573,7 +2289,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestConstraints_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Value MinValue Constraints"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2583,9 +2298,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Value MinValue Constraints Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] unsignedLongValue], 5);
-
         [expectation fulfill];
     }];
 
@@ -2594,7 +2307,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestConstraints_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Value MaxValue Constraints"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2604,9 +2316,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Value MaxValue Constraints Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] unsignedLongValue], 5);
-
         [expectation fulfill];
     }];
 
@@ -2615,7 +2325,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestConstraints_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read attribute INT32U Value NotValue Constraints"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTestCluster * cluster = [[CHIPTestTestCluster alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2625,9 +2334,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Read attribute INT32U Value NotValue Constraints Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertNotEqual([values[@"value"] unsignedLongValue], 6);
-
         [expectation fulfill];
     }];
 
@@ -2637,7 +2344,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestDelayCommands_000000_WaitForMs
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wait 100ms"];
-
     dispatch_queue_t queue = dispatch_get_main_queue();
     WaitForMs(expectation, queue, 100);
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
@@ -2646,7 +2352,6 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
 - (void)testSendClusterTestSubscribe_OnOff_000000_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Set OnOff Attribute to false"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2656,39 +2361,26 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
         NSLog(@"Set OnOff Attribute to false Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
-- (void)testSendClusterTestSubscribe_OnOff_000001_WaitForReport
+- (void)testSendClusterTestSubscribe_OnOff_000001_SubscribeAttribute
 {
-
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Subscribe OnOff Attribute"];
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
+    __block bool initialReportReceived = false;
     [cluster reportAttributeOnOffWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Report: Subscribe OnOff Attribute Error: %@", err);
-
+        NSLog(@"Reporting Test Report: %@", err);
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], false);
-
-        testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = true;
+        initialReportReceived = true;
     }];
-}
-- (void)testSendClusterTestSubscribe_OnOff_000002_SubscribeAttribute
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Subscribe OnOff Attribute"];
-
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
 
     [cluster configureAttributeOnOffWithMinInterval:2
                                         maxInterval:10
@@ -2696,16 +2388,15 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                         NSLog(@"Subscribe OnOff Attribute Error: %@", err);
 
                                         XCTAssertEqual(err.code, 0);
-                                        XCTAssertEqual(testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled, true);
+                                        XCTAssertEqual(initialReportReceived, true);
                                         [expectation fulfill];
                                     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestSubscribe_OnOff_000003_On
+- (void)testSendClusterTestSubscribe_OnOff_000002_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn On the light to see attribute change"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2715,78 +2406,32 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn On the light to see attribute change Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTestSubscribe_OnOff_000004_WaitForReport
+- (void)testSendClusterTestSubscribe_OnOff_000003_WaitForAttributeReport
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check for attribute report"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
     [cluster reportAttributeOnOffWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check for attribute report Error: %@", err);
-
+        NSLog(@"Reporting Test Report: %@", err);
         XCTAssertEqual(err.code, 0);
 
         XCTAssertEqual([values[@"value"] boolValue], true);
-
         [expectation fulfill];
     }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTestSubscribe_OnOff_000005_Off
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Turn Off the light to see attribute change"];
-
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster off:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Turn Off the light to see attribute change Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
-}
-- (void)testSendClusterTestSubscribe_OnOff_000006_WaitForReport
-{
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Check for attribute report"];
-
-    CHIPDevice * device = GetPairedDevice(kDeviceId);
-    dispatch_queue_t queue = dispatch_get_main_queue();
-    CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
-    XCTAssertNotNil(cluster);
-
-    [cluster reportAttributeOnOffWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"Check for attribute report Error: %@", err);
-
-        XCTAssertEqual(err.code, 0);
-
-        XCTAssertEqual([values[@"value"] boolValue], false);
-
-        [expectation fulfill];
-    }];
-
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
 - (void)testSendClusterTest_TC_OO_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2796,9 +2441,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -2828,7 +2471,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2838,9 +2480,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -2849,7 +2489,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_1_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the optional global attribute: FeatureMap"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2859,9 +2498,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the optional global attribute: FeatureMap Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2890,7 +2527,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_1_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back optional global attribute: FeatureMap"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2900,9 +2536,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back optional global attribute: FeatureMap Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedLongValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2912,7 +2546,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the mandatory attribute: OnOff"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2922,9 +2555,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the mandatory attribute: OnOff Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2933,7 +2564,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back mandatory attribute: OnOff"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2943,9 +2573,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back mandatory attribute: OnOff Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2954,7 +2582,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: GlobalSceneControl"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2964,9 +2591,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read LT attribute: GlobalSceneControl Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -2975,7 +2600,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: OnTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -2985,9 +2609,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read LT attribute: OnTime Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -2996,7 +2618,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000004_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: OffWaitTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3006,9 +2627,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read LT attribute: OffWaitTime Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3017,7 +2636,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read LT attribute: StartUpOnOff"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3027,9 +2645,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read LT attribute: StartUpOnOff Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3038,7 +2654,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000006_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: OnTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3050,7 +2665,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                NSLog(@"write the default value to LT attribute: OnTime Error: %@", err);
 
                                XCTAssertEqual(err.code, 0);
-
                                [expectation fulfill];
                            }];
 
@@ -3059,7 +2673,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000007_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: OffWaitTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3071,7 +2684,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                     NSLog(@"write the default value to LT attribute: OffWaitTime Error: %@", err);
 
                                     XCTAssertEqual(err.code, 0);
-
                                     [expectation fulfill];
                                 }];
 
@@ -3080,7 +2692,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000008_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write the default value to LT attribute: StartUpOnOff"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3092,7 +2703,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                      NSLog(@"write the default value to LT attribute: StartUpOnOff Error: %@", err);
 
                                      XCTAssertEqual(err.code, 0);
-
                                      [expectation fulfill];
                                  }];
 
@@ -3101,7 +2711,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: OnTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3111,9 +2720,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back LT attribute: OnTime Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3122,7 +2729,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: OffWaitTime"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3132,9 +2738,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back LT attribute: OffWaitTime Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3143,7 +2747,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_1_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back LT attribute: StartUpOnOff"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3153,9 +2756,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back LT attribute: StartUpOnOff Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3165,7 +2766,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000000_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Off Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3175,7 +2775,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send Off Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3184,7 +2783,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3194,9 +2792,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3205,7 +2801,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000002_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send On Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3215,7 +2810,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send On Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3224,7 +2818,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3234,9 +2827,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -3245,7 +2836,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000004_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Off Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3255,7 +2845,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send Off Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3264,7 +2853,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3274,9 +2862,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3285,7 +2871,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000006_Toggle
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Toggle Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3295,7 +2880,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send Toggle Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3305,7 +2889,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Check on/off attribute value is true after toggle command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3315,9 +2898,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after toggle command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -3326,7 +2907,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000008_Toggle
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Toggle Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3336,7 +2916,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send Toggle Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3346,7 +2925,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Check on/off attribute value is false after toggle command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3356,9 +2934,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after toggle command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3367,7 +2943,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000010_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send On Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3377,7 +2952,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send On Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3386,7 +2960,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3396,9 +2969,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -3407,7 +2978,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000012_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Send Off Command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3417,7 +2987,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Send Off Command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3426,7 +2995,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OO_2_2_000013_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3436,9 +3004,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -3448,7 +3014,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query Interaction Model Version"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3458,7 +3023,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query Interaction Model Version Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3467,7 +3031,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query Vendor Name"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3477,9 +3040,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query Vendor Name Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 32);
-
         [expectation fulfill];
     }];
 
@@ -3488,7 +3049,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query VendorID"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3498,7 +3058,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query VendorID Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3507,7 +3066,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query Product Name"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3517,9 +3075,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query Product Name Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 32);
-
         [expectation fulfill];
     }];
 
@@ -3528,7 +3084,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000004_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query ProductID"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3538,7 +3093,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query ProductID Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3547,7 +3101,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query User Label"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3557,9 +3110,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query User Label Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 32);
-
         [expectation fulfill];
     }];
 
@@ -3568,7 +3119,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000006_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query User Location"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3578,9 +3128,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query User Location Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 2);
-
         [expectation fulfill];
     }];
 
@@ -3589,7 +3137,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query HardwareVersion"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3599,7 +3146,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query HardwareVersion Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3608,7 +3154,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000008_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query HardwareVersionString"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3618,10 +3163,8 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query HardwareVersionString Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] length], 1);
         XCTAssertLessThanOrEqual([values[@"value"] length], 64);
-
         [expectation fulfill];
     }];
 
@@ -3630,7 +3173,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query SoftwareVersion"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3640,7 +3182,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query SoftwareVersion Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3649,7 +3190,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query SoftwareVersionString"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3659,10 +3199,8 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Query SoftwareVersionString Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] length], 1);
         XCTAssertLessThanOrEqual([values[@"value"] length], 64);
-
         [expectation fulfill];
     }];
 
@@ -3671,7 +3209,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query ManufacturingDate"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3686,10 +3223,8 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] length], 8);
         XCTAssertLessThanOrEqual([values[@"value"] length], 16);
-
         [expectation fulfill];
     }];
 
@@ -3698,7 +3233,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000012_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query PartNumber"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3713,9 +3247,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 32);
-
         [expectation fulfill];
     }];
 
@@ -3724,7 +3256,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000013_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query ProductURL"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3739,9 +3270,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 256);
-
         [expectation fulfill];
     }];
 
@@ -3750,7 +3279,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000014_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query ProductLabel"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3765,9 +3293,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 64);
-
         [expectation fulfill];
     }];
 
@@ -3776,7 +3302,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000015_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query SerialNumber"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3791,9 +3316,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertLessThanOrEqual([values[@"value"] length], 32);
-
         [expectation fulfill];
     }];
 
@@ -3802,7 +3325,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000016_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query LocalConfigDisabled"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3817,7 +3339,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3826,7 +3347,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_DM_1_1_000017_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Query Reachable"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBasic * cluster = [[CHIPTestBasic alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -3841,7 +3361,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         }
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3851,7 +3370,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000000_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn on light for color control tests"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3861,7 +3379,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn on light for color control tests Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -3870,7 +3387,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3880,9 +3396,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -3891,7 +3405,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000002_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue shortest distance command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3911,7 +3424,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move to hue shortest distance command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -3920,7 +3432,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000003_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue longest distance command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3940,7 +3451,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move to hue longest distance command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -3949,7 +3459,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000004_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3969,7 +3478,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move to hue up command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -3978,7 +3486,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000005_MoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to hue down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -3998,7 +3505,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move to hue down command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4007,7 +3513,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000006_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4025,7 +3530,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move hue up command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4034,7 +3538,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000007_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue stop command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4052,7 +3555,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move hue stop command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4061,7 +3563,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000008_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4079,7 +3580,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move hue down command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4088,7 +3588,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000009_MoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move hue stop command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4106,7 +3605,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move hue stop command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4115,7 +3613,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000010_StepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step hue up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4135,7 +3632,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Step hue up command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4144,7 +3640,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000011_StepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step hue down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4164,7 +3659,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Step hue down command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4173,7 +3667,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000012_MoveToSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to saturation command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4191,7 +3684,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                   NSLog(@"Move to saturation command Error: %@", err);
 
                   XCTAssertEqual(err.code, 0);
-
                   [expectation fulfill];
               }];
 
@@ -4200,7 +3692,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000013_MoveSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move saturation up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4218,7 +3709,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                 NSLog(@"Move saturation up command Error: %@", err);
 
                 XCTAssertEqual(err.code, 0);
-
                 [expectation fulfill];
             }];
 
@@ -4227,7 +3717,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000014_MoveSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move saturation down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4245,7 +3734,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                 NSLog(@"Move saturation down command Error: %@", err);
 
                 XCTAssertEqual(err.code, 0);
-
                 [expectation fulfill];
             }];
 
@@ -4254,7 +3742,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000015_StepSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step saturation up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4274,7 +3761,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                 NSLog(@"Step saturation up command Error: %@", err);
 
                 XCTAssertEqual(err.code, 0);
-
                 [expectation fulfill];
             }];
 
@@ -4283,7 +3769,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000016_StepSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step saturation down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4303,7 +3788,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                 NSLog(@"Step saturation down command Error: %@", err);
 
                 XCTAssertEqual(err.code, 0);
-
                 [expectation fulfill];
             }];
 
@@ -4312,7 +3796,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000017_MoveToHueAndSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move To current hue and saturation command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4332,7 +3815,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                         NSLog(@"Move To current hue and saturation command Error: %@", err);
 
                         XCTAssertEqual(err.code, 0);
-
                         [expectation fulfill];
                     }];
 
@@ -4341,7 +3823,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000018_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4351,7 +3832,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn off light that we turned on Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4360,7 +3840,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_3_4_000019_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4370,9 +3849,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -4382,7 +3859,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000000_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn on light for color control tests"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4392,7 +3868,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn on light for color control tests Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4401,7 +3876,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4411,9 +3885,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -4422,7 +3894,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000002_MoveToColor
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move to Color command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4442,7 +3913,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
              NSLog(@"Move to Color command Error: %@", err);
 
              XCTAssertEqual(err.code, 0);
-
              [expectation fulfill];
          }];
 
@@ -4451,7 +3921,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000003_MoveColor
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move Color command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4469,7 +3938,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Move Color command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4478,7 +3946,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000004_StopMoveStep
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Stop Move Step command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4492,7 +3959,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
               NSLog(@"Stop Move Step command Error: %@", err);
 
               XCTAssertEqual(err.code, 0);
-
               [expectation fulfill];
           }];
 
@@ -4501,7 +3967,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000005_StepColor
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step Color command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4521,7 +3986,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
             NSLog(@"Step Color command Error: %@", err);
 
             XCTAssertEqual(err.code, 0);
-
             [expectation fulfill];
         }];
 
@@ -4530,7 +3994,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000006_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4540,7 +4003,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn off light that we turned on Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4549,7 +4011,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_5_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4559,9 +4020,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -4571,7 +4030,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000000_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn on light for color control tests"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4581,7 +4039,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn on light for color control tests Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4590,7 +4047,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4600,9 +4056,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -4611,7 +4065,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000002_MoveToColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move To Color Temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4629,7 +4082,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                         NSLog(@"Move To Color Temperature command Error: %@", err);
 
                         XCTAssertEqual(err.code, 0);
-
                         [expectation fulfill];
                     }];
 
@@ -4638,7 +4090,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000003_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move up color temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4660,7 +4111,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                       NSLog(@"Move up color temperature command Error: %@", err);
 
                       XCTAssertEqual(err.code, 0);
-
                       [expectation fulfill];
                   }];
 
@@ -4669,7 +4119,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000004_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Stop Color Temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4691,7 +4140,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                       NSLog(@"Stop Color Temperature command Error: %@", err);
 
                       XCTAssertEqual(err.code, 0);
-
                       [expectation fulfill];
                   }];
 
@@ -4700,7 +4148,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000005_MoveColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Move down color temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4722,7 +4169,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                       NSLog(@"Move down color temperature command Error: %@", err);
 
                       XCTAssertEqual(err.code, 0);
-
                       [expectation fulfill];
                   }];
 
@@ -4731,7 +4177,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000006_StepColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step up color temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4755,7 +4200,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                       NSLog(@"Step up color temperature command Error: %@", err);
 
                       XCTAssertEqual(err.code, 0);
-
                       [expectation fulfill];
                   }];
 
@@ -4764,7 +4208,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000007_StepColorTemperature
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Step down color temperature command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4788,7 +4231,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                       NSLog(@"Step down color temperature command Error: %@", err);
 
                       XCTAssertEqual(err.code, 0);
-
                       [expectation fulfill];
                   }];
 
@@ -4797,7 +4239,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000008_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4807,7 +4248,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn off light that we turned on Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4816,7 +4256,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_6_000009_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4826,9 +4265,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -4838,7 +4275,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000000_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn on light for color control tests"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4848,7 +4284,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn on light for color control tests Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -4857,7 +4292,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4867,9 +4301,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -4878,7 +4310,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000002_EnhancedMoveToHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move To Hue command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4898,7 +4329,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                    NSLog(@"Enhanced Move To Hue command Error: %@", err);
 
                    XCTAssertEqual(err.code, 0);
-
                    [expectation fulfill];
                }];
 
@@ -4908,7 +4338,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Check Remaining time attribute value matched the value sent by the last command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4918,9 +4347,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check Remaining time attribute value matched the value sent by the last command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -4929,7 +4356,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000004_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Down command "];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4947,7 +4373,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Move Hue Down command  Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -4956,7 +4381,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000005_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Stop command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -4974,7 +4398,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -4983,7 +4406,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000006_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5001,7 +4423,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Move Hue Up command Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -5010,7 +4431,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000007_EnhancedMoveHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Move Hue Stop command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5028,7 +4448,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Move Hue Stop command Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -5037,7 +4456,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000008_EnhancedStepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Step Hue Up command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5057,7 +4475,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Step Hue Up command Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -5066,7 +4483,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000009_EnhancedStepHue
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced Step Hue Down command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5086,7 +4502,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                  NSLog(@"Enhanced Step Hue Down command Error: %@", err);
 
                  XCTAssertEqual(err.code, 0);
-
                  [expectation fulfill];
              }];
 
@@ -5095,7 +4510,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000010_EnhancedMoveToHueAndSaturation
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Enhanced move to hue and saturation command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5115,7 +4529,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                                 NSLog(@"Enhanced move to hue and saturation command Error: %@", err);
 
                                 XCTAssertEqual(err.code, 0);
-
                                 [expectation fulfill];
                             }];
 
@@ -5124,7 +4537,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000011_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5134,7 +4546,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn off light that we turned on Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -5143,7 +4554,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_7_000012_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5153,9 +4563,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5165,7 +4573,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000000_On
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn on light for color control tests"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5175,7 +4582,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn on light for color control tests Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -5184,7 +4590,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is true after on command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5194,9 +4599,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is true after on command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5205,7 +4608,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000002_ColorLoopSet
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Color Loop Set Command - Set all Attributs"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5229,7 +4631,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
               NSLog(@"Color Loop Set Command - Set all Attributs Error: %@", err);
 
               XCTAssertEqual(err.code, 0);
-
               [expectation fulfill];
           }];
 
@@ -5238,7 +4639,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopDirection Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5248,9 +4648,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopDirection Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5259,7 +4657,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000004_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopTime Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5269,9 +4666,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopTime Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 100);
-
         [expectation fulfill];
     }];
 
@@ -5280,7 +4675,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopStartEnhancedHue Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5290,9 +4684,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopStartEnhancedHue Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 500);
-
         [expectation fulfill];
     }];
 
@@ -5301,7 +4693,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000006_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopActive Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5311,9 +4702,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopActive Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5322,7 +4711,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000007_ColorLoopSet
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Color Loop Set Command - Start Color Loop"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5346,7 +4734,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
               NSLog(@"Color Loop Set Command - Start Color Loop Error: %@", err);
 
               XCTAssertEqual(err.code, 0);
-
               [expectation fulfill];
           }];
 
@@ -5355,7 +4742,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000008_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopActive Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5365,9 +4751,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopActive Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5377,7 +4761,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"Color Loop Set Command - Set direction and time while running"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5401,7 +4784,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
               NSLog(@"Color Loop Set Command - Set direction and time while running Error: %@", err);
 
               XCTAssertEqual(err.code, 0);
-
               [expectation fulfill];
           }];
 
@@ -5410,7 +4792,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopDirection Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5420,9 +4801,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopDirection Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5431,7 +4810,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000011_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopTime Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5441,9 +4819,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopTime Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 3500);
-
         [expectation fulfill];
     }];
 
@@ -5452,7 +4828,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000012_ColorLoopSet
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Color Loop Set Command - Set direction while running"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5476,7 +4851,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
               NSLog(@"Color Loop Set Command - Set direction while running Error: %@", err);
 
               XCTAssertEqual(err.code, 0);
-
               [expectation fulfill];
           }];
 
@@ -5485,7 +4859,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000013_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check ColorLoopDirection Value"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5495,9 +4868,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check ColorLoopDirection Value Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5506,7 +4877,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000014_Off
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Turn off light that we turned on"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5516,7 +4886,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Turn off light that we turned on Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         [expectation fulfill];
     }];
 
@@ -5525,7 +4894,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_CC_8_000015_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Check on/off attribute value is false after off command"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOnOff * cluster = [[CHIPTestOnOff alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5535,9 +4903,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Check on/off attribute value is false after off command Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] boolValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5547,7 +4913,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5557,9 +4922,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 5);
-
         [expectation fulfill];
     }];
 
@@ -5589,7 +4952,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5599,9 +4961,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 5);
-
         [expectation fulfill];
     }];
 
@@ -5611,7 +4971,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the RO mandatory attribute default: Type"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5621,9 +4980,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the RO mandatory attribute default: Type Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5632,7 +4989,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back the RO mandatory attribute: Type"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5642,9 +4998,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back the RO mandatory attribute: Type Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5653,7 +5007,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the RO mandatory attribute default: ConfigStatus"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5663,9 +5016,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the RO mandatory attribute default: ConfigStatus Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -5674,7 +5025,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000003_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back the RO mandatory attribute: ConfigStatus"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5684,9 +5034,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back the RO mandatory attribute: ConfigStatus Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -5696,7 +5044,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:@"read the RO mandatory attribute default: OperationalStatus"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5706,9 +5053,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the RO mandatory attribute default: OperationalStatus Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5717,7 +5062,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000005_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back the RO mandatory attribute: OperationalStatus"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5727,9 +5071,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back the RO mandatory attribute: OperationalStatus Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5738,7 +5080,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000006_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the RO mandatory attribute default: EndProductType"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5748,9 +5089,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the RO mandatory attribute default: EndProductType Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5759,7 +5098,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000007_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back the RO mandatory attribute: EndProductType"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5769,9 +5107,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back the RO mandatory attribute: EndProductType Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5780,7 +5116,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000008_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the RW mandatory attribute default: Mode"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5790,9 +5125,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the RW mandatory attribute default: Mode Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 0);
-
         [expectation fulfill];
     }];
 
@@ -5801,7 +5134,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000009_WriteAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"write a value into the RW mandatory attribute:: Mode"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5813,7 +5145,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
                              NSLog(@"write a value into the RW mandatory attribute:: Mode Error: %@", err);
 
                              XCTAssertEqual(err.code, 0);
-
                              [expectation fulfill];
                          }];
 
@@ -5822,7 +5153,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_WNCV_2_1_000010_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back the RW mandatory attribute: Mode"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5832,9 +5162,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back the RW mandatory attribute: Mode Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedCharValue], 7);
-
         [expectation fulfill];
     }];
 
@@ -5844,7 +5172,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_BI_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5854,9 +5181,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5886,7 +5211,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_BI_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestBinaryInputBasic * cluster = [[CHIPTestBinaryInputBasic alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5896,9 +5220,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 1);
-
         [expectation fulfill];
     }];
 
@@ -5908,7 +5230,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_TM_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTemperatureMeasurement * cluster = [[CHIPTestTemperatureMeasurement alloc] initWithDevice:device
@@ -5920,9 +5241,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -5931,7 +5250,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_TM_1_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestTemperatureMeasurement * cluster = [[CHIPTestTemperatureMeasurement alloc] initWithDevice:device
@@ -5943,9 +5261,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 3);
-
         [expectation fulfill];
     }];
 
@@ -5955,7 +5271,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OCC_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5965,9 +5280,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"read the global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 2);
-
         [expectation fulfill];
     }];
 
@@ -5976,7 +5289,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTest_TC_OCC_1_1_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
@@ -5986,9 +5298,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertEqual([values[@"value"] unsignedShortValue], 2);
-
         [expectation fulfill];
     }];
 
@@ -5998,7 +5308,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTestOperationalCredentialsCluster_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read number of supported fabrics"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOperationalCredentials * cluster = [[CHIPTestOperationalCredentials alloc] initWithDevice:device
@@ -6010,9 +5319,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Read number of supported fabrics Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] unsignedCharValue], 4);
-
         [expectation fulfill];
     }];
 
@@ -6021,7 +5328,6 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 - (void)testSendClusterTestOperationalCredentialsCluster_000001_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Read number of commissioned fabrics"];
-
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOperationalCredentials * cluster = [[CHIPTestOperationalCredentials alloc] initWithDevice:device
@@ -6033,9 +5339,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
         NSLog(@"Read number of commissioned fabrics Error: %@", err);
 
         XCTAssertEqual(err.code, 0);
-
         XCTAssertGreaterThanOrEqual([values[@"value"] unsignedCharValue], 1);
-
         [expectation fulfill];
     }];
 


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#9677

Seems to not be up to date ZAP wise.