### PR TITLE
Change storage type of Ethernet diagnostic attributes to RAM

### DIFF
--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 54,
+  "featureLevel": 55,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -2930,7 +2930,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2945,7 +2945,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2960,7 +2960,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2975,7 +2975,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -2990,7 +2990,7 @@
               "mfgCode": null,
               "side": "server",
               "included": 1,
-              "storageOption": "External",
+              "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0x0000000000000000",
@@ -5642,5 +5642,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 259
     }
-  ]
+  ],
+  "log": []
 }

--- a/zzz_generated/lighting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/lighting-app/zap-generated/endpoint_config.h
@@ -905,16 +905,12 @@
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* ClusterRevision */                         \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Ethernet Network Diagnostics (server) */                                                      \
-            { 0x0002, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
-              ZAP_LONG_DEFAULTS_INDEX(1945) }, /* PacketRxCount */                                                                 \
-            { 0x0003, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
-              ZAP_LONG_DEFAULTS_INDEX(1953) }, /* PacketTxCount */                                                                 \
-            { 0x0004, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_LONG_DEFAULTS_INDEX(1961) }, /* TxErrCount */ \
-            { 0x0005, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
-              ZAP_LONG_DEFAULTS_INDEX(1969) }, /* CollisionCount */                                                                \
-            { 0x0006, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE),                                                   \
-              ZAP_LONG_DEFAULTS_INDEX(1977) },                              /* OverrunCount */                                     \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                                  \
+            { 0x0002, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1945) }, /* PacketRxCount */                                 \
+            { 0x0003, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1953) }, /* PacketTxCount */                                 \
+            { 0x0004, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1961) }, /* TxErrCount */                                    \
+            { 0x0005, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1969) }, /* CollisionCount */                                \
+            { 0x0006, ZAP_TYPE(INT64U), 8, 0, ZAP_LONG_DEFAULTS_INDEX(1977) }, /* OverrunCount */                                  \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* ClusterRevision */                               \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: AdministratorCommissioning (server) */                                                        \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* ClusterRevision */                                  \


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

With https://github.com/project-chip/connectedhomeip/pull/9667 merged, Ethernet diagnostic attributes are retrieved by a new mechanism with SDK-internal logic run to produce attribute values, in TLV form only.

So now, we have three mechanisms to manage the attributes
1. Internal attributes handled by the "global" attribute store directly.
2. External attributes handled by application-level callback.
3. Platform attributes handled by SDK-internal logic run to produce attribute values, 

For Ethernet diagnostic attributes, we should not mark them as 'external' any more since they are no longer handled by the application-level callback.

#### Change overview
Change storage type of Ethernet diagnostic attributes to RAM

#### Testing
How was this tested? (at least one bullet point required)
* ./chip-tool ethernetnetworkdiagnostics read packet-rx-count 0

```
[1632260951.084713][454525:454532] CHIP:EM: Removed CHIP MessageCounter:00000000 from RetransTable
[1632260951.084721][454525:454532] CHIP:DMG: ReportData =
[1632260951.084725][454525:454532] CHIP:DMG: {
[1632260951.084728][454525:454532] CHIP:DMG: 	AttributeDataList =
[1632260951.084732][454525:454532] CHIP:DMG: 	[
[1632260951.084735][454525:454532] CHIP:DMG: 		AttributeDataElement =
[1632260951.084738][454525:454532] CHIP:DMG: 		{
[1632260951.084742][454525:454532] CHIP:DMG: 			AttributePath =
[1632260951.084748][454525:454532] CHIP:DMG: 			{
[1632260951.084753][454525:454532] CHIP:DMG: 				NodeId = 0xd0aa20ffc084c442,
[1632260951.084758][454525:454532] CHIP:DMG: 				EndpointId = 0x0,
[1632260951.084762][454525:454532] CHIP:DMG: 				ClusterId = 0x37,
[1632260951.084767][454525:454532] CHIP:DMG: 				FieldTag = 0x2,
[1632260951.084771][454525:454532] CHIP:DMG: 			}
[1632260951.084776][454525:454532] CHIP:DMG: 				
[1632260951.084781][454525:454532] CHIP:DMG: 			Data = 0, 
[1632260951.084785][454525:454532] CHIP:DMG: 			DataElementVersion = 0x0,
[1632260951.084789][454525:454532] CHIP:DMG: 		},
[1632260951.084795][454525:454532] CHIP:DMG: 		
[1632260951.084798][454525:454532] CHIP:DMG: 	],
[1632260951.084804][454525:454532] CHIP:DMG: 	
[1632260951.084807][454525:454532] CHIP:DMG: }
[1632260951.084825][454525:454532] CHIP:ZCL: ReadAttributesResponse:
[1632260951.084828][454525:454532] CHIP:ZCL:   ClusterId: 0x0000_0037
[1632260951.084832][454525:454532] CHIP:ZCL:   attributeId: 0x0000_0002
[1632260951.084836][454525:454532] CHIP:ZCL:   status: Success                (0x0000)
[1632260951.084839][454525:454532] CHIP:ZCL:   attribute TLV Type: 0x04
```

