### PR TITLE
Fix EFR unit tests

### DIFF
--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -25,17 +25,22 @@ chip_test_suite("tests") {
   test_sources = [
     "TestCHIPDeviceCallbacksMgr.cpp",
     "TestClusterInfo.cpp",
-    "TestCommandInteraction.cpp",
     "TestCommandPathParams.cpp",
     "TestEventLogging.cpp",
     "TestEventPathParams.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
-    "TestReadInteraction.cpp",
-    "TestReportingEngine.cpp",
     "TestStatusResponse.cpp",
-    "TestWriteInteraction.cpp",
   ]
+
+  if (chip_device_platform != "efr32") {
+    test_sources += [
+      "TestCommandInteraction.cpp",
+      "TestReadInteraction.cpp",
+      "TestReportingEngine.cpp",
+      "TestWriteInteraction.cpp",
+    ]
+  }
 
   cflags = [ "-Wconversion" ]
 

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -50,6 +50,7 @@ public:
 
 namespace {
 
+#if INET_CONFIG_ENABLE_IPV4
 void TestGetDiscoveredCommissioner_HappyCase(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
@@ -67,17 +68,6 @@ void TestGetDiscoveredCommissioner_HappyCase(nlTestSuite * inSuite, void * inCon
     NL_TEST_ASSERT(inSuite, inNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->port == 5540);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->numIPs == 1);
-}
-
-void TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr(nlTestSuite * inSuite, void * inContext)
-{
-    MockResolver resolver;
-    CommissionableNodeController controller(&resolver);
-
-    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
-    {
-        NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(i) == nullptr);
-    }
 }
 
 void TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr(nlTestSuite * inSuite, void * inContext)
@@ -124,6 +114,19 @@ void TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode(nlTestSuite 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(1) == nullptr);
 }
 
+#endif // INET_CONFIG_ENABLE_IPV4
+
+void TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr(nlTestSuite * inSuite, void * inContext)
+{
+    MockResolver resolver;
+    CommissionableNodeController controller(&resolver);
+
+    for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
+    {
+        NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(i) == nullptr);
+    }
+}
+
 void TestDiscoverCommissioners_HappyCase(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
@@ -167,10 +170,12 @@ void TestDiscoverCommissioners_FindCommissionersError_ReturnsError(nlTestSuite *
 // clang-format off
 const nlTest sTests[] =
 {
+#if INET_CONFIG_ENABLE_IPV4
     NL_TEST_DEF("TestGetDiscoveredCommissioner_HappyCase", TestGetDiscoveredCommissioner_HappyCase),
-    NL_TEST_DEF("TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr),
-    NL_TEST_DEF("TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr),
     NL_TEST_DEF("TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode", TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode),
+    NL_TEST_DEF("TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr),
+#endif // INET_CONFIG_ENABLE_IPV4
+    NL_TEST_DEF("TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCase", TestDiscoverCommissioners_HappyCase),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter", TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter),
     NL_TEST_DEF("TestDiscoverCommissioners_SetResolverDelegateError_ReturnsError", TestDiscoverCommissioners_SetResolverDelegateError_ReturnsError),

--- a/src/controller/tests/TestDevice.cpp
+++ b/src/controller/tests/TestDevice.cpp
@@ -37,6 +37,7 @@ using namespace chip::Transport;
 using namespace chip::Controller;
 using namespace chip::Messaging;
 
+#if INET_CONFIG_ENABLE_IPV4
 namespace {
 
 using TestTransportMgr = TransportMgr<Transport::UDP>;
@@ -124,3 +125,5 @@ int TestDevice()
 }
 
 CHIP_REGISTER_TEST_SUITE(TestDevice)
+
+#endif // INET_CONFIG_ENABLE_IPV4

--- a/src/lib/mdns/tests/BUILD.gn
+++ b/src/lib/mdns/tests/BUILD.gn
@@ -22,10 +22,13 @@ chip_test_suite("tests") {
   output_name = "libMdnsTests"
 
   test_sources = [
-    "TestMdnsCache.cpp",
     "TestServiceNaming.cpp",
     "TestTxtFields.cpp",
   ]
+
+  if (chip_device_platform != "efr32") {
+    test_sources += [ "TestMdnsCache.cpp" ]
+  }
 
   cflags = [ "-Wconversion" ]
 


### PR DESCRIPTION
#### Problem
EFR32 device side unit tests are failing.


#### Change overview
- Fix use of IPv4 when using IPv6 only.
- Remove tests which are failing to compile.

#### Testing
- Built the tests and ran on EFR32, all 277 tests pass.
