### PR TITLE
Fix file not found error in ManuelTest

### DIFF
--- a/src/test_driver/linux-cirque/ManualTest.py
+++ b/src/test_driver/linux-cirque/ManualTest.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     if not options.topologyFile:
         raise Exception("Must specify a topology file!")
 
-    with open(options.topologyFile, "r") as fp:
+    with open(os.path.join(CHIP_REPO, options.topologyFile), "r") as fp:
         config_operations = [_parse_mount_dir]
         DEVICE_CONFIG = json.load(fp)
         for op in config_operations:


### PR DESCRIPTION
The relative path has changed to the absolute path.

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

#### Problem
* Fix `file not found error` in ManuelTest
```
$ ./scripts/tests/cirque_tests.sh run_test ManualTest -t src/test_driver/linux-cirque/topologies/three_node_with_thread.json
Start Flask
Flask running in backgroud with pid 45390
Traceback (most recent call last):
  File "/home/t25kim/work/connectedhomeip/scripts/tests/../..//src/test_driver/linux-cirque/ManualTest.py", line 126, in <module>
    with open(options.topologyFile, "r") as fp:
FileNotFoundError: [Errno 2] No such file or directory: 'src/test_driver/linux-cirque/topologies/three_node_with_thread.json'
Cleanup Flask pid 45390
Test log can be found at /tmp/tmp.RBArNwYFo6/ManualTest/device_logs
```

#### Change overview
The relative path has changed to the absolute path.

#### Testing
I ran the following test according to README.md.
```
$ ./scripts/tests/cirque_tests.sh run_test ManualTest -t src/test_driver/linux-cirque/topologies/three_node_with_thread.json
```