### PR TITLE
Ignore location param in QueryImage until Span is supported in ember

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -97,7 +97,7 @@ void OTAProviderExample::SetOTAFilePath(const char * path)
 
 EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * commandObj, uint16_t vendorId, uint16_t productId,
                                                    uint16_t imageType, uint16_t hardwareVersion, uint32_t currentVersion,
-                                                   uint8_t protocolsSupported, const chip::ByteSpan & location,
+                                                   uint8_t protocolsSupported, const chip::Span<const char> & location,
                                                    bool clientCanConsent, const chip::ByteSpan & metadataForServer)
 {
     // TODO: add confiuration for returning BUSY status

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -36,7 +36,7 @@ public:
     // Inherited from OTAProviderDelegate
     EmberAfStatus HandleQueryImage(chip::app::CommandHandler * commandObj, uint16_t vendorId, uint16_t productId,
                                    uint16_t imageType, uint16_t hardwareVersion, uint32_t currentVersion,
-                                   uint8_t protocolsSupported, const chip::ByteSpan & location, bool clientCanConsent,
+                                   uint8_t protocolsSupported, const chip::Span<const char> & location, bool clientCanConsent,
                                    const chip::ByteSpan & metadataForServer) override;
     EmberAfStatus HandleApplyUpdateRequest(chip::app::CommandHandler * commandObj, const chip::ByteSpan & updateToken,
                                            uint32_t newVersion) override;

--- a/src/app/clusters/ota-provider/ota-provider-delegate.h
+++ b/src/app/clusters/ota-provider/ota-provider-delegate.h
@@ -35,7 +35,7 @@ public:
     // TODO(#8605): protocolsSupported should be list of OTADownloadProtocol enums, not uint8_t
     virtual EmberAfStatus HandleQueryImage(CommandHandler * commandObj, uint16_t vendorId, uint16_t productId, uint16_t imageType,
                                            uint16_t hardwareVersion, uint32_t currentVersion, uint8_t protocolsSupported,
-                                           const chip::ByteSpan & location, bool clientCanConsent,
+                                           const chip::Span<const char> & location, bool clientCanConsent,
                                            const chip::ByteSpan & metadataForProvider) = 0;
 
     virtual EmberAfStatus HandleApplyUpdateRequest(CommandHandler * commandObj, const chip::ByteSpan & updateToken,

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -35,7 +35,6 @@ using namespace chip;
 using chip::app::clusters::OTAProviderDelegate;
 
 namespace {
-constexpr uint8_t kLocationParamLength   = 2;   // The expected length of the Location parameter in QueryImage
 constexpr size_t kMaxMetadataLen         = 512; // The maximum length of Metadata in any OTA Provider command
 constexpr size_t kUpdateTokenParamLength = 32;  // The expected length of the Update Token parameter used in multiple commands
 

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -167,20 +167,16 @@ bool emberAfOtaSoftwareUpdateProviderClusterQueryImageCallback(EndpointId endpoi
 
     ChipLogDetail(Zcl, "OTA Provider received QueryImage");
 
-    // TODO: (#7112) change location size checking once CHAR_STRING is supported
-    const size_t locationLen = strlen(reinterpret_cast<char *>(location));
-    if (locationLen != kLocationParamLength)
-    {
-        ChipLogError(Zcl, "expected location length %" PRIu8 ", got %zu", kLocationParamLength, locationLen);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
-    }
-    else if (metadataForProvider.size() > kMaxMetadataLen)
+    // TODO: (#7112) support location param and verify length once CHAR_STRING is supported
+    // Using location parameter is blocked by #5542 (use Span for string arguments). For now, there is no way to safely get the
+    // length of the location string because it is not guaranteed to be null-terminated.
+    Span<const char> locationSpan;
+
+    if (metadataForProvider.size() > kMaxMetadataLen)
     {
         ChipLogError(Zcl, "metadata size %zu exceeds max %zu", metadataForProvider.size(), kMaxMetadataLen);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_ARGUMENT);
     }
-
-    ByteSpan locationSpan(location, locationLen);
 
     status = delegate->HandleQueryImage(commandObj, vendorId, productId, imageType, hardwareVersion, currentVersion,
                                         protocolsSupported, locationSpan, clientCanConsent, metadataForProvider);


### PR DESCRIPTION
#### Problem
* ember passes CHAR_STRING parameters as `uint8_t *` to cluster command handlers
  * this means there is no way to safely get the length of string parameters

#### Change overview
* ignore the `location` string parameter for `QueryImage` for now
* change `QueryImage` delegate handler to take in `Span<const char>` and pass in empty `location` string for now

#### Testing
* tested manually using chip-tool to send QueryImage to `ota-provider-app`
