### PR TITLE
Upload diagnostic logs on Darwin if the build+unit-test task fails.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -257,6 +257,9 @@ jobs:
                   submodules: true
             - name: Setup Environment
               run: brew install openssl pkg-config
+            - name: Try to ensure the directory for diagnostic log collection exists
+              run: |
+                  mkdir -p ~/Library/Logs/DiagnosticReports || true
             - name: Fix pkgconfig link
               working-directory: /usr/local/lib/pkgconfig
               run: |
@@ -292,6 +295,12 @@ jobs:
                       scripts/build/gn_build.sh
                       scripts/tests/gn_tests.sh
                   done
+            - name: Uploading diagnostic logs
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: crash-log-darwin
+                  path: ~/Library/Logs/DiagnosticReports/
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
             # - name: Run Code Coverage


### PR DESCRIPTION
This might allow us some slightly better visibility into unit test
crashes on Darwin.

#### Problem
We have intermittent unit test crashes on Darwin and we have no idea why

#### Change overview
Upload diagnostic logs so we can at least get a stack.

#### Testing
Introduced a purposeful crash in a unit test and pushed to my fork; checked that the CI run uploaded the diagnostic log.