### PR TITLE
Fix wrong loop condition in fake MdnsImpl

### DIFF
--- a/src/platform/fake/MdnsImpl.cpp
+++ b/src/platform/fake/MdnsImpl.cpp
@@ -75,7 +75,7 @@ CHIP_ERROR CheckExpected(CallType type, const MdnsService * service)
         ChipLogProgress(Discovery, "\t%s", service->mSubTypes[i]);
     }
     ChipLogProgress(Discovery, "num text entries = %lu", static_cast<unsigned long>(service->mTextEntrySize));
-    for (size_t i = 0; i < service->mSubTypeSize; ++i)
+    for (size_t i = 0; i < service->mTextEntrySize; ++i)
     {
         ChipLogProgress(Discovery, "\t%s", service->mTextEntries[i].mKey);
     }


### PR DESCRIPTION

#### Problem

This fixes an out of bounds access in TestPlatform:

```
==3694438== Conditional jump or move depends on uninitialised value(s)
==3694438==    at 0x4ADA51E: __vfprintf_internal (vfprintf-internal.c:1688)
==3694438==    by 0x114644: chip::Logging::Platform::LogV(char const*, unsigned char, char const*, __va_list_tag*) (Logging.cpp:14)
==3694438==    by 0x11324F: chip::Logging::LogV(unsigned char, unsigned char, char const*, __va_list_tag*) (CHIPLogging.cpp:161)
==3694438==    by 0x1131BB: chip::Logging::Log(unsigned char, unsigned char, char const*, ...) (CHIPLogging.cpp:139)
==3694438==    by 0x113CFF: chip::Mdns::test::CheckExpected(chip::Mdns::test::CallType, chip::Mdns::MdnsService const*) (MdnsImpl.cpp:80)
==3694438==    by 0x113DF7: chip::Mdns::ChipMdnsPublishService(chip::Mdns::MdnsService const*) (MdnsImpl.cpp:105)
==3694438==    by 0x10F647: chip::Mdns::DiscoveryImplPlatform::Advertise(chip::Mdns::OperationalAdvertisingParameters const&) (Discovery_ImplPlatform.cpp:434)
==3694438==    by 0x10B2CA: (anonymous namespace)::TestStub(_nlTestSuite*, void*) (TestPlatform.cpp:161)
==3694438==    by 0x1144AC: nlTestRunner (nlunit-test.c:213)
==3694438==    by 0x10BCFA: TestMdnsPlatform() (TestPlatform.cpp:227)
==3694438==    by 0x10A282: main (TestPlatform.driver.cpp:32)
```

As this is undefined behavior it may explain the crash others are seeing
with this test.

#### Change overview

Update the loop condition to check the right size.

#### Testing

TestPlatform unit test.
