### PR TITLE
ESP32: Close active BLE connection on PASE session failure.

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -88,6 +88,9 @@ void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
     mFailedCommissioningAttempts++;
     ChipLogError(AppServer, "Commissioning failed (attempt %d): %s", mFailedCommissioningAttempts, ErrorStr(err));
 
+#if CONFIG_NETWORK_LAYER_BLE
+    mServer->getBleLayerObject()->mBleEndPoint->ReleaseBleConnection();
+#endif
     if (mFailedCommissioningAttempts < kMaxFailedCommissioningAttempts)
     {
         // If the number of commissioning attempts have not exceeded maximum retries, let's reopen

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -112,6 +112,9 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
 #endif
     );
 
+#if CONFIG_NETWORK_LAYER_BLE
+    mBleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
+#endif
     SuccessOrExit(err);
 
     err = mSessions.Init(&DeviceLayer::SystemLayer(), &mTransports, &mFabrics, &mMessageCounterManager);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -71,6 +71,10 @@ public:
 
     TransportMgrBase & GetTransportManager() { return mTransports; }
 
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * getBleLayerObject() { return mBleLayer; }
+#endif
+
     CommissioningWindowManager & GetCommissioningWindowManager() { return mCommissioningWindowManager; }
 
     void Shutdown();
@@ -112,6 +116,10 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 
     AppDelegate * mAppDelegate = nullptr;
+
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * mBleLayer = nullptr;
+#endif
 
     ServerTransportMgr mTransports;
     SessionManager mSessions;

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -107,6 +107,7 @@ public:
     bool ConnectionObjectIs(BLE_CONNECTION_OBJECT connObj) { return connObj == mConnObj; }
     void Close();
     void Abort();
+    void ReleaseBleConnection();
 
 private:
     BleLayer * mBle; ///< [READ-ONLY] Pointer to the BleLayer object that owns this object.
@@ -223,7 +224,6 @@ private:
     // Close functions:
     void DoCloseCallback(uint8_t state, uint8_t flags, CHIP_ERROR err);
     void FinalizeClose(uint8_t state, uint8_t flags, CHIP_ERROR err);
-    void ReleaseBleConnection();
     void Free();
     void FreeBtpEngine();
 

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -288,6 +288,7 @@ CHIP_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleConnectionD
 #if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = NULL;
 #endif
+    mBleEndPoint = NULL;
 
     return CHIP_NO_ERROR;
 }
@@ -425,6 +426,7 @@ CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_O
 #if CHIP_ENABLE_CHIPOBLE_TEST
     mTestBleEndPoint = *retEndPoint;
 #endif
+    mBleEndPoint = *retEndPoint;
 
     return CHIP_NO_ERROR;
 }

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -320,6 +320,8 @@ public:
     BLEEndPoint * mTestBleEndPoint;
 #endif
 
+    BLEEndPoint * mBleEndPoint;
+
 private:
     // Private data members:
 

--- a/src/transport/raw/BLE.h
+++ b/src/transport/raw/BLE.h
@@ -91,6 +91,8 @@ public:
 
     CHIP_ERROR SetEndPoint(Ble::BLEEndPoint * endPoint) override;
 
+    Ble::BLEEndPoint * GetEndPoint() { return mBleEndPoint; }
+
 private:
     void ClearState();
 


### PR DESCRIPTION
#### Problem
* When connect command is send from python controller then PASE session is initiated with the device, If a wrong parameter is provided (say the wrong descriptor) then the PASE session fails.
* However, the device stays connected over BLE, hence the next time when we send the connect command with the right parameters from the python controller then it fails due to old connection data, and it simply disconnects BLE and exits the controller.

#### Change overview
* Added the flags for the PASE session which indicate the status of the PASE session.
* Closes the current BLE connection if the PASE failure occurs and restart advertising.

#### Testing
* Build all-clusters-app and perform complete commissioning.
* Tried giving wrong parameters to connect command from the python controller.