### PR TITLE
Remove SetRemoteNodeId/SetLocalNodeId from RendezvousParameters

### DIFF
--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -173,7 +173,7 @@ pychip_internal_Commissioner_BleConnectForPairing(chip::Controller::DeviceCommis
     chip::python::ChipMainThreadScheduleAndWait([&]() {
         chip::RendezvousParameters params;
 
-        params.SetDiscriminator(discriminator).SetSetupPINCode(pinCode).SetRemoteNodeId(remoteNodeId);
+        params.SetDiscriminator(discriminator).SetSetupPINCode(pinCode);
 #if CONFIG_NETWORK_LAYER_BLE
         params.SetBleLayer(chip::DeviceLayer::ConnectivityMgr().GetBleLayer()).SetPeerAddress(chip::Transport::PeerAddress::BLE());
 #endif

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -70,22 +70,6 @@ public:
         return *this;
     }
 
-    bool HasLocalNodeId() const { return mLocalNodeId.HasValue(); }
-    const Optional<NodeId> GetLocalNodeId() const { return mLocalNodeId; }
-    RendezvousParameters & SetLocalNodeId(NodeId nodeId)
-    {
-        mLocalNodeId.SetValue(nodeId);
-        return *this;
-    }
-
-    bool HasRemoteNodeId() const { return mRemoteNodeId.HasValue(); }
-    const Optional<NodeId> GetRemoteNodeId() const { return mRemoteNodeId; }
-    RendezvousParameters & SetRemoteNodeId(NodeId nodeId)
-    {
-        mRemoteNodeId.SetValue(nodeId);
-        return *this;
-    }
-
     bool HasPASEVerifier() const { return mHasPASEVerifier; }
     bool HasCSRNonce() const { return mCSRNonce.HasValue(); }
     const PASEVerifier & GetPASEVerifier() const { return mPASEVerifier; }
@@ -117,9 +101,7 @@ public:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 private:
-    Optional<NodeId> mLocalNodeId;        ///< the local node id
     Transport::PeerAddress mPeerAddress;  ///< the peer node address
-    Optional<NodeId> mRemoteNodeId;       ///< the remote node id
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
     Optional<ByteSpan> mCSRNonce;         ///< CSR Nonce passed by the commissioner


### PR DESCRIPTION
#### Problem
While working on some stuff on the `CHIPDeviceController` side I noticed that those seems unused now.

#### Change overview
 * Remove `SetRemoteNodeId`
 * Remove `SetLocalNodeId`
 
#### Testing
 Just remove and recompiled to see if that's still used...