### PR TITLE
Separate connect/commission and use for BLE.

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -41,7 +41,6 @@ ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 declare chip_detail_logging=false
 declare enable_pybindings=false
 declare chip_mdns
-declare clusters=true
 
 help() {
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -387,15 +387,6 @@ public:
 
     CASESession & GetCASESession() { return mCASESession; }
 
-    CHIP_ERROR SetCSRNonce(ByteSpan csrNonce)
-    {
-        VerifyOrReturnError(csrNonce.size() == sizeof(mCSRNonce), CHIP_ERROR_INVALID_ARGUMENT);
-        memcpy(mCSRNonce, csrNonce.data(), csrNonce.size());
-        return CHIP_NO_ERROR;
-    }
-
-    ByteSpan GetCSRNonce() const { return ByteSpan(mCSRNonce, sizeof(mCSRNonce)); }
-
     MutableByteSpan GetMutableNOCCert() { return MutableByteSpan(mNOCCertBuffer, sizeof(mNOCCertBuffer)); }
 
     CHIP_ERROR SetNOCCertBufferSize(size_t new_size);
@@ -511,8 +502,6 @@ private:
 
     CASESession mCASESession;
     PersistentStorageDelegate * mStorageDelegate = nullptr;
-
-    uint8_t mCSRNonce[kOpCSRNonceLength];
 
     uint8_t mNOCCertBuffer[Credentials::kMaxCHIPCertLength];
     size_t mNOCCertBufferSize = 0;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -108,6 +108,8 @@ ChipError::StorageType pychip_DeviceController_ConnectBLE(chip::Controller::Devi
                                                           uint32_t setupPINCode, chip::NodeId nodeid);
 ChipError::StorageType pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
                                                          uint32_t setupPINCode, chip::NodeId nodeid);
+ChipError::StorageType pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, const char * ssid,
+                                                          const char * password, chip::NodeId nodeid);
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 
 ChipError::StorageType
@@ -320,6 +322,19 @@ ChipError::StorageType pychip_DeviceController_ConnectIP(chip::Controller::Devic
     return devCtrl->PairDevice(nodeid, params).AsInteger();
 }
 
+ChipError::StorageType pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, const char * ssid,
+                                                          const char * password, chip::NodeId nodeid)
+{
+    chip::CommissioningParameters params;
+    if (strcmp(ssid, "") != 0)
+    {
+        chip::WifiCredentials creds;
+        creds.ssid     = chip::ByteSpan(reinterpret_cast<const uint8_t *>(ssid), strlen(ssid));
+        creds.password = chip::ByteSpan(reinterpret_cast<const uint8_t *>(password), strlen(password));
+        params.SetWifiCredentials(creds);
+    }
+    return devCtrl->Commission(nodeid, params).AsInteger();
+}
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
     Device * device;

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -194,6 +194,11 @@ class ChipDeviceController(object):
             lambda: self._dmLib.pychip_DeviceController_ConnectIP(
                 self.devCtrl, ipaddr, setupPinCode, nodeid)
         )
+    
+    def Commission(self, ssid, password, nodeid):
+        return self._ChipStack.CallAsync(
+            lambda: self._dmLib.pychip_DeviceController_Commission(self.devCtrl, ssid, password, nodeid)
+        )
 
     def ResolveNode(self, fabricid, nodeid):
         return self._ChipStack.CallAsync(
@@ -452,6 +457,8 @@ class ChipDeviceController(object):
             self._dmLib.pychip_DeviceController_CloseSession.argtypes = [
                 c_void_p, c_uint64]
             self._dmLib.pychip_DeviceController_CloseSession.restype = c_uint32
+            self._dmLib.pychip_DeviceController_Commission.argtypes = [c_void_p, c_char_p, c_char_p, c_uint64]
+            self._dmLib.pychip_DeviceController_Commission.restype = c_uint32
 
             self._dmLib.pychip_DeviceController_GetAddressAndPort.argtypes = [
                 c_void_p, c_uint64, c_char_p, c_uint64, POINTER(c_uint16)]

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -48,17 +48,9 @@ public:
 
     bool HasPeerAddress() const { return mPeerAddress.IsInitialized(); }
     Transport::PeerAddress GetPeerAddress() const { return mPeerAddress; }
-    const Optional<ByteSpan> GetCSRNonce() const { return mCSRNonce; }
     RendezvousParameters & SetPeerAddress(const Transport::PeerAddress & peerAddress)
     {
         mPeerAddress = peerAddress;
-        return *this;
-    }
-
-    // The lifetime of the buffer csrNonce is pointing to, should exceed the lifetime of RendezvousParameter object.
-    RendezvousParameters & SetCSRNonce(ByteSpan csrNonce)
-    {
-        mCSRNonce.SetValue(csrNonce);
         return *this;
     }
 
@@ -71,7 +63,6 @@ public:
     }
 
     bool HasPASEVerifier() const { return mHasPASEVerifier; }
-    bool HasCSRNonce() const { return mCSRNonce.HasValue(); }
     const PASEVerifier & GetPASEVerifier() const { return mPASEVerifier; }
     RendezvousParameters & SetPASEVerifier(PASEVerifier & verifier)
     {
@@ -104,7 +95,6 @@ private:
     Transport::PeerAddress mPeerAddress;  ///< the peer node address
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
-    Optional<ByteSpan> mCSRNonce;         ///< CSR Nonce passed by the commissioner
 
     PASEVerifier mPASEVerifier;
     bool mHasPASEVerifier = false;
@@ -113,6 +103,47 @@ private:
     Ble::BleLayer * mBleLayer               = nullptr;
     BLE_CONNECTION_OBJECT mConnectionObject = 0;
 #endif // CONFIG_NETWORK_LAYER_BLE
+};
+
+struct WifiCredentials
+{
+    ByteSpan ssid;
+    // TODO(cecille): We should add a PII bytespan concept.
+    ByteSpan password;
+};
+
+class CommissioningParameters
+{
+public:
+    const Optional<ByteSpan> GetCSRNonce() const { return mCSRNonce; }
+    // The lifetime of the buffer csrNonce is pointing to, should exceed the lifetime of RendezvousParameter object.
+    CommissioningParameters & SetCSRNonce(ByteSpan csrNonce)
+    {
+        mCSRNonce.SetValue(csrNonce);
+        return *this;
+    }
+    bool HasCSRNonce() const { return mCSRNonce.HasValue(); }
+
+    const Optional<WifiCredentials> GetWifiCredentials() const { return mWifiCreds; }
+    CommissioningParameters & SetWifiCredentials(WifiCredentials wifiCreds)
+    {
+        mWifiCreds.SetValue(wifiCreds);
+        return *this;
+    }
+    bool HasWifiCredentials() const { return mWifiCreds.HasValue(); }
+    const Optional<ByteSpan> GetThreadOperationalDataset() const { return mThreadOperationalDataset; }
+    CommissioningParameters & SetThreadOperationalDataset(ByteSpan threadOperationalDataset)
+    {
+
+        mThreadOperationalDataset.SetValue(threadOperationalDataset);
+        return *this;
+    }
+    bool HasThreadOperationalDataset() const { return mThreadOperationalDataset.HasValue(); }
+
+private:
+    Optional<ByteSpan> mCSRNonce; ///< CSR Nonce passed by the commissioner
+    Optional<WifiCredentials> mWifiCreds;
+    Optional<ByteSpan> mThreadOperationalDataset;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
Fixes two related issues:
1) "PairDevice" does too much
We want to give developers options for commissioning and right now
we don't have a way for developers to just pair then do their
own custom commissioning. This separates out the pair function from
the commissioning function.

2) BLE commissioning flow was incomplete and in the wrong order
BLE adds opcerts directly, then adds network
credentials and resolves the device in the chip-tool, but doesn't
arm the failsafe or run the commissioning completion flow. The IP
and BLE flows were becoming out of sync and hard to maintain. Goal
here is to provide a single, more flexible comissioning path that
can be used for both BLE and IP.

#### Change overview
- Stops the PairDevice command from automatically commissioning or setting operational credentials
- Adds explicit commission function to commission the device
- Moves commissioning parameters into their own structure
- Combines BLE and IP comissioning paths
- Updates chip-device-ctrl and chip-tool to use the new functions.

#### Testing
- used chip-tool and chip-device-ctrl to commission then read parameters from M5 BLE and lighting app using IP
