### PR TITLE
Add cluster id code for struct and enum in xml

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -18,6 +18,7 @@ limitations under the License.
   <domain name="General"/>
 
   <enum name="StatusCode" type="ENUM8">
+    <cluster code="0x003c"/>
      <item name="Success" value="0x00"/>
      <item name="Busy" value="0x01"/>
      <item name="GeneralError" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -39,6 +39,7 @@ limitations under the License.
   </cluster>
 
   <enum name="ApplicationBasicStatus" type="ENUM8">
+    <cluster code="0x050d"/>
     <item name="Stopped" value="0x00"/>
     <item name="ActiveVisibleFocus" value="0x01"/>
     <item name="ActiveHidden" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -47,11 +47,13 @@ limitations under the License.
   </cluster>
       
   <struct name="ApplicationLauncherApp">
+    <cluster code="0x050c"/>
     <item name="catalogVendorId" type="INT16U"/>
     <item name="applicationId" type="CHAR_STRING"/>
   </struct>
 
   <enum name="ApplicationLauncherStatus" type="ENUM8">
+    <cluster code="0x050c"/>
     <item name="Success" value="0x00"/>
     <item name="AppNotAvailable" value="0x01"/>
     <item name="SystemBusy" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -42,12 +42,14 @@ limitations under the License.
   </cluster>
 
   <struct name="AudioOutputInfo">
+    <cluster code="0x050b"/>
     <item name="index" type="INT8U"/>
     <item name="outputType" type="AudioOutputType"/>
     <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 
   <enum name="AudioOutputType" type="ENUM8">
+    <cluster code="0x050b"/>
     <item name="Hdmi" value="0x00"/>
     <item name="Bt" value="0x01"/>
     <item name="Optical" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -17,16 +17,19 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
     <enum name="OTAQueryStatus" type="ENUM8">
+        <cluster code="0x0029"/>
         <item name="UpdateAvailable" value="0x0"/>
         <item name="Busy" value="0x1"/>
         <item name="NotAvailable" value="0x2"/>
     </enum>
     <enum name="OTAApplyUpdateAction" type="ENUM8">
+        <cluster code="0x0029"/>
         <item name="Proceed" value="0x0"/>
         <item name="AwaitNextAction" value="0x1"/>
         <item name="Discontinue" value="0x2"/>
     </enum>
     <enum name="OTADownloadProtocol" type="ENUM8">
+        <cluster code="0x0029"/>
         <item name="BDXSynchronous" value="0x0"/>
         <item name="BDXAsynchronous" value="0x1"/>
         <item name="HTTPS" value="0x2"/>
@@ -79,6 +82,7 @@ limitations under the License.
         </command>
     </cluster>
     <enum name="OTAAnnouncementReason" type="ENUM8">
+        <cluster code="0x002a"/>
         <item name="SimpleAnnouncement" value="0x0"/>
         <item name="UpdateAvailable" value="0x1"/>
         <item name="CriticalUpdateAvailable" value="0x2"/>

--- a/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioning.xml
@@ -17,6 +17,7 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
     <enum name="NetworkCommissioningError" type="ENUM8">
+        <cluster code="0x0031"/>
         <item name="Success" value="0x0"/>
         <item name="OutOfRange" value="0x1"/>
         <item name="BoundsExceeded" value="0x2"/>
@@ -46,6 +47,7 @@ limitations under the License.
         <field name="WPA3-PERSONAL" mask="0x10"/>
     </bitmap>
     <struct name="WiFiInterfaceScanResult">
+        <cluster code="0x0031"/>
         <item name="Security" type="BITMAP8"/>
         <item name="SSID" type="OCTET_STRING"/>
         <item name="BSSID" type="OCTET_STRING"/>
@@ -53,6 +55,7 @@ limitations under the License.
         <item name="FrequencyBand" type="INT32U"/>
     </struct>
     <struct name="ThreadInterfaceScanResult">
+        <cluster code="0x0031"/>
         <item name="DiscoveryResponse" type="OCTET_STRING"/>
     </struct>
     <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -58,16 +58,19 @@ limitations under the License.
   </cluster>
 
   <struct name="ContentLaunchAdditionalInfo">
+    <cluster code="0x050a"/>
     <item name="name" type="CHAR_STRING"/>
     <item name="value" type="CHAR_STRING"/>
   </struct>
 
   <enum name="ContentLaunchMetricType" type="ENUM8">
+    <cluster code="0x050a"/>
     <item name="PIXELS" value="0x00"/>
     <item name="PERCENTAGE" value="0x01"/>
   </enum>
 
   <struct name="ContentLaunchDimension">
+    <cluster code="0x050a"/>
     <!-- TODO: Convert to double once it is supported -->
     <item name="width" type="CHAR_STRING"/>
     <!-- TODO: Convert to double once it is supported -->
@@ -76,6 +79,7 @@ limitations under the License.
   </struct>
 
   <struct name="ContentLaunchStyleInformation">
+    <cluster code="0x050a"/>
     <item name="imageUrl" type="CHAR_STRING"/>
     <item name="color" type="CHAR_STRING"/>
     <!-- TODO: Convert to struct ContentLaunchDimension once is supported -->
@@ -83,6 +87,7 @@ limitations under the License.
   </struct>
 
   <struct name="ContentLaunchBrandingInformation">
+    <cluster code="0x050a"/>
     <item name="providerName" type="CHAR_STRING"/>
     <!-- TODO: Convert to struct ContentLaunchStyleInformation once is supported -->
     <item name="background" type="INT8U"/>
@@ -98,6 +103,7 @@ limitations under the License.
 
 
   <enum name="ContentLaunchParameterEnum" type="ENUM8">
+    <cluster code="0x050a"/>
     <item name="Actor" value="0x00"/>
     <item name="Channel" value="0x01"/>
     <item name="Character" value="0x02"/>
@@ -112,17 +118,20 @@ limitations under the License.
   </enum>
 
   <enum name="ContentLaunchStreamingType" type="ENUM8">
+    <cluster code="0x050a"/>
     <item name="DASH" value="0x00"/>
     <item name="HLS" value="0x01"/>
   </enum>
 
   <enum name="ContentLaunchStatus" type="ENUM8">
+    <cluster code="0x050a"/>
     <item name="Success" value="0x00"/>
     <item name="UrlNotAvailable" value="0x01"/>
     <item name="AuthFailed" value="0x02"/>
   </enum>
 
   <struct name="ContentLaunchParamater">
+    <cluster code="0x050a"/>
     <item name="Type" type="ContentLaunchParameterEnum"/>
     <item name="Value" type="CHAR_STRING"/>
     <item name="ExternalIDList" type="ARRAY" entryType="ContentLaunchAdditionalInfo" length="254"/>

--- a/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
@@ -18,6 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="DeviceType">
+    <cluster code="0x001d"/>
     <item name="type" type="DEVTYPE_ID"/>
     <item name="revision" type="INT16U"/>
   </struct>

--- a/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
@@ -17,11 +17,13 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
     <enum name="LogsIntent" type="ENUM8">
+        <cluster code="0x0032"/>
         <item name="EndUserSupport" value="0x0"/>
         <item name="NetworkDiag" value="0x1"/>
         <item name="CrashLogs" value="0x2"/>
     </enum>
     <enum name="LogsStatus" type="ENUM8">
+        <cluster code="0x0032"/>
         <item name="Success" value="0x0"/>
         <item name="Exhausted" value="0x1"/>
         <item name="NoLogs" value="0x2"/>
@@ -29,6 +31,7 @@ limitations under the License.
         <item name="Denied" value="0x4"/>
     </enum>
     <enum name="LogsTransferProtocol" type="ENUM8">
+        <cluster code="0x0032"/>
         <item name="ResponsePayload" value="0x0"/>
         <item name="BDX" value="0x1"/>
     </enum>

--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -17,6 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <enum name="PHYRateType" type="ENUM8">
+    <cluster code="0x0037"/>
     <item name="10M" value="0x00"/>
     <item name="100M" value="0x01"/>
     <item name="1000M" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -18,6 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="LabelStruct">
+    <cluster code="0x0040"/>
     <item name="label" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
     <item name="value" type="OCTET_STRING" length="16"/> <!-- TODO: Change this to CHAR_STRING once it is supported #6112 -->
   </struct>

--- a/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
@@ -17,16 +17,19 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <enum name="GeneralCommissioningError" type="ENUM8">
+    <cluster code="0x0030"/>
     <item name="Ok" value="0x0"/>
     <item name="ValueOutsideRange" value="0x1"/>
     <item name="InvalidAuthentication" value="0x2"/>
   </enum>
   <enum name="RegulatoryLocationType" type="ENUM8">
+    <cluster code="0x0030"/>
     <item name="Indoor" value="0x0"/>
     <item name="Outdoor" value="0x1"/>
     <item name="IndoorOutdoor" value="0x2"/>
   </enum>
   <struct name="BasicCommissioningInfoType">
+    <cluster code="0x0030"/>
     <item name="FailSafeExpiryLengthMs" type="INT32U"/>
   </struct>  
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -17,6 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <enum name="HardwareFaultType" type="ENUM8">
+    <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
     <item name="Radio" value="0x01"/>
     <item name="Sensor" value="0x02"/>
@@ -30,6 +31,7 @@ limitations under the License.
     <item name="TamperDetected" value="0x0A"/>
   </enum>
   <enum name="RadioFaultType" type="ENUM8">
+    <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
     <item name="WiFiFault" value="0x01"/>
     <item name="CellularFault" value="0x02"/>
@@ -39,12 +41,14 @@ limitations under the License.
     <item name="EthernetFault" value="0x06"/>    
   </enum>
   <enum name="NetworkFaultType" type="ENUM8">
+    <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
     <item name="HardwareFailure" value="0x01"/>
     <item name="NetworkJammed" value="0x02"/>
     <item name="ConnectionFailed" value="0x03"/>
   </enum>
   <enum name="BootReasonType" type="ENUM8">
+    <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
     <item name="PowerOnReboot" value="0x01"/>
     <item name="BrownOutReset" value="0x02"/>
@@ -54,6 +58,7 @@ limitations under the License.
     <item name="SoftwareReset" value="0x06"/>
   </enum>  
   <enum name="InterfaceType" type="ENUM8">
+    <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
     <item name="WiFi" value="0x01"/>
     <item name="Ethernet" value="0x02"/>
@@ -61,6 +66,7 @@ limitations under the License.
     <item name="Thread" value="0x04"/>
   </enum>
   <struct name="NetworkInterfaceType">
+    <cluster code="0x0033"/>
     <!-- TODO: CHAR_STRING not supported yet in structs. -->
     <item name="Name" type="OCTET_STRING" length="32"/>
     <item name="FabricConnected" type="BOOLEAN"/>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -18,12 +18,14 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="GroupState">
+    <cluster code="0xF004"/>
     <item name="VendorId" type="INT16U"/>
     <item name="VendorGroupId" type="INT16U"/>
     <item name="GroupKeySetIndex" type="INT16U"/>
   </struct>
 
   <struct name="GroupKey">
+    <cluster code="0xF004"/>
     <item name="VendorId" type="INT16U"/>
     <item name="GroupKeyIndex" type="INT16U"/>
     <item name="GroupKeyRoot" type="OCTET_STRING" length="16"/>
@@ -32,6 +34,7 @@ limitations under the License.
   </struct>
 
   <enum name="GroupKeySecurityPolicy" type="ENUM8">
+    <cluster code="0xF004"/>
     <item name="Standard" value="0x00"/>
     <item name="LowLatency" value="0x01"/>
   </enum>

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -39,12 +39,14 @@ limitations under the License.
   </cluster>
 
   <enum name="KeypadInputStatus" type="ENUM8">
+    <cluster code="0x0509"/>
     <item name="Success" value="0x00"/>
     <item name="UnsupportedKey" value="0x01"/>
     <item name="InvalidKeyInCurrentState" value="0x02"/>
   </enum>
 
   <enum name="KeypadInputCecKeyCode" type="ENUM8">
+    <cluster code="0x0509"/>
     <item name="Select" value="0x00"/>
     <item name="Up" value="0x01"/>
     <item name="Down" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -50,6 +50,7 @@ limitations under the License.
   </cluster>
 
   <struct name="MediaInputInfo">
+    <cluster code="0x0507"/>
     <item name="index" type="INT8U"/>
     <item name="inputType" type="MediaInputType"/>
     <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
@@ -57,6 +58,7 @@ limitations under the License.
   </struct>
 
   <enum name="MediaInputType" type="ENUM8">
+    <cluster code="0x0507"/>
     <item name="Internal" value="0x00"/>
     <item name="Aux" value="0x01"/>
     <item name="Coax" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -142,11 +142,13 @@ limitations under the License.
   </cluster>
 
   <struct name="MediaPlaybackPosition">
+    <cluster code="0x0506"/>
     <item name="updatedAt" type="INT64U"/>
     <item name="position" type="INT64U"/>    
   </struct>
 
   <enum name="MediaPlaybackState" type="ENUM8">
+    <cluster code="0x0506"/>
     <item name="Playing" value="0x00"/>
     <item name="Paused" value="0x01"/>
     <item name="NotPlaying" value="0x02"/>
@@ -154,6 +156,7 @@ limitations under the License.
   </enum>
 
   <enum name="MediaPlaybackStatus" type="ENUM8">
+    <cluster code="0x0506"/>
     <item name="Success" value="0x00"/>
     <item name="InvalidStateForCommand" value="0x01"/>
     <item name="NotAllowed" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -18,17 +18,20 @@ limitations under the License.
   <domain name="General"/>
 
   <enum name="OnOffEffectIdentifier" type="enum8">
+    <cluster code="0x0006"/>
     <item name="DelayedAllOff" value="0x00"/>
     <item name="DyingLight" value="0x01"/>
   </enum>
 
   <enum name="OnOffDelayedAllOffEffectVariant" type="enum8">
+    <cluster code="0x0006"/>
     <item name="FadeToOffIn_0p8Seconds" value="0x00"/>
     <item name="NoFade" value="0x01"/>
     <item name="50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" value="0x02"/>
   </enum>
 
   <enum name="OnOffDyingLightEffectVariant" type="enum8">
+    <cluster code="0x0006"/>
     <item name="20PercenterDimUpIn_0p5SecondsThenFadeToOffIn_1Second" value="0x00"/>
   </enum>
 

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -18,6 +18,7 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="FabricDescriptor">
+    <cluster code="0x003E"/>
     <item name="FabricIndex" type="INT8U"/>
     <item name="RootPublicKey" type="OCTET_STRING" length="65"/>
     <item name="VendorId" type="INT16U"/> <!-- Change INT16U to new type VendorID #2395 -->
@@ -27,6 +28,7 @@ limitations under the License.
   </struct>
 
   <enum name="NodeOperationalCertStatus" type="ENUM8">
+    <cluster code="0x003E"/>
     <item name="SUCCESS" value="0x00"/>
     <item name="InvalidPublicKey" value="0x01"/>
     <item name="InvalidNodeOpId" value="0x02"/>
@@ -40,6 +42,7 @@ limitations under the License.
   </enum>
 
   <struct name="NOCStruct">
+    <cluster code="0x003E"/>
     <item name="FabricIndex" type="INT8U"/>
     <item name="NOC" type="OCTET_STRING"/>
   </struct>

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -63,6 +63,7 @@ limitations under the License.
   </bitmap>
 
   <enum name="PumpOperationMode" type="ENUM8">
+    <cluster code="0x0200"/>
     <item name="Normal" value="0x0"/>
     <item name="Minimum" value="0x1"/>
     <item name="Maximum" value="0x2"/>
@@ -70,6 +71,7 @@ limitations under the License.
   </enum>
 
   <enum name="PumpControlMode" type="ENUM8">
+    <cluster code="0x0200"/>
     <item name="ConstantSpeed" value="0x0"/>
     <item name="ConstantPressure" value="0x1"/>
     <item name="ProportionalPressure" value="0x2"/>

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -17,6 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <struct name="ThreadMetrics">
+    <cluster code="0x0034"/>
     <item name="Id" type="INT64U"/>
     <!-- TODO: CHAR_STRING not supported yet in structs. -->
     <item name="Name" type="OCTET_STRING" length="8"/>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -42,13 +42,15 @@ limitations under the License.
   </cluster>
 
   <enum name="NavigateTargetStatus" type="ENUM8">
-      <item name="Success" value="0x00"/>
-      <item name="AppNotAvailable" value="0x01"/>
-      <item name="SystemBusy" value="0x02"/>
+    <cluster code="0x0505"/>
+    <item name="Success" value="0x00"/>
+    <item name="AppNotAvailable" value="0x01"/>
+    <item name="SystemBusy" value="0x02"/>
   </enum>
 
   <struct name="NavigateTargetTargetInfo">
-      <item name="identifier" type="INT8U"/>
-      <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
+    <cluster code="0x0505"/>
+    <item name="identifier" type="INT8U"/>
+    <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -18,11 +18,13 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <struct name="TestListStructOctet">
+    <cluster code="0x050F"/>
     <item name="fabricIndex" type="INT64U"/>
     <item name="operationalCert" type="OCTET_STRING" length="32"/>
   </struct>
 
   <enum name="SimpleEnum" type="ENUM8">
+    <cluster code="0x050F"/>
     <item name="Unspecified" value="0x00"/>
     <item name="ValueA" value="0x01"/>
     <item name="ValueB" value="0x02"/>
@@ -30,6 +32,7 @@ limitations under the License.
   </enum>
   
   <struct name="SimpleStruct">
+    <cluster code="0x050F"/>
     <item name="a" type="UINT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
     <item name="c" define="SIMPLE_ENUM" type="ENUM8" optional="false"/>
@@ -37,15 +40,17 @@ limitations under the License.
     <item name="e" type="CHAR_STRING" optional="false"/>
   </struct>
 
-   <struct name="NestedStruct">
+  <struct name="NestedStruct">
+    <cluster code="0x050F"/>
     <item name="a" type="UINT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
-     <!--
-     <item name="c" type="SimpleStruct" optional="false"/>
-     -->
-   </struct>
+    <!--
+    <item name="c" type="SimpleStruct" optional="false"/>
+    -->
+  </struct>
 
-   <struct name="NestedStructList">
+  <struct name="NestedStructList">
+    <cluster code="0x050F"/>
     <item name="a" type="UINT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
      <!--
@@ -55,11 +60,12 @@ limitations under the License.
     <item name="e" type="UINT32U" array="true" optional="false"/>
     <item name="f" type="OCTET_STRING" array="true" optional="false"/>
     <item name="g" type="UINT8U" array="true" optional="false"/>
-   </struct>
+  </struct>
 
-   <struct name="DoubleNestedStructList">
+  <struct name="DoubleNestedStructList">
+    <cluster code="0x050F"/>
     <item name="a" type="NestedStructList" array="true" optional="false"/>
-   </struct>
+  </struct>
    
   <cluster>
     <domain>CHIP</domain>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -14,12 +14,14 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <enum name="NetworkFault" type="ENUM8">
+    <cluster code="0x0035"/>
     <item name="Unspecified" value="0x00"/>
     <item name="LinkDown" value="0x01"/>
     <item name="HardwareFailure" value="0x02"/>
     <item name="NetworkJammed" value="0x03"/>
   </enum>
   <enum name="RoutingRole" type="ENUM8">
+    <cluster code="0x0035"/>
     <item name="Unspecified" value="0x00"/>
     <item name="Unassigned" value="0x01"/>
     <item name="SleepyEndDevice" value="0x02"/>
@@ -29,6 +31,7 @@ limitations under the License.
     <item name="Leader" value="0x06"/>
   </enum>
   <struct name="NeighborTable">
+    <cluster code="0x0035"/>
     <item name="ExtAddress" type="INT64U"/>
     <item name="Age" type="INT32U"/>
     <item name="Rloc16" type="INT16U"/>
@@ -45,6 +48,7 @@ limitations under the License.
     <item name="IsChild" type="BOOLEAN"/>
   </struct>
   <struct name="RouteTable">
+    <cluster code="0x0035"/>
     <item name="ExtAddress" type="INT64U"/>
     <item name="Rloc16" type="INT16U"/>
     <item name="RouterId" type="INT8U"/>
@@ -57,10 +61,12 @@ limitations under the License.
     <item name="LinkEstablished" type="BOOLEAN"/>
   </struct>
   <struct name="SecurityPolicy">
+    <cluster code="0x0035"/>
     <item name="RotationTime" type="INT16U"/>
     <item name="Flags" type="INT8U"/>
   </struct>
   <struct name="OperationalDatasetComponents">
+    <cluster code="0x0035"/>
     <item name="ActiveTimestampPresent" type="BOOLEAN"/>
     <item name="PendingTimestampPresent" type="BOOLEAN"/>
     <item name="MasterKeyPresent" type="BOOLEAN"/>

--- a/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/tv-channel-cluster.xml
@@ -56,6 +56,7 @@ limitations under the License.
   </cluster>
 
   <struct name="TvChannelInfo">
+    <cluster code="0x0504"/>
     <item name="majorNumber" type="INT16U"/>
     <item name="minorNumber" type="INT16U"/>
     <item name="name" type="OCTET_STRING" length="32"/> <!-- Change this to CHAR_STRING once it is supported #6112 -->
@@ -64,6 +65,7 @@ limitations under the License.
   </struct>
 
   <struct name="TvChannelLineupInfo">
+    <cluster code="0x0504"/>
     <item name="operatorName" type="CHAR_STRING"/>
     <item name="lineupName" type="CHAR_STRING"/>
     <item name="postalCode" type="CHAR_STRING"/>
@@ -71,10 +73,12 @@ limitations under the License.
   </struct>
 
   <enum name="TvChannelLineupInfoType" type="ENUM8">
+    <cluster code="0x0504"/>
     <item name="Mso" value="0x00"/>
   </enum>
 
   <enum name="TvChannelErrorType" type="ENUM8">
+    <cluster code="0x0504"/>
     <item name="MultipleMatches" value="0x00"/>
     <item name="NoMatches" value="0x01"/>
   </enum>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -17,6 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   <enum name="SecurityType" type="ENUM8">
+    <cluster code="0x0036"/>
     <item name="Unspecified" value="0x00"/>
     <item name="None" value="0x01"/>
     <item name="WEP" value="0x02"/>
@@ -25,6 +26,7 @@ limitations under the License.
     <item name="WPA3" value="0x05"/>    
   </enum>
   <enum name="WiFiVersionType" type="ENUM8">
+    <cluster code="0x0036"/>
     <item name="802.11a" value="0x00"/>
     <item name="802.11b" value="0x01"/>
     <item name="802.11g" value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -86,6 +86,7 @@ limitations under the License.
 
   <!-- Window Covering Descriptive Enum Set -->
   <enum name="WcType" type="ENUM8">
+    <cluster code="0x0102"/>
     <item value="00" name="Rollershade"/>
     <item value="01" name="Rollershade2Motor"/>
     <item value="02" name="RollershadeExterior"/>
@@ -100,6 +101,7 @@ limitations under the License.
   </enum>
 
   <enum name="WcEndProductType" type="ENUM8">
+    <cluster code="0x0102"/>
     <item value="00" name="RollerShade"/>  
     <item value="01" name="RomanShade"/>
     <item value="02" name="BalloonShade"/>

--- a/src/app/zap-templates/zcl/data-model/silabs/ami.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ami.xml
@@ -32,22 +32,26 @@ limitations under the License.
      <field name="messageConfirmation" mask="0x80"/>
    </bitmap>
    <enum name="MessagingControlTransmission" type="ENUM8">
+     <cluster code="0x0703"/>
      <item name="normal" value="0x00"/>
      <item name="normalAndAnonymous" value="0x01"/>
      <item name="anonymous" value="0x02"/>
      <item name="reserved" value="0x03"/>
    </enum>
    <enum name="MessagingControlImportance" type="ENUM8">
+     <cluster code="0x0703"/>
      <item name="low" value="0x00"/>
      <item name="medium" value="0x04"/>
      <item name="high" value="0x08"/>
      <item name="critical" value="0x0C"/>
    </enum>
    <enum name="MessagingControlEnhancedConfirmation" type="ENUM8">
+     <cluster code="0x0703"/>
      <item name="notRequired" value="0x00"/>
      <item name="required" value="0x20"/>
    </enum>
    <enum name="MessagingControlConfirmation" type="ENUM8">
+     <cluster code="0x0703"/>
      <item name="notRequired" value="0x00"/>
      <item name="required" value="0x80"/>
    </enum>
@@ -130,6 +134,7 @@ limitations under the License.
   </cluster>
   <!-- SE extension to the Alarms cluster. -->
   <enum name="EventId" type="ENUM8">
+    <cluster code="0x0703"/>
     <item value="0x00" name="MeterCoverRemoved"/>
     <item value="0x01" name="MeterCoverClosed"/>
     <item value="0x02" name="StrongMagneticField"/>


### PR DESCRIPTION
#### Problem
In order to add support for complicated type for issue 8895, we need to build relationship between cluster and struct/enum. Latest zap has added support to build relationship between cluster and struct/enum via cluster id code within struct and enum.
We need to update xml with cluster id code for struct and enum
#### Change overview
 update xml with cluster id code for struct and enum

#### Testing
How was this tested? (at least one bullet point required)
Compilation.
