### PR TITLE
Modifying yamls to remove the disabled tag from the steps which have writeAttribute commands and also update the appropriate templates

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_FLW_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:
@@ -38,8 +37,8 @@ tests:
           error: 1
 
     - label: "reads back global attribute: ClusterRevision"
-      command: "readAttribute"
       disabled: true
+      command: "readAttribute"
       attribute: "ClusterRevision"
       response:
           value: 2

--- a/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OCC_1_1.yaml
@@ -28,7 +28,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:
@@ -37,6 +36,7 @@ tests:
           error: 1
 
     - label: "reads back global attribute: ClusterRevision"
+      disabled: true
       command: "readAttribute"
       attribute: "ClusterRevision"
       response:

--- a/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_PCC_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_RH_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TM_1_1.yaml
@@ -28,7 +28,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSUIC_1_1.yaml
@@ -29,7 +29,6 @@ tests:
     - label:
           "write the default values to mandatory global attribute:
           ClusterRevision"
-      disabled: true
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WNCV_1_1.yaml
@@ -31,7 +31,7 @@ tests:
       command: "writeAttribute"
       attribute: "ClusterRevision"
       arguments:
-          value: 2
+          value: 5
       response:
           error: 1
 

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -5577,7 +5577,7 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     CHIPTestWindowCovering * cluster = [[CHIPTestWindowCovering alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    uint16_t clusterRevisionArgument = 2U;
+    uint16_t clusterRevisionArgument = 5U;
     [cluster
         writeAttributeClusterRevisionWithValue:clusterRevisionArgument
                                responseHandler:^(NSError * err, NSDictionary * values) {
@@ -5909,6 +5909,29 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
 
+- (void)testSendClusterTest_TC_FLW_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestFlowMeasurement * cluster = [[CHIPTestFlowMeasurement alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 2U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
 - (void)testSendClusterTest_TC_TM_1_1_000000_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"read the global attribute: ClusterRevision"];
@@ -5932,7 +5955,31 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_TM_1_1_000001_ReadAttribute
+- (void)testSendClusterTest_TC_TM_1_1_000001_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestTemperatureMeasurement * cluster = [[CHIPTestTemperatureMeasurement alloc] initWithDevice:device
+                                                                                             endpoint:1
+                                                                                                queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 3U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+- (void)testSendClusterTest_TC_TM_1_1_000002_ReadAttribute
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
 
@@ -5977,24 +6024,25 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
-- (void)testSendClusterTest_TC_OCC_1_1_000001_ReadAttribute
+- (void)testSendClusterTest_TC_OCC_1_1_000001_WriteAttribute
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"reads back global attribute: ClusterRevision"];
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
 
     CHIPDevice * device = GetPairedDevice(kDeviceId);
     dispatch_queue_t queue = dispatch_get_main_queue();
     CHIPTestOccupancySensing * cluster = [[CHIPTestOccupancySensing alloc] initWithDevice:device endpoint:1 queue:queue];
     XCTAssertNotNil(cluster);
 
-    [cluster readAttributeClusterRevisionWithResponseHandler:^(NSError * err, NSDictionary * values) {
-        NSLog(@"reads back global attribute: ClusterRevision Error: %@", err);
+    uint16_t clusterRevisionArgument = 2U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
 
-        XCTAssertEqual(err.code, 0);
-
-        XCTAssertEqual([values[@"value"] unsignedShortValue], 2);
-
-        [expectation fulfill];
-    }];
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }
@@ -6042,6 +6090,174 @@ bool testSendClusterTestSubscribe_OnOff_000001_WaitForReport_Fulfilled = false;
 
         [expectation fulfill];
     }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_LVL_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestLevelControl * cluster = [[CHIPTestLevelControl alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 4U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_CC_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestColorControl * cluster = [[CHIPTestColorControl alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 4U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_RH_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestRelativeHumidityMeasurement * cluster = [[CHIPTestRelativeHumidityMeasurement alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 1U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_MC_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestRelativeHumidityMeasurement * cluster = [[CHIPTestRelativeHumidityMeasurement alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 1U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_TSTAT_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestThermostat * cluster = [[CHIPTestThermostat alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 5U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_PCC_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestPumpConfigurationAndControl * cluster = [[CHIPTestPumpConfigurationAndControl alloc] initWithDevice:device
+                                                                                                       endpoint:1
+                                                                                                          queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 3U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
+
+    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
+}
+
+- (void)testSendClusterTest_TC_TSUIC_1_1_000000_WriteAttribute
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"write the default values to mandatory global attribute: ClusterRevision"];
+
+    CHIPDevice * device = GetPairedDevice(kDeviceId);
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    CHIPTestThermostatUserInterfaceConfiguration * cluster =
+        [[CHIPTestThermostatUserInterfaceConfiguration alloc] initWithDevice:device endpoint:1 queue:queue];
+    XCTAssertNotNil(cluster);
+
+    uint16_t clusterRevisionArgument = 2U;
+    [cluster
+        writeAttributeClusterRevisionWithValue:clusterRevisionArgument
+                               responseHandler:^(NSError * err, NSDictionary * values) {
+                                   NSLog(@"write the default values to mandatory global attribute: ClusterRevision Error: %@", err);
+
+                                   XCTAssertEqual(err.code, 1);
+                                   [expectation fulfill];
+                               }];
 
     [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
 }

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -19298,7 +19298,7 @@ private:
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        uint16_t clusterRevisionArgument = 2U;
+        uint16_t clusterRevisionArgument = 5U;
         err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel(),
                                                     clusterRevisionArgument);
 
@@ -20440,6 +20440,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterFlowMeasurementCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -20451,11 +20454,76 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterFlowMeasurementCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterFlowMeasurementCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterFlowMeasurementCommandWriteAttribute_0()
+    {
+        ChipLogProgress(
+            chipTool,
+            "Flow Measurement - write the default values to mandatory global attribute: ClusterRevision: Sending command...");
+
+        chip::Controller::FlowMeasurementClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 2U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterFlowMeasurementCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(
+            chipTool,
+            "Flow Measurement - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
+
+        Test_TC_FLW_1_1 * runner = reinterpret_cast<Test_TC_FLW_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterFlowMeasurementCommandWriteAttribute_0_SuccessResponse(void * context, uint16_t clusterRevision)
+    {
+        ChipLogProgress(
+            chipTool,
+            "Flow Measurement - write the default values to mandatory global attribute: ClusterRevision: Success Response");
+
+        Test_TC_FLW_1_1 * runner = reinterpret_cast<Test_TC_FLW_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_TM_1_1 : public TestCommand
@@ -20484,7 +20552,10 @@ public:
             err = TestSendClusterTemperatureMeasurementCommandReadAttribute_0();
             break;
         case 1:
-            err = TestSendClusterTemperatureMeasurementCommandReadAttribute_1();
+            err = TestSendClusterTemperatureMeasurementCommandWriteAttribute_1();
+            break;
+        case 2:
+            err = TestSendClusterTemperatureMeasurementCommandReadAttribute_2();
             break;
         }
 
@@ -20497,7 +20568,7 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 2;
+    const uint16_t mTestCount = 3;
 
     //
     // Tests methods
@@ -20568,34 +20639,40 @@ private:
         runner->NextTest();
     }
 
-    // Test reads back global attribute: ClusterRevision
+    // Test write the default values to mandatory global attribute: ClusterRevision
     using SuccessCallback_1 = void (*)(void * context, uint16_t clusterRevision);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{
-        OnTestSendClusterTemperatureMeasurementCommandReadAttribute_1_SuccessResponse, this
+        OnTestSendClusterTemperatureMeasurementCommandWriteAttribute_1_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
-        OnTestSendClusterTemperatureMeasurementCommandReadAttribute_1_FailureResponse, this
+        OnTestSendClusterTemperatureMeasurementCommandWriteAttribute_1_FailureResponse, this
     };
 
-    bool mIsFailureExpected_1 = 0;
+    bool mIsFailureExpected_1 = 1;
 
-    CHIP_ERROR TestSendClusterTemperatureMeasurementCommandReadAttribute_1()
+    CHIP_ERROR TestSendClusterTemperatureMeasurementCommandWriteAttribute_1()
     {
-        ChipLogProgress(chipTool, "Temperature Measurement - reads back global attribute: ClusterRevision: Sending command...");
+        ChipLogProgress(chipTool,
+                        "Temperature Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Sending command...");
 
         chip::Controller::TemperatureMeasurementClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        uint16_t clusterRevisionArgument = 3U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel(),
+                                                    clusterRevisionArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterTemperatureMeasurementCommandReadAttribute_1_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterTemperatureMeasurementCommandWriteAttribute_1_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Temperature Measurement - reads back global attribute: ClusterRevision: Failure Response");
+        ChipLogProgress(
+            chipTool,
+            "Temperature Measurement - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
 
         Test_TC_TM_1_1 * runner = reinterpret_cast<Test_TC_TM_1_1 *>(context);
 
@@ -20609,14 +20686,74 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterTemperatureMeasurementCommandReadAttribute_1_SuccessResponse(void * context,
+    static void OnTestSendClusterTemperatureMeasurementCommandWriteAttribute_1_SuccessResponse(void * context,
+                                                                                               uint16_t clusterRevision)
+    {
+        ChipLogProgress(
+            chipTool,
+            "Temperature Measurement - write the default values to mandatory global attribute: ClusterRevision: Success Response");
+
+        Test_TC_TM_1_1 * runner = reinterpret_cast<Test_TC_TM_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_1 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    // Test reads back global attribute: ClusterRevision
+    using SuccessCallback_2 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_2> mOnSuccessCallback_2{
+        OnTestSendClusterTemperatureMeasurementCommandReadAttribute_2_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_2{
+        OnTestSendClusterTemperatureMeasurementCommandReadAttribute_2_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_2 = 0;
+
+    CHIP_ERROR TestSendClusterTemperatureMeasurementCommandReadAttribute_2()
+    {
+        ChipLogProgress(chipTool, "Temperature Measurement - reads back global attribute: ClusterRevision: Sending command...");
+
+        chip::Controller::TemperatureMeasurementClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        err = cluster.ReadAttributeClusterRevision(mOnSuccessCallback_2.Cancel(), mOnFailureCallback_2.Cancel());
+
+        return err;
+    }
+
+    static void OnTestSendClusterTemperatureMeasurementCommandReadAttribute_2_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool, "Temperature Measurement - reads back global attribute: ClusterRevision: Failure Response");
+
+        Test_TC_TM_1_1 * runner = reinterpret_cast<Test_TC_TM_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_2 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterTemperatureMeasurementCommandReadAttribute_2_SuccessResponse(void * context,
                                                                                               uint16_t clusterRevision)
     {
         ChipLogProgress(chipTool, "Temperature Measurement - reads back global attribute: ClusterRevision: Success Response");
 
         Test_TC_TM_1_1 * runner = reinterpret_cast<Test_TC_TM_1_1 *>(context);
 
-        if (runner->mIsFailureExpected_1 == true)
+        if (runner->mIsFailureExpected_2 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
@@ -20660,7 +20797,7 @@ public:
             err = TestSendClusterOccupancySensingCommandReadAttribute_0();
             break;
         case 1:
-            err = TestSendClusterOccupancySensingCommandReadAttribute_1();
+            err = TestSendClusterOccupancySensingCommandWriteAttribute_1();
             break;
         }
 
@@ -20743,34 +20880,40 @@ private:
         runner->NextTest();
     }
 
-    // Test reads back global attribute: ClusterRevision
+    // Test write the default values to mandatory global attribute: ClusterRevision
     using SuccessCallback_1 = void (*)(void * context, uint16_t clusterRevision);
     chip::Callback::Callback<SuccessCallback_1> mOnSuccessCallback_1{
-        OnTestSendClusterOccupancySensingCommandReadAttribute_1_SuccessResponse, this
+        OnTestSendClusterOccupancySensingCommandWriteAttribute_1_SuccessResponse, this
     };
     chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_1{
-        OnTestSendClusterOccupancySensingCommandReadAttribute_1_FailureResponse, this
+        OnTestSendClusterOccupancySensingCommandWriteAttribute_1_FailureResponse, this
     };
 
-    bool mIsFailureExpected_1 = 0;
+    bool mIsFailureExpected_1 = 1;
 
-    CHIP_ERROR TestSendClusterOccupancySensingCommandReadAttribute_1()
+    CHIP_ERROR TestSendClusterOccupancySensingCommandWriteAttribute_1()
     {
-        ChipLogProgress(chipTool, "Occupancy Sensing - reads back global attribute: ClusterRevision: Sending command...");
+        ChipLogProgress(
+            chipTool,
+            "Occupancy Sensing - write the default values to mandatory global attribute: ClusterRevision: Sending command...");
 
         chip::Controller::OccupancySensingClusterTest cluster;
         cluster.Associate(mDevice, 1);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = cluster.ReadAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel());
+        uint16_t clusterRevisionArgument = 2U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_1.Cancel(), mOnFailureCallback_1.Cancel(),
+                                                    clusterRevisionArgument);
 
         return err;
     }
 
-    static void OnTestSendClusterOccupancySensingCommandReadAttribute_1_FailureResponse(void * context, uint8_t status)
+    static void OnTestSendClusterOccupancySensingCommandWriteAttribute_1_FailureResponse(void * context, uint8_t status)
     {
-        ChipLogProgress(chipTool, "Occupancy Sensing - reads back global attribute: ClusterRevision: Failure Response");
+        ChipLogProgress(
+            chipTool,
+            "Occupancy Sensing - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
 
         Test_TC_OCC_1_1 * runner = reinterpret_cast<Test_TC_OCC_1_1 *>(context);
 
@@ -20784,22 +20927,17 @@ private:
         runner->NextTest();
     }
 
-    static void OnTestSendClusterOccupancySensingCommandReadAttribute_1_SuccessResponse(void * context, uint16_t clusterRevision)
+    static void OnTestSendClusterOccupancySensingCommandWriteAttribute_1_SuccessResponse(void * context, uint16_t clusterRevision)
     {
-        ChipLogProgress(chipTool, "Occupancy Sensing - reads back global attribute: ClusterRevision: Success Response");
+        ChipLogProgress(
+            chipTool,
+            "Occupancy Sensing - write the default values to mandatory global attribute: ClusterRevision: Success Response");
 
         Test_TC_OCC_1_1 * runner = reinterpret_cast<Test_TC_OCC_1_1 *>(context);
 
         if (runner->mIsFailureExpected_1 == true)
         {
             ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
-            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
-            return;
-        }
-
-        if (clusterRevision != 2U)
-        {
-            ChipLogError(chipTool, "Error: Value mismatch. Expected: '%s'", "2");
             runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
             return;
         }
@@ -21011,6 +21149,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterLevelControlCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21022,11 +21163,74 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterLevelControlCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterLevelControlCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterLevelControlCommandWriteAttribute_0()
+    {
+        ChipLogProgress(
+            chipTool,
+            "Level Control - write the default values to mandatory global attribute: ClusterRevision: Sending command...");
+
+        chip::Controller::LevelControlClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 4U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterLevelControlCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(
+            chipTool, "Level Control - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
+
+        Test_TC_LVL_1_1 * runner = reinterpret_cast<Test_TC_LVL_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterLevelControlCommandWriteAttribute_0_SuccessResponse(void * context, uint16_t clusterRevision)
+    {
+        ChipLogProgress(
+            chipTool, "Level Control - write the default values to mandatory global attribute: ClusterRevision: Success Response");
+
+        Test_TC_LVL_1_1 * runner = reinterpret_cast<Test_TC_LVL_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_CC_1_1 : public TestCommand
@@ -21051,6 +21255,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterColorControlCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21062,11 +21269,74 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterColorControlCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterColorControlCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterColorControlCommandWriteAttribute_0()
+    {
+        ChipLogProgress(
+            chipTool,
+            "Color Control - write the default values to mandatory global attribute: ClusterRevision: Sending command...");
+
+        chip::Controller::ColorControlClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 4U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterColorControlCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(
+            chipTool, "Color Control - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
+
+        Test_TC_CC_1_1 * runner = reinterpret_cast<Test_TC_CC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterColorControlCommandWriteAttribute_0_SuccessResponse(void * context, uint16_t clusterRevision)
+    {
+        ChipLogProgress(
+            chipTool, "Color Control - write the default values to mandatory global attribute: ClusterRevision: Success Response");
+
+        Test_TC_CC_1_1 * runner = reinterpret_cast<Test_TC_CC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_RH_1_1 : public TestCommand
@@ -21091,6 +21361,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21102,11 +21375,77 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0()
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Sending command...");
+
+        chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 1U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Failure Response");
+
+        Test_TC_RH_1_1 * runner = reinterpret_cast<Test_TC_RH_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_SuccessResponse(void * context,
+                                                                                                    uint16_t clusterRevision)
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Success Response");
+
+        Test_TC_RH_1_1 * runner = reinterpret_cast<Test_TC_RH_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_MC_1_1 : public TestCommand
@@ -21131,6 +21470,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21142,11 +21484,77 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0()
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Sending command...");
+
+        chip::Controller::RelativeHumidityMeasurementClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 1U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Failure Response");
+
+        Test_TC_MC_1_1 * runner = reinterpret_cast<Test_TC_MC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterRelativeHumidityMeasurementCommandWriteAttribute_0_SuccessResponse(void * context,
+                                                                                                    uint16_t clusterRevision)
+    {
+        ChipLogProgress(chipTool,
+                        "Relative Humidity Measurement - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Success Response");
+
+        Test_TC_MC_1_1 * runner = reinterpret_cast<Test_TC_MC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_TSTAT_1_1 : public TestCommand
@@ -21171,6 +21579,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterThermostatCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21182,11 +21593,73 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterThermostatCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterThermostatCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterThermostatCommandWriteAttribute_0()
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat - write the default values to mandatory global attribute: ClusterRevision: Sending command...");
+
+        chip::Controller::ThermostatClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 5U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterThermostatCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat - write the default values to mandatory global attribute: ClusterRevision: Failure Response");
+
+        Test_TC_TSTAT_1_1 * runner = reinterpret_cast<Test_TC_TSTAT_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterThermostatCommandWriteAttribute_0_SuccessResponse(void * context, uint16_t clusterRevision)
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat - write the default values to mandatory global attribute: ClusterRevision: Success Response");
+
+        Test_TC_TSTAT_1_1 * runner = reinterpret_cast<Test_TC_TSTAT_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_PCC_1_1 : public TestCommand
@@ -21211,6 +21684,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21222,11 +21698,77 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0()
+    {
+        ChipLogProgress(chipTool,
+                        "Pump Configuration and Control - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Sending command...");
+
+        chip::Controller::PumpConfigurationAndControlClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 3U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0_FailureResponse(void * context, uint8_t status)
+    {
+        ChipLogProgress(chipTool,
+                        "Pump Configuration and Control - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Failure Response");
+
+        Test_TC_PCC_1_1 * runner = reinterpret_cast<Test_TC_PCC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void OnTestSendClusterPumpConfigurationAndControlCommandWriteAttribute_0_SuccessResponse(void * context,
+                                                                                                    uint16_t clusterRevision)
+    {
+        ChipLogProgress(chipTool,
+                        "Pump Configuration and Control - write the default values to mandatory global attribute: ClusterRevision: "
+                        "Success Response");
+
+        Test_TC_PCC_1_1 * runner = reinterpret_cast<Test_TC_PCC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 class Test_TC_TSUIC_1_1 : public TestCommand
@@ -21251,6 +21793,9 @@ public:
         // incorrect mTestIndex value observed when we get the response.
         switch (mTestIndex++)
         {
+        case 0:
+            err = TestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0();
+            break;
         }
 
         if (CHIP_NO_ERROR != err)
@@ -21262,11 +21807,79 @@ public:
 
 private:
     std::atomic_uint16_t mTestIndex;
-    const uint16_t mTestCount = 0;
+    const uint16_t mTestCount = 1;
 
     //
     // Tests methods
     //
+
+    // Test write the default values to mandatory global attribute: ClusterRevision
+    using SuccessCallback_0 = void (*)(void * context, uint16_t clusterRevision);
+    chip::Callback::Callback<SuccessCallback_0> mOnSuccessCallback_0{
+        OnTestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0_SuccessResponse, this
+    };
+    chip::Callback::Callback<DefaultFailureCallback> mOnFailureCallback_0{
+        OnTestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0_FailureResponse, this
+    };
+
+    bool mIsFailureExpected_0 = 1;
+
+    CHIP_ERROR TestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0()
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat User Interface Configuration - write the default values to mandatory global attribute: "
+                        "ClusterRevision: Sending command...");
+
+        chip::Controller::ThermostatUserInterfaceConfigurationClusterTest cluster;
+        cluster.Associate(mDevice, 1);
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        uint16_t clusterRevisionArgument = 2U;
+        err = cluster.WriteAttributeClusterRevision(mOnSuccessCallback_0.Cancel(), mOnFailureCallback_0.Cancel(),
+                                                    clusterRevisionArgument);
+
+        return err;
+    }
+
+    static void OnTestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0_FailureResponse(void * context,
+                                                                                                             uint8_t status)
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat User Interface Configuration - write the default values to mandatory global attribute: "
+                        "ClusterRevision: Failure Response");
+
+        Test_TC_TSUIC_1_1 * runner = reinterpret_cast<Test_TC_TSUIC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == false)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a success callback. Got failure callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
+
+    static void
+    OnTestSendClusterThermostatUserInterfaceConfigurationCommandWriteAttribute_0_SuccessResponse(void * context,
+                                                                                                 uint16_t clusterRevision)
+    {
+        ChipLogProgress(chipTool,
+                        "Thermostat User Interface Configuration - write the default values to mandatory global attribute: "
+                        "ClusterRevision: Success Response");
+
+        Test_TC_TSUIC_1_1 * runner = reinterpret_cast<Test_TC_TSUIC_1_1 *>(context);
+
+        if (runner->mIsFailureExpected_0 == true)
+        {
+            ChipLogError(chipTool, "Error: The test was expecting a failure callback. Got success callback");
+            runner->SetCommandExitStatus(CHIP_ERROR_INTERNAL);
+            return;
+        }
+
+        runner->NextTest();
+    }
 };
 
 void registerCommandsTests(Commands & commands)


### PR DESCRIPTION
Vivien's fix to generate methods for writeAttributes has merged , so modifying the following step from a bunch of the existing yamls

<img width="700" alt="133845254-59686f84-8927-4ddf-ab7b-3593f1c47297" src="https://user-images.githubusercontent.com/84206864/133856278-6a641b87-6005-4f6f-bfe1-2f4e134976b9.png">

Validated with local runs that the response for write commands to Read-only attributes is not a success ,
[1631901443226] [31976:5832212] CHIP: [ZCL] 0x108826064attr not writable


How was this tested? (at least one bullet point required)
Ran the tests locally and they are all passing