### PR TITLE
Add configuration option for more verbose VerifyOrDie messages.

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2489,5 +2489,15 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+ *
+ * @brief If true, VerifyOrDie() calls with no message will use an
+ *        automatically generated message that makes it clear what failed.
+ */
+#ifndef CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+#define CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE 0
+#endif
+
+/**
  * @}
  */

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -28,6 +28,7 @@
 
 #ifdef __cplusplus
 
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -493,7 +494,12 @@ inline void chipDie(void)
  *  @sa #chipDie
  *
  */
+#if CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
+#define VerifyOrDie(aCondition)                                                                                                    \
+    nlABORT_ACTION(aCondition, ChipLogDetail(Support, "VerifyOrDie failure at %s:%d: %s", __FILE__, __LINE__, #aCondition))
+#else // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 #define VerifyOrDie(aCondition) nlABORT(aCondition)
+#endif // CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE
 
 /**
  *  @def VerifyOrDieWithMsg(aCondition, aModule, aMessage, ...)

--- a/src/platform/Darwin/CHIPPlatformConfig.h
+++ b/src/platform/Darwin/CHIPPlatformConfig.h
@@ -37,6 +37,8 @@
 #define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
 #define CHIP_CONFIG_ERROR_SOURCE 1
 
+#define CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0

--- a/src/platform/Linux/CHIPPlatformConfig.h
+++ b/src/platform/Linux/CHIPPlatformConfig.h
@@ -41,6 +41,8 @@ using CHIP_CONFIG_PERSISTED_STORAGE_KEY_TYPE = const char *;
 #define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
 #define CHIP_CONFIG_ERROR_SOURCE 1
 
+#define CHIP_CONFIG_VERBOSE_VERIFY_OR_DIE 1
+
 // ==================== Security Adaptations ====================
 
 #define CHIP_CONFIG_USE_OPENSSL_ECC 0


### PR DESCRIPTION
We have a lot of VerifyOrDie with no messages, and when they fail it's
hard to tell what went wrong.  This change adds a configuration option
to automatically generate a verbose message string for VerifyOrDie if
one is not provided.  The option is off by default but enabled for
Darwin and Linux.

Log from a failing unit test without this change:

```
[1631900831920] [73638:57013508] CHIP: [EM] Piggybacking Ack for MessageCounter:0000000D with msg
../../third_party/pigweed/repo/targets/host/run_test: line 18: 73638 Abort trap: 6           "$@"
INF Test 1/1: [FAIL] TestReliableMessageProtocol
```

Log from the same failure with this change:

```
[1631900926163] [79197:57035322] CHIP: [EM] Piggybacking Ack for MessageCounter:0000000D with msg
[1631900926163] [79197:57035322] CHIP: [SPT] VerifyOrDie failure at ../../src/messaging/ReliableMessageMgr.cpp:262: rc != nullptr && !rc->IsOccupied()
../../third_party/pigweed/repo/targets/host/run_test: line 18: 79197 Abort trap: 6           "$@"
INF Test 1/1: [FAIL] TestReliableMessageProtocol
```

#### Problem
See above

#### Change overview
See above

#### Testing
Manually ran a unit test that fails in VerifyOrDie on Mac; see logs above.