### PR TITLE
T txt record

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -252,6 +252,11 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
         if (fabricInfo.IsInitialized())
         {
             uint8_t mac[8];
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+            bool tcpSupported = true;
+#else
+            bool tcpSupported = false;
+#endif
 
             const auto advertiseParameters =
                 chip::Mdns::OperationalAdvertisingParameters()
@@ -260,6 +265,7 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
                     .SetPort(GetSecuredPort())
                     .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
                                           Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
+                    .SetTcpSupported(Optional<bool>(tcpSupported))
                     .EnableIpV4(true);
 
             auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
@@ -334,9 +340,16 @@ CHIP_ERROR MdnsServer::Advertise(bool commissionableNode, chip::Mdns::Commission
     ReturnErrorOnFailure(GenerateRotatingDeviceId(rotatingDeviceIdHexBuffer, ArraySize(rotatingDeviceIdHexBuffer)));
     advertiseParameters.SetRotatingId(chip::Optional<const char *>::Value(rotatingDeviceIdHexBuffer));
 #endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    bool tcpSupported = true;
+#else
+    bool tcpSupported = false;
+#endif
 
-    advertiseParameters.SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
-                                             Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL));
+    advertiseParameters
+        .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
+                              Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
+        .SetTcpSupported(Optional<bool>(tcpSupported));
 
     if (mode != chip::Mdns::CommissioningMode::kEnabledEnhanced)
     {

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -252,11 +252,6 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
         if (fabricInfo.IsInitialized())
         {
             uint8_t mac[8];
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-            bool tcpSupported = true;
-#else
-            bool tcpSupported = false;
-#endif
 
             const auto advertiseParameters =
                 chip::Mdns::OperationalAdvertisingParameters()
@@ -265,7 +260,7 @@ CHIP_ERROR MdnsServer::AdvertiseOperational()
                     .SetPort(GetSecuredPort())
                     .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
                                           Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
-                    .SetTcpSupported(Optional<bool>(tcpSupported))
+                    .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
                     .EnableIpV4(true);
 
             auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
@@ -340,16 +335,11 @@ CHIP_ERROR MdnsServer::Advertise(bool commissionableNode, chip::Mdns::Commission
     ReturnErrorOnFailure(GenerateRotatingDeviceId(rotatingDeviceIdHexBuffer, ArraySize(rotatingDeviceIdHexBuffer)));
     advertiseParameters.SetRotatingId(chip::Optional<const char *>::Value(rotatingDeviceIdHexBuffer));
 #endif
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    bool tcpSupported = true;
-#else
-    bool tcpSupported = false;
-#endif
 
     advertiseParameters
         .SetMRPRetryIntervals(Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_INITIAL_RETRY_INTERVAL),
                               Optional<uint32_t>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL))
-        .SetTcpSupported(Optional<bool>(tcpSupported));
+        .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT));
 
     if (mode != chip::Mdns::CommissioningMode::kEnabledEnhanced)
     {

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -104,6 +104,12 @@ public:
         intervalIdle   = mMrpRetryIntervalIdle;
         intervalActive = mMrpRetryIntervalActive;
     }
+    Derived & SetTcpSupported(Optional<bool> tcpSupported)
+    {
+        mTcpSupported = tcpSupported;
+        return *reinterpret_cast<Derived *>(this);
+    }
+    Optional<bool> GetTcpSupported() const { return mTcpSupported; }
 
 private:
     uint16_t mPort                   = CHIP_PORT;
@@ -112,7 +118,8 @@ private:
     size_t mMacLength                = 0;
     Optional<uint32_t> mMrpRetryIntervalIdle;
     Optional<uint32_t> mMrpRetryIntervalActive;
-}; // namespace Mdns
+    Optional<bool> mTcpSupported;
+};
 
 /// Defines parameters required for advertising a CHIP node
 /// over mDNS as an 'operationally ready' node.

--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -144,9 +144,11 @@ private:
 
     struct CommonTxtEntryStorage
     {
-        // CRA and CRI are both 3 chars + '=' = 4 + 1 for nullchar
-        char mrpRetryIntervalIdleBuf[kTxtRetryIntervalIdleMaxLength + 4 + 1];
-        char mrpRetryIntervalActiveBuf[kTxtRetryIntervalActiveMaxLength + 4 + 1];
+        // +2 for all to account for '=' and terminating nullchar
+        char mrpRetryIntervalIdleBuf[KeySize(TxtFieldKey::kMrpRetryIntervalIdle) + ValSize(TxtFieldKey::kMrpRetryIntervalIdle) + 2];
+        char mrpRetryIntervalActiveBuf[KeySize(TxtFieldKey::kMrpRetryIntervalActive) +
+                                       ValSize(TxtFieldKey::kMrpRetryIntervalActive) + 2];
+        char tcpSupportedBuf[KeySize(TxtFieldKey::kTcpSupport) + ValSize(TxtFieldKey::kTcpSupport) + 2];
     };
     template <class Derived>
     CHIP_ERROR AddCommonTxtEntries(const BaseAdvertisingParams<Derived> & params, CommonTxtEntryStorage & storage,
@@ -202,6 +204,14 @@ private:
                                     (writtenCharactersNumber < sizeof(storage.mrpRetryIntervalActiveBuf)),
                                 CHIP_ERROR_INVALID_STRING_LENGTH);
             txtFields[numTxtFields++] = storage.mrpRetryIntervalActiveBuf;
+        }
+        if (params.GetTcpSupported().HasValue())
+        {
+            size_t writtenCharactersNumber =
+                snprintf(storage.tcpSupportedBuf, sizeof(storage.tcpSupportedBuf), "T=%d", params.GetTcpSupported().Value());
+            VerifyOrReturnError((writtenCharactersNumber > 0) && (writtenCharactersNumber < sizeof(storage.tcpSupportedBuf)),
+                                CHIP_ERROR_INVALID_STRING_LENGTH);
+            txtFields[numTxtFields++] = storage.tcpSupportedBuf;
         }
         return CHIP_NO_ERROR;
     }

--- a/src/lib/mdns/TxtFields.cpp
+++ b/src/lib/mdns/TxtFields.cpp
@@ -183,95 +183,55 @@ uint32_t GetRetryInterval(const ByteSpan & value)
 
 TxtFieldKey GetTxtFieldKey(const ByteSpan & key)
 {
-    if (IsKey(key, "D"))
+    for (auto & info : txtFieldInfo)
     {
-        return TxtFieldKey::kLongDiscriminator;
+        if (IsKey(key, info.keyStr))
+        {
+            return info.key;
+        }
     }
-    else if (IsKey(key, "VP"))
-    {
-        return TxtFieldKey::kVendorProduct;
-    }
-    else if (IsKey(key, "CM"))
-    {
-        return TxtFieldKey::kCommissioningMode;
-    }
-    else if (IsKey(key, "DT"))
-    {
-        return TxtFieldKey::kDeviceType;
-    }
-    else if (IsKey(key, "DN"))
-    {
-        return TxtFieldKey::kDeviceName;
-    }
-    else if (IsKey(key, "RI"))
-    {
-        return TxtFieldKey::kRotatingDeviceId;
-    }
-    else if (IsKey(key, "PI"))
-    {
-        return TxtFieldKey::kPairingInstruction;
-    }
-    else if (IsKey(key, "PH"))
-    {
-        return TxtFieldKey::kPairingHint;
-    }
-    else if (IsKey(key, "CRI"))
-    {
-        return TxtFieldKey::kMrpRetryIntervalIdle;
-    }
-    else if (IsKey(key, "CRA"))
-    {
-        return TxtFieldKey::kMrpRetryIntervalActive;
-    }
-    else if (IsKey(key, "T"))
-    {
-        return TxtFieldKey::kTcpSupport;
-    }
-    else
-    {
-        return TxtFieldKey::kUnknown;
-    }
+    return TxtFieldKey::kUnknown;
 }
 
 } // namespace Internal
 
 void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DiscoveredNodeData & nodeData)
 {
-    Internal::TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
+    TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
     switch (keyType)
     {
-    case Internal::TxtFieldKey::kLongDiscriminator:
+    case TxtFieldKey::kLongDiscriminator:
         nodeData.longDiscriminator = Internal::GetLongDiscriminator(val);
         break;
-    case Internal::TxtFieldKey::kVendorProduct:
+    case TxtFieldKey::kVendorProduct:
         nodeData.vendorId  = Internal::GetVendor(val);
         nodeData.productId = Internal::GetProduct(val);
         break;
-    case Internal::TxtFieldKey::kCommissioningMode:
+    case TxtFieldKey::kCommissioningMode:
         nodeData.commissioningMode = Internal::GetCommissioningMode(val);
         break;
-    case Internal::TxtFieldKey::kDeviceType:
+    case TxtFieldKey::kDeviceType:
         nodeData.deviceType = Internal::GetDeviceType(val);
         break;
-    case Internal::TxtFieldKey::kDeviceName:
+    case TxtFieldKey::kDeviceName:
         Internal::GetDeviceName(val, nodeData.deviceName);
         break;
-    case Internal::TxtFieldKey::kRotatingDeviceId:
+    case TxtFieldKey::kRotatingDeviceId:
         Internal::GetRotatingDeviceId(val, nodeData.rotatingId, &nodeData.rotatingIdLen);
         break;
-    case Internal::TxtFieldKey::kPairingInstruction:
+    case TxtFieldKey::kPairingInstruction:
         Internal::GetPairingInstruction(val, nodeData.pairingInstruction);
         break;
-    case Internal::TxtFieldKey::kPairingHint:
+    case TxtFieldKey::kPairingHint:
         nodeData.pairingHint = Internal::GetPairingHint(val);
         break;
-    case Internal::TxtFieldKey::kMrpRetryIntervalIdle:
+    case TxtFieldKey::kMrpRetryIntervalIdle:
         nodeData.mrpRetryIntervalIdle = Internal::GetRetryInterval(val);
         break;
-    case Internal::TxtFieldKey::kMrpRetryIntervalActive:
+    case TxtFieldKey::kMrpRetryIntervalActive:
         nodeData.mrpRetryIntervalActive = Internal::GetRetryInterval(val);
         break;
-    case Internal::TxtFieldKey::kTcpSupport:
+    case TxtFieldKey::kTcpSupport:
         nodeData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(val);
         break;
     default:
@@ -283,13 +243,13 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedN
 {
     switch (Internal::GetTxtFieldKey(key))
     {
-    case Internal::TxtFieldKey::kMrpRetryIntervalIdle:
+    case TxtFieldKey::kMrpRetryIntervalIdle:
         nodeData.mMrpRetryIntervalIdle = Internal::GetRetryInterval(value);
         break;
-    case Internal::TxtFieldKey::kMrpRetryIntervalActive:
+    case TxtFieldKey::kMrpRetryIntervalActive:
         nodeData.mMrpRetryIntervalActive = Internal::GetRetryInterval(value);
         break;
-    case Internal::TxtFieldKey::kTcpSupport:
+    case TxtFieldKey::kTcpSupport:
         nodeData.mSupportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
         break;
     default:

--- a/src/lib/mdns/TxtFields.h
+++ b/src/lib/mdns/TxtFields.h
@@ -27,8 +27,29 @@
 namespace chip {
 namespace Mdns {
 
-#ifdef CHIP_CONFIG_TEST
-namespace Internal {
+// Operational node TXT entries
+static constexpr size_t kTxtRetryIntervalIdleMaxLength   = 7; // [CRI] 0-3600000
+static constexpr size_t kTxtRetryIntervalActiveMaxLength = 7; // [CRA] 0-3600000
+static constexpr size_t kMaxRetryInterval                = 3600000;
+static constexpr size_t kKeyTcpSupportMaxLength          = 1;
+
+// Commissionable/commissioner node TXT entries
+static constexpr size_t kKeyDiscriminatorMaxLength           = 5;
+static constexpr size_t kKeyVendorProductMaxLength           = 11;
+static constexpr size_t kKeyAdditionalCommissioningMaxLength = 1;
+static constexpr size_t kKeyCommissioningModeMaxLength       = 1;
+static constexpr size_t kKeyDeviceTypeMaxLength              = 5;
+static constexpr size_t kKeyDeviceNameMaxLength              = 32;
+static constexpr size_t kKeyRotatingIdMaxLength              = 100;
+static constexpr size_t kKeyPairingInstructionMaxLength      = 128;
+static constexpr size_t kKeyPairingHintMaxLength             = 10;
+
+enum class TxtKeyUse : uint8_t
+{
+    kNone,
+    kCommon,
+    kCommission,
+};
 
 enum class TxtFieldKey : uint8_t
 {
@@ -45,7 +66,34 @@ enum class TxtFieldKey : uint8_t
     kMrpRetryIntervalIdle,
     kMrpRetryIntervalActive,
     kTcpSupport,
+    kCount,
 };
+
+namespace Internal {
+struct TxtFieldInfo
+{
+    TxtFieldKey key;
+    size_t valMaxSize;
+    char keyStr[4];
+    TxtKeyUse use;
+};
+
+constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCount)] = {
+    { TxtFieldKey::kUnknown, 0, "", TxtKeyUse::kNone },
+    { TxtFieldKey::kLongDiscriminator, kKeyDiscriminatorMaxLength, "D", TxtKeyUse::kCommission },
+    { TxtFieldKey::kVendorProduct, kKeyVendorProductMaxLength, "VP", TxtKeyUse::kCommission },
+    { TxtFieldKey::kAdditionalPairing, kKeyAdditionalCommissioningMaxLength, "AP", TxtKeyUse::kCommission },
+    { TxtFieldKey::kCommissioningMode, kKeyCommissioningModeMaxLength, "CM", TxtKeyUse::kCommission },
+    { TxtFieldKey::kDeviceType, kKeyDeviceTypeMaxLength, "DT", TxtKeyUse::kCommission },
+    { TxtFieldKey::kDeviceName, kKeyDeviceNameMaxLength, "DN", TxtKeyUse::kCommission },
+    { TxtFieldKey::kRotatingDeviceId, kKeyRotatingIdMaxLength, "RI", TxtKeyUse::kCommission },
+    { TxtFieldKey::kPairingInstruction, kKeyPairingInstructionMaxLength, "PI", TxtKeyUse::kCommission },
+    { TxtFieldKey::kPairingHint, kKeyPairingHintMaxLength, "PH", TxtKeyUse::kCommission },
+    { TxtFieldKey::kMrpRetryIntervalIdle, kTxtRetryIntervalIdleMaxLength, "CRI", TxtKeyUse::kCommon },
+    { TxtFieldKey::kMrpRetryIntervalActive, kTxtRetryIntervalActiveMaxLength, "CRA", TxtKeyUse::kCommon },
+    { TxtFieldKey::kTcpSupport, kKeyTcpSupportMaxLength, "T", TxtKeyUse::kCommon },
+};
+#ifdef CHIP_CONFIG_TEST
 
 TxtFieldKey GetTxtFieldKey(const ByteSpan & key);
 
@@ -59,9 +107,80 @@ void GetDeviceName(const ByteSpan & value, char * name);
 void GetRotatingDeviceId(const ByteSpan & value, uint8_t * rotatingId, size_t * len);
 uint16_t GetPairingHint(const ByteSpan & value);
 void GetPairingInstruction(const ByteSpan & value, char * pairingInstruction);
-
-} // namespace Internal
 #endif
+} // namespace Internal
+
+constexpr size_t MaxKeyLen(TxtKeyUse use)
+{
+    size_t max = 0;
+    for (auto & info : Internal::txtFieldInfo)
+    {
+        if (use == info.use)
+        {
+            max = sizeof(info.keyStr) > max ? sizeof(info.keyStr) : max;
+        }
+    }
+    // minus 1 becuase sizeof includes the null terminator.
+    return max - 1;
+}
+constexpr size_t TotalKeyLen(TxtKeyUse use)
+{
+    size_t total = 0;
+    for (auto & info : Internal::txtFieldInfo)
+    {
+        if (use == info.use)
+        {
+            total += sizeof(info.keyStr) - 1;
+        }
+    }
+    return total;
+}
+
+constexpr size_t MaxValueLen(TxtKeyUse use)
+{
+    size_t max = 0;
+    for (auto & info : Internal::txtFieldInfo)
+    {
+        if (use == info.use)
+        {
+            max = info.valMaxSize > max ? info.valMaxSize : max;
+        }
+    }
+    // minus 1 becuase sizeof includes the null terminator.
+    return max - 1;
+}
+constexpr size_t TotalValueLen(TxtKeyUse use)
+{
+    size_t total = 0;
+    for (auto & info : Internal::txtFieldInfo)
+    {
+        if (use == info.use)
+        {
+            total += info.valMaxSize - 1;
+        }
+    }
+    return total;
+}
+constexpr uint8_t KeyCount(TxtKeyUse use)
+{
+    uint8_t count = 0;
+    for (auto & info : Internal::txtFieldInfo)
+    {
+        if (use == info.use)
+        {
+            count++;
+        }
+    }
+    return count;
+}
+constexpr size_t KeySize(TxtFieldKey key)
+{
+    return sizeof(Internal::txtFieldInfo[static_cast<int>(key)].keyStr) - 1;
+}
+constexpr size_t ValSize(TxtFieldKey key)
+{
+    return Internal::txtFieldInfo[static_cast<int>(key)].valMaxSize;
+}
 
 void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DiscoveredNodeData & nodeData);
 void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedNodeData & nodeData);

--- a/src/lib/mdns/minimal/tests/CheckOnlyServer.h
+++ b/src/lib/mdns/minimal/tests/CheckOnlyServer.h
@@ -299,7 +299,7 @@ private:
             found = false;
         }
     };
-    static constexpr size_t kMaxExpectedTxt = 10;
+    static constexpr size_t kMaxExpectedTxt = 11;
     KV mExpectedTxt[kMaxExpectedTxt];
     size_t mNumExpectedTxtRecords = 0;
     size_t mNumReceivedTxtRecords = 0;

--- a/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
+++ b/src/lib/mdns/minimal/tests/TestAdvertiser.cpp
@@ -70,6 +70,7 @@ OperationalAdvertisingParameters operationalParams1 =
         .SetMac(ByteSpan(kMac))
         .SetPort(CHIP_PORT)
         .EnableIpV4(true)
+        .SetTcpSupported(chip::Optional<bool>(false))
         .SetMRPRetryIntervals(chip::Optional<uint32_t>(32), chip::Optional<uint32_t>(33));
 OperationalAdvertisingParameters operationalParams2 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId2).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
@@ -81,7 +82,7 @@ OperationalAdvertisingParameters operationalParams5 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId5).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
 OperationalAdvertisingParameters operationalParams6 =
     OperationalAdvertisingParameters().SetPeerId(kPeerId6).SetMac(ByteSpan(kMac)).SetPort(CHIP_PORT).EnableIpV4(true);
-const QNamePart txtOperational1Parts[]  = { "CRI=32", "CRA=33" };
+const QNamePart txtOperational1Parts[]  = { "CRI=32", "CRA=33", "T=0" };
 PtrResourceRecord ptrOperationalService = PtrResourceRecord(kDnsSdQueryName, kMatterOperationalQueryName);
 PtrResourceRecord ptrOperational1       = PtrResourceRecord(kMatterOperationalQueryName, kInstanceName1);
 SrvResourceRecord srvOperational1       = SrvResourceRecord(kInstanceName1, kHostnameName, CHIP_PORT);
@@ -169,11 +170,12 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeEnhanced =
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetTcpSupported(chip::Optional<bool>(true))
         .SetMRPRetryIntervals(chip::Optional<uint32_t>(3600000),
                               chip::Optional<uint32_t>(3600005)); // 3600005 is more than the max so should be adjusted down
 QNamePart txtCommissionableNodeParamsLargeEnhancedParts[] = { "D=22",          "VP=555+897",       "CM=2",       "DT=25",
                                                               "DN=testy-test", "RI=id_that_spins", "PI=Pair me", "PH=3",
-                                                              "CRA=3600000",   "CRI=3600000" };
+                                                              "CRA=3600000",   "CRI=3600000",      "T=1" };
 FullQName txtCommissionableNodeParamsLargeEnhancedName    = FullQName(txtCommissionableNodeParamsLargeEnhancedParts);
 TxtResourceRecord txtCommissionableNodeParamsLargeEnhanced =
     TxtResourceRecord(instanceName, txtCommissionableNodeParamsLargeEnhancedName);

--- a/src/lib/mdns/platform/tests/TestPlatform.cpp
+++ b/src/lib/mdns/platform/tests/TestPlatform.cpp
@@ -49,14 +49,16 @@ OperationalAdvertisingParameters operationalParams2 = OperationalAdvertisingPara
                                                           .SetMac(ByteSpan(kMac))
                                                           .SetPort(CHIP_PORT)
                                                           .EnableIpV4(true)
-                                                          .SetMRPRetryIntervals(Optional<uint32_t>(32), Optional<uint32_t>(33));
+                                                          .SetMRPRetryIntervals(Optional<uint32_t>(32), Optional<uint32_t>(33))
+                                                          .SetTcpSupported(Optional<bool>(true));
 test::ExpectedCall operationalCall2 = test::ExpectedCall()
                                           .SetProtocol(MdnsServiceProtocol::kMdnsProtocolTcp)
                                           .SetServiceName("_matter")
                                           .SetInstanceName("5555666677778888-1212343456567878")
                                           .SetHostName(host)
                                           .AddTxt("CRI", "32")
-                                          .AddTxt("CRA", "33");
+                                          .AddTxt("CRA", "33")
+                                          .AddTxt("T", "1");
 
 CommissionAdvertisingParameters commissionableNodeParamsSmall =
     CommissionAdvertisingParameters()
@@ -88,6 +90,7 @@ CommissionAdvertisingParameters commissionableNodeParamsLargeBasic =
         .SetPairingInstr(chip::Optional<const char *>("Pair me"))
         .SetProductId(chip::Optional<uint16_t>(897))
         .SetRotatingId(chip::Optional<const char *>("id_that_spins"))
+        .SetTcpSupported(chip::Optional<bool>(true))
         .SetMRPRetryIntervals(
             chip::Optional<uint32_t>(3600000),
             chip::Optional<uint32_t>(3600005)); // 3600005 is over the max, so this should be adjusted by the platform
@@ -104,6 +107,7 @@ test::ExpectedCall commissionableLargeBasic = test::ExpectedCall()
                                                   .AddTxt("RI", "id_that_spins")
                                                   .AddTxt("PI", "Pair me")
                                                   .AddTxt("PH", "3")
+                                                  .AddTxt("T", "1")
                                                   .AddTxt("CRI", "3600000")
                                                   .AddTxt("CRA", "3600000")
                                                   .AddSubtype("_S2")

--- a/src/platform/fake/MdnsImpl.h
+++ b/src/platform/fake/MdnsImpl.h
@@ -166,7 +166,7 @@ struct ExpectedCall
         }
     }
 
-    static constexpr size_t kMaxTxtRecords          = 10;
+    static constexpr size_t kMaxTxtRecords          = 11;
     static constexpr size_t kMaxSubtypes            = 10;
     CallType callType                               = CallType::kUnknown;
     MdnsServiceProtocol protocol                    = MdnsServiceProtocol::kMdnsProtocolUnknown;


### PR DESCRIPTION
#### Problem
Spec update added T txt record to the common txt records section - we weren't handling this in either the commissionable or operational advertisements. Also, I got sick of tracking all the hard coded txt record stuff - attempted to consolidate before adding more to the pile.

#### Change overview
- consolidates txt record sizing into a constexpr function that calculates from a table.
- adds T txt record to operational and commissioning adverts on minimal and platform mdns.

#### Testing
- see unit tests
- confirmed on linux build of lightning app with avahi

