### PR TITLE
Remove redundant duplicate message logging.

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -352,7 +352,6 @@ void SessionManager::MessageDispatch(const PacketHeader & packetHeader, const Tr
     CHIP_ERROR err = session->GetPeerMessageCounter().VerifyOrTrustFirst(packetHeader.GetMessageCounter());
     if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
     {
-        ChipLogDetail(Inet, "Received a duplicate message with MessageCounter: %" PRIu32, packetHeader.GetMessageCounter());
         isDuplicate = SessionManagerDelegate::DuplicateMessage::Yes;
         err         = CHIP_NO_ERROR;
     }
@@ -433,7 +432,6 @@ void SessionManager::SecureMessageDispatch(const PacketHeader & packetHeader, co
         err = state->GetSessionMessageCounter().GetPeerMessageCounter().Verify(packetHeader.GetMessageCounter());
         if (err == CHIP_ERROR_DUPLICATE_MESSAGE_RECEIVED)
         {
-            ChipLogDetail(Inet, "Received a duplicate message with MessageCounter: %" PRIu32, packetHeader.GetMessageCounter());
             isDuplicate = SessionManagerDelegate::DuplicateMessage::Yes;
             err         = CHIP_NO_ERROR;
         }


### PR DESCRIPTION
We already log the duplicate at the point when we actually drop it.

#### Problem
Logs that look like this:
```
[1632511832.268209][33148:33148] CHIP:IN: Received a duplicate message with MessageCounter: 1366413728
[1632511832.268237][33148:33148] CHIP:IN: Received a duplicate message with MessageCounter:1366413728 on exchange 16911r
```

#### Change overview
Just keep the second of those messages.

#### Testing
No behavior changes.