### PR TITLE
[bluez] Remove filtering by service UUID

### DIFF
--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -273,25 +273,20 @@ int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
         self->RemoveDevice(bluez_object_get_device1(&object));
     }
 
-    /* Search for matter/chip UUID only */
-    GVariantBuilder uuidsBuilder;
-    GVariant * uuids;
-    g_variant_builder_init(&uuidsBuilder, G_VARIANT_TYPE("as"));
-    g_variant_builder_add(&uuidsBuilder, "s", CHIP_BLE_UUID_SERVICE_STRING);
-    uuids = g_variant_builder_end(&uuidsBuilder);
-
-    /* Search for LE only: Advertises */
+    // Search for LE only.
+    // Do NOT add filtering by UUID as it is done by the following kernel function:
+    // https://github.com/torvalds/linux/blob/bdb575f872175ed0ecf2638369da1cb7a6e86a14/net/bluetooth/mgmt.c#L9258.
+    // The function requires that devices advertise its services' UUIDs in UUID16/32/128 fields
+    // while the Matter specification requires only FLAGS (0x01) and SERVICE_DATA_16 (0x16) fields
+    // in the advertisement packets.
     GVariantBuilder filterBuilder;
-    GVariant * filter;
-
     g_variant_builder_init(&filterBuilder, G_VARIANT_TYPE("a{sv}"));
     g_variant_builder_add(&filterBuilder, "{sv}", "Transport", g_variant_new_string("le"));
-    g_variant_builder_add(&filterBuilder, "{sv}", "UUIDs", uuids);
-    filter = g_variant_builder_end(&filterBuilder);
+    GVariant * filter = g_variant_builder_end(&filterBuilder);
 
     if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter, filter, self->mCancellable, &error))
     {
-        /* Not critical: ignore if fails */
+        // Not critical: ignore if fails
         ChipLogError(Ble, "Failed to set discovery filters: %s", error->message);
         g_error_free(error);
     }


### PR DESCRIPTION
#### Problem
Bluez device filtering by service UUID is done by the following Linux kernel function: https://github.com/torvalds/linux/blob/bdb575f872175ed0ecf2638369da1cb7a6e86a14/net/bluetooth/mgmt.c#L9258. The function requires that devices advertise its services' UUIDs in UUID16/32/128 fields while the Matter specification requires only FLAGS (0x01) and SERVICE_DATA_16 (0x16) fields in the advertisement packets. Hence not all spec-compliant devices can be discovered using the current implementation.

#### Change overview
Revert filtering by UUID introduced by https://github.com/project-chip/connectedhomeip/pull/9583

#### Testing
Tested manually with nRF Connect examples which do not advertise UUID16/32/128 fields.
