### PR TITLE
Fixes for open pairing window on chip-tool

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -55,7 +55,8 @@ class PairingCommand : public Command,
 {
 public:
     PairingCommand(const char * commandName, PairingMode mode, PairingNetworkType networkType) :
-        Command(commandName), mPairingMode(mode), mNetworkType(networkType), mRemoteAddr{ IPAddress::Any, INET_NULL_INTERFACEID }
+        Command(commandName), mPairingMode(mode), mNetworkType(networkType), mRemoteAddr{ IPAddress::Any, INET_NULL_INTERFACEID },
+        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
         switch (networkType)
         {
@@ -139,8 +140,7 @@ private:
     CHIP_ERROR PairWithCode(NodeId remoteId, chip::SetupPayload payload);
     CHIP_ERROR PairWithoutSecurity(NodeId remoteId, PeerAddress address);
     CHIP_ERROR Unpair(NodeId remoteId);
-    CHIP_ERROR OpenCommissioningWindow(NodeId remoteId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
-                                       uint8_t option);
+    CHIP_ERROR OpenCommissioningWindow();
 
     void InitCallbacks();
     CHIP_ERROR SetupNetwork();
@@ -177,4 +177,10 @@ private:
     chip::Controller::NetworkCommissioningCluster mCluster;
     chip::EndpointId mEndpointId = 0;
     chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
+
+    static void OnDeviceConnectedFn(void * context, chip::Controller::Device * device);
+    static void OnDeviceConnectionFailureFn(void * context, NodeId deviceId, CHIP_ERROR error);
+
+    chip::Callback::Callback<chip::Controller::OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<chip::Controller::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 };


### PR DESCRIPTION
#### Problem
It looks like the previous version would generate a random nodeid
and then attempt to open the pairing window on that. Issue #9550
indicates a general failure to send commands after provisioning,
but it actually looks like the open pairing window command is the
only one affected. Issue speculates that PersistDevice was not
called, but I confirmed that PersistDevice IS called. However,
the data for a randomly generated node id would not be present
so the symptoms may match.

We also need to connect to the device before sending the open
pairing window command as it is a standard cluster command. 

#### Change overview
Don't generate random id for open pairing window call.
Added calls to connect to the device before opening the pairing window.

#### Testing
Tested command sequence on chip-tool using lightning app on linux
./chip-tool pairing onnetwork 0 20202021 3840 fc00::a 5540
./chip-tool onoff on 1
./chip-tool pairing open-commissioning-window 0 5000 1 3840
./chip-tool pairing onnetwork 0 20202021 3840 fc00::a 5540
./chip-tool onoff on 1
