### PR TITLE
Add a controller factory to vend controllers per Fabric

### DIFF
--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -27,6 +27,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #endif
 
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -34,6 +35,8 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
+
+using DeviceControllerFactory = chip::Controller::DeviceControllerFactory;
 
 void Commands::Register(const char * clusterName, commands_list commandsList)
 {
@@ -46,7 +49,8 @@ void Commands::Register(const char * clusterName, commands_list commandsList)
 int Commands::Run(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Controller::CommissionerInitParams initParams;
+    chip::Controller::FactoryInitParams factoryInitParams;
+    chip::Controller::SetupParams commissionerParams;
     Command * command = nullptr;
     NodeId localId;
     NodeId remoteId;
@@ -73,14 +77,14 @@ int Commands::Run(int argc, char ** argv)
     ChipLogProgress(Controller, "Read local id 0x" ChipLogFormatX64 ", remote id 0x" ChipLogFormatX64, ChipLogValueX64(localId),
                     ChipLogValueX64(remoteId));
 
-    initParams.storageDelegate = &mStorage;
+    factoryInitParams.storageDelegate = &mStorage;
+    factoryInitParams.listenPort      = mStorage.GetListenPort();
 
     err = mOpCredsIssuer.Initialize(mStorage);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", chip::ErrorStr(err)));
 
-    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
+    commissionerParams.operationalCredentialsDelegate = &mOpCredsIssuer;
 
-    err = mController.SetUdpListenPort(mStorage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", chip::ErrorStr(err)));
 
     chip::Credentials::SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
@@ -104,19 +108,22 @@ int Commands::Run(int argc, char ** argv)
         err = mOpCredsIssuer.GenerateNOCChainAfterValidation(localId, 0, ephemeralKey.Pubkey(), rcacSpan, icacSpan, nocSpan);
         SuccessOrExit(err);
 
-        initParams.ephemeralKeypair = &ephemeralKey;
-        initParams.controllerRCAC   = rcacSpan;
-        initParams.controllerICAC   = icacSpan;
-        initParams.controllerNOC    = nocSpan;
+        commissionerParams.ephemeralKeypair = &ephemeralKey;
+        commissionerParams.controllerRCAC   = rcacSpan;
+        commissionerParams.controllerICAC   = icacSpan;
+        commissionerParams.controllerNOC    = nocSpan;
 
-        err = mController.Init(initParams);
+        // init the factory, then setup the Controller
+        err = DeviceControllerFactory::GetInstance().Init(factoryInitParams);
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Controller Factory failed to initialize"));
+        err = DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, mController);
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", chip::ErrorStr(err)));
     }
 
 #if CONFIG_USE_SEPARATE_EVENTLOOP
     // ServiceEvents() calls StartEventLoopTask(), which is paired with the
     // StopEventLoopTask() below.
-    err = mController.ServiceEvents();
+    err = DeviceControllerFactory::GetInstance().ServiceEvents();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Run Loop: %s", chip::ErrorStr(err)));
 #endif // CONFIG_USE_SEPARATE_EVENTLOOP
 

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -19,7 +19,7 @@
 #include <app-common/zap-generated/enums.h>
 #include <app/util/util.h>
 #include <controller/CHIPDevice.h>
-#include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPArgParser.hpp>
@@ -229,17 +229,16 @@ int main(int argc, char * argv[])
 
     chip::Logging::SetLogFilter(mStorage.GetLoggingLevel());
 
-    err = mController.SetUdpListenPort(mStorage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "failed to set UDP port: %s", chip::ErrorStr(err)));
 
     // Until #9518 is fixed, the only way to open a CASE session to another node is to commission it first using the
     // DeviceController API. Thus, the ota-requestor-app must do self commissioning and then read CASE credentials from persistent
     // storage to connect to the Provider node. See README.md for instructions.
     // NOTE: Controller is initialized in this call
-    err = DoExampleSelfCommissioning(mController, &mOpCredsIssuer, &mStorage, mStorage.GetLocalNodeId());
+    err = DoExampleSelfCommissioning(mController, &mOpCredsIssuer, &mStorage, mStorage.GetLocalNodeId(), mStorage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(SoftwareUpdate, "example self-commissioning failed: %s", chip::ErrorStr(err)));
 
-    err = mController.ServiceEvents();
+    err = chip::Controller::DeviceControllerFactory::GetInstance().ServiceEvents();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "ServiceEvents() failed: %s", chip::ErrorStr(err)));
 
     ChipLogProgress(SoftwareUpdate, "Attempting to connect to device 0x%" PRIX64, providerNodeId);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -40,7 +40,7 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 #include <ControllerShellCommands.h>
-#include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <platform/KeyValueStoreManager.h>
@@ -212,16 +212,17 @@ CHIP_ERROR InitCommissioner()
 {
     NodeId localId = chip::kPlaceholderNodeId;
 
-    chip::Controller::CommissionerInitParams params;
+    chip::Controller::FactoryInitParams factoryParams;
+    chip::Controller::SetupParams params;
 
-    params.storageDelegate                = &gServerStorage;
-    params.mDeviceAddressUpdateDelegate   = nullptr;
+    factoryParams.storageDelegate = &gServerStorage;
+    // use a different listen port for the commissioner.
+    factoryParams.listenPort              = LinuxDeviceOptions::GetInstance().securedCommissionerPort;
+    params.deviceAddressUpdateDelegate    = nullptr;
     params.operationalCredentialsDelegate = &gOpCredsIssuer;
 
     ReturnErrorOnFailure(gOpCredsIssuer.Initialize(gServerStorage));
 
-    // use a different listen port for the commissioner.
-    ReturnErrorOnFailure(gCommissioner.SetUdpListenPort(LinuxDeviceOptions::GetInstance().securedCommissionerPort));
     // No need to explicitly set the UDC port since we will use default
     ReturnErrorOnFailure(gCommissioner.SetUdcListenPort(LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort));
 
@@ -251,7 +252,9 @@ CHIP_ERROR InitCommissioner()
     params.controllerICAC   = icacSpan;
     params.controllerNOC    = nocSpan;
 
-    ReturnErrorOnFailure(gCommissioner.Init(params));
+    auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
+    ReturnErrorOnFailure(factory.Init(factoryParams));
+    ReturnErrorOnFailure(factory.SetupCommissioner(params, gCommissioner));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -34,6 +34,8 @@ static_library("controller") {
     "CHIPDevice.h",
     "CHIPDeviceController.cpp",
     "CHIPDeviceController.h",
+    "CHIPDeviceControllerFactory.cpp",
+    "CHIPDeviceControllerFactory.h",
     "DeviceAddressUpdateDelegate.h",
     "EmptyDataModelHandler.cpp",
     "ExampleOperationalCredentialsIssuer.cpp",

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -165,15 +165,13 @@ public:
      *   still using them, it can lead to unknown behavior and crashes.
      *
      * @param[in] params       Wrapper object for transport manager etc.
-     * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
      * @param[in] fabric        Local administrator that's initializing this device object
      */
-    void Init(ControllerDeviceInitParams params, uint16_t listenPort, FabricIndex fabric)
+    void Init(ControllerDeviceInitParams params, FabricIndex fabric)
     {
         mSessionManager  = params.sessionManager;
         mExchangeMgr     = params.exchangeMgr;
         mInetLayer       = params.inetLayer;
-        mListenPort      = listenPort;
         mFabricIndex     = fabric;
         mStorageDelegate = params.storageDelegate;
         mIDAllocator     = params.idAllocator;
@@ -196,15 +194,14 @@ public:
      *   is actually paired.
      *
      * @param[in] params       Wrapper object for transport manager etc.
-     * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
      * @param[in] deviceId     Node ID of the device
      * @param[in] peerAddress  The location of the peer. MUST be of type Transport::Type::kUdp
      * @param[in] fabric        Local administrator that's initializing this device object
      */
-    void Init(ControllerDeviceInitParams params, uint16_t listenPort, NodeId deviceId, const Transport::PeerAddress & peerAddress,
+    void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress,
               FabricIndex fabric)
     {
-        Init(params, mListenPort, fabric);
+        Init(params, fabric);
         mDeviceId = deviceId;
         mState    = ConnectionState::Connecting;
 
@@ -521,8 +518,6 @@ private:
 
     static void OnOpenPairingWindowSuccessResponse(void * context);
     static void OnOpenPairingWindowFailureResponse(void * context, uint8_t status);
-
-    uint16_t mListenPort;
 
     FabricIndex mFabricIndex = Transport::kUndefinedFabricIndex;
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -198,8 +198,7 @@ public:
      * @param[in] peerAddress  The location of the peer. MUST be of type Transport::Type::kUdp
      * @param[in] fabric        Local administrator that's initializing this device object
      */
-    void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress,
-              FabricIndex fabric)
+    void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress, FabricIndex fabric)
     {
         Init(params, fabric);
         mDeviceId = deviceId;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -121,8 +121,6 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     VerifyOrReturnError(params.systemState->SystemLayer() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(params.systemState->InetLayer() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    mListenPort = params.listenPort;
-
     mStorageDelegate = params.storageDelegate;
 #if CONFIG_NETWORK_LAYER_BLE
     VerifyOrReturnError(params.systemState->BleLayer() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -273,7 +271,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
             err = device->Deserialize(deviceInfo);
             VerifyOrExit(err == CHIP_NO_ERROR, ReleaseDevice(device));
 
-            device->Init(GetControllerDeviceInitParams(), mListenPort, mFabricIndex);
+            device->Init(GetControllerDeviceInitParams(), mFabricIndex);
         }
     }
 
@@ -747,7 +745,7 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     err = mPairingSession.MessageDispatch().Init(mSystemState->SessionMgr());
     SuccessOrExit(err);
 
-    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, fabric->GetFabricIndex());
+    device->Init(GetControllerDeviceInitParams(), remoteDeviceId, peerAddress, fabric->GetFabricIndex());
 
     mSystemState->SystemLayer()->StartTimer(kSessionEstablishmentTimeout, OnSessionEstablishmentTimeoutCallback, this);
     if (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle)
@@ -828,7 +826,7 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
 
     testSecurePairingSecret->ToSerializable(device->GetPairing());
 
-    device->Init(GetControllerDeviceInitParams(), mListenPort, remoteDeviceId, peerAddress, mFabricIndex);
+    device->Init(GetControllerDeviceInitParams(), remoteDeviceId, peerAddress, mFabricIndex);
 
     device->Serialize(serialized);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -100,10 +100,6 @@ struct ControllerInitParams
 
     uint16_t controllerVendorId;
 
-    /* The port used for operational communication to listen for and send messages over UDP/TCP.
-     * The default value of `0` will pick any available port. */
-    uint16_t listenPort = 0;
-
     FabricId fabricId = kUndefinedFabricId;
 };
 
@@ -299,7 +295,6 @@ protected:
 #endif
     DeviceControllerSystemState * mSystemState = nullptr;
 
-    uint16_t mListenPort;
     uint16_t GetInactiveDeviceIndex();
     uint16_t FindDeviceIndex(SessionHandle session);
     uint16_t FindDeviceIndex(NodeId id);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -32,6 +32,7 @@
 #include <controller-clusters/zap-generated/CHIPClientCallbacks.h>
 #include <controller/AbstractMdnsDiscoveryController.h>
 #include <controller/CHIPDevice.h>
+#include <controller/CHIPDeviceControllerSystemState.h>
 #include <controller/DeviceControllerInteractionModelDelegate.h>
 #include <controller/OperationalCredentialsDelegate.h>
 #include <credentials/CHIPOperationalCredentials.h>
@@ -82,15 +83,9 @@ void BasicFailure(void * context, uint8_t status);
 struct ControllerInitParams
 {
     PersistentStorageDelegate * storageDelegate = nullptr;
-    System::Layer * systemLayer                 = nullptr;
-    Inet::InetLayer * inetLayer                 = nullptr;
-
-#if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * bleLayer = nullptr;
-#endif
-    DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
+    DeviceControllerSystemState * systemState   = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
+    DeviceAddressUpdateDelegate * deviceAddressUpdateDelegate = nullptr;
 #endif
     OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
 
@@ -108,6 +103,8 @@ struct ControllerInitParams
     /* The port used for operational communication to listen for and send messages over UDP/TCP.
      * The default value of `0` will pick any available port. */
     uint16_t listenPort = 0;
+
+    FabricId fabricId = kUndefinedFabricId;
 };
 
 enum CommissioningStage : uint8_t
@@ -247,21 +244,11 @@ public:
 
     void PersistDevice(Device * device);
 
-    CHIP_ERROR SetUdpListenPort(uint16_t listenPort);
-
     virtual void ReleaseDevice(Device * device);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     void RegisterDeviceAddressUpdateDelegate(DeviceAddressUpdateDelegate * delegate) { mDeviceAddressUpdateDelegate = delegate; }
 #endif
-
-    // ----- IO -----
-    /**
-     * @brief
-     * Start the event loop task within the CHIP stack
-     * @return CHIP_ERROR   The return status
-     */
-    CHIP_ERROR ServiceEvents();
 
     /**
      * @brief Get the Compressed Fabric ID assigned to the device.
@@ -273,7 +260,14 @@ public:
      */
     uint64_t GetFabricId() const { return mFabricId; }
 
-    DeviceControllerInteractionModelDelegate * GetInteractionModelDelegate() { return mInteractionModelDelegate; }
+    DeviceControllerInteractionModelDelegate * GetInteractionModelDelegate()
+    {
+        if (mSystemState != nullptr)
+        {
+            return mSystemState->IMDelegate();
+        }
+        return nullptr;
+    }
 
 protected:
     enum class State
@@ -296,24 +290,14 @@ protected:
     PeerId mLocalId    = PeerId();
     FabricId mFabricId = kUndefinedFabricId;
 
-    DeviceTransportMgr * mTransportMgr                             = nullptr;
-    SessionManager * mSessionManager                               = nullptr;
-    Messaging::ExchangeManager * mExchangeMgr                      = nullptr;
-    secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
-    PersistentStorageDelegate * mStorageDelegate                   = nullptr;
-    DeviceControllerInteractionModelDelegate * mDefaultIMDelegate  = nullptr;
+    PersistentStorageDelegate * mStorageDelegate = nullptr;
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
     // TODO(cecille): Make this configuarable.
     static constexpr int kMaxCommissionableNodes = 10;
     Mdns::DiscoveredNodeData mCommissionableNodes[kMaxCommissionableNodes];
 #endif
-    Inet::InetLayer * mInetLayer = nullptr;
-#if CONFIG_NETWORK_LAYER_BLE
-    Ble::BleLayer * mBleLayer = nullptr;
-#endif
-    System::Layer * mSystemLayer                                         = nullptr;
-    DeviceControllerInteractionModelDelegate * mInteractionModelDelegate = nullptr;
+    DeviceControllerSystemState * mSystemState = nullptr;
 
     uint16_t mListenPort;
     uint16_t GetInactiveDeviceIndex();
@@ -328,7 +312,6 @@ protected:
     void PersistNextKeyId();
 
     FabricIndex mFabricIndex = Transport::kMinValidFabricIndex;
-    Transport::FabricTable mFabrics;
 
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate;
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -1,0 +1,284 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Implementation of CHIP Device Controller Factory, a utility/manager class
+ *      that vends Controller objects
+ */
+
+#include <controller/CHIPDeviceControllerFactory.h>
+
+#include <lib/support/ErrorStr.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/ConfigurationManager.h>
+#endif
+
+using namespace chip::Inet;
+using namespace chip::System;
+using namespace chip::Credentials;
+
+namespace chip {
+namespace Controller {
+
+CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
+{
+
+    // SystemState is only set the first time init is called, after that it is managed
+    // internally. If SystemState is set then init has already completed.
+    if (mSystemState != nullptr)
+    {
+        ChipLogError(Controller, "Device Controller Factory already initialized...");
+        return CHIP_NO_ERROR;
+    }
+
+    mListenPort      = params.listenPort;
+    mStorageDelegate = params.storageDelegate;
+
+    CHIP_ERROR err = InitSystemState(params);
+
+    return err;
+}
+
+CHIP_ERROR DeviceControllerFactory::InitSystemState()
+{
+    FactoryInitParams params;
+    if (mSystemState != nullptr)
+    {
+        params.systemLayer = mSystemState->SystemLayer();
+        params.inetLayer   = mSystemState->InetLayer();
+#if CONFIG_NETWORK_LAYER_BLE
+        params.bleLayer = mSystemState->BleLayer();
+#endif
+    }
+
+    return InitSystemState(params);
+}
+
+CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
+{
+    if (mSystemState != nullptr && mSystemState->IsInitialized())
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    if (mSystemState != nullptr)
+    {
+        mSystemState->Release();
+        chip::Platform::Delete(mSystemState);
+        mSystemState = nullptr;
+    }
+
+    DeviceControllerSystemStateParams stateParams;
+#if CONFIG_DEVICE_LAYER
+    ReturnErrorOnFailure(DeviceLayer::PlatformMgr().InitChipStack());
+
+    stateParams.systemLayer = &DeviceLayer::SystemLayer();
+    stateParams.inetLayer   = &DeviceLayer::InetLayer;
+#else
+    stateParams.systemLayer = params.systemLayer;
+    stateParams.inetLayer   = params.inetLayer;
+    ChipLogError(Controller, "Warning: Device Controller Factory should be with a CHIP Device Layer...");
+#endif // CONFIG_DEVICE_LAYER
+
+    VerifyOrReturnError(stateParams.systemLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(stateParams.inetLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+#if CONFIG_NETWORK_LAYER_BLE
+#if CONFIG_DEVICE_LAYER
+    stateParams.bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
+#else
+    stateParams.bleLayer = params.bleLayer;
+#endif // CONFIG_DEVICE_LAYER
+    VerifyOrReturnError(stateParams.bleLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+#endif
+
+    stateParams.transportMgr = chip::Platform::New<DeviceTransportMgr>();
+
+    ReturnErrorOnFailure(stateParams.transportMgr->Init(
+        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::kIPAddressType_IPv6).SetListenPort(mListenPort)
+#if INET_CONFIG_ENABLE_IPV4
+            ,
+        Transport::UdpListenParameters(stateParams.inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(mListenPort)
+#endif
+#if CONFIG_NETWORK_LAYER_BLE
+            ,
+        Transport::BleListenParameters(stateParams.bleLayer)
+#endif
+            ));
+
+    if (params.imDelegate == nullptr)
+    {
+        params.imDelegate = chip::Platform::New<DeviceControllerInteractionModelDelegate>();
+    }
+
+    stateParams.fabricTable           = chip::Platform::New<Transport::FabricTable>();
+    stateParams.sessionMgr            = chip::Platform::New<SessionManager>();
+    stateParams.exchangeMgr           = chip::Platform::New<Messaging::ExchangeManager>();
+    stateParams.messageCounterManager = chip::Platform::New<secure_channel::MessageCounterManager>();
+
+    ReturnErrorOnFailure(stateParams.fabricTable->Init(mStorageDelegate));
+    ReturnErrorOnFailure(stateParams.sessionMgr->Init(stateParams.systemLayer, stateParams.transportMgr, stateParams.fabricTable,
+                                                      stateParams.messageCounterManager));
+    ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
+    ReturnErrorOnFailure(stateParams.messageCounterManager->Init(stateParams.exchangeMgr));
+
+    stateParams.imDelegate = params.imDelegate;
+    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(stateParams.exchangeMgr, stateParams.imDelegate));
+
+    // store the system state
+    mSystemState = chip::Platform::New<DeviceControllerSystemState>(stateParams);
+    ChipLogDetail(Controller, "System State Initialized...");
+    return CHIP_NO_ERROR;
+}
+
+void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    controllerParams.deviceAddressUpdateDelegate = params.deviceAddressUpdateDelegate;
+#endif
+    controllerParams.operationalCredentialsDelegate = params.operationalCredentialsDelegate;
+    controllerParams.ephemeralKeypair               = params.ephemeralKeypair;
+    controllerParams.controllerNOC                  = params.controllerNOC;
+    controllerParams.controllerICAC                 = params.controllerICAC;
+    controllerParams.controllerRCAC                 = params.controllerRCAC;
+    controllerParams.fabricId                       = params.fabricId;
+
+    controllerParams.systemState        = mSystemState;
+    controllerParams.storageDelegate    = mStorageDelegate;
+    controllerParams.controllerVendorId = params.controllerVendorId;
+}
+
+CHIP_ERROR DeviceControllerFactory::SetupController(SetupParams params, DeviceController & controller)
+{
+    VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(InitSystemState());
+
+    ControllerInitParams controllerParams;
+    PopulateInitParams(controllerParams, params);
+
+    CHIP_ERROR err = controller.Init(controllerParams);
+    return err;
+}
+
+CHIP_ERROR DeviceControllerFactory::SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner)
+{
+    VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(InitSystemState());
+
+    CommissionerInitParams commissionerParams;
+    PopulateInitParams(commissionerParams, params);
+    commissionerParams.pairingDelegate = params.pairingDelegate;
+
+    CHIP_ERROR err = commissioner.Init(commissionerParams);
+    return err;
+}
+
+CHIP_ERROR DeviceControllerFactory::ServiceEvents()
+{
+    VerifyOrReturnError(mSystemState != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+#if CONFIG_DEVICE_LAYER
+    ReturnErrorOnFailure(DeviceLayer::PlatformMgr().StartEventLoopTask());
+#endif // CONFIG_DEVICE_LAYER
+
+    return CHIP_NO_ERROR;
+}
+
+DeviceControllerFactory::~DeviceControllerFactory()
+{
+    if (mSystemState != nullptr)
+    {
+        mSystemState->Release();
+        chip::Platform::Delete(mSystemState);
+        mSystemState = nullptr;
+    }
+    mStorageDelegate = nullptr;
+}
+
+CHIP_ERROR DeviceControllerSystemState::Shutdown()
+{
+    VerifyOrReturnError(mRefCount == 1, CHIP_ERROR_INCORRECT_STATE);
+
+    ChipLogDetail(Controller, "Shutting down the System State, this will teardown the CHIP Stack");
+
+    // Shut down the interaction model
+    app::InteractionModelEngine::GetInstance()->Shutdown();
+
+#if CONFIG_DEVICE_LAYER
+    //
+    // We can safely call PlatformMgr().Shutdown(), which like DeviceController::Shutdown(),
+    // expects to be called with external thread synchronization and will not try to acquire the
+    // stack lock.
+    //
+    // Actually stopping the event queue is a separable call that applications will have to sequence.
+    // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling
+    // DeviceController::Shutdown() in the CONFIG_DEVICE_LAYER configuration
+    //
+    ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
+#endif
+
+    // TODO(#6668): Some exchange has leak, shutting down ExchangeManager will cause a assert fail.
+    // if (mExchangeMgr != nullptr)
+    // {
+    //     mExchangeMgr->Shutdown();
+    // }
+    if (mSessionMgr != nullptr)
+    {
+        mSessionMgr->Shutdown();
+    }
+
+    mSystemLayer = nullptr;
+    mInetLayer   = nullptr;
+    if (mTransportMgr != nullptr)
+    {
+        chip::Platform::Delete(mTransportMgr);
+        mTransportMgr = nullptr;
+    }
+
+    if (mMessageCounterManager != nullptr)
+    {
+        chip::Platform::Delete(mMessageCounterManager);
+        mMessageCounterManager = nullptr;
+    }
+
+    if (mExchangeMgr != nullptr)
+    {
+        chip::Platform::Delete(mExchangeMgr);
+        mExchangeMgr = nullptr;
+    }
+
+    if (mSessionMgr != nullptr)
+    {
+        chip::Platform::Delete(mSessionMgr);
+        mSessionMgr = nullptr;
+    }
+
+    if (mIMDelegate != nullptr)
+    {
+        chip::Platform::Delete(mIMDelegate);
+        mIMDelegate = nullptr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -1,0 +1,117 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      DeviceControllerFactory is a singleton utility class that manages the
+ *      runtime DeviceControllerSystemState and provides APIs to setup DeviceControllers
+ *      and DeviceCommissioners.
+ *
+ *      Together with the SystemState this class implicitly manages the lifecycle of the underlying
+ *      CHIP stack. It lazily initializes the CHIPStack when setting up Controllers if the SystemState
+ *      was previously shutdown.
+ */
+
+#pragma once
+
+#include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerSystemState.h>
+
+namespace chip {
+
+namespace Controller {
+
+struct SetupParams
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    DeviceAddressUpdateDelegate * deviceAddressUpdateDelegate = nullptr;
+#endif
+    OperationalCredentialsDelegate * operationalCredentialsDelegate = nullptr;
+
+    /* The following keypair must correspond to the public key used for generating
+    controllerNOC. It's used by controller to establish CASE sessions with devices */
+    Crypto::P256Keypair * ephemeralKeypair = nullptr;
+
+    /* The following certificates must be in x509 DER format */
+    ByteSpan controllerNOC;
+    ByteSpan controllerICAC;
+    ByteSpan controllerRCAC;
+
+    FabricId fabricId = kUndefinedFabricId;
+
+    uint16_t controllerVendorId;
+
+    // The Device Pairing Delegated used to initialize a Commissioner
+    DevicePairingDelegate * pairingDelegate = nullptr;
+};
+
+// TODO everything other than the storage delegate here should be removed.
+// We're blocked because of the need to support !CHIP_DEVICE_LAYER
+struct FactoryInitParams
+{
+    PersistentStorageDelegate * storageDelegate           = nullptr;
+    System::Layer * systemLayer                           = nullptr;
+    Inet::InetLayer * inetLayer                           = nullptr;
+    DeviceControllerInteractionModelDelegate * imDelegate = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * bleLayer = nullptr;
+#endif
+
+    /* The port used for operational communication to listen for and send messages over UDP/TCP.
+     * The default value of `0` will pick any available port. */
+    uint16_t listenPort = 0;
+};
+
+class DeviceControllerFactory
+{
+public:
+    static DeviceControllerFactory & GetInstance()
+    {
+        static DeviceControllerFactory instance;
+        return instance;
+    }
+
+    CHIP_ERROR Init(FactoryInitParams params);
+    CHIP_ERROR SetupController(SetupParams params, DeviceController & controller);
+    CHIP_ERROR SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner);
+
+    // ----- IO -----
+    /**
+     * @brief
+     * Start the event loop task within the CHIP stack
+     * @return CHIP_ERROR   The return status
+     */
+    CHIP_ERROR ServiceEvents();
+
+    ~DeviceControllerFactory();
+    DeviceControllerFactory(DeviceControllerFactory const &) = delete;
+    void operator=(DeviceControllerFactory const &) = delete;
+
+private:
+    DeviceControllerFactory(){};
+    void PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params);
+    CHIP_ERROR InitSystemState(FactoryInitParams params);
+    CHIP_ERROR InitSystemState();
+
+    uint16_t mListenPort;
+    PersistentStorageDelegate * mStorageDelegate = nullptr;
+    DeviceControllerSystemState * mSystemState   = nullptr;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -1,0 +1,146 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      DeviceControllerSystemState is a representation of all the runtime state
+ *      inside of CHIP that can be shared across Controllers and Commissioners.
+ *
+ *      The System State assumes it's being owned by and managed by the DeviceControllerFactory.
+ *      It will automatically shutdown the underlying CHIP Stack when its reference count
+ *      decreases to "1".
+ *
+ */
+
+#pragma once
+
+#include <controller/DeviceControllerInteractionModelDelegate.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/TransportMgr.h>
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
+#if CONFIG_NETWORK_LAYER_BLE
+#include <ble/BleLayer.h>
+#endif
+
+namespace chip {
+
+namespace Controller {
+
+struct DeviceControllerSystemStateParams
+{
+    System::Layer * systemLayer = nullptr;
+    Inet::InetLayer * inetLayer = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * bleLayer = nullptr;
+#endif
+    DeviceTransportMgr * transportMgr                             = nullptr;
+    SessionManager * sessionMgr                                   = nullptr;
+    Messaging::ExchangeManager * exchangeMgr                      = nullptr;
+    secure_channel::MessageCounterManager * messageCounterManager = nullptr;
+    Transport::FabricTable * fabricTable                          = nullptr;
+    DeviceControllerInteractionModelDelegate * imDelegate         = nullptr;
+};
+
+// A representation of the internal state maintained by the DeviceControllerFactory
+// and refcounted by Device Controllers.
+// Expects that the creator of this object is the last one to release it.
+class DeviceControllerSystemState
+{
+public:
+    ~DeviceControllerSystemState(){};
+    DeviceControllerSystemState(DeviceControllerSystemStateParams params) :
+        mSystemLayer(params.systemLayer), mInetLayer(params.inetLayer), mTransportMgr(params.transportMgr),
+        mSessionMgr(params.sessionMgr), mExchangeMgr(params.exchangeMgr), mMessageCounterManager(params.messageCounterManager),
+        mFabrics(params.fabricTable), mIMDelegate(params.imDelegate)
+    {
+#if CONFIG_NETWORK_LAYER_BLE
+        mBleLayer = params.bleLayer;
+#endif
+    };
+
+    DeviceControllerSystemState * Retain()
+    {
+        if (mRefCount == std::numeric_limits<uint32_t>::max())
+        {
+            abort();
+        }
+        ++mRefCount;
+        return this;
+    };
+
+    void Release()
+    {
+        if (mRefCount == 0)
+        {
+            abort();
+        }
+
+        mRefCount--;
+        if (mRefCount == 1)
+        {
+            // Only the factory should have a ref now, shutdown and release the underlying objects
+            Shutdown();
+        }
+        else if (mRefCount == 0)
+        {
+            this->~DeviceControllerSystemState();
+        }
+    };
+    bool IsInitialized()
+    {
+        return mSystemLayer != nullptr && mInetLayer != nullptr && mTransportMgr != nullptr && mSessionMgr != nullptr &&
+            mExchangeMgr != nullptr && mMessageCounterManager != nullptr && mFabrics != nullptr;
+    };
+
+    System::Layer * SystemLayer() { return mSystemLayer; };
+    Inet::InetLayer * InetLayer() { return mInetLayer; };
+    DeviceTransportMgr * TransportMgr() { return mTransportMgr; };
+    SessionManager * SessionMgr() { return mSessionMgr; };
+    Messaging::ExchangeManager * ExchangeMgr() { return mExchangeMgr; }
+    secure_channel::MessageCounterManager * MessageCounterManager() { return mMessageCounterManager; };
+    Transport::FabricTable * Fabrics() { return mFabrics; };
+    DeviceControllerInteractionModelDelegate * IMDelegate() { return mIMDelegate; }
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * BleLayer() { return mBleLayer; };
+#endif
+
+private:
+    DeviceControllerSystemState(){};
+
+    System::Layer * mSystemLayer = nullptr;
+    Inet::InetLayer * mInetLayer = nullptr;
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * mBleLayer = nullptr;
+#endif
+    DeviceTransportMgr * mTransportMgr                             = nullptr;
+    SessionManager * mSessionMgr                                   = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr                      = nullptr;
+    secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
+    Transport::FabricTable * mFabrics                              = nullptr;
+    DeviceControllerInteractionModelDelegate * mIMDelegate         = nullptr;
+
+    std::atomic<uint32_t> mRefCount{ 1 };
+
+    CHIP_ERROR Shutdown();
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -51,6 +51,7 @@
 #include <app/server/Mdns.h>
 #include <controller/CHIPDevice.h>
 #include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationVerifierExample.h>
@@ -207,19 +208,21 @@ ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Control
                                                                         nocSpan);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 
-    CommissionerInitParams initParams;
-    initParams.storageDelegate                = &sStorageDelegate;
-    initParams.mDeviceAddressUpdateDelegate   = &sDeviceAddressUpdateDelegate;
+    FactoryInitParams factoryParams;
+    factoryParams.storageDelegate = &sStorageDelegate;
+    factoryParams.imDelegate      = &PythonInteractionModelDelegate::Instance();
+
+    SetupParams initParams;
+    initParams.deviceAddressUpdateDelegate    = &sDeviceAddressUpdateDelegate;
     initParams.pairingDelegate                = &sPairingDelegate;
     initParams.operationalCredentialsDelegate = &sOperationalCredentialsIssuer;
-    initParams.imDelegate                     = &PythonInteractionModelDelegate::Instance();
     initParams.ephemeralKeypair               = &ephemeralKey;
     initParams.controllerRCAC                 = rcacSpan;
     initParams.controllerICAC                 = icacSpan;
     initParams.controllerNOC                  = nocSpan;
 
-    (*outDevCtrl)->SetUdpListenPort(0);
-    err = (*outDevCtrl)->Init(initParams);
+    ReturnErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryParams).AsInteger());
+    err = DeviceControllerFactory::GetInstance().SetupCommissioner(initParams, **outDevCtrl);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err.AsInteger());
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
     chip::app::MdnsServer::Instance().StartServer(chip::Mdns::CommissioningMode::kDisabled);

--- a/src/controller/tests/TestDevice.cpp
+++ b/src/controller/tests/TestDevice.cpp
@@ -91,7 +91,7 @@ void TestDevice_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext
     Inet::IPAddress mockAddr;
     Inet::IPAddress::FromString("127.0.0.1", mockAddr);
     PeerAddress addr = PeerAddress::UDP(mockAddr, CHIP_PORT);
-    device.Init(params, CHIP_PORT, mockNodeId, addr, mockFabricIndex);
+    device.Init(params, mockNodeId, addr, mockFabricIndex);
 
     device.OperationalCertProvisioned();
     NL_TEST_ASSERT(inSuite, device.EstablishConnectivity(nullptr, nullptr) == CHIP_NO_ERROR);

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -32,6 +32,7 @@
 #include <platform/CHIPDeviceBuildConfig.h>
 
 #include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationVerifier.h>
 #include <credentials/examples/DeviceAttestationVerifierExample.h>
 #include <lib/support/CHIPMem.h>
@@ -65,6 +66,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 @property (readonly) uint16_t listenPort;
 @end
 
+// TODO Replace Shared Controller with a Controller Factory Singleton
 @implementation CHIPDeviceController
 
 + (CHIPDeviceController *)sharedController
@@ -171,23 +173,21 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
             return;
         }
 
+        chip::Controller::FactoryInitParams params;
+        chip::Controller::SetupParams commissionerParams;
+
         if (_listenPort) {
-            errorCode = _cppCommissioner->SetUdpListenPort(_listenPort);
-            if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
-                return;
-            }
+            params.listenPort = _listenPort;
         }
 
         // Initialize device attestation verifier
         chip::Credentials::SetDeviceAttestationVerifier(chip::Credentials::Examples::GetExampleDACVerifier());
 
-        chip::Controller::CommissionerInitParams params;
-
         params.storageDelegate = _persistentStorageDelegateBridge;
-        params.mDeviceAddressUpdateDelegate = _pairingDelegateBridge;
-        params.pairingDelegate = _pairingDelegateBridge;
+        commissionerParams.deviceAddressUpdateDelegate = _pairingDelegateBridge;
+        commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
-        params.operationalCredentialsDelegate = _operationalCredentialsDelegate;
+        commissionerParams.operationalCredentialsDelegate = _operationalCredentialsDelegate;
 
         chip::Crypto::P256Keypair ephemeralKey;
         errorCode = ephemeralKey.Initialize();
@@ -209,13 +209,20 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
             return;
         }
 
-        params.ephemeralKeypair = &ephemeralKey;
-        params.controllerRCAC = rcac;
-        params.controllerICAC = icac;
-        params.controllerNOC = noc;
-        params.controllerVendorId = vendorId;
+        commissionerParams.ephemeralKeypair = &ephemeralKey;
+        commissionerParams.controllerRCAC = rcac;
+        commissionerParams.controllerICAC = icac;
+        commissionerParams.controllerNOC = noc;
+        commissionerParams.controllerVendorId = vendorId;
 
-        errorCode = _cppCommissioner->Init(params);
+        // TODO Replace Shared Controller with a Controller Factory Singleton
+        auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
+        errorCode = factory.Init(params);
+        if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
+            return;
+        }
+
+        errorCode = factory.SetupCommissioner(commissionerParams, *_cppCommissioner);
         if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
             return;
         }

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -184,6 +184,8 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
+    // TODO Store more than one delegate and add API to query delegates to check if incoming messages are for them.
+    // Do the same for the UMHs as well
     void SetDelegate(ExchangeMgrDelegate * delegate) { mDelegate = delegate; }
 
     SessionManager * GetSessionManager() const { return mSessionManager; }


### PR DESCRIPTION
#### Problem
Our current SDK implementation only allows for a single Fabric Commissioner/Controller and assumes all the state is owned by that object. 

We need to be able to setup multiple Commissioner/Controller objects per Fabric to be able to manage and communicate with more than one Fabric at the same time while being able to reuse the underlying platform, messaging, and networking stacks. 

#### Change overview
This PR is a refactor to establish the direction we want to move the SDK in. 
**There are a few issues that prevent us from creating multiple Controllers/Commissioners even after this PR but I will get to addressing those immediately after this.** 

The following changes have been made:
1. Add a Factory class to own and manage the underlying system state. This factory can then setup Controller/Commissioner objects with the necessary state. 
2. Anything that didn't require to be Fabric scoped has been moved into the system state object. 
3. Hotfixes to all consumers to use the Factory to setup a Commissioner  

The following changes need to be made:
1. Need to be able to either a) handle multiple controllers per Fabric b) only allow one controller per Fabric 
2. Exchange* has 2 delegates, both of which need to be able handle "Lists" of delegates where there may be a delegate per Fabric. For connections where a secure session exists we know the fabric index of the peer so we can easily select the right delegate to give the message to, but for unsecure and unsolicited messages I think we need to give it some more thought.
3. Darwin SDK needs a refactor to move away from a singleton Darwin CHIPDeviceController object. 
4. mDNS is also a singleton with a single delegate. We need to make sure all our singletons can service multiple clients. 

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
Manually tested chip-tool, python controller, and iOS CHIPTool.
