### PR TITLE
[server] Enhance server storage logs

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -86,20 +86,23 @@ private:
     {
         CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
         {
-            ChipLogProgress(AppServer, "Retrieved value from server storage.");
-            return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
+            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size));
+            ChipLogProgress(AppServer, "Retrieved from server storage: %s", key);
+            return CHIP_NO_ERROR;
         }
 
         CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
         {
-            ChipLogProgress(AppServer, "Stored value in server storage");
-            return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
+            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size));
+            ChipLogProgress(AppServer, "Saved into server storage: %s", key);
+            return CHIP_NO_ERROR;
         }
 
         CHIP_ERROR SyncDeleteKeyValue(const char * key) override
         {
-            ChipLogProgress(AppServer, "Delete value in server storage");
-            return DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
+            ReturnErrorOnFailure(DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key));
+            ChipLogProgress(AppServer, "Deleted from server storage: %s", key);
+            return CHIP_NO_ERROR;
         }
     };
 


### PR DESCRIPTION
#### Problem
Currently, applications print lots of "Retrieved value from server storage" messages on startup, even if the value was
actually not found in the storage. 

#### Change overview
Make sure the logs are printed only when a value is really loaded, stored or deleted and add information about the key.

#### Testing
Tested manually with Linux and nRF Connect applications.
