### PR TITLE
Handle a lost standalone ack correctly.

### DIFF
--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -50,7 +50,7 @@ CHIP_ERROR ExchangeMessageDispatch::SendMessage(SessionHandle session, uint16_t 
     payloadHeader.SetExchangeID(exchangeId).SetMessageType(protocol, type).SetInitiator(isInitiator);
 
     // If there is a pending acknowledgment piggyback it on this message.
-    if (reliableMessageContext->ShouldPiggybackAck())
+    if (reliableMessageContext->HasPiggybackAckPending())
     {
         payloadHeader.SetAckMessageCounter(reliableMessageContext->TakePendingPeerAckMessageCounter());
 

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -50,7 +50,7 @@ CHIP_ERROR ExchangeMessageDispatch::SendMessage(SessionHandle session, uint16_t 
     payloadHeader.SetExchangeID(exchangeId).SetMessageType(protocol, type).SetInitiator(isInitiator);
 
     // If there is a pending acknowledgment piggyback it on this message.
-    if (reliableMessageContext->IsAckPending())
+    if (reliableMessageContext->ShouldPiggybackAck())
     {
         payloadHeader.SetAckMessageCounter(reliableMessageContext->TakePendingPeerAckMessageCounter());
 

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -59,7 +59,7 @@ public:
 
     /**
      * Take the pending peer ack message counter from the context.  This must
-     * only be called when ShouldPiggybackAck() is true.  After this call,
+     * only be called when HasPiggybackAckPending() is true.  After this call,
      * IsAckPending() will be false; it's the caller's responsibility to send
      * the ack.
      */
@@ -74,7 +74,7 @@ public:
      * If true, TakePendingPeerAckMessageCounter will return a valid value that
      * should be included as an ack in the message.
      */
-    bool ShouldPiggybackAck() const;
+    bool HasPiggybackAckPending() const;
 
     /**
      *  Get the initial retransmission interval. It would be the time to wait before
@@ -191,39 +191,39 @@ protected:
     enum class Flags : uint16_t
     {
         /// When set, signifies that this context is the initiator of the exchange.
-        kFlagInitiator = 0x0001,
+        kFlagInitiator = (1u << 0),
 
         /// When set, signifies that a response is expected for a message that is being sent.
-        kFlagResponseExpected = 0x0002,
+        kFlagResponseExpected = (1u << 1),
 
         /// When set, automatically request an acknowledgment whenever a message is sent via UDP.
-        kFlagAutoRequestAck = 0x0004,
+        kFlagAutoRequestAck = (1u << 2),
 
         /// Internal and debug only: when set, the exchange layer does not send an acknowledgment.
-        kFlagDropAckDebug = 0x0008,
+        kFlagDropAckDebug = (1u << 3),
 
         /// When set, signifies current reliable message context is in usage.
-        kFlagOccupied = 0x0010,
+        kFlagOccupied = (1u << 4),
 
         /// When set, signifies that there is an acknowledgment pending to be sent back.
-        kFlagAckPending = 0x0020,
+        kFlagAckPending = (1u << 5),
 
         /// When set, signifies that there has once been an acknowledgment
         /// pending to be sent back.  In that case,
         /// mPendingPeerAckMessageCounter is a valid message counter value for
         /// some message we have needed to acknowledge in the past.
-        kFlagHasHadAckPending = 0x0040,
+        kFlagAckMessageCounterIsValid = (1u << 6),
 
         /// When set, signifies that at least one message has been received from peer on this exchange context.
-        kFlagMsgRcvdFromPeer = 0x0080,
+        kFlagMsgRcvdFromPeer = (1u << 7),
 
         /// When set, signifies that this exchange is waiting for a call to SendMessage.
-        kFlagWillSendMessage = 0x00100,
+        kFlagWillSendMessage = (1u << 8),
 
         /// When set, signifies that we are currently in the middle of HandleMessage.
-        kFlagHandlingMessage = 0x0200,
+        kFlagHandlingMessage = (1u << 9),
         /// When set, we have had Close() or Abort() called on us already.
-        kFlagClosed = 0x0400,
+        kFlagClosed = (1u << 10),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -58,15 +58,23 @@ public:
     CHIP_ERROR FlushAcks();
 
     /**
-     * Take the pending peer ack message counter from the context.  This must only be called
-     * when IsAckPending() is true.  After this call, IsAckPending() will be
-     * false; it's the caller's responsibility to send the ack.
+     * Take the pending peer ack message counter from the context.  This must
+     * only be called when ShouldPiggybackAck() is true.  After this call,
+     * IsAckPending() will be false; it's the caller's responsibility to send
+     * the ack.
      */
     uint32_t TakePendingPeerAckMessageCounter()
     {
         SetAckPending(false);
         return mPendingPeerAckMessageCounter;
     }
+
+    /**
+     * Check whether we have an ack to piggyback on the message we are sending.
+     * If true, TakePendingPeerAckMessageCounter will return a valid value that
+     * should be included as an ack in the message.
+     */
+    bool ShouldPiggybackAck() const;
 
     /**
      *  Get the initial retransmission interval. It would be the time to wait before
@@ -200,16 +208,22 @@ protected:
         /// When set, signifies that there is an acknowledgment pending to be sent back.
         kFlagAckPending = 0x0020,
 
+        /// When set, signifies that there has once been an acknowledgment
+        /// pending to be sent back.  In that case,
+        /// mPendingPeerAckMessageCounter is a valid message counter value for
+        /// some message we have needed to acknowledge in the past.
+        kFlagHasHadAckPending = 0x0040,
+
         /// When set, signifies that at least one message has been received from peer on this exchange context.
-        kFlagMsgRcvdFromPeer = 0x0040,
+        kFlagMsgRcvdFromPeer = 0x0080,
 
         /// When set, signifies that this exchange is waiting for a call to SendMessage.
-        kFlagWillSendMessage = 0x0080,
+        kFlagWillSendMessage = 0x00100,
 
         /// When set, signifies that we are currently in the middle of HandleMessage.
-        kFlagHandlingMessage = 0x0100,
+        kFlagHandlingMessage = 0x0200,
         /// When set, we have had Close() or Abort() called on us already.
-        kFlagClosed = 0x0200,
+        kFlagClosed = 0x0400,
     };
 
     BitFlags<Flags> mFlags; // Internal state flags

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -267,7 +267,16 @@ CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, Re
     bool added     = false;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrDie(rc != nullptr && !rc->IsOccupied());
+    VerifyOrDie(rc != nullptr);
+
+    if (rc->IsOccupied())
+    {
+        // This can happen if we have a misbehaving peer that is not sending
+        // acks with its application-level responses when it should, so we end
+        // up with two outstanding app-level messages both waiting for an ack.
+        // Just give up and error out in that case.
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 
     for (RetransTableEntry & entry : mRetransTable)
     {

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -76,7 +76,7 @@ public:
         if (mDropAckResponse)
         {
             auto * rc = ec->GetReliableMessageContext();
-            if (rc->ShouldPiggybackAck())
+            if (rc->HasPiggybackAckPending())
             {
                 (void) rc->TakePendingPeerAckMessageCounter();
             }
@@ -1253,6 +1253,9 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
      * 2) The responder sends a standalone ack, which is lost.
      * 3) The responder sends an application-level response.
      * 4) The initiator sends a reliable response to the app-level response.
+     *
+     * This should succeed, with all application-level messages being delivered
+     * and no crashes.
      */
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
@@ -1361,6 +1364,21 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     // And that there are no un-acked messages left.
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
+
+/**
+ * TODO: A test that we should have but can't write with the existing
+ * infrastructure we have:
+ *
+ * 1. A sends message 1 to B
+ * 2. B is slow to respond, A does a resend and the resend is delayed in the network.
+ * 3. B responds with message 2, which acks message 1.
+ * 4. A sends message 3 to B
+ * 5. B sends standalone ack to message 3, which is lost
+ * 6. The duplicate message from step 3 is delivered and triggers a standalone ack.
+ * 7. B responds with message 4, which should carry a piggyback ack for message 3
+ *    (this is the part that needs testing!)
+ * 8. A sends message 5 to B.
+ */
 
 // Test Suite
 


### PR DESCRIPTION
If a standalone ack gets lost and then there is an application-level
reply to the message that triggered the standalone ack, we want to
piggyback an ack on that application-level reply as well.  Otherwise
the other side can end up in a state where it has two outstanding
unacknowledged messages (the message we are replying to, and the reply
to our reply), which it can't handle.

The other change here is to fix ReliableMessageMgr to not crash if the
peer misbehaves and skips sending that piggyback ack described above.
Instead, we just error out from sending the response to the peer's
broken message.

Fixes https://github.com/project-chip/connectedhomeip/issues/9796

#### Problem
See above.

#### Change overview
See above.

#### Testing
New unit test passes.