### PR TITLE
use CHIP_ERROR_POSIX instead of MapErrorPOSIX

### DIFF
--- a/src/platform/Tizen/SystemTimeSupport.cpp
+++ b/src/platform/Tizen/SystemTimeSupport.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR GetClock_RealTime(uint64_t & curTime)
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
     {
-        return MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
     if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
     {
@@ -85,7 +85,7 @@ CHIP_ERROR GetClock_RealTimeMS(uint64_t & curTime)
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
     {
-        return MapErrorPOSIX(errno);
+        return CHIP_ERROR_POSIX(errno);
     }
     if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
     {
@@ -107,7 +107,7 @@ CHIP_ERROR SetClock_RealTime(uint64_t newCurTime)
     tv.tv_usec = static_cast<long>(newCurTime % UINT64_C(1000000));
     if (settimeofday(&tv, nullptr) != 0)
     {
-        return (errno == EPERM) ? CHIP_ERROR_ACCESS_DENIED : MapErrorPOSIX(errno);
+        return (errno == EPERM) ? CHIP_ERROR_ACCESS_DENIED : CHIP_ERROR_POSIX(errno);
     }
 #if CHIP_PROGRESS_LOGGING
     {


### PR DESCRIPTION
#### Problem
Tot Tizen platform fails to build

#### Change overview
use the CHIP_ERROR_POSIX macro instead of the now-internal-only MapErrorPosix method

#### Testing
Tizen compilation
