### PR TITLE
Update xml

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -134,6 +134,6 @@ limitations under the License.
     <cluster code="0x050a"/>
     <item name="Type" type="ContentLaunchParameterEnum"/>
     <item name="Value" type="CHAR_STRING"/>
-    <item name="ExternalIDList" type="ARRAY" entryType="ContentLaunchAdditionalInfo" length="254"/>
+    <item name="ExternalIDList" type="ContentLaunchAdditionalInfo" array="true" length="254"/>
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -74,7 +74,7 @@ limitations under the License.
     <item name="OffPremiseServicesReachableIPv6" type="BOOLEAN"/>
     <!-- TODO: HWADR not supported yet -->
     <item name="HardwareAddress" type="OCTET_STRING" length="8"/>
-    <item name="Type" type="ENUM8"/>
+    <item name="Type" type="InterfaceType"/>
   </struct>
   <cluster>
     <domain>General</domain>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -16,7 +16,6 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-
   <struct name="TestListStructOctet">
     <cluster code="0x050F"/>
     <item name="fabricIndex" type="INT64U"/>
@@ -33,40 +32,36 @@ limitations under the License.
   
   <struct name="SimpleStruct">
     <cluster code="0x050F"/>
-    <item name="a" type="UINT8U" optional="false"/>
+    <item name="a" type="INT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
-    <item name="c" define="SIMPLE_ENUM" type="ENUM8" optional="false"/>
+    <item name="c" type="SimpleEnum" optional="false"/>
     <item name="d" type="OCTET_STRING" optional="false"/>
     <item name="e" type="CHAR_STRING" optional="false"/>
   </struct>
 
   <struct name="NestedStruct">
     <cluster code="0x050F"/>
-    <item name="a" type="UINT8U" optional="false"/>
+    <item name="a" type="INT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
-    <!--
     <item name="c" type="SimpleStruct" optional="false"/>
-    -->
   </struct>
 
   <struct name="NestedStructList">
     <cluster code="0x050F"/>
-    <item name="a" type="UINT8U" optional="false"/>
+    <item name="a" type="INT8U" optional="false"/>
     <item name="b" type="BOOLEAN" optional="false"/>
-     <!--
     <item name="c" type="SimpleStruct" optional="false"/>
-     -->
     <item name="d" type="SimpleStruct" array="true" optional="false"/>
-    <item name="e" type="UINT32U" array="true" optional="false"/>
+    <item name="e" type="INT32U" array="true" optional="false"/>
     <item name="f" type="OCTET_STRING" array="true" optional="false"/>
-    <item name="g" type="UINT8U" array="true" optional="false"/>
+    <item name="g" type="INT8U" array="true" optional="false"/>
   </struct>
 
   <struct name="DoubleNestedStructList">
     <cluster code="0x050F"/>
     <item name="a" type="NestedStructList" array="true" optional="false"/>
   </struct>
-   
+
   <cluster>
     <domain>CHIP</domain>
     <name>Test Cluster</name>

--- a/zzz_generated/all-clusters-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/attribute-size.cpp
@@ -342,7 +342,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -30,18 +30,27 @@
 // Struct for SimpleStruct
 typedef struct _SimpleStruct
 {
-    /* TYPE WARNING: unknown defaults to */ uint8_t * a;
+    uint8_t a;
     bool b;
     uint8_t c;
     chip::ByteSpan d;
     uint8_t * e;
 } SimpleStruct;
 
+// Struct for NestedStruct
+typedef struct _NestedStruct
+{
+    uint8_t a;
+    bool b;
+    SimpleStruct c;
+} NestedStruct;
+
 // Struct for NestedStructList
 typedef struct _NestedStructList
 {
-    /* TYPE WARNING: unknown defaults to */ uint8_t * a;
+    uint8_t a;
     bool b;
+    SimpleStruct c;
     /* TYPE WARNING: array array defaults to */ uint8_t * d;
     /* TYPE WARNING: array array defaults to */ uint8_t * e;
     /* TYPE WARNING: array array defaults to */ uint8_t * f;
@@ -53,6 +62,21 @@ typedef struct _DoubleNestedStructList
 {
     /* TYPE WARNING: array array defaults to */ uint8_t * a;
 } DoubleNestedStructList;
+
+// Struct for ContentLaunchAdditionalInfo
+typedef struct _ContentLaunchAdditionalInfo
+{
+    uint8_t * name;
+    uint8_t * value;
+} ContentLaunchAdditionalInfo;
+
+// Struct for ContentLaunchParamater
+typedef struct _ContentLaunchParamater
+{
+    uint8_t Type;
+    uint8_t * Value;
+    /* TYPE WARNING: array array defaults to */ uint8_t * ExternalIDList;
+} ContentLaunchParamater;
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -109,13 +133,6 @@ typedef struct _ConfigureReportingStatusRecord
     chip::AttributeId attributeId;
 } ConfigureReportingStatusRecord;
 
-// Struct for ContentLaunchAdditionalInfo
-typedef struct _ContentLaunchAdditionalInfo
-{
-    uint8_t * name;
-    uint8_t * value;
-} ContentLaunchAdditionalInfo;
-
 // Struct for ContentLaunchBrandingInformation
 typedef struct _ContentLaunchBrandingInformation
 {
@@ -134,14 +151,6 @@ typedef struct _ContentLaunchDimension
     uint8_t * height;
     uint8_t metric;
 } ContentLaunchDimension;
-
-// Struct for ContentLaunchParamater
-typedef struct _ContentLaunchParamater
-{
-    uint8_t Type;
-    uint8_t * Value;
-    /* TYPE WARNING: array array defaults to */ uint8_t * ExternalIDList;
-} ContentLaunchParamater;
 
 // Struct for ContentLaunchStyleInformation
 typedef struct _ContentLaunchStyleInformation
@@ -264,13 +273,6 @@ typedef struct _NeighborTable
     bool FullNetworkData;
     bool IsChild;
 } NeighborTable;
-
-// Struct for NestedStruct
-typedef struct _NestedStruct
-{
-    /* TYPE WARNING: unknown defaults to */ uint8_t * a;
-    bool b;
-} NestedStruct;
 
 // Struct for NetworkInterfaceType
 typedef struct _NetworkInterfaceType

--- a/zzz_generated/bridge-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/bridge-app/zap-generated/attribute-size.cpp
@@ -242,7 +242,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/lighting-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/lighting-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/lock-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/lock-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/pump-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/pump-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/pump-controller-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/pump-controller-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/temperature-measurement-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/temperature-measurement-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/thermostat/zap-generated/attribute-size.cpp
+++ b/zzz_generated/thermostat/zap-generated/attribute-size.cpp
@@ -342,7 +342,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/tv-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/tv-app/zap-generated/attribute-size.cpp
@@ -305,7 +305,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/tv-casting-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/tv-casting-app/zap-generated/attribute-size.cpp
@@ -342,7 +342,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }

--- a/zzz_generated/window-app/zap-generated/attribute-size.cpp
+++ b/zzz_generated/window-app/zap-generated/attribute-size.cpp
@@ -144,7 +144,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             }
             entryOffset = static_cast<uint16_t>(entryOffset + 10);
             copyListMember(write ? dest : (uint8_t *) &entry->Type, write ? (uint8_t *) &entry->Type : src, write, &entryOffset,
-                           sizeof(entry->Type)); // ENUM8
+                           sizeof(entry->Type)); // InterfaceType
             break;
         }
         }


### PR DESCRIPTION
#### Problem
In order to add support for complicated type for issue 8895, we need explicitly to mark struct item as array=true for array processing inside struct, the zap has already added the support for array query and check.
We need to update xml with array for struct item

#### Change overview
    --update xml with array for struct item
    --update InterfaceType for NetworkInterfaceType struct

#### Testing
How was this tested? (at least one bullet point required)
Compilation and presubmit validation.