### PR TITLE
[linux] Fix possible infinite loop

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -88,7 +88,7 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                 struct rtattr * routeInfo         = IFA_RTA(addressMessage);
                 size_t rtl                        = IFA_PAYLOAD(header);
 
-                while (rtl && RTA_OK(routeInfo, rtl))
+                for (; rtl && RTA_OK(routeInfo, rtl); routeInfo = RTA_NEXT(routeInfo, rtl))
                 {
                     if (routeInfo->rta_type == IFA_LOCAL)
                     {
@@ -115,7 +115,6 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                             ChipLogDetail(DeviceLayer, "Failed to report IP address: %" CHIP_ERROR_FORMAT, status.Format());
                         }
                     }
-                    routeInfo = RTA_NEXT(routeInfo, rtl);
                 }
             }
         }


### PR DESCRIPTION
#### Problem
Linux tools consume 100% CPU on my PC when doing nothing. The code for getting Wi-Fi IP address may enter an infinite
loop when the expected wlan interface does not exist.

#### Change overview
Make the loop finite :).

#### Testing
Tested manually that now the CPU usage is negligible.