### PR TITLE
Treat ENOBUFS as success when doing an MRP send.

### DIFF
--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -80,7 +80,20 @@ CHIP_ERROR ExchangeMessageDispatch::SendMessage(SessionHandle session, uint16_t 
         std::unique_ptr<ReliableMessageMgr::RetransTableEntry, decltype(deleter)> entryOwner(entry, deleter);
 
         ReturnErrorOnFailure(PrepareMessage(session, payloadHeader, std::move(message), entryOwner->retainedBuf));
-        ReturnErrorOnFailure(SendPreparedMessage(session, entryOwner->retainedBuf));
+        CHIP_ERROR err = SendPreparedMessage(session, entryOwner->retainedBuf);
+        if (err == System::MapErrorPOSIX(ENOBUFS))
+        {
+            // sendmsg on BSD-based systems never blocks, no matter how the
+            // socket is configured, and will return ENOBUFS in situation in
+            // which Linux, for example, blocks.
+            //
+            // This is typically a transient situation, so we pretend like this
+            // packet drop happened somewhere on the network instead of inside
+            // sendmsg and will just resend it in the normal MRP way later.
+            ChipLogError(ExchangeManager, "Ignoring ENOBUFS: %" CHIP_ERROR_FORMAT, err.Format());
+            err = CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(err);
         reliableMessageMgr->StartRetransmision(entryOwner.release());
     }
     else


### PR DESCRIPTION
#### Problem
ENOBUFS is a transient send failure on Darwin that we are treating as fatal in all cases.

#### Change overview
Treat it as a success in the narrowly scoped case of an MRP-enabled send, where MRP itself can be used to recover from the transient failure.

The other option would be to do this check in `src/inet/IPEndPointBasis.cpp`, but then we could not restrict it to MRP-only cases.

#### Testing
Did lots of CI retriggers with this change and did not see any more ENOBUFS-caused test failures, nor a higher incidence of other timeout failures.