### PR TITLE
fix to avoid looping indefinitely when moving to finalValue when equal to current value

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -235,7 +235,7 @@ uint16_t ColorControlServer::computeTransitionTimeFromStateAndRate(ColorControlS
     transitionTime *= 10;
     transitionTime /= rate;
 
-    // If transitionTime == 0, force 1 step    
+    // If transitionTime == 0, force 1 step
     transitionTime = std::max(0, transitionTime);
 
     if (transitionTime > MAX_INT16U_VALUE)

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -236,7 +236,7 @@ uint16_t ColorControlServer::computeTransitionTimeFromStateAndRate(ColorControlS
     transitionTime /= rate;
 
     // If transitionTime == 0, force 1 step
-    transitionTime = std::max(0, transitionTime);
+    transitionTime = transitionTime == 0 ? 1 : transitionTime;
 
     if (transitionTime > MAX_INT16U_VALUE)
     {

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -231,17 +231,12 @@ uint16_t ColorControlServer::computeTransitionTimeFromStateAndRate(ColorControlS
         min = p->currentValue;
     }
 
-    // If currentValue == finalValue, force 1 step
-    if (max == min)
-    {
-        transitionTime = 1;
-    }
-    else
-    {
-        transitionTime = max - min;
-        transitionTime *= 10;
-        transitionTime /= rate;
-    }
+    transitionTime = max - min;
+    transitionTime *= 10;
+    transitionTime /= rate;
+
+    // If transitionTime == 0, force 1 step    
+    transitionTime = std::max(0, transitionTime);
 
     if (transitionTime > MAX_INT16U_VALUE)
     {

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -231,9 +231,17 @@ uint16_t ColorControlServer::computeTransitionTimeFromStateAndRate(ColorControlS
         min = p->currentValue;
     }
 
-    transitionTime = max - min;
-    transitionTime *= 10;
-    transitionTime /= rate;
+    // If currentValue == finalValue, force 1 step
+    if (max == min)
+    {
+        transitionTime = 1;
+    }
+    else
+    {
+        transitionTime = max - min;
+        transitionTime *= 10;
+        transitionTime /= rate;
+    }
 
     if (transitionTime > MAX_INT16U_VALUE)
     {


### PR DESCRIPTION
#### Problem
When calculating transitionTime from current value and final value, if current and final value are equal, transitionTime ends up being equal to 0 and causes the application to indefinitely try to get to the final value when current value is equal to the final value.

#### Change overview
Added a check when calculating transitionTime that if current value and final value are the same, sets the transitionTime to 1. This forces the normal execution to happen for one iteration.

#### Testing
* Automated testing to validate that previous features were not affected
* Manual testing to validate specific test case where current and final value are equal
