### PR TITLE
Static / dynamic allocator

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -78,6 +78,7 @@ static_library("support") {
     "FibonacciUtils.h",
     "FixedBufferAllocator.cpp",
     "FixedBufferAllocator.h",
+    "GenericAllocator.h",
     "LifetimePersistedCounter.cpp",
     "LifetimePersistedCounter.h",
     "ObjectLifeCycle.h",

--- a/src/lib/support/GenericAllocator.h
+++ b/src/lib/support/GenericAllocator.h
@@ -1,0 +1,325 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *        Dual static / dynamic allocator. This allocator can be configured
+ *        to use either a static pool of size N or dynamic allocation
+ *        if N is set to 0. This class can be used to manage non-reference-counted
+ *        pools (ex. for private data members) where some nodes may wish to use
+ *        static allocation of variable sizes and others may wish to use dynamic.
+ *
+ *        To use this class, declare the class with the desired pool size, then
+ *        use allocate / free / etc. as required. For example, to use an allocator
+ *        for ints
+ *        #ifdef USE_STATIC
+ *        #define POOL_SIZE 5
+ *        #else
+ *        #define POOL_SIZE 0
+ *        GenericAllocator<int, POOL_SIZE> allocator;
+ *        int* ptr = allocator.Allocate();
+ *        *ptr = 3;
+ *        ptr = allocator.Allocate();
+ *        *ptr = 2;
+ *        for (auto & a: allocator) {
+ *            printf("ranged for: %d\n", a);
+ *        }
+ *        for (auto it = allocator.begin(); it != allocator.end();++it)
+ *        {
+ *            printf("iterator: %d\n", *it);
+ *        }
+ *        for (auto it = allocator.begin(); it != allocator.end();)
+ *        {
+ *            it = allocator.Free(it);
+ *        }
+ *
+ */
+
+#pragma once
+
+#include <lib/support/CHIPMem.h>
+#include <list>
+#include <optional>
+#include <stdint.h>
+#include <stdio.h>
+
+namespace chip {
+namespace Internal {
+
+template <typename T>
+struct ListWrapper
+{
+    T data;
+    ListWrapper<T> * next = nullptr;
+};
+template <typename T>
+class AllocatorDataBase
+{
+public:
+    virtual ~AllocatorDataBase() = default;
+    virtual T * Allocate()       = 0;
+    virtual void Free(T * data)  = 0;
+    virtual size_t GetN() const  = 0;
+    virtual ListWrapper<T> * GetHead() { return nullptr; }
+    virtual T * GetArray() { return nullptr; }
+    virtual bool * GetInUse() { return nullptr; }
+};
+
+template <typename T, size_t N>
+class AllocatorData : public AllocatorDataBase<T>
+{
+public:
+    AllocatorData()
+    {
+        for (auto & inUse : mInUse)
+        {
+            inUse = false;
+        }
+    }
+    T * Allocate() override
+    {
+        for (size_t i = 0; i < N; ++i)
+        {
+            if (!mInUse[i])
+            {
+                mInUse[i] = true;
+                return &mData[i];
+            }
+        }
+        return nullptr;
+    }
+    void Free(T * data) override
+    {
+        for (size_t i = 0; i < N; ++i)
+        {
+            {
+                if (&mData[i] == data && mInUse[i])
+                {
+                    mInUse[i] = false;
+                    return;
+                }
+            }
+        }
+    }
+    size_t GetN() const override { return N; }
+    T * GetArray() override { return mData; }
+    bool * GetInUse() override { return mInUse; }
+
+private:
+    T mData[N];
+    bool mInUse[N];
+};
+
+template <typename T>
+class AllocatorData<T, 0> : public AllocatorDataBase<T>
+{
+public:
+    ~AllocatorData()
+    {
+        while (head != nullptr)
+        {
+            Free(&head->data);
+        }
+    }
+    T * Allocate() override
+    {
+        auto * newLW = Platform::New<ListWrapper<T>>();
+        if (newLW != nullptr)
+        {
+            if (head == nullptr)
+            {
+                head = newLW;
+            }
+            else
+            {
+                tail->next = newLW;
+            }
+            tail = newLW;
+        }
+        return &newLW->data;
+    }
+    void Free(T * data) override
+    {
+        ListWrapper<T> * prev = nullptr;
+        ListWrapper<T> * curr = head;
+        while (curr != nullptr)
+        {
+            if (data == &curr->data)
+            {
+                if (curr == head)
+                {
+                    head = curr->next;
+                }
+                else
+                {
+                    prev->next = curr->next;
+                    if (curr == tail)
+                    {
+                        tail = prev;
+                    }
+                }
+                Platform::MemoryFree(curr);
+                return;
+            }
+            prev = curr;
+            curr = curr->next;
+        }
+    }
+    size_t GetN() const override { return 0; }
+    ListWrapper<T> * GetHead() override { return head; }
+
+private:
+    ListWrapper<T> * head = nullptr;
+    ListWrapper<T> * tail = nullptr;
+};
+
+} // namespace Internal
+
+template <typename T, size_t N>
+class GenericAllocator;
+
+template <typename T>
+class GenericAllocatorIterator
+{
+public:
+    GenericAllocatorIterator(Internal::AllocatorDataBase<T> * data) : mData(data)
+    {
+        mIdx    = 0;
+        listPtr = mData->GetHead();
+        if (mData->GetN() != 0 && mData->GetInUse() != nullptr)
+        {
+            while (mIdx < mData->GetN() && mData->GetInUse()[mIdx] == false)
+            {
+                ++mIdx;
+            }
+        }
+    }
+    GenericAllocatorIterator<T> & SetEnd()
+    {
+        mIdx    = mData->GetN();
+        listPtr = nullptr;
+        return *this;
+    }
+    bool IsEnd() { return listPtr == nullptr && mIdx == mData->GetN(); }
+
+    GenericAllocatorIterator<T> & operator++()
+    {
+        if (listPtr != nullptr)
+        {
+            listPtr = listPtr->next;
+        }
+        if (mData->GetInUse() != nullptr)
+        {
+            mIdx++;
+            while (mIdx < mData->GetN() && mData->GetInUse()[mIdx] == false)
+            {
+                ++mIdx;
+            }
+        }
+        return *this;
+    }
+
+    bool operator==(const GenericAllocatorIterator<T> & rhs) const
+    {
+        return rhs.mData == mData && rhs.mIdx == mIdx && rhs.listPtr == listPtr;
+    }
+    bool operator!=(const GenericAllocatorIterator<T> & rhs) const { return !(*this == rhs); }
+    T & operator*()
+    {
+        if (listPtr != nullptr)
+        {
+            return listPtr->data;
+        }
+        else
+        {
+            return mData->GetArray()[mIdx];
+        }
+    }
+    T * operator->()
+    {
+        if (listPtr != nullptr)
+        {
+            return &listPtr->data;
+        }
+        else
+        {
+            return &(mData->GetArray()[mIdx]);
+        }
+    }
+
+    GenericAllocatorIterator<T> & Free()
+    {
+        if (listPtr != nullptr)
+        {
+            Internal::ListWrapper<T> * temp = listPtr;
+            listPtr                         = listPtr->next;
+            mData->Free(&temp->data);
+        }
+        else if (mData->GetInUse() != nullptr && mIdx < mData->GetN())
+        {
+            mData->Free(&(mData->GetArray()[mIdx]));
+            operator++();
+        }
+        return *this;
+    }
+
+private:
+    Internal::AllocatorDataBase<T> * mData;
+    size_t mIdx                        = 0;
+    Internal::ListWrapper<T> * listPtr = nullptr;
+};
+
+template <typename T>
+class GenericAllocatorBase
+{
+public:
+    GenericAllocatorBase(Internal::AllocatorDataBase<T> * data) : mData(data) {}
+    virtual ~GenericAllocatorBase()                                              = default;
+    virtual bool IsDynamic()                                                     = 0;
+    virtual T * Allocate()                                                       = 0;
+    virtual GenericAllocatorIterator<T> & Free(GenericAllocatorIterator<T> & it) = 0;
+    virtual void Free(T * data)                                                  = 0;
+    virtual GenericAllocatorIterator<T> begin()                                  = 0;
+    virtual GenericAllocatorIterator<T> end()                                    = 0;
+
+private:
+    Internal::AllocatorDataBase<T> * mData;
+};
+
+/**
+ * Allocates from either a static pool or from the heap depending on configuration.
+ *
+ * @tparam T is the class that is being allocated
+ * @tparam N is the size of the pool, or 0 for dynamic allocation from the heap.
+ */
+template <typename T, size_t N>
+class GenericAllocator : public GenericAllocatorBase<T>
+{
+public:
+    GenericAllocator() : GenericAllocatorBase<T>(&mData) {}
+    ~GenericAllocator() {}
+    bool IsDynamic() override { return N == 0; }
+    T * Allocate() override { return mData.Allocate(); }
+    GenericAllocatorIterator<T> & Free(GenericAllocatorIterator<T> & it) override { return it.Free(); }
+    void Free(T * data) override { mData.Free(data); }
+    GenericAllocatorIterator<T> begin() override { return GenericAllocatorIterator<T>(&mData); }
+    GenericAllocatorIterator<T> end() override { return GenericAllocatorIterator<T>(&mData).SetEnd(); }
+
+private:
+    Internal::AllocatorData<T, N> mData;
+};
+} // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -33,6 +33,7 @@ chip_test_suite("tests") {
     "TestDefer.cpp",
     "TestErrorStr.cpp",
     "TestFixedBufferAllocator.cpp",
+    "TestGenericAllocator.cpp",
     "TestOwnerOf.cpp",
     "TestPool.cpp",
     "TestPrivateHeap.cpp",

--- a/src/lib/support/tests/TestGenericAllocator.cpp
+++ b/src/lib/support/tests/TestGenericAllocator.cpp
@@ -1,0 +1,276 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for CHIP Memory Management
+ *      code functionality.
+ *
+ */
+
+#include <inttypes.h>
+
+#include <lib/support/GenericAllocator.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::Logging;
+
+static void TestGenericAllocator_StaticDynamic(nlTestSuite * inSuite, void * inContext)
+{
+    GenericAllocator<int, 0> allocator_dynamic;
+    GenericAllocator<int, 1> allocator_static;
+    NL_TEST_ASSERT(inSuite, allocator_dynamic.IsDynamic());
+    NL_TEST_ASSERT(inSuite, !allocator_static.IsDynamic());
+}
+
+template <typename T, size_t N>
+bool TestCount(nlTestSuite * inSuite, GenericAllocator<T, N> & allocator, int nAllocated)
+{
+    int count = 0;
+    for (auto & a : allocator)
+    {
+        count++;
+        (void) a;
+    }
+    NL_TEST_ASSERT(inSuite, count == nAllocated);
+    bool ranged_for_ok = count == nAllocated;
+    if (!ranged_for_ok)
+    {
+        ChipLogError(Discovery, "Testing ranged for count - expected %d, got %d", nAllocated, count);
+    }
+
+    count = 0;
+    for (auto it = allocator.begin(); it != allocator.end(); ++it)
+    {
+        count++;
+    }
+    NL_TEST_ASSERT(inSuite, count == nAllocated);
+    bool iterator_ok = count == nAllocated;
+    if (!iterator_ok)
+    {
+        ChipLogError(Discovery, "Testing ranged for count - expected %d, got %d", nAllocated, count);
+    }
+    return ranged_for_ok && iterator_ok;
+}
+
+template <typename T, size_t N>
+void TestGenericAllocator(nlTestSuite * inSuite, const T * const testVals)
+{
+    // We need at least 4 values for this test.
+    static_assert(N == 0 || N > 3, "TestGenericAllocator must be used with an allocator of at least size 3.");
+    bool countOk;
+
+    GenericAllocator<T, N> allocator;
+    bool expectDynamic = N == 0;
+    NL_TEST_ASSERT(inSuite, allocator.IsDynamic() == expectDynamic);
+    constexpr int nAllocations = N > 0 ? N : 5;
+
+    // First test that range based for loop and iterator access work with empty allocations
+    ChipLogProgress(Discovery, "Testing empty on creation");
+    TestCount<T, N>(inSuite, allocator, 0);
+
+    // We should be able to allocate at least nAllocations. Test that the count is correct after each.
+    ChipLogProgress(Discovery, "Testing allocations");
+    for (int i = 0; i < nAllocations; ++i)
+    {
+        T * ptr = allocator.Allocate();
+        NL_TEST_ASSERT(inSuite, ptr != nullptr);
+        if (ptr == nullptr)
+        {
+            return;
+        }
+        *ptr    = testVals[i];
+        countOk = TestCount<T, N>(inSuite, allocator, i + 1);
+        NL_TEST_ASSERT(inSuite, countOk);
+    }
+
+    // Check that all the values are as we expect.
+    int c = 0;
+    for (auto & a : allocator)
+    {
+        NL_TEST_ASSERT(inSuite, a == testVals[c++]);
+    }
+    // Ensure nothing changed.
+    countOk = TestCount<T, N>(inSuite, allocator, nAllocations);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    // Remove a value at the start, at the end and in the middle and
+    // We know N is at least 4 because we checked in the assert above.
+    ChipLogProgress(Discovery, "Testing free using iterator");
+    int middleVal = nAllocations / 2;
+    c             = 0;
+    for (auto it = allocator.begin(); it != allocator.end();)
+    {
+        if (c == 0 || c == middleVal || c == (nAllocations - 1))
+        {
+            it = allocator.Free(it);
+        }
+        else
+        {
+            ++it;
+        }
+        c++;
+    }
+    countOk = TestCount<T, N>(inSuite, allocator, nAllocations - 3);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    // Assure the correct values were removed
+    c = 0;
+    for (auto & a : allocator)
+    {
+        if (c == 0 || c == middleVal || c == (nAllocations - 1))
+        {
+            c++;
+        }
+        NL_TEST_ASSERT(inSuite, a == testVals[c++]);
+    }
+
+    // Try adding back a value and assure we have the right count.
+    allocator.Allocate();
+    countOk = TestCount<T, N>(inSuite, allocator, nAllocations - 2);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    // Free everything and assure we have nothing.
+    for (auto it = allocator.begin(); it != allocator.end();)
+    {
+        it = allocator.Free(it);
+    }
+    countOk = TestCount<T, N>(inSuite, allocator, 0);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    // Test Free using the data pointer
+    ChipLogProgress(Discovery, "Testing free using pointer");
+    T * allocations[nAllocations];
+    for (int i = 0; i < nAllocations; ++i)
+    {
+        allocations[i] = allocator.Allocate();
+        NL_TEST_ASSERT(inSuite, allocations[i] != nullptr);
+        if (allocations[i] == nullptr)
+        {
+            return;
+        }
+        *allocations[i] = testVals[i];
+        countOk         = TestCount<T, N>(inSuite, allocator, i + 1);
+        NL_TEST_ASSERT(inSuite, countOk);
+    }
+
+    // Remove the same three values as before
+    allocator.Free(allocations[0]);
+    allocator.Free(allocations[middleVal]);
+    allocator.Free(allocations[nAllocations - 1]);
+
+    // Assure the correct values were removed
+    c = 0;
+    for (auto & a : allocator)
+    {
+        if (c == 0 || c == middleVal || c == (nAllocations - 1))
+        {
+            c++;
+        }
+        NL_TEST_ASSERT(inSuite, a == testVals[c++]);
+    }
+
+    // Try adding back a value and assure we have the right count.
+    allocations[0] = allocator.Allocate();
+    countOk        = TestCount<T, N>(inSuite, allocator, nAllocations - 2);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    // Free everything and assure we have nothing. This frees the same values we had before and should cause no problems with double
+    // frees.
+    for (int i = 0; i < nAllocations; i++)
+    {
+        allocator.Free(allocations[i]);
+    }
+    countOk = TestCount<T, N>(inSuite, allocator, 0);
+    NL_TEST_ASSERT(inSuite, countOk);
+
+    if (N != 0)
+    {
+        ChipLogProgress(Discovery, "Test overallocations");
+        T * ptr;
+        for (int i = 0; i < nAllocations; ++i)
+        {
+            ptr = allocator.Allocate();
+            NL_TEST_ASSERT(inSuite, ptr != nullptr);
+            countOk = TestCount<T, N>(inSuite, allocator, i + 1);
+            NL_TEST_ASSERT(inSuite, countOk);
+        }
+        // Next one should fail.
+        ptr = allocator.Allocate();
+        NL_TEST_ASSERT(inSuite, ptr == nullptr);
+    }
+}
+
+// Test values.
+constexpr int intTestVals[5] = { 1, 2, 3, 4, 5 };
+
+class TestClass
+{
+public:
+    constexpr TestClass(int intVal, bool boolVal, uint32_t u32Val) : mIntVal(intVal), mBoolVal(boolVal), mU32Val(u32Val) {}
+    TestClass() {}
+    bool operator==(const TestClass & other) const
+    {
+        return mIntVal == other.mIntVal && other.mBoolVal == mBoolVal && mU32Val == other.mU32Val;
+    }
+
+public:
+    int mIntVal      = 0;
+    bool mBoolVal    = false;
+    uint32_t mU32Val = 0;
+};
+
+constexpr TestClass classTestVals[5] = {
+    { -11, true, 58 }, { -2, false, 78 }, { 0, false, 97 }, { 5, true, 10098 }, { 7, true, 98 }
+};
+
+void TestGenericAllocator_Dynamic(nlTestSuite * inSuite, void * inContext)
+{
+    TestGenericAllocator<int, 0>(inSuite, intTestVals);
+    TestGenericAllocator<TestClass, 0>(inSuite, classTestVals);
+}
+
+void TestGenericAllocator_Static(nlTestSuite * inSuite, void * inContext)
+{
+    TestGenericAllocator<int, 5>(inSuite, intTestVals);
+    TestGenericAllocator<TestClass, 5>(inSuite, classTestVals);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = {
+    NL_TEST_DEF("Test GenericAllocator static/dynamic", TestGenericAllocator_StaticDynamic), //
+    NL_TEST_DEF("Test GenericAllocator::Allocate dynamic", TestGenericAllocator_Dynamic),    //
+    NL_TEST_DEF("Test GenericAllocator::Allocate static", TestGenericAllocator_Static),      //
+    NL_TEST_SENTINEL()                                                                       //
+};
+
+int TestGenericAllocator()
+{
+    nlTestSuite theSuite = { "CHIP Generic allocator", &sTests[0], nullptr, nullptr };
+    chip::Platform::MemoryInit();
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestGenericAllocator)


### PR DESCRIPTION
#### Problem
This is just a draft - wanted to get some feedback.

We have the System the SystemObjectPool to do pool based allocations now, but I was also working on a similar pool allocator for the mdns stuff and I wanted to get some feedback on incorporating this style of pool into the SystemObjectPool and whether that would mess anything up for you.

Desirable properties of the GenericAllocator
- Can pass GenericAllocatorBase<T> pointer to a function that isn't templated on the pool size (see second commit for example)
- Uses the iterator style that's similar to the std implementations - this means we can use range-based for loops over the allocator which can make the code a bit more readable and works well with the current minimal mdns style
- Can opt to use heap or static pool for each allocator - ie, can have a mix of heap and static as required.

Drawbacks
- iterator style means we don't have the lock on the data like in the Funtion style of the SystemObjectPool. I think this is reasonable - it's fairly standard knowledge to not blindly manipulate an object while iterating through. This iterator usage matches what happens for std::list et. al.
- SystemObjectPool does stats tracking that isn't implemented yet in GenericAllocator

So Question - would you be open to the idea of incorporating some of this functionality into the SystemObjectPool, such that we could have a SystemObjectPoolBase<T>, an iterator accessor and per-pool heap/static configurability? 

#### Change overview
Adds an Example for a static/dynamic allocator with tests, and shows how the allocator / iterator and base pointer would be use in the mdns layer.

#### Testing
- unit tests added, mdns covered by minimal mdns unit tests for query responder and TestAdvertiser. Also confirmed mdns still working on lighting app in linux.