### PR TITLE
Fix MRP to not happen over BTP again.

### DIFF
--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -33,6 +33,8 @@ static_library("transport") {
     "SecureSession.h",
     "SecureSessionMgr.cpp",
     "SecureSessionMgr.h",
+    "SessionHandle.cpp",
+    "SessionHandle.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",
     "TransportMgrBase.h",

--- a/src/transport/SessionHandle.cpp
+++ b/src/transport/SessionHandle.cpp
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <transport/PeerConnectionState.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/SessionHandle.h>
+
+namespace chip {
+
+using namespace Transport;
+
+const PeerAddress * SessionHandle::GetPeerAddress(SecureSessionMgr * ssm) const
+{
+    if (IsSecure())
+    {
+        PeerConnectionState * state = ssm->GetPeerConnectionState(*this);
+        if (state == nullptr)
+        {
+            return nullptr;
+        }
+
+        return &state->GetPeerAddress();
+    }
+
+    return &GetUnauthenticatedSession()->GetPeerAddress();
+}
+
+} // namespace chip

--- a/src/transport/SessionHandle.h
+++ b/src/transport/SessionHandle.h
@@ -17,7 +17,12 @@
 
 #pragma once
 
+#include <app/util/basic-types.h>
+#include <lib/core/NodeId.h>
+#include <lib/core/Optional.h>
+#include <transport/FabricTable.h>
 #include <transport/UnauthenticatedSessionTable.h>
+#include <transport/raw/PeerAddress.h>
 
 namespace chip {
 
@@ -67,7 +72,12 @@ public:
     const Optional<uint16_t> & GetPeerSessionId() const { return mPeerSessionId; }
     const Optional<uint16_t> & GetLocalSessionId() const { return mLocalSessionId; }
 
-    Transport::UnauthenticatedSessionHandle GetUnauthenticatedSession() { return mUnauthenticatedSessionHandle.Value(); }
+    // Return the peer address for this session.  May return null if the peer
+    // address is not known.  This can happen for secure sessions that have been
+    // torn down, at the very least.
+    const Transport::PeerAddress * GetPeerAddress(SecureSessionMgr * ssm) const;
+
+    Transport::UnauthenticatedSessionHandle GetUnauthenticatedSession() const { return mUnauthenticatedSessionHandle.Value(); }
 
 private:
     friend class SecureSessionMgr;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -23,6 +23,8 @@
 #include <lib/support/ReferenceCountedHandle.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <system/TimeSource.h>
+#include <transport/MessageCounter.h>
+#include <transport/PeerMessageCounter.h>
 #include <transport/raw/PeerAddress.h>
 
 namespace chip {


### PR DESCRIPTION
We were incorrectly doing MRP over BTP, because there was no peer
connection state for our insecure session when doing a SPAKE
handshake.

The various header include additions were needed to fix header files
that used types without declaring them and hence depended on other
headers being included before them.

Fixes https://github.com/project-chip/connectedhomeip/issues/9738

#### Problem
We are doing MRP over BTP, which is very broken because BTP modifies the message packetbuffer before sending it.

#### Change overview
Go back to not doing MRP over BTP.

#### Testing
Manually did ble-wifi pairing from chip-tool to an m5stack and verified that it works again.