### PR TITLE
Remove ip cluster flags

### DIFF
--- a/docs/guides/ip_commissioning.md
+++ b/docs/guides/ip_commissioning.md
@@ -40,7 +40,7 @@ device into commissioning mode.
 ### linux builds with an ethernet connection
 
 ```bash
-gn gen out/debug --args='chip_ip_commissioning=true'
+gn gen out/debug
 ninja -C out/debug
 ```
 
@@ -59,7 +59,7 @@ The controller builds with IP commissioning support by default, but you can turn
 it on or off using
 
 ```
-scripts/build_python.sh --clusters_for_ip_commissioning <true/false>
+scripts/build_python.sh
 ```
 
 There are two ways to connect via IP: **Discover then connect ip**

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -39,10 +39,6 @@ source_set("app-main") {
   if (chip_enable_pw_rpc) {
     defines += [ "PW_RPC_ENABLED" ]
   }
-  if (chip_ip_commissioning) {
-    # BLE and on-network. Code defaults to BLE if this is not set.
-    defines += [ "CONFIG_RENDEZVOUS_MODE=6" ]
-  }
   if (chip_build_libshell) {
     defines += [ "ENABLE_CHIP_SHELL" ]
   }

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -101,7 +101,6 @@ class AndroidBuilder(Builder):
             gn_args['target_cpu'] = self.board.TargetCpuName()
             gn_args['android_ndk_root'] = os.environ['ANDROID_NDK_HOME']
             gn_args['android_sdk_root'] = os.environ['ANDROID_HOME']
-            gn_args['chip_use_clusters_for_ip_commissioning'] = 'true'
 
             args = '--args=%s' % (' '.join([
                 '%s="%s"' % (key, shlex.quote(value))

--- a/scripts/build/expected_all_platform_commands.txt
+++ b/scripts/build/expected_all_platform_commands.txt
@@ -108,7 +108,7 @@ west build --cmake-only -d {out}/nrf-nrf5340-pump_controller -b nrf5340dk_nrf534
 python3 build/chip/java/tests/generate_jars_for_test.py
 
 # Generating android-arm-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
+gn gen --check --fail-on-unused-args {out}/android-arm-chip_tool '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -117,7 +117,7 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 python3 build/chip/java/tests/generate_jars_for_test.py
 
 # Generating android-arm64-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-arm64-chip_tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
+gn gen --check --fail-on-unused-args {out}/android-arm64-chip_tool '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -126,7 +126,7 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 python3 build/chip/java/tests/generate_jars_for_test.py
 
 # Generating android-x64-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-x64-chip_tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
+gn gen --check --fail-on-unused-args {out}/android-x64-chip_tool '--args=target_os="android" target_cpu="x64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -135,7 +135,7 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 python3 build/chip/java/tests/generate_jars_for_test.py
 
 # Generating android-x86-chip_tool
-gn gen --check --fail-on-unused-args {out}/android-x86-chip_tool '--args=target_os="android" target_cpu="x86" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_use_clusters_for_ip_commissioning="true"'
+gn gen --check --fail-on-unused-args {out}/android-x86-chip_tool '--args=target_os="android" target_cpu="x86" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME"'
 
 # Accepting NDK licenses
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -62,27 +62,27 @@ file_name=${0##*/}
 
 while (($#)); do
     case $1 in
-    --help | -h)
-        help
-        exit 1
-        ;;
-    --chip_detail_logging | -d)
-        chip_detail_logging=$2
-        shift
-        ;;
-    --chip_mdns | -m)
-        chip_mdns=$2
-        shift
-        ;;
-    --enable_pybindings | -p)
-        enable_pybindings=$2
-        shift
-        ;;
-    -*)
-        help
-        echo "Unknown Option \"$1\""
-        exit 1
-        ;;
+        --help | -h)
+            help
+            exit 1
+            ;;
+        --chip_detail_logging | -d)
+            chip_detail_logging=$2
+            shift
+            ;;
+        --chip_mdns | -m)
+            chip_mdns=$2
+            shift
+            ;;
+        --enable_pybindings | -p)
+            enable_pybindings=$2
+            shift
+            ;;
+        -*)
+            help
+            echo "Unknown Option \"$1\""
+            exit 1
+            ;;
     esac
     shift
 done

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -54,8 +54,6 @@ Input Options:
                                                             By default it is false.
   -m, --chip_mdns           ChipMDNSValue                   Specify ChipMDNSValue as platform or minimal.
                                                             By default it is minimal.
-  -c, --clusters_for_ip_commissioning  true/false           Specify whether to use clusters for IP commissioning.
-                                                            By default it is true.
   -p, --enable_pybindings   EnableValue                     Specify whether to enable pybindings as python controller.
 "
 }
@@ -64,31 +62,27 @@ file_name=${0##*/}
 
 while (($#)); do
     case $1 in
-        --help | -h)
-            help
-            exit 1
-            ;;
-        --chip_detail_logging | -d)
-            chip_detail_logging=$2
-            shift
-            ;;
-        --chip_mdns | -m)
-            chip_mdns=$2
-            shift
-            ;;
-        --clusters_for_ip_commissioning | -c)
-            clusters=$2
-            shift
-            ;;
-        --enable_pybindings | -p)
-            enable_pybindings=$2
-            shift
-            ;;
-        -*)
-            help
-            echo "Unknown Option \"$1\""
-            exit 1
-            ;;
+    --help | -h)
+        help
+        exit 1
+        ;;
+    --chip_detail_logging | -d)
+        chip_detail_logging=$2
+        shift
+        ;;
+    --chip_mdns | -m)
+        chip_mdns=$2
+        shift
+        ;;
+    --enable_pybindings | -p)
+        enable_pybindings=$2
+        shift
+        ;;
+    -*)
+        help
+        echo "Unknown Option \"$1\""
+        exit 1
+        ;;
     esac
     shift
 done
@@ -102,7 +96,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 # Generates ninja files
 [[ -n "$chip_mdns" ]] && chip_mdns_arg="chip_mdns=\"$chip_mdns\"" || chip_mdns_arg=""
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_use_clusters_for_ip_commissioning=$clusters chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg"
 
 # Compiles python files
 # Check pybindings was requested

--- a/scripts/examples/android_app_ide.sh
+++ b/scripts/examples/android_app_ide.sh
@@ -38,4 +38,4 @@ fi
 source scripts/activate.sh
 # Build CMake for Android Studio
 echo "build ide"
-gn gen --check --fail-on-unused-args out/"android_$TARGET_CPU" --args="target_os=\"android\" target_cpu=\"$TARGET_CPU\" android_ndk_root=\"$ANDROID_NDK_HOME\" android_sdk_root=\"$ANDROID_HOME\" chip_use_clusters_for_ip_commissioning=\"true\"" --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py
+gn gen --check --fail-on-unused-args out/"android_$TARGET_CPU" --args="target_os=\"android\" target_cpu=\"$TARGET_CPU\" android_ndk_root=\"$ANDROID_NDK_HOME\" android_sdk_root=\"$ANDROID_HOME\"" --ide=json --json-ide-script=//scripts/examples/gn_to_cmakelists.py

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -103,14 +103,6 @@ static_library("app") {
     "reporting/Engine.h",
   ]
 
-  if (chip_ip_commissioning) {
-    defines = [
-      "CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING=1",
-      "CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY=1",
-      "CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING=1",
-    ]
-  }
-
   public_deps = [
     ":app_buildconfig",
     "${chip_root}/src/lib/support",

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -15,5 +15,4 @@
 declare_args() {
   # Temporary flag for interaction model and echo protocols, set it to true to enable
   chip_app_use_echo = false
-  chip_ip_commissioning = false
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1180,12 +1180,7 @@ void DeviceCommissioner::OnSessionEstablished()
 
     // TODO: Add code to receive OpCSR from the device, and process the signing request
     // For IP rendezvous, this is sent as part of the state machine.
-#if CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING
     bool sendOperationalCertsImmediately = !mIsIPRendezvous;
-#else
-    bool sendOperationalCertsImmediately = true;
-#endif
-
     if (sendOperationalCertsImmediately)
     {
         err = SendOperationalCertificateSigningRequestCommand(device);
@@ -1468,13 +1463,11 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(De
     ChipLogProgress(Controller, "Operational credentials provisioned on device %p", device);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-#if CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING
     if (mIsIPRendezvous)
     {
         AdvanceCommissioningStage(CHIP_NO_ERROR);
     }
     else
-#endif
     {
         mPairingSession.ToSerializable(device->GetPairing());
         mSystemLayer->CancelTimer(OnSessionEstablishmentTimeoutCallback, this);
@@ -1750,6 +1743,7 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, Device * device)
         if (device == deviceBeingPaired && commissioner->mCommissioningStage == CommissioningStage::kFindOperational)
         {
             commissioner->AdvanceCommissioningStage(CHIP_NO_ERROR);
+            return;
         }
     }
 
@@ -1960,7 +1954,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
         PersistDeviceList();
         if (mPairingDelegate != nullptr)
         {
-            mPairingDelegate->OnStatusUpdate(DevicePairingDelegate::SecurePairingSuccess);
+            mPairingDelegate->OnCommissioningComplete(device->GetDeviceId(), CHIP_NO_ERROR);
         }
         RendezvousCleanup(CHIP_NO_ERROR);
         break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1740,7 +1740,7 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, Device * device)
     if (commissioner->mDeviceBeingPaired < kNumMaxActiveDevices)
     {
         Device * deviceBeingPaired = &commissioner->mActiveDevices[commissioner->mDeviceBeingPaired];
-        if (device == deviceBeingPaired && commissioner->mCommissioningStage == CommissioningStage::kFindOperational)
+        if (device == deviceBeingPaired && commissioner->mIsIPRendezvous)
         {
             commissioner->AdvanceCommissioningStage(CHIP_NO_ERROR);
             return;

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -93,7 +93,6 @@ if (chip_device_platform != "none") {
       "CHIP_ENABLE_OPENTHREAD=${chip_enable_openthread}",
       "CHIP_WITH_GIO=${chip_with_gio}",
       "OPENTHREAD_CONFIG_ENABLE_TOBLE=false",
-      "CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING=${chip_use_clusters_for_ip_commissioning}",
       "CHIP_DEVICE_CONFIG_ENABLE_MDNS=${chip_device_config_enable_mdns}",
       "CHIP_BYPASS_RENDEZVOUS=${chip_bypass_rendezvous}",
       "CHIP_STACK_LOCK_TRACKING_ENABLED=${chip_stack_lock_tracking_log}",
@@ -209,7 +208,6 @@ if (chip_device_platform != "none") {
       chip_device_config_enable_mdns = chip_mdns != "none"
       defines += [
         "CHIP_DEVICE_CONFIG_ENABLE_MDNS=${chip_device_config_enable_mdns}",
-        "CONFIG_USE_CLUSTERS_FOR_IP_COMMISSIONING=${chip_use_clusters_for_ip_commissioning}",
         "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"controller/java/AndroidKeyValueStoreManagerImpl.h\"",
       ]
     }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -71,9 +71,6 @@ declare_args() {
   } else {
     chip_mdns = "none"
   }
-
-  # Enables full cluster-based commissioning for already-on-network devices.
-  chip_use_clusters_for_ip_commissioning = false
 }
 
 _chip_device_layer = "none"


### PR DESCRIPTION
#### Problem
- IP commissioning gets short circuited by CASE when using the chip tool - resolve gets called twice and we call the completion callback which cases chip-tool to early exit. This seems to cause a race where sometimes the device was being persisted in the cleanup, but sometimes it was not.
- The chip tool isn't compiled with the ip clustering flags on by default (chip-device-ctrl is). These have been fairly well tested in the TEs now, so we should just get rid of the gates.

#### Change overview
- removes flags for IP commissioning - full ip commissioning is now enabled by default everywhere
- fixes an early exit on ip commissioning that was causing issues for chip-tool

#### Testing
Tested with chip-tool ip pairing and command sending using linux lighting app.
