### PR TITLE
KVS: Add error check for large offset reads

### DIFF
--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -56,6 +56,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     {
         return err;
     }
+    else if (offset_bytes > read_size)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     Platform::ScopedMemoryBuffer<uint8_t> buf;
     VerifyOrReturnError(buf.Alloc(read_size), CHIP_ERROR_NO_MEMORY);


### PR DESCRIPTION
#### Problem
Linux KVS doesn't check the offset size is smaller then the actual size. #9479 

#### Change overview
Added a check and return an error. 

#### Testing
Ran the persistent storage example/test app for linux which includes a test for offset reads. 
