### PR TITLE
Regenerate after DiscoverAttributes command is removed

### DIFF
--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -14654,36 +14654,6 @@ private:
 \*----------------------------------------------------------------------------*/
 
 /*
- * Discover Attributes
- */
-class DiscoverPowerSourceAttributes : public ModelCommand
-{
-public:
-    DiscoverPowerSourceAttributes() : ModelCommand("discover") { ModelCommand::AddArguments(); }
-
-    ~DiscoverPowerSourceAttributes()
-    {
-        delete onSuccessCallback;
-        delete onFailureCallback;
-    }
-
-    CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
-    {
-        ChipLogProgress(chipTool, "Sending cluster (0x0000) command (0x0C) on endpoint %" PRIu8, endpointId);
-
-        chip::Controller::PowerSourceCluster cluster;
-        cluster.Associate(device, endpointId);
-        return cluster.DiscoverAttributes(onSuccessCallback->Cancel(), onFailureCallback->Cancel());
-    }
-
-private:
-    chip::Callback::Callback<DefaultSuccessCallback> * onSuccessCallback =
-        new chip::Callback::Callback<DefaultSuccessCallback>(OnDefaultSuccessResponse, this);
-    chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
-        new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-};
-
-/*
  * Attribute Status
  */
 class ReadPowerSourceStatus : public ModelCommand
@@ -24848,7 +24818,6 @@ void registerClusterPowerSource(Commands & commands)
     const char * clusterName = "PowerSource";
 
     commands_list clusterCommands = {
-        make_unique<DiscoverPowerSourceAttributes>(),          //
         make_unique<ReadPowerSourceStatus>(),                  //
         make_unique<ReadPowerSourceOrder>(),                   //
         make_unique<ReadPowerSourceDescription>(),             //

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.cpp
@@ -8563,14 +8563,6 @@ CHIP_ERROR OperationalCredentialsCluster::ReadAttributeClusterRevision(Callback:
 
 // PowerSource Cluster Commands
 // PowerSource Cluster Attributes
-CHIP_ERROR PowerSourceCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback,
-                                                  Callback::Cancelable * onFailureCallback)
-{
-    COMMAND_HEADER("DiscoverPowerSourceAttributes", PowerSource::Id);
-    buf.Put8(kFrameControlGlobalCommand).Put8(seqNum).Put32(Globals::Commands::Ids::DiscoverAttributes).Put32(0x0000).Put8(0xFF);
-    COMMAND_FOOTER();
-}
-
 CHIP_ERROR PowerSourceCluster::ReadAttributeStatus(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {

--- a/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
+++ b/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h
@@ -989,7 +989,6 @@ public:
     ~PowerSourceCluster() {}
 
     // Cluster Attributes
-    CHIP_ERROR DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeOrder(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
     CHIP_ERROR ReadAttributeDescription(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);


### PR DESCRIPTION
#### Problem
TOT not compiling because of regen issues.

#### Change overview
Regenerate after "DiscoverAttributes" command is removed.

#### Testing
Tested with build on Darwin.
