### PR TITLE
Track file/line for POSIX errors when that's enabled for CHIP_ERROR

### DIFF
--- a/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
+++ b/examples/platform/nrfconnect/util/test/TestInetCommon.cpp
@@ -127,7 +127,7 @@ void ServiceEvents(struct ::timeval & aSleepTime)
     int selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, &aSleepTime);
     if (selectRes < 0)
     {
-        LOG_INF("select failed: %s", ErrorStr(System::MapErrorPOSIX(errno)));
+        LOG_INF("select failed: %s", ErrorStr(CHIP_ERROR_POSIX(errno)));
         return;
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -179,7 +179,7 @@ jint JNI_OnLoad(JavaVM * jvm, void * reserved)
     // Create and start the IO thread.
     sShutdown  = false;
     pthreadErr = pthread_create(&sIOThread, NULL, IOThreadMain, NULL);
-    VerifyOrExit(pthreadErr == 0, err = System::MapErrorPOSIX(pthreadErr));
+    VerifyOrExit(pthreadErr == 0, err = CHIP_ERROR_POSIX(pthreadErr));
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -64,10 +64,10 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
     mShouldRunEventLoop.store(true, std::memory_order_relaxed);
 
     int ret = pthread_cond_init(&mEventQueueStoppedCond, nullptr);
-    VerifyOrReturnError(ret == 0, System::MapErrorPOSIX(ret));
+    VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
 
     ret = pthread_mutex_init(&mStateLock, nullptr);
-    VerifyOrReturnError(ret == 0, System::MapErrorPOSIX(ret));
+    VerifyOrReturnError(ret == 0, CHIP_ERROR_POSIX(ret));
 
     mHasValidChipTask = false;
 
@@ -211,11 +211,11 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
 {
     int err;
     err = pthread_attr_init(&mChipTaskAttr);
-    VerifyOrReturnError(err == 0, System::MapErrorPOSIX(err));
+    VerifyOrReturnError(err == 0, CHIP_ERROR_POSIX(err));
     err = pthread_attr_getschedparam(&mChipTaskAttr, &mChipTaskSchedParam);
-    VerifyOrReturnError(err == 0, System::MapErrorPOSIX(err));
+    VerifyOrReturnError(err == 0, CHIP_ERROR_POSIX(err));
     err = pthread_attr_setschedpolicy(&mChipTaskAttr, SCHED_RR);
-    VerifyOrReturnError(err == 0, System::MapErrorPOSIX(err));
+    VerifyOrReturnError(err == 0, CHIP_ERROR_POSIX(err));
 
     //
     // We need to grab the lock here since we have to protect setting
@@ -233,7 +233,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StartEventLoopTask()
 
     pthread_mutex_unlock(&mStateLock);
 
-    return System::MapErrorPOSIX(err);
+    return CHIP_ERROR_POSIX(err);
 }
 
 template <class ImplClass>
@@ -290,7 +290,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_StopEventLoopTask()
 
 exit:
     mHasValidChipTask = false;
-    return System::MapErrorPOSIX(err);
+    return CHIP_ERROR_POSIX(err);
 }
 
 template <class ImplClass>

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -477,7 +477,7 @@ CHIP_ERROR DNSResolver::ProcessGetAddrInfoResult(int returnCode, struct addrinfo
             err = INET_ERROR_DNS_TRY_AGAIN;
             break;
         case EAI_SYSTEM:
-            err = chip::System::MapErrorPOSIX(errno);
+            err = CHIP_ERROR_POSIX(errno);
             break;
         default:
             err = INET_ERROR_DNS_NO_RECOVERY;

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -198,7 +198,7 @@ static CHIP_ERROR SocketsSetMulticastLoopback(int aSocket, bool aLoopback, int a
     const unsigned int lValue = aLoopback;
     if (setsockopt(aSocket, aProtocol, aOption, &lValue, sizeof(lValue)) != 0)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
 
     return CHIP_NO_ERROR;
@@ -265,7 +265,7 @@ static CHIP_ERROR SocketsIPv4JoinLeaveMulticastGroup(int aSocket, InterfaceId aI
 
     if (setsockopt(aSocket, IPPROTO_IP, aCommand, &lMulticastRequest, sizeof(lMulticastRequest)) != 0)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
     return CHIP_NO_ERROR;
 }
@@ -287,7 +287,7 @@ static CHIP_ERROR SocketsIPv6JoinLeaveMulticastGroup(int aSocket, InterfaceId aI
 
     if (setsockopt(aSocket, IPPROTO_IPV6, aCommand, &lMulticastRequest, sizeof(lMulticastRequest)) != 0)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
     return CHIP_NO_ERROR;
 }
@@ -684,7 +684,7 @@ CHIP_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, const IPAddress & a
         sa.sin6_scope_id = static_cast<decltype(sa.sin6_scope_id)>(aInterfaceId);
 
         if (bind(mSocket, reinterpret_cast<const sockaddr *>(&sa), static_cast<unsigned>(sizeof(sa))) != 0)
-            lRetval = chip::System::MapErrorPOSIX(errno);
+            lRetval = CHIP_ERROR_POSIX(errno);
 
             // Instruct the kernel that any messages to multicast destinations should be
             // sent down the interface specified by the caller.
@@ -713,7 +713,7 @@ CHIP_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, const IPAddress & a
         sa.sin_addr   = aAddress.ToIPv4();
 
         if (bind(mSocket, reinterpret_cast<const sockaddr *>(&sa), static_cast<unsigned>(sizeof(sa))) != 0)
-            lRetval = chip::System::MapErrorPOSIX(errno);
+            lRetval = CHIP_ERROR_POSIX(errno);
 
             // Instruct the kernel that any messages to multicast destinations should be
             // sent down the interface to which the specified IPv4 address is bound.
@@ -750,7 +750,7 @@ CHIP_ERROR IPEndPointBasis::BindInterface(IPAddressType aAddressType, InterfaceI
         // Stop interface-based filtering.
         if (setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, "", 0) == -1)
         {
-            lRetval = chip::System::MapErrorPOSIX(errno);
+            lRetval = CHIP_ERROR_POSIX(errno);
         }
     }
     else
@@ -760,13 +760,13 @@ CHIP_ERROR IPEndPointBasis::BindInterface(IPAddressType aAddressType, InterfaceI
 
         if (if_indextoname(aInterfaceId, lInterfaceName) == NULL)
         {
-            lRetval = chip::System::MapErrorPOSIX(errno);
+            lRetval = CHIP_ERROR_POSIX(errno);
         }
 
         if (lRetval == CHIP_NO_ERROR &&
             setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, lInterfaceName, socklen_t(strlen(lInterfaceName))) == -1)
         {
-            lRetval = chip::System::MapErrorPOSIX(errno);
+            lRetval = CHIP_ERROR_POSIX(errno);
         }
     }
 
@@ -899,7 +899,7 @@ CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     // Send IP packet.
     const ssize_t lenSent = sendmsg(mSocket, &msgHeader, 0);
     if (lenSent == -1)
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     if (lenSent != aBuffer->DataLength())
         return CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG;
     return CHIP_NO_ERROR;
@@ -930,13 +930,13 @@ CHIP_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 
         mSocket = ::socket(family, aType, aProtocol);
         if (mSocket == -1)
-            return chip::System::MapErrorPOSIX(errno);
+            return CHIP_ERROR_POSIX(errno);
         ReturnErrorOnFailure(static_cast<System::LayerSockets *>(Layer().SystemLayer())->StartWatchingSocket(mSocket, &mWatch));
 
         mAddrType = aAddressType;
 
         // NOTE WELL: the errors returned by setsockopt() here are not
-        // returned as Inet layer chip::System::MapErrorPOSIX(errno)
+        // returned as Inet layer CHIP_ERROR_POSIX(errno)
         // codes because they are normally expected to fail on some
         // platforms where the socket option code is defined in the
         // header files but not [yet] implemented. Certainly, there is
@@ -1052,7 +1052,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
 
         if (rcvLen < 0)
         {
-            lStatus = chip::System::MapErrorPOSIX(errno);
+            lStatus = CHIP_ERROR_POSIX(errno);
         }
         else if (rcvLen > lBuffer->AvailableDataLength())
         {
@@ -1131,7 +1131,7 @@ void IPEndPointBasis::HandlePendingIO(uint16_t aPort)
     }
     else
     {
-        if (OnReceiveError != nullptr && lStatus != chip::System::MapErrorPOSIX(EAGAIN))
+        if (OnReceiveError != nullptr && lStatus != CHIP_ERROR_POSIX(EAGAIN))
         {
             OnReceiveError(this, lStatus, nullptr);
         }
@@ -1227,7 +1227,7 @@ CHIP_ERROR IPEndPointBasis::SendMsg(const IPPacketInfo * aPktInfo, chip::System:
     nw_connection_send(mConnection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
         if (error)
         {
-            res = chip::System::MapErrorPOSIX(nw_error_get_error_code(error));
+            res = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
         }
         else
         {
@@ -1258,7 +1258,7 @@ void IPEndPointBasis::HandleDataReceived(const nw_connection_t & aConnection)
                     errno                          = nw_error_get_error_code(receive_error);
                     if (!(error_domain == nw_error_domain_posix && errno == ECANCELED))
                     {
-                        CHIP_ERROR error = chip::System::MapErrorPOSIX(errno);
+                        CHIP_ERROR error = CHIP_ERROR_POSIX(errno);
                         IPPacketInfo packetInfo;
                         GetPacketInfo(aConnection, packetInfo);
                         dispatch_async(mDispatchQueue, ^{
@@ -1402,7 +1402,7 @@ CHIP_ERROR IPEndPointBasis::StartListener()
 
         case nw_listener_state_failed:
             ChipLogDetail(Inet, "Listener: Failed");
-            res = chip::System::MapErrorPOSIX(nw_error_get_error_code(error));
+            res = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
             break;
 
         case nw_listener_state_ready:
@@ -1458,7 +1458,7 @@ CHIP_ERROR IPEndPointBasis::StartConnection(nw_connection_t & aConnection)
 
         case nw_connection_state_failed:
             ChipLogDetail(Inet, "Connection: Failed");
-            res = chip::System::MapErrorPOSIX(nw_error_get_error_code(error));
+            res = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
             break;
 
         case nw_connection_state_ready:

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -99,7 +99,7 @@ DLL_EXPORT CHIP_ERROR GetInterfaceName(InterfaceId intfId, char * nameBuf, size_
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
         char intfName[IF_NAMESIZE];
         if (if_indextoname(intfId, intfName) == nullptr)
-            return chip::System::MapErrorPOSIX(errno);
+            return CHIP_ERROR_POSIX(errno);
         if (strlen(intfName) >= nameBufSize)
             return CHIP_ERROR_NO_MEMORY;
         strcpy(nameBuf, intfName);
@@ -172,7 +172,7 @@ DLL_EXPORT CHIP_ERROR InterfaceNameToId(const char * intfName, InterfaceId & int
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
     intfId = if_nametoindex(intfName);
     if (intfId == 0)
-        return (errno == ENXIO) ? INET_ERROR_UNKNOWN_INTERFACE : chip::System::MapErrorPOSIX(errno);
+        return (errno == ENXIO) ? INET_ERROR_UNKNOWN_INTERFACE : CHIP_ERROR_POSIX(errno);
     return CHIP_NO_ERROR;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR InetLayer::InitQueueLimiter(void)
 {
     if (sem_init(&mDroppableEvents, 0, INET_CONFIG_MAX_DROPPABLE_EVENTS) != 0)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
     return CHIP_NO_ERROR;
 }

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -210,7 +210,7 @@ static void TestInetError(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = MapErrorPOSIX(EPERM);
+    err = CHIP_ERROR_POSIX(EPERM);
     NL_TEST_ASSERT(inSuite, DescribeErrorPOSIX(err));
     NL_TEST_ASSERT(inSuite, err.IsRange(ChipError::Range::kPOSIX));
 }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2038,8 +2038,8 @@
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #define _CHIP_CONFIG_IsPlatformPOSIXErrorNonCritical(CODE)                                                                         \
-    ((CODE) == chip::System::MapErrorPOSIX(EHOSTUNREACH) || (CODE) == chip::System::MapErrorPOSIX(ENETUNREACH) ||                  \
-     (CODE) == chip::System::MapErrorPOSIX(EADDRNOTAVAIL) || (CODE) == chip::System::MapErrorPOSIX(EPIPE))
+    ((CODE) == CHIP_ERROR_POSIX(EHOSTUNREACH) || (CODE) == CHIP_ERROR_POSIX(ENETUNREACH) ||                                        \
+     (CODE) == CHIP_ERROR_POSIX(EADDRNOTAVAIL) || (CODE) == CHIP_ERROR_POSIX(EPIPE))
 #else // !CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #define _CHIP_CONFIG_IsPlatformPOSIXErrorNonCritical(CODE) 0
 #endif // !CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/messaging/ErrorCategory.cpp
+++ b/src/messaging/ErrorCategory.cpp
@@ -37,7 +37,7 @@ bool IsIgnoredMulticastSendError(CHIP_ERROR err)
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
         err == System::MapErrorLwIP(ERR_RTE)
 #else
-        err == System::MapErrorPOSIX(ENETUNREACH) || err == System::MapErrorPOSIX(EADDRNOTAVAIL)
+        err == CHIP_ERROR_POSIX(ENETUNREACH) || err == CHIP_ERROR_POSIX(EADDRNOTAVAIL)
 #endif
         ;
 }
@@ -57,7 +57,7 @@ CHIP_ERROR FilterUDPSendError(CHIP_ERROR err, bool isMulticast)
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS || CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-        if (err == System::MapErrorPOSIX(ENETUNREACH) || err == System::MapErrorPOSIX(EADDRNOTAVAIL))
+        if (err == CHIP_ERROR_POSIX(ENETUNREACH) || err == CHIP_ERROR_POSIX(EADDRNOTAVAIL))
         {
             err = CHIP_NO_ERROR;
         }

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -47,6 +47,7 @@
 namespace chip {
 namespace System {
 
+namespace Internal {
 /**
  * This implements a mapping function for CHIP System Layer errors that allows mapping integers in the number space of the
  * underlying POSIX network and OS stack errors into a platform- or system-specific range. Error codes beyond those currently
@@ -60,6 +61,7 @@ DLL_EXPORT CHIP_ERROR MapErrorPOSIX(int aError)
 {
     return (aError == 0 ? CHIP_NO_ERROR : CHIP_ERROR(ChipError::Range::kPOSIX, static_cast<ChipError::ValueType>(aError)));
 }
+} // namespace Internal
 
 /**
  * This implements a function to return an NULL-terminated OS-specific descriptive C string, associated with the specified, mapped
@@ -124,7 +126,7 @@ bool FormatPOSIXError(char * buf, uint16_t bufSize, CHIP_ERROR err)
  */
 DLL_EXPORT CHIP_ERROR MapErrorZephyr(int aError)
 {
-    return MapErrorPOSIX(-aError);
+    return Internal::MapErrorPOSIX(-aError);
 }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -61,6 +61,12 @@ DLL_EXPORT CHIP_ERROR MapErrorPOSIX(int aError)
 {
     return (aError == 0 ? CHIP_NO_ERROR : CHIP_ERROR(ChipError::Range::kPOSIX, static_cast<ChipError::ValueType>(aError)));
 }
+
+DLL_EXPORT CHIP_ERROR MapErrorPOSIX(int aError, const char * file, unsigned int line)
+{
+    return (aError == 0 ? CHIP_NO_ERROR
+                        : CHIP_ERROR(ChipError::Range::kPOSIX, static_cast<ChipError::ValueType>(aError), file, line));
+}
 } // namespace Internal
 
 /**

--- a/src/system/SystemError.h
+++ b/src/system/SystemError.h
@@ -41,10 +41,15 @@
 
 #ifdef __cplusplus
 
+#define CHIP_ERROR_POSIX(code) chip::System::Internal::MapErrorPOSIX(code)
+
 namespace chip {
 namespace System {
 
+namespace Internal {
 extern CHIP_ERROR MapErrorPOSIX(int code);
+} // namespace Internal
+
 extern const char * DescribeErrorPOSIX(CHIP_ERROR code);
 extern void RegisterPOSIXErrorFormatter();
 extern bool FormatPOSIXError(char * buf, uint16_t bufSize, CHIP_ERROR err);

--- a/src/system/SystemError.h
+++ b/src/system/SystemError.h
@@ -41,13 +41,18 @@
 
 #ifdef __cplusplus
 
+#if CHIP_CONFIG_ERROR_SOURCE
+#define CHIP_ERROR_POSIX(code) chip::System::Internal::MapErrorPOSIX(code, __FILE__, __LINE__)
+#else // CHIP_CONFIG_ERROR_SOURCE
 #define CHIP_ERROR_POSIX(code) chip::System::Internal::MapErrorPOSIX(code)
+#endif // CHIP_CONFIG_ERROR_SOURCE
 
 namespace chip {
 namespace System {
 
 namespace Internal {
 extern CHIP_ERROR MapErrorPOSIX(int code);
+extern CHIP_ERROR MapErrorPOSIX(int code, const char * file, unsigned int line);
 } // namespace Internal
 
 extern const char * DescribeErrorPOSIX(CHIP_ERROR code);

--- a/src/system/SystemLayerImplLibevent.cpp
+++ b/src/system/SystemLayerImplLibevent.cpp
@@ -345,7 +345,7 @@ CHIP_ERROR LayerImplLibevent::UpdateWatch(SocketWatch * watch, short eventFlags)
         if ((flags & O_NONBLOCK) == 0)
         {
             int status = ::fcntl(watch->mFD, F_SETFL, flags | O_NONBLOCK);
-            VerifyOrReturnError(status == 0, chip::System::MapErrorPOSIX(errno));
+            VerifyOrReturnError(status == 0, CHIP_ERROR_POSIX(errno));
         }
         watch->mEvent = event_new(mEventBase, watch->mFD, eventFlags, SocketCallbackHandler, watch);
         VerifyOrReturnError(watch->mEvent != nullptr, CHIP_ERROR_NO_MEMORY);

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -375,7 +375,7 @@ void LayerImplSelect::HandleEvents()
 
     if (mSelectResult < 0)
     {
-        ChipLogError(DeviceLayer, "select failed: %s\n", ErrorStr(System::MapErrorPOSIX(errno)));
+        ChipLogError(DeviceLayer, "select failed: %s\n", ErrorStr(CHIP_ERROR_POSIX(errno)));
         return;
     }
 

--- a/src/system/WakeEvent.cpp
+++ b/src/system/WakeEvent.cpp
@@ -64,13 +64,13 @@ CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
     int fds[2];
 
     if (::pipe(fds) < 0)
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
 
     if (SetNonBlockingMode(fds[FD_READ]) < 0)
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
 
     if (SetNonBlockingMode(fds[FD_WRITE]) < 0)
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
 
     mReadFD  = fds[FD_READ];
     mWriteFD = fds[FD_WRITE];
@@ -101,7 +101,7 @@ void WakeEvent::Confirm()
         res = ::read(mReadFD, buffer, sizeof(buffer));
         if (res < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
         {
-            ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(chip::System::MapErrorPOSIX(errno)));
+            ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(CHIP_ERROR_POSIX(errno)));
             return;
         }
     } while (res == sizeof(buffer));
@@ -113,7 +113,7 @@ CHIP_ERROR WakeEvent::Notify()
 
     if (::write(mWriteFD, &byte, 1) < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
 
     return CHIP_NO_ERROR;
@@ -126,7 +126,7 @@ CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
     mReadFD = ::eventfd(0, 0);
     if (mReadFD == -1)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
 
     ReturnErrorOnFailure(systemLayer.StartWatchingSocket(mReadFD, &mReadWatch));
@@ -149,7 +149,7 @@ void WakeEvent::Confirm()
 
     if (::read(mReadFD, &value, sizeof(value)) < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
     {
-        ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(chip::System::MapErrorPOSIX(errno)));
+        ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(CHIP_ERROR_POSIX(errno)));
     }
 }
 
@@ -159,7 +159,7 @@ CHIP_ERROR WakeEvent::Notify()
 
     if (::write(mReadFD, &value, sizeof(value)) < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
     {
-        return chip::System::MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
 
     return CHIP_NO_ERROR;

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -132,7 +132,7 @@ public:
 
         // Should be able to send a message to itself by just calling send.
         err = tcp.SendMessage(Transport::PeerAddress::TCP(addr), std::move(buffer));
-        if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
+        if (err == CHIP_ERROR_POSIX(EADDRNOTAVAIL))
         {
             // TODO(#2698): the underlying system does not support IPV6. This early return
             // should be removed and error should be made fatal.

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -140,7 +140,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
 
     // Should be able to send a message to itself by just calling send.
     err = udp.SendMessage(Transport::PeerAddress::UDP(addr, udp.GetBoundPort()), std::move(buffer));
-    if (err == System::MapErrorPOSIX(EADDRNOTAVAIL))
+    if (err == CHIP_ERROR_POSIX(EADDRNOTAVAIL))
     {
         // TODO(#2698): the underlying system does not support IPV6. This early return
         // should be removed and error should be made fatal.


### PR DESCRIPTION
#### Problem
POSIX errors represented as CHIP_ERROR don't have useful file/line information.

#### Change overview
Change them to have it.

#### Testing
Tried introducing a POSIX error in a common codepath (`IPEndPointBasis::SendMsg`) and looked at the resulting logging from our unit tests.