### PR TITLE
Ensure no chained buffers in GetDataPtr

### DIFF
--- a/src/app/data-model/Decode.h
+++ b/src/app/data-model/Decode.h
@@ -65,12 +65,7 @@ inline CHIP_ERROR Decode(TLV::TLVReader & reader, ByteSpan & x)
 //
 inline CHIP_ERROR Decode(TLV::TLVReader & reader, Span<const char> & x)
 {
-    ByteSpan bs;
-
-    VerifyOrReturnError(reader.GetType() == TLV::kTLVType_UTF8String, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
-    ReturnErrorOnFailure(reader.Get(bs));
-    x = Span<const char>(Uint8::to_const_char(bs.data()), bs.size());
-    return CHIP_NO_ERROR;
+    return reader.Get(x);
 }
 
 /*

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -428,7 +428,9 @@ public:
     CHIP_ERROR Get(float & v);
 
     /**
-     * Get the value of the current element as a chip::ByteSpan
+     * Get the value of the current element as a chip::ByteSpan.
+     *
+     * The Span is updated to point to data directly within the backing buffer.
      *
      * @param[out]  v                       Receives the value associated with current TLV element.
      *
@@ -438,6 +440,20 @@ public:
      *
      */
     CHIP_ERROR Get(chip::ByteSpan & v);
+
+    /**
+     * Get the value of the current element as a chip::Span<const char>
+     *
+     * The Span is updated to point to data directly within the backing buffer.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV bytes array, or
+     *                                      the reader is not positioned on an element.
+     *
+     */
+    CHIP_ERROR Get(chip::Span<const char> & v);
 
     /**
      * Get the value of the current byte or UTF8 string element.
@@ -838,7 +854,7 @@ protected:
     CHIP_ERROR SkipToEndOfContainer();
     CHIP_ERROR VerifyElement();
     uint64_t ReadTag(TLVTagControl tagControl, const uint8_t *& p);
-    CHIP_ERROR EnsureData(CHIP_ERROR noDataErr);
+    CHIP_ERROR EnsureData(CHIP_ERROR noDataErr, bool permitChaining = true);
     CHIP_ERROR ReadData(uint8_t * buf, uint32_t len);
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
     TLVElementType ElementType() const;

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -4215,7 +4215,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("CHIP TLV Skip non-contiguous",        CheckCHIPTLVSkipCircular),
     NL_TEST_DEF("CHIP TLV ByteSpan",                   CheckCHIPTLVByteSpan),
     NL_TEST_DEF("CHIP TLV Check reserve",              CheckCloseContainerReserve),
-    NL_TEST_DEF("CHIP TLV Reader Fuzz Test",             TLVReaderFuzzTest),
+    NL_TEST_DEF("CHIP TLV Reader Fuzz Test",           TLVReaderFuzzTest),
     NL_TEST_DEF("CHIP TLV GetStringView Test",         CheckGetStringView),
     NL_TEST_DEF("CHIP TLV GetByteView Test",           CheckGetByteView),
     NL_TEST_DEF("CHIP TLV Check Chained Test",         CheckChainedBuffers),

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -4215,7 +4215,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("CHIP TLV Skip non-contiguous",        CheckCHIPTLVSkipCircular),
     NL_TEST_DEF("CHIP TLV ByteSpan",                   CheckCHIPTLVByteSpan),
     NL_TEST_DEF("CHIP TLV Check reserve",              CheckCloseContainerReserve),
-    //NL_TEST_DEF("CHIP TLV Reader Fuzz Test",           TLVReaderFuzzTest),
+    NL_TEST_DEF("CHIP TLV Reader Fuzz Test",             TLVReaderFuzzTest),
     NL_TEST_DEF("CHIP TLV GetStringView Test",         CheckGetStringView),
     NL_TEST_DEF("CHIP TLV GetByteView Test",           CheckGetByteView),
     NL_TEST_DEF("CHIP TLV Check Chained Test",         CheckChainedBuffers),


### PR DESCRIPTION
#### Problem

There is fairly liberal use of the TLVReader::GetDataPtr method within the SDK to read out octet and UTF-8 strings from packet buffers. The assumption in most places is that the underlying backing buffer is contiguous.

However, the actual backing buffer used in most cases does permit chaining, which if present, will result in fairly egregious bugs that will manifest in highly unobvious ways. In practice however in most cases, the actual underlying packet buffers are contiguous and are not chained, especially those that go to/from LWIP.

#### Solution

While the long term correct solution is to move to ContiguousBufferTLVReader, this provides a short/medium term fix to actually ensure we're being safe when making those calls and to at least emit an error if not so.

This PR also adds `Get(Span<const chars> &v)` to the TLVReader class that finally rounds out the Span-based getters on that class.

#### Testing

Added unit tests to validate chaining minimally (there were none before), and then to validate that we do emit an error if trying to read out Spans from a reader backed by chained packet buffers.