### PR TITLE
[naming] Fix typo in GetExchangeManager method.

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -145,7 +145,7 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow()
             DeviceLayer::SystemLayer().StartTimer(mCommissioningTimeoutSeconds * 1000, HandleCommissioningWindowTimeout, this));
     }
 
-    ReturnErrorOnFailure(mServer->GetExchangManager().RegisterUnsolicitedMessageHandlerForType(
+    ReturnErrorOnFailure(mServer->GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(
         Protocols::SecureChannel::MsgType::PBKDFParamRequest, &mPairingSession));
 
     ReturnErrorOnFailure(StartAdvertisement());
@@ -264,7 +264,7 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement()
 {
     RestoreDiscriminator();
 
-    mServer->GetExchangManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
+    mServer->GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
     mPairingSession.Clear();
 
     mCommissioningWindowOpen = false;

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -63,7 +63,7 @@ public:
 
     Transport::FabricTable & GetFabricTable() { return mFabrics; }
 
-    Messaging::ExchangeManager & GetExchangManager() { return mExchangeMgr; }
+    Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }
 
     SessionIDAllocator & GetSessionIDAllocator() { return mSessionIDAllocator; }
 


### PR DESCRIPTION
#### Problem
Small typo in method name.
