### PR TITLE
Do not disable BLE if a fabric has not been provisioned on the device

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -135,10 +135,10 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
         ChipLogProgress(AppServer, "Rendezvous and secure pairing skipped");
         SuccessOrExit(err = AddTestCommissioning());
     }
-    else if (DeviceLayer::ConnectivityMgr().IsWiFiStationProvisioned() || DeviceLayer::ConnectivityMgr().IsThreadProvisioned())
+    else if (GetFabricTable().FabricCount() != 0)
     {
-        // If the network is already provisioned, proactively disable BLE advertisement.
-        ChipLogProgress(AppServer, "Network already provisioned. Disabling BLE advertisement");
+        // The device is already commissioned, proactively disable BLE advertisement.
+        ChipLogProgress(AppServer, "Fabric already provisioned. Disabling BLE advertisement");
         chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
     }
     else

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -135,7 +135,8 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
         ChipLogProgress(AppServer, "Rendezvous and secure pairing skipped");
         SuccessOrExit(err = AddTestCommissioning());
     }
-    else if (GetFabricTable().FabricCount() != 0)
+    else if ((DeviceLayer::ConnectivityMgr().IsWiFiStationProvisioned() || DeviceLayer::ConnectivityMgr().IsThreadProvisioned()) &&
+             (GetFabricTable().FabricCount() != 0))
     {
         // The device is already commissioned, proactively disable BLE advertisement.
         ChipLogProgress(AppServer, "Fabric already commissioned. Disabling BLE advertisement");

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR Server::Init(AppDelegate * delegate, uint16_t secureServicePort, uint
     else if (GetFabricTable().FabricCount() != 0)
     {
         // The device is already commissioned, proactively disable BLE advertisement.
-        ChipLogProgress(AppServer, "Fabric already provisioned. Disabling BLE advertisement");
+        ChipLogProgress(AppServer, "Fabric already commissioned. Disabling BLE advertisement");
         chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
     }
     else

--- a/src/transport/FabricTable.h
+++ b/src/transport/FabricTable.h
@@ -382,6 +382,8 @@ public:
     CHIP_ERROR Init(PersistentStorageDelegate * storage);
     CHIP_ERROR SetFabricDelegate(FabricTableDelegate * delegate);
 
+    uint8_t FabricCount() const { return mFabricCount; }
+
     ConstFabricIterator cbegin() const { return ConstFabricIterator(mStates, 0, CHIP_CONFIG_MAX_DEVICE_ADMINS); }
     ConstFabricIterator cend() const
     {
@@ -398,6 +400,7 @@ private:
     FabricTableDelegate * mDelegate = nullptr;
 
     FabricIndex mNextAvailableFabricIndex = kMinValidFabricIndex;
+    uint8_t mFabricCount                  = 0;
 };
 
 } // namespace Transport


### PR DESCRIPTION
#### Problem
* Fixes #9832 

#### Change overview
Server application was checking the network status to determine if the the device is already provisioned. This code was added long ago, and worked since fabric commissioning was not supported then.

This change uses fabric table to determine if the device is currently commissioned, instead of checking for network status.

#### Testing
Tested BLE commissioning process on m5stack (by configuring it with WiFi credentials through menuconfig) and chip-tool.
