### PR TITLE
Add _I subtype to operational discovery.

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -24,7 +24,7 @@ using namespace ::chip;
 CHIP_ERROR DiscoverCommissionablesCommand::Run()
 {
     mCommissioner = GetExecContext()->commissioner;
-    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, (uint16_t) 0);
+    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, (uint64_t) 0);
     return mCommissioner->DiscoverCommissionableNodes(filter);
 }
 

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -65,7 +65,7 @@ static CHIP_ERROR discover(bool printHeader)
         streamer_printf(sout, "Discover:        ");
     }
 
-    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, (uint16_t) 0);
+    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, (uint64_t) 0);
     gCommissioner->DiscoverCommissionableNodes(filter);
 
     streamer_printf(sout, "done\r\n");

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -331,7 +331,7 @@ ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::De
 
 ChipError::StorageType pychip_DeviceController_DiscoverAllCommissionableNodes(chip::Controller::DeviceCommissioner * devCtrl)
 {
-    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, static_cast<uint16_t>(0));
+    Mdns::DiscoveryFilter filter(Mdns::DiscoveryFilterType::kNone, static_cast<uint64_t>(0));
     return devCtrl->DiscoverCommissionableNodes(filter).AsInteger();
 }
 

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -52,13 +52,15 @@ static constexpr size_t kKeyPairingInstructionMaxLength      = 128;
 static constexpr size_t kKeyPairingHintMaxLength             = 10;
 
 // Commissionable/commissioner node subtypes
-static constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4; // _S<dd>
-static constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6; // _L<dddd>
-static constexpr size_t kSubTypeVendorMaxLength                  = 7; // _V<ddddd>
-static constexpr size_t kSubTypeDeviceTypeMaxLength              = 5; // _T<ddd>
-static constexpr size_t kSubTypeCommissioningModeMaxLength       = 3; // _C<d>
-static constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3; // _A<d>
-static constexpr size_t kSubTypeMaxNumber                        = 6;
+static constexpr size_t kSubTypeShortDiscriminatorMaxLength      = 4;  // _S<dd>
+static constexpr size_t kSubTypeLongDiscriminatorMaxLength       = 6;  // _L<dddd>
+static constexpr size_t kSubTypeVendorMaxLength                  = 7;  // _V<ddddd>
+static constexpr size_t kSubTypeDeviceTypeMaxLength              = 5;  // _T<ddd>
+static constexpr size_t kSubTypeCommissioningModeMaxLength       = 3;  // _C<d>
+static constexpr size_t kSubTypeAdditionalCommissioningMaxLength = 3;  // _A<d>
+static constexpr size_t kSubTypeCompressedFabricIdMaxLength      = 18; //_I<16-hex-digits>
+// These are the max vals for comissioning adverts
+static constexpr size_t kSubTypeMaxNumber   = 6;
 static constexpr size_t kSubTypeTotalLength = kSubTypeShortDiscriminatorMaxLength + kSubTypeLongDiscriminatorMaxLength +
     kSubTypeVendorMaxLength + kSubTypeDeviceTypeMaxLength + kSubTypeCommissioningModeMaxLength +
     kSubTypeAdditionalCommissioningMaxLength;

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -141,8 +141,8 @@ private:
 
     FullQName GetCommisioningTextEntries(const CommissionAdvertisingParameters & params);
 
-    // Max number of records for operational = PTR, SRV, TXT, A, AAAA, no subtypes.
-    static constexpr size_t kMaxOperationalRecords  = 5;
+    // Max number of records for operational = PTR, SRV, TXT, A, AAAA, I subtype.
+    static constexpr size_t kMaxOperationalRecords  = 6;
     static constexpr size_t kMaxOperationalNetworks = 5;
     QueryResponderAllocator<kMaxOperationalRecords> mQueryResponderAllocatorOperational[kMaxOperationalNetworks];
     // Max number of records for commissionable = 7 x PTR (base + 6 sub types - _S, _L, _D, _T, _C, _A), SRV, TXT, A, AAAA
@@ -277,22 +277,21 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         }
     }
 
-    FullQName operationalServiceName =
-        operationalAllocator->AllocateQName(kOperationalServiceName, kOperationalProtocol, kLocalDomain);
-    FullQName operationalServerName =
+    FullQName serviceName = operationalAllocator->AllocateQName(kOperationalServiceName, kOperationalProtocol, kLocalDomain);
+    FullQName instanceName =
         operationalAllocator->AllocateQName(nameBuffer, kOperationalServiceName, kOperationalProtocol, kLocalDomain);
 
     ReturnErrorOnFailure(MakeHostName(nameBuffer, sizeof(nameBuffer), params.GetMac()));
-    FullQName serverName = operationalAllocator->AllocateQName(nameBuffer, kLocalDomain);
+    FullQName hostName = operationalAllocator->AllocateQName(nameBuffer, kLocalDomain);
 
-    if ((operationalServiceName.nameCount == 0) || (operationalServerName.nameCount == 0) || (serverName.nameCount == 0))
+    if ((serviceName.nameCount == 0) || (instanceName.nameCount == 0) || (hostName.nameCount == 0))
     {
         ChipLogError(Discovery, "Failed to allocate QNames.");
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    if (!operationalAllocator->AddResponder<PtrResponder>(operationalServiceName, operationalServerName)
-             .SetReportAdditional(operationalServerName)
+    if (!operationalAllocator->AddResponder<PtrResponder>(serviceName, instanceName)
+             .SetReportAdditional(instanceName)
              .SetReportInServiceListing(true)
              .IsValid())
     {
@@ -300,22 +299,22 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    if (!operationalAllocator->AddResponder<SrvResponder>(SrvResourceRecord(operationalServerName, serverName, params.GetPort()))
-             .SetReportAdditional(serverName)
+    if (!operationalAllocator->AddResponder<SrvResponder>(SrvResourceRecord(instanceName, hostName, params.GetPort()))
+             .SetReportAdditional(hostName)
              .IsValid())
     {
         ChipLogError(Discovery, "Failed to add SRV record mDNS responder");
         return CHIP_ERROR_NO_MEMORY;
     }
-    if (!operationalAllocator->AddResponder<TxtResponder>(TxtResourceRecord(operationalServerName, mEmptyTextEntries))
-             .SetReportAdditional(serverName)
+    if (!operationalAllocator->AddResponder<TxtResponder>(TxtResourceRecord(instanceName, mEmptyTextEntries))
+             .SetReportAdditional(hostName)
              .IsValid())
     {
         ChipLogError(Discovery, "Failed to add TXT record mDNS responder");
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    if (!operationalAllocator->AddResponder<IPv6Responder>(serverName).IsValid())
+    if (!operationalAllocator->AddResponder<IPv6Responder>(hostName).IsValid())
     {
         ChipLogError(Discovery, "Failed to add IPv6 mDNS responder");
         return CHIP_ERROR_NO_MEMORY;
@@ -323,11 +322,25 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
 
     if (params.IsIPv4Enabled())
     {
-        if (!operationalAllocator->AddResponder<IPv4Responder>(serverName).IsValid())
+        if (!operationalAllocator->AddResponder<IPv4Responder>(hostName).IsValid())
         {
             ChipLogError(Discovery, "Failed to add IPv4 mDNS responder");
             return CHIP_ERROR_NO_MEMORY;
         }
+    }
+    MakeServiceSubtype(nameBuffer, sizeof(nameBuffer),
+                       DiscoveryFilter(DiscoveryFilterType::kCompressedFabricId, params.GetPeerId().GetCompressedFabricId()));
+    FullQName compressedFabricIdSubtype = operationalAllocator->AllocateQName(
+        nameBuffer, kSubtypeServiceNamePart, kOperationalServiceName, kOperationalProtocol, kLocalDomain);
+    ReturnErrorCodeIf(compressedFabricIdSubtype.nameCount == 0, CHIP_ERROR_NO_MEMORY);
+
+    if (!operationalAllocator->AddResponder<PtrResponder>(compressedFabricIdSubtype, instanceName)
+             .SetReportAdditional(instanceName)
+             .SetReportInServiceListing(true)
+             .IsValid())
+    {
+        ChipLogError(Discovery, "Failed to add device type PTR record mDNS responder");
+        return CHIP_ERROR_NO_MEMORY;
     }
 
     ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Operational device'.");
@@ -601,7 +614,7 @@ FullQName AdvertiserMinMdns::GetCommisioningTextEntries(const CommissionAdvertis
     {
         return allocator->AllocateQNameFromArray(txtFields, numTxtFields);
     }
-} // namespace
+}
 
 bool AdvertiserMinMdns::ShouldAdvertiseOn(const chip::Inet::InterfaceId id, const chip::Inet::IPAddress & addr)
 {

--- a/src/lib/mdns/Resolver.h
+++ b/src/lib/mdns/Resolver.h
@@ -208,16 +208,17 @@ enum class DiscoveryFilterType : uint8_t
     kDeviceType,
     kCommissioningMode,
     kInstanceName,
-    kCommissioner
+    kCommissioner,
+    kCompressedFabricId,
 };
 struct DiscoveryFilter
 {
     DiscoveryFilterType type;
-    uint16_t code;
+    uint64_t code;
     const char * instanceName;
     DiscoveryFilter() : type(DiscoveryFilterType::kNone), code(0) {}
     DiscoveryFilter(DiscoveryFilterType newType) : type(newType) {}
-    DiscoveryFilter(DiscoveryFilterType newType, uint16_t newCode) : type(newType), code(newCode) {}
+    DiscoveryFilter(DiscoveryFilterType newType, uint64_t newCode) : type(newType), code(newCode) {}
     DiscoveryFilter(DiscoveryFilterType newType, const char * newInstanceName) : type(newType), instanceName(newInstanceName) {}
 };
 enum class DiscoveryType

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_S%u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_S%" PRIu64, subtype.code);
         break;
     case DiscoveryFilterType::kLong:
         // 12-bit number
@@ -111,16 +111,18 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_L%u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_L%" PRIu64, subtype.code);
         break;
     case DiscoveryFilterType::kVendor:
-        // Vendor ID is 16-bit, so if it fits in the code, it's good.
-        // NOTE: size here is wrong, will be changed in upcming PR to remove leading zeros.
-        requiredSize = snprintf(buffer, bufferLen, "_V%u", subtype.code);
+        if (subtype.code >= 1 << 16)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        requiredSize = snprintf(buffer, bufferLen, "_V%" PRIu64, subtype.code);
         break;
     case DiscoveryFilterType::kDeviceType:
         // TODO: Not totally clear the size required here: see spec issue #3226
-        requiredSize = snprintf(buffer, bufferLen, "_T%u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_T%" PRIu64, subtype.code);
         break;
     case DiscoveryFilterType::kCommissioningMode:
         requiredSize = snprintf(buffer, bufferLen, "_CM");
@@ -130,7 +132,10 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_D%u", subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_D%" PRIu64, subtype.code);
+        break;
+    case DiscoveryFilterType::kCompressedFabricId:
+        requiredSize = snprintf(buffer, bufferLen, "_I%" PRIX64, subtype.code);
         break;
     case DiscoveryFilterType::kInstanceName:
         requiredSize = snprintf(buffer, bufferLen, "%s", subtype.instanceName);
@@ -174,6 +179,11 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
         {
             requiredSize =
                 snprintf(buffer + subtypeLen, bufferLen - subtypeLen, ".%s.%s", kSubtypeServiceNamePart, kCommissionerServiceName);
+        }
+        else if (type == DiscoveryType::kOperational)
+        {
+            requiredSize =
+                snprintf(buffer + subtypeLen, bufferLen - subtypeLen, ".%s.%s", kSubtypeServiceNamePart, kOperationalServiceName);
         }
         else
         {

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_S%" PRIu64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_S%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kLong:
         // 12-bit number
@@ -111,18 +111,18 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_L%" PRIu64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_L%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kVendor:
         if (subtype.code >= 1 << 16)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_V%" PRIu64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_V%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kDeviceType:
         // TODO: Not totally clear the size required here: see spec issue #3226
-        requiredSize = snprintf(buffer, bufferLen, "_T%" PRIu64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_T%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kCommissioningMode:
         requiredSize = snprintf(buffer, bufferLen, "_CM");
@@ -132,10 +132,12 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        requiredSize = snprintf(buffer, bufferLen, "_D%" PRIu64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_D%" PRIu16, static_cast<uint16_t>(subtype.code));
         break;
     case DiscoveryFilterType::kCompressedFabricId:
-        requiredSize = snprintf(buffer, bufferLen, "_I%" PRIX64, subtype.code);
+        requiredSize = snprintf(buffer, bufferLen, "_I");
+        return Encoding::BytesToHex(subtype.code, &buffer[requiredSize], bufferLen - requiredSize,
+                                    Encoding::HexFlags::kUppercaseAndNullTerminate);
         break;
     case DiscoveryFilterType::kInstanceName:
         requiredSize = snprintf(buffer, bufferLen, "%s", subtype.instanceName);

--- a/src/lib/mdns/ServiceNaming.h
+++ b/src/lib/mdns/ServiceNaming.h
@@ -27,7 +27,7 @@
 
 namespace chip {
 namespace Mdns {
-constexpr size_t kMaxSubtypeDescSize           = 19; // _I service subtype.
+constexpr size_t kMaxSubtypeDescSize           = 19; // _I service subtype = 16 chars for 64-bit id, + 2 for "_I" + nullchar
 constexpr char kSubtypeServiceNamePart[]       = "_sub";
 constexpr char kCommissionableServiceName[]    = "_matterc";
 constexpr char kOperationalServiceName[]       = "_matter";

--- a/src/lib/mdns/ServiceNaming.h
+++ b/src/lib/mdns/ServiceNaming.h
@@ -27,7 +27,7 @@
 
 namespace chip {
 namespace Mdns {
-constexpr size_t kMaxSubtypeDescSize           = 16; // max 16 char service name
+constexpr size_t kMaxSubtypeDescSize           = 19; // _I service subtype.
 constexpr char kSubtypeServiceNamePart[]       = "_sub";
 constexpr char kCommissionableServiceName[]    = "_matterc";
 constexpr char kOperationalServiceName[]       = "_matter";

--- a/src/lib/mdns/minimal/tests/CheckOnlyServer.h
+++ b/src/lib/mdns/minimal/tests/CheckOnlyServer.h
@@ -88,6 +88,10 @@ public:
         if (!header.GetFlags().IsTruncated())
         {
             NL_TEST_ASSERT(mInSuite, mTotalRecords == GetNumExpectedRecords());
+            if (mTotalRecords != GetNumExpectedRecords())
+            {
+                ChipLogError(Discovery, "Received %d records, expected %d", mTotalRecords, GetNumExpectedRecords());
+            }
             mHeaderFound = true;
         }
     }

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -64,6 +64,13 @@ const QNamePart kInstanceNameParts2[]           = { "5555666677778888-1212343456
 const FullQName kInstanceName2                  = FullQName(kInstanceNameParts2);
 const QNamePart kTxtRecordEmptyParts[]          = { "=" };
 const FullQName kTxtRecordEmptyName             = FullQName(kTxtRecordEmptyParts);
+const QNamePart kCompressedIdSubParts1[]        = { "_IBEEFBEEFF00DF00D", "_sub", "_matter", "_tcp", "local" };
+FullQName kCompressedIdSubName1                 = FullQName(kCompressedIdSubParts1);
+const QNamePart kCompressedIdSubParts2[]        = { "_I5555666677778888", "_sub", "_matter", "_tcp", "local" };
+FullQName kCompressedIdSubName2                 = FullQName(kCompressedIdSubParts2);
+PtrResourceRecord ptrServiceSubCompressedId1    = PtrResourceRecord(kDnsSdQueryName, kCompressedIdSubName1);
+PtrResourceRecord ptrServiceSubCompressedId2    = PtrResourceRecord(kDnsSdQueryName, kCompressedIdSubName2);
+
 OperationalAdvertisingParameters operationalParams1 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId1).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams2 =
@@ -206,6 +213,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     // Test for PTR response to _services request.
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
     server.AddExpectedRecord(&ptrOperationalService);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId1);
     NL_TEST_ASSERT(inSuite, SendQuery(kDnsSdQueryName) == CHIP_NO_ERROR);
 
     // These check that the requested records added are sent out correctly.
@@ -242,6 +250,7 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
     server.Reset();
     server.AddExpectedRecord(&ptrOperationalService);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId1);
     NL_TEST_ASSERT(inSuite, SendQuery(kDnsSdQueryName) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, server.GetHeaderFound());
@@ -266,6 +275,8 @@ void OperationalAdverts(nlTestSuite * inSuite, void * inContext)
     ChipLogProgress(Discovery, "Checking response to _services._dns-sd._udp.local");
     server.AddExpectedRecord(&ptrOperationalService);
     server.AddExpectedRecord(&ptrOperationalService);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId1);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId2);
     NL_TEST_ASSERT(inSuite, SendQuery(kDnsSdQueryName) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, server.GetHeaderFound());
@@ -447,6 +458,8 @@ void CommissionableAndOperationalAdverts(nlTestSuite * inSuite, void * inContext
     server.AddExpectedRecord(&ptrServiceSubCM);
     server.AddExpectedRecord(&ptrServiceSubVendor);
     server.AddExpectedRecord(&ptrServiceSubDeviceType);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId1);
+    server.AddExpectedRecord(&ptrServiceSubCompressedId2);
     NL_TEST_ASSERT(inSuite, SendQuery(kDnsSdQueryName) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, server.GetHeaderFound());

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -48,6 +48,7 @@ test::ExpectedCall operationalCall1 = test::ExpectedCall()
                                           .SetServiceName("_matter")
                                           .SetInstanceName("BEEFBEEFF00DF00D-1111222233334444")
                                           .SetHostName(host)
+                                          .AddSubtype("_IBEEFBEEFF00DF00D")
                                           .AddTxt("CRI", "32")
                                           .AddTxt("CRA", "33");
 OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingParameters()
@@ -61,6 +62,7 @@ test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetServiceName("_matter")
                                           .SetInstanceName("5555666677778888-1212343456567878")
                                           .SetHostName(host)
+                                          .AddSubtype("_I5555666677778888")
                                           .AddTxt("CRI", "32")
                                           .AddTxt("CRA", "33");
 

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -18,7 +18,7 @@
 #include "BytesToHex.h"
 
 #include <cstring>
-
+#include <stdio.h>
 namespace chip {
 namespace Encoding {
 
@@ -109,6 +109,18 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_he
     }
 
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BytesToHex(uint64_t src, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags)
+{
+    uint8_t buf[8];
+    for (int i = 7; i >= 0; --i)
+    {
+        buf[i] = src & 0xFF;
+        src    = src >> 8;
+    }
+
+    return BytesToHex(buf, 8, dest_hex, dest_size_max, flags);
 }
 
 size_t HexToBytes(const char * srcHex, const size_t srcLen, uint8_t * destBytes, size_t destMaxLen)

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -72,6 +72,36 @@ enum class HexFlags : int
 
 CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags);
 
+/**
+ * Encode a uin64_t into hexadecimal, with or without null-termination
+ * and using either lowercase or uppercase hex.
+ *
+ * Default is lowercase output, not null-terminated.
+ *
+ * If `flags` has `HexFlags::kNullTerminate` set, treat `dest_hex` as a
+ * null-terminated string buffer. The function returns CHIP_ERROR_BUFFER_TOO_SMALL
+ * if `dest_size_max` can't fit the entire encoded buffer, and the
+ * null-terminator if enabled. This function will never output truncated data.
+ * The result either fits and is written, or does not fit and nothing is written
+ * to `dest_hex`.
+ *
+ * On success, number of bytes written to destination is always
+ *   output_size = 16 + ((flags & HexFlags::kNullTerminate) ? 1 : 0);
+ *
+ * @param src_bytes Pointer to non-null buffer to convert
+ * @param src_size Number of bytes to convert from src_bytes
+ * @param [out] dest_hex Destination buffer to receive hex encoding
+ * @param dest_size_max Maximum buffer size for the hex encoded `dest_hex` buffer
+ *                      including null-terminator if needed.
+ * @param flags Flags from `HexFlags` for formatting options
+ *
+ * @return CHIP_ERROR_BUFFER_TOO_SMALL on dest_max_size too small to fit output
+ * @return CHIP_ERROR_INVALID_ARGUMENT if either src_bytes or dest_hex is nullptr
+ * @return CHIP_NO_ERROR on success
+ */
+
+CHIP_ERROR BytesToHex(uint64_t src, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags);
+
 // Alias for Uppercase option, no null-termination
 inline CHIP_ERROR BytesToUppercaseHexBuffer(const uint8_t * src_bytes, size_t src_size, char * dest_hex_buf, size_t dest_size_max)
 {

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -88,8 +88,7 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_he
  * On success, number of bytes written to destination is always
  *   output_size = 16 + ((flags & HexFlags::kNullTerminate) ? 1 : 0);
  *
- * @param src_bytes Pointer to non-null buffer to convert
- * @param src_size Number of bytes to convert from src_bytes
+ * @param src 64-bit number to convert
  * @param [out] dest_hex Destination buffer to receive hex encoding
  * @param dest_size_max Maximum buffer size for the hex encoded `dest_hex` buffer
  *                      including null-terminator if needed.

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -190,10 +190,51 @@ void TestBytesToHexErrors(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+void TestBytesToHexUint64(nlTestSuite * inSuite, void * inContext)
+{
+    // Different values in each byte and each nibble should let us know if the conversion is correct.
+    uint64_t test = 0x0123456789ABCDEF;
+    char buf[17];
+    char upperExpected[] = "0123456789ABCDEF";
+    char lowerExpected[] = "0123456789abcdef";
+
+    // Lower case.
+    memset(buf, 1, sizeof(buf));
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf), HexFlags::kNone) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, memcmp(buf, lowerExpected, strlen(lowerExpected)) == 0);
+    // No null termination.
+    NL_TEST_ASSERT(inSuite, buf[16] == 1);
+
+    // Upper case.
+    memset(buf, 1, sizeof(buf));
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf), HexFlags::kUppercase) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, memcmp(buf, upperExpected, strlen(upperExpected)) == 0);
+    // No null termination.
+    NL_TEST_ASSERT(inSuite, buf[16] == 1);
+
+    // Lower case with null termination.
+    memset(buf, 1, sizeof(buf));
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf), HexFlags::kNullTerminate) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, memcmp(buf, lowerExpected, sizeof(lowerExpected)) == 0);
+
+    // Upper case with null termination.
+    memset(buf, 1, sizeof(buf));
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf), HexFlags::kUppercaseAndNullTerminate) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, memcmp(buf, upperExpected, sizeof(upperExpected)) == 0);
+
+    // Too small buffer
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf) - 2, HexFlags::kNone) == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf) - 2, HexFlags::kUppercase) == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite, BytesToHex(test, buf, sizeof(buf) - 1, HexFlags::kNullTerminate) == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite,
+                   BytesToHex(test, buf, sizeof(buf) - 1, HexFlags::kUppercaseAndNullTerminate) == CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
 const nlTest sTests[] = {
     NL_TEST_DEF("TestBytesToHexNotNullTerminated", TestBytesToHexNotNullTerminated), //
     NL_TEST_DEF("TestBytesToHexNullTerminated", TestBytesToHexNullTerminated),       //
     NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                       //
+    NL_TEST_DEF("TestBytesToHexUint64", TestBytesToHexUint64),                       //
     NL_TEST_SENTINEL()                                                               //
 };
 


### PR DESCRIPTION
#### Problem
Spec updates added a _I subtype to operational discovery advertisements that is meant to be used to search for devices in a particular fabric. Original code was written before this was added, so this was not handled in the SDK.

#### Change overview
Add _I subtype to the discovery filter and service naming code, adds _I to operational network advertisements in minimal and platform. Also changes names in minimal mdns advertising to match dns-sd spec. Adds tests for service naming and advertisers

#### Testing
- service naming unit tests in TestServiceNaming
- minimal adverts tested in TestAdvertiser
- platform adverts tested in TestPlatform
- tested manually on linux lighting app using avahi
