### PR TITLE
include algorithm to avoid implicit declaration of std::min()

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <algorithm>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/CHIPCert.h>
 #include <lib/core/CHIPTLV.h>

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -26,6 +26,7 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+#include <algorithm>
 #include <inttypes.h>
 #include <stddef.h>
 


### PR DESCRIPTION
#### Problem
Some files make use of min() (which is namespaced from std). Clang 3.8 considers this an implicit declaration and requires `#include <algorithm>` to remedy. This causes build breaks when compiling w/ Clang3.8

####  Proposed Solution
add `#include <algorithm>` in files that use std::min()