### PR TITLE
[Android] Support Multi-Admin button to check ECM/BCM/Revoke features

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -30,6 +30,7 @@ import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
 import com.google.chip.chiptool.attestation.AttestationTestFragment
+import com.google.chip.chiptool.clusterclient.MultiAdminClientFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
 import com.google.chip.chiptool.clusterclient.SensorClientFragment
 import com.google.chip.chiptool.echoclient.EchoClientFragment
@@ -120,6 +121,10 @@ class CHIPToolActivity :
 
   override fun handleSensorClicked() {
     showFragment(SensorClientFragment.newInstance())
+  }
+
+  override fun handleMultiAdminClicked() {
+    showFragment(MultiAdminClientFragment.newInstance())
   }
 
   override fun handleAttestationTestClicked() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/SelectActionFragment.kt
@@ -53,6 +53,7 @@ class SelectActionFragment : Fragment() {
       echoClientBtn.setOnClickListener { getCallback()?.handleEchoClientClicked() }
       onOffClusterBtn.setOnClickListener { getCallback()?.handleOnOffClicked() }
       sensorClustersBtn.setOnClickListener{ getCallback()?.handleSensorClicked() }
+      multiAdminClusterBtn.setOnClickListener{ getCallback()?.handleMultiAdminClicked() }
       attestationTestBtn.setOnClickListener { getCallback()?.handleAttestationTestClicked() }
     }
   }
@@ -112,6 +113,8 @@ class SelectActionFragment : Fragment() {
     fun handleOnOffClicked()
     /** Notifies listener of Sensor Clusters button click. */
     fun handleSensorClicked()
+    /** Notifies listener of Multi-admin Clusters button click. */
+    fun handleMultiAdminClicked()
     /** Notifies listener of attestation command button clicked. */
     fun handleAttestationTestClicked()
     /** Notifies listener of a click to manually input the CHIP device address.. */

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -64,10 +64,6 @@ class MultiAdminClientFragment : Fragment() {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
     }
 
-    override fun onSendMessageComplete(message: String?) {
-      multiAdminClusterCommandStatus.text = requireContext().getString(R.string.message_response, message)
-    }
-
     override fun onNotifyChipConnectionClosed() {
       Log.d(TAG, "onNotifyChipConnectionClosed")
     }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -1,19 +1,33 @@
 package com.google.chip.chiptool.clusterclient
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import chip.devicecontroller.ChipClusters
+import chip.devicecontroller.ChipDeviceController
+import com.google.chip.chiptool.ChipClient
+import com.google.chip.chiptool.GenericChipDeviceListener
 import com.google.chip.chiptool.R
+import com.google.chip.chiptool.util.DeviceIdUtil
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClusterFabricIdEd
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClusterDeviceIdEd
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.discriminatorEd
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.setupPinCodeEd
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClustCommandStatus
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.multiAdminClusterUpdateAddressBtn
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.basicCommissioningMethodBtn
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.enhancedCommissioningMethodBtn
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.revokeBtn
+import kotlinx.android.synthetic.main.on_off_client_fragment.*
 import kotlinx.coroutines.*
 
 class MultiAdminClientFragment : Fragment() {
+  private val deviceController: ChipDeviceController
+    get() = ChipClient.getDeviceController(requireContext())
+
   private val scope = CoroutineScope(Dispatchers.Main + Job())
 
   override fun onCreateView(
@@ -22,11 +36,48 @@ class MultiAdminClientFragment : Fragment() {
     savedInstanceState: Bundle?
   ): View {
     return inflater.inflate(R.layout.multi_admin_client_fragment, container, false).apply {
+      deviceController.setCompletionListener(ChipControllerCallback())
 
       multiAdminClusterUpdateAddressBtn.setOnClickListener { updateAddressClick() }
       basicCommissioningMethodBtn.setOnClickListener { scope.launch { sendBasicCommissioningCommandClick() } }
       enhancedCommissioningMethodBtn.setOnClickListener { scope.launch { sendEnhancedCommissioningCommandClick() } }
       revokeBtn.setOnClickListener { scope.launch { sendRevokeCommandClick() } }
+    }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    // TODO: use the fabric ID that was used to commission the device
+    val testFabricId = "5544332211"
+    val testDiscriminaotr = "3840"
+    val testSetupPinCode = 20202021L
+    multiAdminClusterFabricIdEd.setText(testFabricId)
+    multiAdminClusterDeviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
+    discriminatorEd.setText(testDiscriminaotr)
+    setupPinCodeEd.setText(testSetupPinCode.toString())
+  }
+
+  inner class ChipControllerCallback : GenericChipDeviceListener() {
+    override fun onConnectDeviceComplete() {}
+
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+      Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
+    }
+
+    override fun onSendMessageComplete(message: String?) {
+      multiAdminClustCommandStatus.text = requireContext().getString(R.string.echo_status_response, message)
+    }
+
+    override fun onNotifyChipConnectionClosed() {
+      Log.d(TAG, "onNotifyChipConnectionClosed")
+    }
+
+    override fun onCloseBleComplete() {
+      Log.d(TAG, "onCloseBleComplete")
+    }
+
+    override fun onError(error: Throwable?) {
+      Log.d(TAG, "onError: $error")
     }
   }
 
@@ -36,15 +87,46 @@ class MultiAdminClientFragment : Fragment() {
   }
 
   private fun updateAddressClick() {
+    try{
+      deviceController.updateDevice(
+              multiAdminClusterFabricIdEd.text.toString().toULong().toLong(),
+              multiAdminClusterDeviceIdEd.text.toString().toULong().toLong()
+      )
+      showMessage("Address update started")
+    } catch (ex: Exception) {
+      showMessage("Address update failed: $ex")
+    }
   }
 
   private suspend fun sendBasicCommissioningCommandClick() {
+    val testDuration = 100
+    deviceController.openPairingWindow(multiAdminClusterDeviceIdEd.text.toString().toULong().toLong(), testDuration)
   }
 
   private suspend fun sendEnhancedCommissioningCommandClick() {
+    val testDuration = 100
+    val testIteration = 800
+    deviceController.openPairingWindowWithPIN(multiAdminClusterDeviceIdEd.text.toString().toULong().toLong(), testDuration, testIteration,
+            discriminatorEd.text.toString().toInt(),  setupPinCodeEd.text.toString().toULong().toLong())
   }
 
   private suspend fun sendRevokeCommandClick() {
+    getAdministratorCommissioningClusterForDevice().revokeCommissioning(object : ChipClusters.DefaultClusterCallback {
+      override fun onSuccess() {
+        showMessage("Revoke Commissioning success")
+      }
+
+      override fun onError(ex: Exception) {
+        showMessage("Revoke Commissioning  failure $ex")
+        Log.e(TAG, "Revoke Commissioning  failure", ex)
+      }
+    })
+  }
+
+  private suspend fun getAdministratorCommissioningClusterForDevice(): ChipClusters.AdministratorCommissioningCluster {
+    return ChipClusters.AdministratorCommissioningCluster(
+            ChipClient.getConnectedDevicePointer(requireContext(), multiAdminClusterDeviceIdEd.text.toString().toLong()), 0
+    )
   }
 
   private fun showMessage(msg: String) {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -16,7 +16,7 @@ import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClus
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClusterDeviceIdEd
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.discriminatorEd
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.setupPinCodeEd
-import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClustCommandStatus
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClusterCommandStatus
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.multiAdminClusterUpdateAddressBtn
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.basicCommissioningMethodBtn
 import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.enhancedCommissioningMethodBtn
@@ -65,7 +65,7 @@ class MultiAdminClientFragment : Fragment() {
     }
 
     override fun onSendMessageComplete(message: String?) {
-      multiAdminClustCommandStatus.text = requireContext().getString(R.string.echo_status_response, message)
+      multiAdminClusterCommandStatus.text = requireContext().getString(R.string.message_response, message)
     }
 
     override fun onNotifyChipConnectionClosed() {
@@ -131,7 +131,7 @@ class MultiAdminClientFragment : Fragment() {
 
   private fun showMessage(msg: String) {
     requireActivity().runOnUiThread {
-      multiAdminClustCommandStatus.text = msg
+      multiAdminClusterCommandStatus.text = msg
     }
   }
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -1,0 +1,60 @@
+package com.google.chip.chiptool.clusterclient
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.google.chip.chiptool.R
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.multiAdminClustCommandStatus
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.multiAdminClusterUpdateAddressBtn
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.basicCommissioningMethodBtn
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.enhancedCommissioningMethodBtn
+import kotlinx.android.synthetic.main.multi_admin_client_fragment.view.revokeBtn
+import kotlinx.coroutines.*
+
+class MultiAdminClientFragment : Fragment() {
+  private val scope = CoroutineScope(Dispatchers.Main + Job())
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View {
+    return inflater.inflate(R.layout.multi_admin_client_fragment, container, false).apply {
+
+      multiAdminClusterUpdateAddressBtn.setOnClickListener { updateAddressClick() }
+      basicCommissioningMethodBtn.setOnClickListener { scope.launch { sendBasicCommissioningCommandClick() } }
+      enhancedCommissioningMethodBtn.setOnClickListener { scope.launch { sendEnhancedCommissioningCommandClick() } }
+      revokeBtn.setOnClickListener { scope.launch { sendRevokeCommandClick() } }
+    }
+  }
+
+  override fun onStop() {
+    super.onStop()
+    scope.cancel()
+  }
+
+  private fun updateAddressClick() {
+  }
+
+  private suspend fun sendBasicCommissioningCommandClick() {
+  }
+
+  private suspend fun sendEnhancedCommissioningCommandClick() {
+  }
+
+  private suspend fun sendRevokeCommandClick() {
+  }
+
+  private fun showMessage(msg: String) {
+    requireActivity().runOnUiThread {
+      multiAdminClustCommandStatus.text = msg
+    }
+  }
+
+  companion object {
+    private const val TAG = "MultiAdminClientFragment"
+    fun newInstance(): MultiAdminClientFragment = MultiAdminClientFragment()
+  }
+}

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -49,11 +49,11 @@ class MultiAdminClientFragment : Fragment() {
     super.onStart()
     // TODO: use the fabric ID that was used to commission the device
     val testFabricId = "5544332211"
-    val testDiscriminaotr = "3840"
+    val testDiscriminator = "3840"
     val testSetupPinCode = 20202021L
     multiAdminClusterFabricIdEd.setText(testFabricId)
     multiAdminClusterDeviceIdEd.setText(DeviceIdUtil.getLastDeviceId(requireContext()).toString())
-    discriminatorEd.setText(testDiscriminaotr)
+    discriminatorEd.setText(testDiscriminator)
     setupPinCodeEd.setText(testSetupPinCode.toString())
   }
 

--- a/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <EditText
+        android:id="@+id/multiAdminClusterFabricIdEd"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/multiAdminClusterDeviceIdEd"
+        android:inputType="text"
+        android:textSize="20sp"
+        android:hint="@string/enter_fabric_id_hint_text"/>
+
+    <EditText
+        android:id="@+id/multiAdminClusterDeviceIdEd"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/multiAdminClusterFabricIdEd"
+        android:layout_toEndOf="@id/multiAdminClusterFabricIdEd"
+        android:inputType="text"
+        android:textSize="20sp"
+        android:hint="@string/enter_device_id_hint_text"/>
+
+    <Button
+        android:id="@+id/multiAdminClusterUpdateAddressBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:text="@string/update_device_address_btn_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/multiAdminClusterFabricIdEd"/>
+
+    <Button
+        android:id="@+id/basicCommissioningMethodBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:text="@string/basic_commissioning_method_btn_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/multiAdminClusterUpdateAddressBtn"/>
+
+    <EditText
+        android:id="@+id/discriminatorEd"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintEnd_toStartOf="@id/setupPinCodeEd"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/basicCommissioningMethodBtn"
+        android:inputType="text"
+        android:textSize="20sp"
+        android:hint="@string/enter_discriminator_hint_text"/>
+
+    <EditText
+        android:id="@+id/setupPinCodeEd"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/discriminatorEd"
+        app:layout_constraintTop_toBottomOf="@id/basicCommissioningMethodBtn"
+        android:inputType="text"
+        android:textSize="20sp"
+        android:hint="@string/enter_setup_pin_code_hint_text"/>
+
+    <Button
+        android:id="@+id/enhancedCommissioningMethodBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintTop_toBottomOf="@id/discriminatorEd"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="@string/enhanced_commissioning_method_btn_text" />
+
+    <Button
+        android:id="@+id/revokeBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:layout_constraintTop_toBottomOf="@id/enhancedCommissioningMethodBtn"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="@string/revoke_btn_text" />
+
+    <TextView
+        android:id="@+id/multiAdminClustCommandStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@id/revokeBtn"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:singleLine="false"
+        android:minLines="4"
+        android:textSize="20sp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/multi_admin_client_fragment.xml
@@ -95,7 +95,7 @@
         android:text="@string/revoke_btn_text" />
 
     <TextView
-        android:id="@+id/multiAdminClustCommandStatus"
+        android:id="@+id/multiAdminClusterCommandStatus"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="16dp"

--- a/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
@@ -52,6 +52,14 @@
         android:text="@string/sensor_client_btn_text" />
 
     <Button
+        android:id="@+id/multiAdminClusterBtn"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/multi_admin_client_btn_text" />
+
+    <Button
         android:id="@+id/attestationTestBtn"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="sensor_client_last_value_text">Last value: %1$.2f %2$s</string>
     <string name="sensor_client_read_error_text">Failed to read the sensor: %1$s</string>
 
+    <string name="message_response">Received response:\n\n%1$s</string>
     <string name="multi_admin_client_btn_text">Multi-admin cluster</string>
     <string name="basic_commissioning_method_btn_text">Basic Commissioning Method</string>
     <string name="enter_discriminator_hint_text">Enter Discriminator</string>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -92,7 +92,6 @@
     <string name="sensor_client_last_value_text">Last value: %1$.2f %2$s</string>
     <string name="sensor_client_read_error_text">Failed to read the sensor: %1$s</string>
 
-    <string name="message_response">Received response:\n\n%1$s</string>
     <string name="multi_admin_client_btn_text">Multi-admin cluster</string>
     <string name="basic_commissioning_method_btn_text">Basic Commissioning Method</string>
     <string name="enter_discriminator_hint_text">Enter Discriminator</string>

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -92,4 +92,10 @@
     <string name="sensor_client_last_value_text">Last value: %1$.2f %2$s</string>
     <string name="sensor_client_read_error_text">Failed to read the sensor: %1$s</string>
 
+    <string name="multi_admin_client_btn_text">Multi-admin cluster</string>
+    <string name="basic_commissioning_method_btn_text">Basic Commissioning Method</string>
+    <string name="enter_discriminator_hint_text">Enter Discriminator</string>
+    <string name="enter_setup_pin_code_hint_text">Enter Setup PIN Code</string>
+    <string name="enhanced_commissioning_method_btn_text">Enhanced Commissioning Method</string>
+    <string name="revoke_btn_text">Revoke</string>
 </resources>

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -562,20 +562,22 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
     return true;
 }
 
-JNI_METHOD(jboolean, openPairingWindowWithPIN)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration, jint iteration, jint discriminator, jlong setupPinCode)
+JNI_METHOD(jboolean, openPairingWindowWithPIN)
+(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration, jint iteration, jint discriminator, jlong setupPinCode)
 {
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err      = CHIP_NO_ERROR;
     Device * chipDevice = nullptr;
     std::string QRCode;
-    std::string manualPairingCode;    
+    std::string manualPairingCode;
     chip::SetupPayload setupPayload;
     setupPayload.discriminator = discriminator;
-    setupPayload.setUpPINCode = setupPinCode;
+    setupPayload.setUpPINCode  = setupPinCode;
 
     GetCHIPDevice(env, handle, deviceId, &chipDevice);
 
-    err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kTokenWithRandomPIN,setupPayload);
+    err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kTokenWithRandomPIN,
+                                        setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -562,6 +562,30 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
     return true;
 }
 
+JNI_METHOD(jboolean, openPairingWindowWithPIN)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration, jint iteration, jint discriminator, jlong setupPinCode)
+{
+    StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    Device * chipDevice = nullptr;
+    std::string QRCode;
+    std::string manualPairingCode;    
+    chip::SetupPayload setupPayload;
+    setupPayload.discriminator = discriminator;
+    setupPayload.setUpPINCode = setupPinCode;
+
+    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+
+    err = chipDevice->OpenPairingWindow(duration, chip::Controller::Device::CommissioningWindowOption::kTokenWithRandomPIN,setupPayload);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "OpenPairingWindow failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+    }
+
+    return true;
+}
+
 static bool JavaBytesToUUID(JNIEnv * env, jbyteArray value, chip::Ble::ChipBleUUID & uuid)
 {
     const auto valueBegin  = env->GetByteArrayElements(value, nullptr);

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -568,8 +568,6 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
     StackLockGuard lock(JniReferences::GetInstance().GetStackLock());
     CHIP_ERROR err      = CHIP_NO_ERROR;
     Device * chipDevice = nullptr;
-    std::string QRCode;
-    std::string manualPairingCode;
     chip::SetupPayload setupPayload;
     setupPayload.discriminator = discriminator;
     setupPayload.setUpPINCode  = setupPinCode;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -223,9 +223,11 @@ public class ChipDeviceController {
     return openPairingWindow(deviceControllerPtr, deviceId, duration);
   }
 
-  public boolean openPairingWindowWithPIN(long deviceId, int duration, int iteration, int discriminator, long setupPinCode) {
-    return openPairingWindowWithPIN(deviceControllerPtr, deviceId, duration, iteration, discriminator, setupPinCode);
-  }    
+  public boolean openPairingWindowWithPIN(
+      long deviceId, int duration, int iteration, int discriminator, long setupPinCode) {
+    return openPairingWindowWithPIN(
+        deviceControllerPtr, deviceId, duration, iteration, discriminator, setupPinCode);
+  }
 
   public boolean isActive(long deviceId) {
     return isActive(deviceControllerPtr, deviceId);
@@ -270,7 +272,13 @@ public class ChipDeviceController {
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 
-  private native boolean openPairingWindowWithPIN(long deviceControllerPtr, long deviceId, int duration, int iteration, int discriminator, long setupPinCode);
+  private native boolean openPairingWindowWithPIN(
+      long deviceControllerPtr,
+      long deviceId,
+      int duration,
+      int iteration,
+      int discriminator,
+      long setupPinCode);
 
   private native boolean isActive(long deviceControllerPtr, long deviceId);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -223,6 +223,10 @@ public class ChipDeviceController {
     return openPairingWindow(deviceControllerPtr, deviceId, duration);
   }
 
+  public boolean openPairingWindowWithPIN(long deviceId, int duration, int iteration, int discriminator, long setupPinCode) {
+    return openPairingWindowWithPIN(deviceControllerPtr, deviceId, duration, iteration, discriminator, setupPinCode);
+  }    
+
   public boolean isActive(long deviceId) {
     return isActive(deviceControllerPtr, deviceId);
   }
@@ -265,6 +269,8 @@ public class ChipDeviceController {
       long deviceControllerPtr, long deviceId, ChipCommandType command, int value);
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
+
+  private native boolean openPairingWindowWithPIN(long deviceControllerPtr, long deviceId, int duration, int iteration, int discriminator, long setupPinCode);
 
   private native boolean isActive(long deviceControllerPtr, long deviceId);
 


### PR DESCRIPTION
#### Problem
* Need to verify Multi-Admin feature on Android chip-tool 
* TE5 supports Multi-Admin feature including ECM/BCM/Revoke function

#### Change overview
* Create new button to create multi-admin fragment and add ECM/BCM Revoke buttion

#### Testing
* 1st Admin execute IP Commissioning with controllee
* Press Multi-Admin button and Enter ECM/BCM/Revoke
* 2nd execute IP Commissioning with controllee