### PR TITLE
Close commissioning window after 20 failed commissioning attempts

### DIFF
--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -77,7 +77,7 @@ private:
 
     CHIP_ERROR StopAdvertisement();
 
-    CHIP_ERROR PrepareCommissioningWindow(uint16_t commissioningTimeoutSeconds, uint16_t & allocatedSessionID);
+    CHIP_ERROR OpenCommissioningWindow();
 
     AppDelegate * mAppDelegate = nullptr;
     Server * mServer           = nullptr;
@@ -90,6 +90,18 @@ private:
 
     SessionIDAllocator * mIDAllocator = nullptr;
     PASESession mPairingSession;
+
+    uint16_t mCommissioningTimeoutSeconds = 0;
+
+    uint8_t mFailedCommissioningAttempts = 0;
+
+    bool mUseECM = false;
+    PASEVerifier mECMPASEVerifier;
+    uint16_t mECMDiscriminator = 0;
+    uint16_t mECMPasscodeID    = 0;
+    uint32_t mECMIterations    = 0;
+    uint32_t mECMSaltLength    = 0;
+    uint8_t mECMSalt[kPBKDFMaximumSaltLen];
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
As per spec, the commissioning window should be closed after 20 failed commissioning attempts.
The current code doesn't implement this logic. The advertisements stop after 1 failed attempt of commissioning.

#### Change overview

- Track number of consecutive failed commissioning attempts
- Reopen commissioning window if failed attempts do not cross threshold
- Once the limit is crossed, close the commissioning window
- The admin/controller can reopen the window, at which time the count of failed attempts will reset to 0

#### Testing
Tested using chip-tool controller app and all-cluster-app server app. Induced commissioning failures using incorrect setup PIN code. Confirmed that the commissioning can be performed if number of failed attempts is less than 20. If the test is repeated by inducing failures 20 times, the window closes (and commissioning cannot be performed by using the correct PIN afterwards).  