### PR TITLE
Add rpc builds to python build scripts

### DIFF
--- a/examples/all-clusters-app/esp32/sdkconfig_m5stack_rpc.defaults
+++ b/examples/all-clusters-app/esp32/sdkconfig_m5stack_rpc.defaults
@@ -1,0 +1,56 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      CI uses this to select the ESP32 M5Stack.
+#
+CONFIG_IDF_TARGET="esp32"
+CONFIG_IDF_TARGET_ESP32=y
+CONFIG_DEVICE_TYPE_M5STACK=y
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD_115200B=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+
+#enable BT
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+
+#enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Vendor and product id
+CONFIG_DEVICE_VENDOR_ID=0x235A
+CONFIG_DEVICE_PRODUCT_ID=0x4541
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 5k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
+
+# PW RPC Debug channel
+CONFIG_EXAMPLE_UART_PORT_NUM=0
+CONFIG_EXAMPLE_UART_BAUD_RATE=115200
+CONFIG_EXAMPLE_UART_RXD=3
+CONFIG_EXAMPLE_UART_TXD=1
+CONFIG_ENABLE_PW_RPC=y

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -40,6 +40,7 @@ class Context:
     def SetupBuilders(self, platforms: Sequence[Platform],
                       boards: Sequence[Board],
                       applications: Sequence[Application],
+                      enable_rpcs: bool,
                       enable_flashbundle: bool):
         """Configures internal builders for the given platform/board/app combination.
 
@@ -67,7 +68,7 @@ class Context:
 
         if not applications:
             applications = set().union(*[
-                TargetRelations.ApplicationsForPlatform(platform)
+                TargetRelations.ApplicationsForPlatform(platform, enable_rpcs)
                 for platform in platforms
             ])
 
@@ -89,7 +90,8 @@ class Context:
             for board in sorted(boards):
                 for application in sorted(applications):
                     builder = self.builder_factory.Create(
-                        platform, board, application, enable_flashbundle=enable_flashbundle)
+                        platform, board, application, enable_flashbundle=enable_flashbundle,
+                        enable_rpcs=enable_rpcs)
                     if not builder:
                         logging.debug('Builder not supported for tuple %s/%s/%s', platform,
                                       board, application)

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -113,9 +113,15 @@ def ValidateRepoPath(context, parameter, value):
     default=False,
     is_flag=True,
     help='Skip timestaps in log output')
+@click.option(
+    '--rpc',
+    default=False,
+    is_flag=True,
+    help='Build with debug RPCs enabled.'
+)
 @click.pass_context
 def main(context, log_level, platform, board, app, repo, out_prefix, clean,
-         dry_run, dry_run_output, enable_flashbundle, no_log_timestamps):
+         dry_run, dry_run_output, enable_flashbundle, no_log_timestamps, rpc):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s %(levelname)-7s %(message)s'
     if no_log_timestamps:
@@ -145,6 +151,7 @@ before running this script.
         platforms=[build.Platform.FromArgName(name) for name in platform],
         boards=[build.Board.FromArgName(name) for name in board],
         applications=[build.Application.FromArgName(name) for name in app],
+        enable_rpcs=rpc,
         enable_flashbundle=enable_flashbundle)
 
     if clean:

--- a/scripts/build/builders/builder.py
+++ b/scripts/build/builders/builder.py
@@ -117,6 +117,8 @@ class Builder(ABC):
             shutil.copyfile(source_name, target_full_name)
             shutil.copymode(source_name, target_full_name)
 
-    def SetIdentifier(self, platform: str, board: str, app: str):
+    def SetIdentifier(self, platform: str, board: str, app: str, enable_rpcs: bool = False):
         self.identifier = '-'.join([platform, board, app])
+        if enable_rpcs:
+            self.identifier = self.identifier + "-rpc"
         self.output_dir = os.path.join(self.output_prefix, self.identifier)

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -69,14 +69,17 @@ class Efr32Builder(GnBuilder):
                  runner,
                  output_prefix: str,
                  app: Efr32App = Efr32App.LIGHT,
-                 board: Efr32Board = Efr32Board.BRD4161A):
+                 board: Efr32Board = Efr32Board.BRD4161A,
+                 enable_rpcs: bool = False):
         super(Efr32Builder, self).__init__(
             root=os.path.join(root, 'examples', app.ExampleName(), 'efr32'),
             runner=runner,
             output_prefix=output_prefix)
-
         self.app = app
         self.board = board
+        self.gn_build_args = ['efr32_board="%s"' % board.GnArgName()]
+        if enable_rpcs:
+            self.gn_build_args.append('import("//with_pw_rpc.gni")')
 
     def GnBuildArgs(self):
         return ['efr32_board="%s"' % self.board.GnArgName()]

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -68,17 +68,18 @@ class Esp32App(Enum):
         return self.AppNamePrefix + '.flashbundle.txt'
 
 
-def DefaultsFileName(board: Esp32Board, app: Esp32App):
+def DefaultsFileName(board: Esp32Board, app: Esp32App, enable_rpcs: bool):
     if app != Esp32App.ALL_CLUSTERS:
         # only all-clusters has a specific defaults name
         return None
 
+    rpc = "_rpc" if enable_rpcs else ""
     if board == Esp32Board.DevKitC:
-        return 'sdkconfig.defaults'
+        return 'sdkconfig{}.defaults'.format(rpc)
     elif board == Esp32Board.M5Stack:
-        return 'sdkconfig_m5stack.defaults'
+        return 'sdkconfig_m5stack{}.defaults'.format(rpc)
     elif board == Esp32Board.C3DevKit:
-        return 'sdkconfig_c3devkit.defaults'
+        return 'sdkconfig_c3devkit{}.defaults'.format(rpc)
     else:
         raise Exception('Unknown board type')
 
@@ -90,10 +91,12 @@ class Esp32Builder(Builder):
                  runner,
                  output_prefix: str,
                  board: Esp32Board = Esp32Board.M5Stack,
-                 app: Esp32App = Esp32App.ALL_CLUSTERS):
+                 app: Esp32App = Esp32App.ALL_CLUSTERS,
+                 enable_rpcs: bool = False):
         super(Esp32Builder, self).__init__(root, runner, output_prefix)
         self.board = board
         self.app = app
+        self.enable_rpcs = enable_rpcs
 
     def _IdfEnvExecute(self, cmd, cwd=None, title=None):
         self._Execute(
@@ -105,7 +108,7 @@ class Esp32Builder(Builder):
         if os.path.exists(os.path.join(self.output_dir, 'build.ninja')):
             return
 
-        defaults = DefaultsFileName(self.board, self.app)
+        defaults = DefaultsFileName(self.board, self.app, self.enable_rpcs)
 
         cmd = 'idf.py'
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -125,6 +125,7 @@ class HostBuilder(GnBuilder):
             self.map_name: os.path.join(self.output_dir, self.map_name)
         }
 
-    def SetIdentifier(self, platform: str, board: str, app: str):
+# todo
+    def SetIdentifier(self, platform: str, board: str, app: str, enable_rpcs: bool = False):
         super(HostBuilder, self).SetIdentifier(
-            self.board.PlatformName(), self.board.BoardName(), app)
+            self.board.PlatformName(), self.board.BoardName(), app, enable_rpcs)

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -95,10 +95,12 @@ class NrfConnectBuilder(Builder):
                  runner,
                  output_prefix: str,
                  app: NrfApp = NrfApp.LIGHT,
-                 board: NrfBoard = NrfBoard.NRF52840):
+                 board: NrfBoard = NrfBoard.NRF52840,
+                 enable_rpcs: bool = False):
         super(NrfConnectBuilder, self).__init__(root, runner, output_prefix)
         self.app = app
         self.board = board
+        self.enable_rpcs = enable_rpcs
 
     def generate(self):
         if not os.path.exists(self.output_dir):
@@ -130,12 +132,13 @@ class NrfConnectBuilder(Builder):
             cmd = '''
 source "$ZEPHYR_BASE/zephyr-env.sh";
 export GNUARMEMB_TOOLCHAIN_PATH="$PW_PIGWEED_CIPD_INSTALL_DIR";
-west build --cmake-only -d {outdir} -b {board} {sourcedir}
+west build --cmake-only -d {outdir} -b {board} {sourcedir}{rpcs}
         '''.format(
                 outdir=shlex.quote(self.output_dir),
                 board=self.board.GnArgName(),
                 sourcedir=shlex.quote(os.path.join(
-                    self.root, 'examples', self.app.ExampleName(), 'nrfconnect'))
+                    self.root, 'examples', self.app.ExampleName(), 'nrfconnect')),
+                rpcs=" -- -DOVERLAY_CONFIG=rpc.overlay" if self.enable_rpcs else ""
             ).strip()
 
             self._Execute(['bash', '-c', cmd],


### PR DESCRIPTION
#### Problem
The build scripts can't build the application with the RPC debug interface enabled for testing.

#### Change overview
Add --rpc option which builds applications with the rpc debug interface enabled.

#### Testing
Used scripts to build the following app/board versions with RPC enabled, flashed and verified RPCs worked with console.
- esp all-clusters
- efr lighting
- nrf lighting
