### PR TITLE
[python]:Disable OriginalSetupCode option in command 'open-commissioning-window'

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -858,7 +858,7 @@ class DeviceMgrCmd(Cmd):
 
         Options:
           -t  Timeout (in seconds)     
-          -o  Option  [OriginalSetupCode = 0, TokenWithRandomPIN = 1, TokenWithProvidedPIN = 2]
+          -o  Option  [TokenWithRandomPIN = 1, TokenWithProvidedPIN = 2]
           -d  Discriminator Value
           -i  Iteration
 
@@ -875,12 +875,16 @@ class DeviceMgrCmd(Cmd):
             parser.add_argument(
                 "-t", type=int, default=0, dest='timeout')
             parser.add_argument(
-                "-o", type=int, default=0, dest='option')
+                "-o", type=int, default=1, dest='option')
             parser.add_argument(
                 "-i", type=int, default=0, dest='iteration')
             parser.add_argument(
                 "-d", type=int, default=0, dest='discriminator')
             args = parser.parse_args(arglist[1:])
+
+            if args.option < 1 or args.option > 2:
+                print("Invalid option specified!")
+                raise ValueError("Invalid option specified")
 
             self.devCtrl.OpenCommissioningWindow(
                 int(arglist[0]), args.timeout, args.iteration, args.discriminator, args.option)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Feedback from CSG, Option  [OriginalSetupCode = 0] in python command 'open-commissioning-window' is used to open Basic Commissioning Window(BCM), 'open-commissioning-window' is supposed to open extended commissioning(ECM) only since there is already a separate command for BCM. 

#### Change overview
Disable OriginalSetupCode option in command 'open-commissioning-window'

#### Testing
How was this tested? (at least one bullet point required)
```
chip-device-ctrl > open-commissioning-window 12344321 -t 3 -o 0 -d 3840 -i 1000
Invalid option specified!

open-commissioning-window <nodeid> [options]

Options:
  -t  Timeout (in seconds)     
  -o  Option  [TokenWithRandomPIN = 1, TokenWithProvidedPIN = 2]
  -d  Discriminator Value
  -i  Iteration

  This command is used by a current Administrator to instruct a Node to go into commissioning mode
```

