### PR TITLE
Add DeviceController::PairDevice(NodeId remoteId, const char * setupCode) API that looks for the device over supported networks resolves #9343

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -20,14 +20,15 @@
 
 #include "../common/Command.h"
 
-class DiscoverCommissionablesCommand : public Command
+class DiscoverCommissionablesCommand : public Command, public chip::Controller::DeviceDiscoveryDelegate
 {
 public:
     DiscoverCommissionablesCommand() : Command("commissionables") {}
-    CHIP_ERROR Run() override;
-    uint16_t GetWaitDurationInSeconds() const override { return 3; }
-    void Shutdown() override;
 
-private:
-    ChipDeviceCommissioner * mCommissioner;
+    /////////// DeviceDiscoveryDelegate Interface /////////
+    void OnDiscoveredDevice(const chip::Mdns::DiscoveredNodeData & nodeData) override;
+
+    /////////// Command Interface /////////
+    CHIP_ERROR Run() override;
+    uint16_t GetWaitDurationInSeconds() const override { return 30; }
 };

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -50,6 +50,76 @@ public:
     PairOnNetwork() : PairingCommand("onnetwork", PairingMode::OnNetwork, PairingNetworkType::None) {}
 };
 
+class PairOnNetworkShort : public PairingCommand
+{
+public:
+    PairOnNetworkShort() :
+        PairingCommand("onnetwork-short", PairingMode::OnNetwork, PairingNetworkType::None, chip::Mdns::DiscoveryFilterType::kShort)
+    {}
+};
+
+class PairOnNetworkLong : public PairingCommand
+{
+public:
+    PairOnNetworkLong() :
+        PairingCommand("onnetwork-long", PairingMode::OnNetwork, PairingNetworkType::None, chip::Mdns::DiscoveryFilterType::kLong)
+    {}
+};
+
+class PairOnNetworkVendor : public PairingCommand
+{
+public:
+    PairOnNetworkVendor() :
+        PairingCommand("onnetwork-vendor", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kVendor)
+    {}
+};
+
+class PairOnNetworkFabric : public PairingCommand
+{
+public:
+    PairOnNetworkFabric() :
+        PairingCommand("onnetwork-fabric", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kCompressedFabricId)
+    {}
+};
+
+class PairOnNetworkCommissioningMode : public PairingCommand
+{
+public:
+    PairOnNetworkCommissioningMode() :
+        PairingCommand("onnetwork-commissioning-mode", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kCommissioningMode)
+    {}
+};
+
+class PairOnNetworkCommissioner : public PairingCommand
+{
+public:
+    PairOnNetworkCommissioner() :
+        PairingCommand("onnetwork-commissioner", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kCommissioner)
+    {}
+};
+
+class PairOnNetworkDeviceType : public PairingCommand
+{
+public:
+    PairOnNetworkDeviceType() :
+        PairingCommand("onnetwork-device-type", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kDeviceType)
+    {}
+};
+
+class PairOnNetworkInstanceName : public PairingCommand
+{
+public:
+    PairOnNetworkInstanceName() :
+        PairingCommand("onnetwork-instance-name", PairingMode::OnNetwork, PairingNetworkType::None,
+                       chip::Mdns::DiscoveryFilterType::kInstanceName)
+    {}
+};
+
 class PairBleWiFi : public PairingCommand
 {
 public:
@@ -87,11 +157,24 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),        make_unique<PairBypass>(),
-        make_unique<PairQRCode>(),    make_unique<PairManualCode>(),
-        make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
-        make_unique<PairSoftAP>(),    make_unique<Ethernet>(),
-        make_unique<PairOnNetwork>(), make_unique<OpenCommissioningWindow>(),
+        make_unique<Unpair>(),
+        make_unique<PairBypass>(),
+        make_unique<PairQRCode>(),
+        make_unique<PairManualCode>(),
+        make_unique<PairBleWiFi>(),
+        make_unique<PairBleThread>(),
+        make_unique<PairSoftAP>(),
+        make_unique<Ethernet>(),
+        make_unique<PairOnNetwork>(),
+        make_unique<PairOnNetworkShort>(),
+        make_unique<PairOnNetworkLong>(),
+        make_unique<PairOnNetworkVendor>(),
+        make_unique<PairOnNetworkCommissioningMode>(),
+        make_unique<PairOnNetworkCommissioner>(),
+        make_unique<PairOnNetworkDeviceType>(),
+        make_unique<PairOnNetworkDeviceType>(),
+        make_unique<PairOnNetworkInstanceName>(),
+        make_unique<OpenCommissioningWindow>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -131,30 +131,12 @@ void PairingCommand::OnDeviceConnectionFailureFn(void * context, NodeId deviceId
 
 CHIP_ERROR PairingCommand::PairWithQRCode(NodeId remoteId)
 {
-    SetupPayload payload;
-    ReturnErrorOnFailure(QRCodeSetupPayloadParser(mOnboardingPayload).populatePayload(payload));
-
-    chip::RendezvousInformationFlags rendezvousInformation = payload.rendezvousInformation;
-    ReturnErrorCodeIf(rendezvousInformation != RendezvousInformationFlag::kBLE, CHIP_ERROR_INVALID_ARGUMENT);
-
-    return PairWithCode(remoteId, payload);
+    return GetExecContext()->commissioner->PairDevice(remoteId, mOnboardingPayload);
 }
 
 CHIP_ERROR PairingCommand::PairWithManualCode(NodeId remoteId)
 {
-    SetupPayload payload;
-    ReturnErrorOnFailure(ManualSetupPayloadParser(mOnboardingPayload).populatePayload(payload));
-    return PairWithCode(remoteId, payload);
-}
-
-CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId, SetupPayload payload)
-{
-    RendezvousParameters params = RendezvousParameters()
-                                      .SetSetupPINCode(payload.setUpPINCode)
-                                      .SetDiscriminator(payload.discriminator)
-                                      .SetPeerAddress(PeerAddress::BLE());
-
-    return GetExecContext()->commissioner->PairDevice(remoteId, params);
+    return GetExecContext()->commissioner->PairDevice(remoteId, mOnboardingPayload);
 }
 
 CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -94,6 +94,8 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
         err = Pair(remoteId, PeerAddress::BLE());
         break;
     case PairingMode::OnNetwork:
+        err = PairWithMdns(remoteId);
+        break;
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;
@@ -161,6 +163,35 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
         RendezvousParameters().SetSetupPINCode(mSetupPINCode).SetDiscriminator(mDiscriminator).SetPeerAddress(address);
 
     return GetExecContext()->commissioner->PairDevice(remoteId, params);
+}
+
+CHIP_ERROR PairingCommand::PairWithMdns(NodeId remoteId)
+{
+    Mdns::DiscoveryFilter filter(mFilterType);
+    switch (mFilterType)
+    {
+    case chip::Mdns::DiscoveryFilterType::kNone:
+        break;
+    case chip::Mdns::DiscoveryFilterType::kShort:
+    case chip::Mdns::DiscoveryFilterType::kLong:
+    case chip::Mdns::DiscoveryFilterType::kCompressedFabricId:
+    case chip::Mdns::DiscoveryFilterType::kVendor:
+    case chip::Mdns::DiscoveryFilterType::kDeviceType:
+        filter.code = mDiscoveryFilterCode;
+        break;
+    case chip::Mdns::DiscoveryFilterType::kCommissioningMode:
+        break;
+    case chip::Mdns::DiscoveryFilterType::kCommissioner:
+        filter.code = 1;
+        break;
+    case chip::Mdns::DiscoveryFilterType::kInstanceName:
+        filter.code         = 0;
+        filter.instanceName = mDiscoveryFilterInstanceName;
+        break;
+    }
+
+    GetExecContext()->commissioner->RegisterDeviceDiscoveryDelegate(this);
+    return GetExecContext()->commissioner->DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR PairingCommand::PairWithoutSecurity(NodeId remoteId, PeerAddress address)
@@ -436,6 +467,25 @@ void PairingCommand::OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR err)
     {
         // Set exit status only if the address update failed.
         // Otherwise wait for OnCommissioningComplete() callback.
+        SetCommandExitStatus(err);
+    }
+}
+
+void PairingCommand::OnDiscoveredDevice(const chip::Mdns::DiscoveredNodeData & nodeData)
+{
+    const uint16_t port = nodeData.port;
+    char buf[chip::Inet::kMaxIPAddressStringLength];
+    nodeData.ipAddress[0].ToString(buf);
+    ChipLogProgress(chipTool, "Discovered Device: %s:%u", buf, port);
+
+    // Stop Mdns discovery. Is it the right method ?
+    GetExecContext()->commissioner->RegisterDeviceDiscoveryDelegate(nullptr);
+
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : INET_NULL_INTERFACEID;
+    PeerAddress peerAddress       = PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
+    CHIP_ERROR err                = Pair(mRemoteId, peerAddress);
+    if (CHIP_NO_ERROR != err)
+    {
         SetCommandExitStatus(err);
     }
 }

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -86,7 +86,6 @@ public:
             break;
         case PairingMode::QRCode:
         case PairingMode::ManualCode:
-            AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
             AddArgument("payload", &mOnboardingPayload);
             break;
         case PairingMode::Ble:

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -121,7 +121,7 @@ for j in "${iter_array[@]}"; do
         # the data is there yet.
         background_pid="$(</tmp/pid)"
         echo "          * Pairing to device"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing onnetwork 0 20202021 3840 ::1 5540
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing onnetwork-long 20202021 3840
         echo "          * Starting test run: $i"
         "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i"
         # Prevent cleanup trying to kill a process we already killed.

--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -121,7 +121,7 @@ for j in "${iter_array[@]}"; do
         # the data is there yet.
         background_pid="$(</tmp/pid)"
         echo "          * Pairing to device"
-        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing onnetwork-long 20202021 3840
+        "${test_case_wrapper[@]}" out/debug/standalone/chip-tool pairing qrcode MT:D8XA0CQM00KA0648G00
         echo "          * Starting test run: $i"
         "${test_case_wrapper[@]}" out/debug/standalone/chip-tool tests "$i"
         # Prevent cleanup trying to kill a process we already killed.

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -374,17 +374,18 @@ CHIP_ERROR BleLayer::CancelBleIncompleteConnection()
     return err;
 }
 
-CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t connDiscriminator)
+CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState,
+                                                     BleConnectionDelegate::OnConnectionCompleteFunct onSuccess,
+                                                     BleConnectionDelegate::OnConnectionErrorFunct onError)
 {
-
     VerifyOrReturnError(mState == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mConnectionDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mBleTransport != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    mConnectionDelegate->OnConnectionComplete = OnConnectionComplete;
-    mConnectionDelegate->OnConnectionError    = OnConnectionError;
-    // TODO: We are passing the same parameter two times, should take a look at it to see if we can remove one of them.
-    mConnectionDelegate->NewConnection(this, this, connDiscriminator);
+    mConnectionDelegate->OnConnectionComplete = onSuccess;
+    mConnectionDelegate->OnConnectionError    = onError;
+
+    mConnectionDelegate->NewConnection(this, appState == nullptr ? this : appState, connDiscriminator);
 
     return CHIP_NO_ERROR;
 }

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -247,7 +247,9 @@ public:
     CHIP_ERROR Shutdown();
 
     CHIP_ERROR CancelBleIncompleteConnection();
-    CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t connDiscriminator);
+    CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState = nullptr,
+                                               BleConnectionDelegate::OnConnectionCompleteFunct onSucess = OnConnectionComplete,
+                                               BleConnectionDelegate::OnConnectionErrorFunct onError     = OnConnectionError);
     CHIP_ERROR NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj);
     CHIP_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
 

--- a/src/controller/AbstractMdnsDiscoveryController.cpp
+++ b/src/controller/AbstractMdnsDiscoveryController.cpp
@@ -41,6 +41,10 @@ void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::
         if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0)
         {
             discoveredNode = nodeData;
+            if (mDeviceDiscoveryDelegate != nullptr)
+            {
+                mDeviceDiscoveryDelegate->OnDiscoveredDevice(nodeData);
+            }
             return;
         }
     }
@@ -50,6 +54,10 @@ void AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(const chip::Mdns::
         if (!discoveredNode.IsValid())
         {
             discoveredNode = nodeData;
+            if (mDeviceDiscoveryDelegate != nullptr)
+            {
+                mDeviceDiscoveryDelegate->OnDiscoveredDevice(nodeData);
+            }
             return;
         }
     }

--- a/src/controller/AbstractMdnsDiscoveryController.h
+++ b/src/controller/AbstractMdnsDiscoveryController.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <controller/DeviceDiscoveryDelegate.h>
 #include <lib/mdns/Resolver.h>
 #include <lib/support/Span.h>
 #include <platform/CHIPDeviceConfig.h>
@@ -52,6 +53,7 @@ protected:
     const Mdns::DiscoveredNodeData * GetDiscoveredNode(int idx);
     virtual DiscoveredNodeList GetDiscoveredNodes() = 0;
     chip::Mdns::Resolver * mResolver;
+    DeviceDiscoveryDelegate * mDeviceDiscoveryDelegate = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -41,6 +41,8 @@ static_library("controller") {
     "EmptyDataModelHandler.cpp",
     "ExampleOperationalCredentialsIssuer.cpp",
     "ExampleOperationalCredentialsIssuer.h",
+    "SetUpCodePairer.cpp",
+    "SetUpCodePairer.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -37,6 +37,7 @@ static_library("controller") {
     "CHIPDeviceControllerFactory.cpp",
     "CHIPDeviceControllerFactory.h",
     "DeviceAddressUpdateDelegate.h",
+    "DeviceDiscoveryDelegate.h",
     "EmptyDataModelHandler.cpp",
     "ExampleOperationalCredentialsIssuer.cpp",
     "ExampleOperationalCredentialsIssuer.h",

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -598,7 +598,7 @@ DeviceCommissioner::DeviceCommissioner() :
     mOnAttestationFailureCallback(OnAttestationFailureResponse, this), mOnCSRFailureCallback(OnCSRFailureResponse, this),
     mOnCertFailureCallback(OnAddNOCFailureResponse, this), mOnRootCertFailureCallback(OnRootCertFailureResponse, this),
     mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this),
-    mDeviceNOCChainCallback(OnDeviceNOCChainGeneration, this)
+    mDeviceNOCChainCallback(OnDeviceNOCChainGeneration, this), mSetUpCodePairer(this)
 {
     mPairingDelegate      = nullptr;
     mDeviceBeingPaired    = kNumMaxActiveDevices;
@@ -642,6 +642,10 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     mUdcServer->SetInstanceNameResolver(this);
     mUdcServer->SetUserConfirmationProvider(this);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
+
+#if CONFIG_NETWORK_LAYER_BLE
+    mSetUpCodePairer.SetBleLayer(mSystemState->BleLayer());
+#endif // CONFIG_NETWORK_LAYER_BLE
     return CHIP_NO_ERROR;
 }
 
@@ -672,6 +676,11 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
 
     DeviceController::Shutdown();
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode)
+{
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode);
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParameters & params)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -137,6 +137,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     ReturnErrorOnFailure(Mdns::Resolver::Instance().SetResolverDelegate(this));
     RegisterDeviceAddressUpdateDelegate(params.deviceAddressUpdateDelegate);
+    RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
     Mdns::Resolver::Instance().StartResolver(params.systemState->InetLayer(), kMdnsPort);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
@@ -230,6 +231,7 @@ CHIP_ERROR DeviceController::Shutdown()
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     Mdns::Resolver::Instance().SetResolverDelegate(nullptr);
     mDeviceAddressUpdateDelegate = nullptr;
+    mDeviceDiscoveryDelegate     = nullptr;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
     return CHIP_NO_ERROR;
@@ -1645,7 +1647,8 @@ void DeviceCommissioner::OnNodeDiscoveryComplete(const chip::Mdns::DiscoveredNod
     {
         mUdcServer->OnCommissionableNodeFound(nodeData);
     }
-    return AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(nodeData);
+
+    AbstractMdnsDiscoveryController::OnNodeDiscoveryComplete(nodeData);
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -62,6 +62,7 @@
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 #include <controller/DeviceAddressUpdateDelegate.h>
+#include <controller/DeviceDiscoveryDelegate.h>
 #include <lib/mdns/Resolver.h>
 #endif
 
@@ -86,6 +87,7 @@ struct ControllerInitParams
     DeviceControllerSystemState * systemState   = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     DeviceAddressUpdateDelegate * deviceAddressUpdateDelegate = nullptr;
+    DeviceDiscoveryDelegate * deviceDiscoveryDelegate         = nullptr;
 #endif
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 
@@ -244,6 +246,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     void RegisterDeviceAddressUpdateDelegate(DeviceAddressUpdateDelegate * delegate) { mDeviceAddressUpdateDelegate = delegate; }
+    void RegisterDeviceDiscoveryDelegate(DeviceDiscoveryDelegate * delegate) { mDeviceDiscoveryDelegate = delegate; }
 #endif
 
     /**

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -35,6 +35,7 @@
 #include <controller/CHIPDeviceControllerSystemState.h>
 #include <controller/DeviceControllerInteractionModelDelegate.h>
 #include <controller/OperationalCredentialsDelegate.h>
+#include <controller/SetUpCodePairer.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPCore.h>
@@ -381,6 +382,21 @@ public:
     // ----- Connection Management -----
     /**
      * @brief
+     *   Pair a CHIP device with the provided code. The code can be either a QRCode
+     *   or a Manual Setup Code.
+     *   Use registered DevicePairingDelegate object to receive notifications on
+     *   pairing status updates.
+     *
+     *   Note: Pairing process requires that the caller has registered PersistentStorageDelegate
+     *         in the Init() call.
+     *
+     * @param[in] remoteDeviceId        The remote device Id.
+     * @param[in] setUpCode             The setup code for connecting to the device
+     */
+    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode);
+
+    /**
+     * @brief
      *   Pair a CHIP device with the provided Rendezvous connection parameters.
      *   Use registered DevicePairingDelegate object to receive notifications on
      *   pairing status updates.
@@ -688,6 +704,7 @@ private:
     Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 
     Callback::Callback<OnNOCChainGeneration> mDeviceNOCChainCallback;
+    SetUpCodePairer mSetUpCodePairer;
 
     PASESession mPairingSession;
 };

--- a/src/controller/DeviceDiscoveryDelegate.h
+++ b/src/controller/DeviceDiscoveryDelegate.h
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/mdns/Resolver.h>
+#include <lib/support/DLLUtil.h>
+
+namespace chip {
+namespace Controller {
+
+/// Callbacks for CHIP device discovery
+class DLL_EXPORT DeviceDiscoveryDelegate
+{
+public:
+    virtual ~DeviceDiscoveryDelegate() {}
+    virtual void OnDiscoveredDevice(const chip::Mdns::DiscoveredNodeData & nodeData) = 0;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -1,0 +1,178 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Implementation of SetUp Code Pairer, a class that parses a given
+ *      setup code and uses the extracted informations to discover and
+ *      filter commissionables nodes, before initiating the pairing process.
+ *
+ */
+
+#include <controller/SetUpCodePairer.h>
+
+#include <controller/CHIPDeviceController.h>
+#include <lib/mdns/Resolver.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace Controller {
+
+CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode)
+{
+    SetupPayload payload;
+
+    bool isQRCode = strncmp(setUpCode, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
+    ReturnErrorOnFailure(isQRCode ? QRCodeSetupPayloadParser(setUpCode).populatePayload(payload)
+                                  : ManualSetupPayloadParser(setUpCode).populatePayload(payload));
+
+    mRemoteId     = remoteId;
+    mSetUpPINCode = payload.setUpPINCode;
+
+    return Connect(payload.rendezvousInformation, payload.discriminator, !isQRCode);
+}
+
+CHIP_ERROR SetUpCodePairer::Connect(RendezvousInformationFlag rendezvousInformation, uint16_t discriminator, bool isShort)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    bool isRunning = false;
+
+    bool searchOverAll = rendezvousInformation == RendezvousInformationFlag::kNone;
+    if (searchOverAll || rendezvousInformation == RendezvousInformationFlag::kBLE)
+    {
+        if (CHIP_NO_ERROR == (err = StartDiscoverOverBle(discriminator, isShort)))
+        {
+            isRunning = true;
+        }
+        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
+    }
+
+    if (searchOverAll || rendezvousInformation == RendezvousInformationFlag::kOnNetwork)
+    {
+        if (CHIP_NO_ERROR == (err = StartDiscoverOverIP(discriminator, isShort)))
+        {
+            isRunning = true;
+        }
+        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
+    }
+
+    if (searchOverAll || rendezvousInformation == RendezvousInformationFlag::kSoftAP)
+    {
+        if (CHIP_NO_ERROR == (err = StartDiscoverOverSoftAP(discriminator, isShort)))
+        {
+            isRunning = true;
+        }
+        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
+    }
+
+    return isRunning ? CHIP_NO_ERROR : CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR SetUpCodePairer::StartDiscoverOverBle(uint16_t discriminator, bool isShort)
+{
+#if CONFIG_NETWORK_LAYER_BLE
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    return mBleLayer->NewBleConnectionByDiscriminator(discriminator, this, OnDiscoveredDeviceOverBleSuccess,
+                                                      OnDiscoveredDeviceOverBleError);
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CONFIG_NETWORK_LAYER_BLE
+}
+
+CHIP_ERROR SetUpCodePairer::StopConnectOverBle()
+{
+#if CONFIG_NETWORK_LAYER_BLE
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    return mBleLayer->CancelBleIncompleteConnection();
+#else
+    return CHIP_NO_ERROR;
+#endif // CONFIG_NETWORK_LAYER_BLE
+}
+
+CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(uint16_t discriminator, bool isShort)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    mCommissioner->RegisterDeviceDiscoveryDelegate(this);
+    Mdns::DiscoveryFilter filter(isShort ? Mdns::DiscoveryFilterType::kShort : Mdns::DiscoveryFilterType::kLong, discriminator);
+    return mCommissioner->DiscoverCommissionableNodes(filter);
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+}
+
+CHIP_ERROR SetUpCodePairer::StopConnectOverIP()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    mCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetUpCodePairer::StartDiscoverOverSoftAP(uint16_t discriminator, bool isShort)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
+{
+    return CHIP_NO_ERROR;
+}
+
+void SetUpCodePairer::OnDeviceDiscovered(RendezvousParameters & params)
+{
+    LogErrorOnFailure(mCommissioner->PairDevice(mRemoteId, params.SetSetupPINCode(mSetUpPINCode)));
+}
+
+#if CONFIG_NETWORK_LAYER_BLE
+void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
+{
+    LogErrorOnFailure(StopConnectOverIP());
+    LogErrorOnFailure(StopConnectOverSoftAP());
+
+    Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
+    RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress).SetConnectionObject(connObj);
+    OnDeviceDiscovered(params);
+}
+
+void SetUpCodePairer::OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj)
+{
+    (static_cast<SetUpCodePairer *>(appState))->OnDiscoveredDeviceOverBle(connObj);
+}
+
+void SetUpCodePairer::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err)
+{
+    LogErrorOnFailure(err);
+}
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+void SetUpCodePairer::OnDiscoveredDevice(const Mdns::DiscoveredNodeData & nodeData)
+{
+    LogErrorOnFailure(StopConnectOverBle());
+    LogErrorOnFailure(StopConnectOverIP());
+    LogErrorOnFailure(StopConnectOverSoftAP());
+
+    Inet::InterfaceId interfaceId      = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId[0] : INET_NULL_INTERFACEID;
+    Transport::PeerAddress peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port, interfaceId);
+    RendezvousParameters params        = RendezvousParameters().SetPeerAddress(peerAddress);
+    OnDeviceDiscovered(params);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -1,0 +1,95 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Declaration of SetUp Code Pairer, a class that parses a given
+ *      setup code and uses the extracted informations to discover and
+ *      filter commissionables nodes, before initiating the pairing process.
+ *
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/NodeId.h>
+#include <lib/support/DLLUtil.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <protocols/secure_channel/RendezvousParameters.h>
+#include <setup_payload/ManualSetupPayloadParser.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
+
+#if CONFIG_NETWORK_LAYER_BLE
+#include <ble/BleLayer.h>
+#endif // CONFIG_NETWORK_BLE
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+#include <controller/DeviceDiscoveryDelegate.h>
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
+namespace chip {
+namespace Controller {
+
+class DeviceCommissioner;
+
+class DLL_EXPORT SetUpCodePairer
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    : public DeviceDiscoveryDelegate
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+{
+public:
+    SetUpCodePairer(DeviceCommissioner * commissioner) : mCommissioner(commissioner) {}
+    virtual ~SetUpCodePairer() {}
+
+    CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode);
+
+#if CONFIG_NETWORK_LAYER_BLE
+    void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; };
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+private:
+    CHIP_ERROR Connect(RendezvousInformationFlag rendezvousInformation, uint16_t discriminator, bool isShort);
+    CHIP_ERROR StartDiscoverOverBle(uint16_t discriminator, bool isShort);
+    CHIP_ERROR StopConnectOverBle();
+    CHIP_ERROR StartDiscoverOverIP(uint16_t discriminator, bool isShort);
+    CHIP_ERROR StopConnectOverIP();
+    CHIP_ERROR StartDiscoverOverSoftAP(uint16_t discriminator, bool isShort);
+    CHIP_ERROR StopConnectOverSoftAP();
+
+    void OnDeviceDiscovered(RendezvousParameters & params);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    /////////// DeviceDiscoveryDelegate Interface /////////
+    void OnDiscoveredDevice(const chip::Mdns::DiscoveredNodeData & nodeData) override;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
+
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * mBleLayer = nullptr;
+    void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj);
+    /////////// BLEConnectionDelegate Callbacks /////////
+    static void OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj);
+    static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+    DeviceCommissioner * mCommissioner = nullptr;
+    chip::NodeId mRemoteId;
+    uint32_t mSetUpPINCode = 0;
+};
+
+} // namespace Controller
+} // namespace chip


### PR DESCRIPTION
#### Problem

As of today, `CHIPDeviceController::PairDevice` API requires the user to pass  the ip, port and interfaceId of the device to connect to.

This PR introduce an additional API, that takes a `const char * setupCode` and search over supported networks for a device (currently BLE/IP).
The current `CHIPDeviceController` is already complex, and I would expect the new code to grow as more edge cases are coming in. As a result I have added a separate class for the mentioned work.

As a separate issue I think it will be helpful to spend some times on how the mdns records are retrieved. Currently `AbstractMdnsDiscoveryController` is used to look over the network for commissionable nodes. It is not very practical because under the hood, there is a “Browse” operation which ends up beeing broken into multiples “Resolve”.  `AbstractMdnsDiscoveryController` does not have a way to know when the multiple resolves are done for a single browse, and so there is no easy way for the user of the API to know when it is time to retrieve commissionable nodes results.

#### Change overview
 * Update `src/platform/Darwin/MdnsImpl.cpp` to support browsing for subtypes
 * Update `src/setup_payload/` headers to use `#pragma once` since that’s missing and it was causing conflicts…
 * Add a new class `chip::Controller::SetUpCodeParser` which parses a setup code and extract the relevant `rendezvousInformation` in order to search for the target peripheral
 * Update `chip-tool` to have a few additional commands for browsing mdns
 * Update `chip-tool` `pairing qrcode` and `pairing manualcode` APIs to use the new `SetupCodeParser::PairDevice` interface

#### Testing
`scripts/tests/test_suites.sh` has been changed so it uses the new API in order to find which device it needs to connect to. This should exercise the API, as well as the `minimal` and Darwin mdns backends.
