### PR TITLE
Make the attribute access Read method a bit easier to implement.

### DIFF
--- a/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
+++ b/src/app/clusters/ethernet_network_diagnostics_server/ethernet_network_diagnostics_server.cpp
@@ -40,15 +40,15 @@ public:
     // Register for the EthernetNetworkDiagnostics cluster on all endpoints.
     EthernetDiagosticsAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), EthernetNetworkDiagnostics::Id) {}
 
-    CHIP_ERROR Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead) override;
+    CHIP_ERROR Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead) override;
 
 private:
-    CHIP_ERROR ReadIfSupported(CHIP_ERROR (ConnectivityManager::*getter)(uint64_t &), TLV::TLVWriter * aWriter);
+    CHIP_ERROR ReadIfSupported(CHIP_ERROR (ConnectivityManager::*getter)(uint64_t &), const AttributeValueEncoder & aEncoder);
 };
 
 EthernetDiagosticsAttrAccess gAttrAccess;
 
-CHIP_ERROR EthernetDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead)
+CHIP_ERROR EthernetDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead)
 {
     if (aClusterInfo.mClusterId != EthernetNetworkDiagnostics::Id)
     {
@@ -60,19 +60,19 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::T
     switch (aClusterInfo.mFieldId)
     {
     case Ids::PacketRxCount: {
-        return ReadIfSupported(&ConnectivityManager::GetEthPacketRxCount, aWriter);
+        return ReadIfSupported(&ConnectivityManager::GetEthPacketRxCount, aEncoder);
     }
     case Ids::PacketTxCount: {
-        return ReadIfSupported(&ConnectivityManager::GetEthPacketTxCount, aWriter);
+        return ReadIfSupported(&ConnectivityManager::GetEthPacketTxCount, aEncoder);
     }
     case Ids::TxErrCount: {
-        return ReadIfSupported(&ConnectivityManager::GetEthTxErrCount, aWriter);
+        return ReadIfSupported(&ConnectivityManager::GetEthTxErrCount, aEncoder);
     }
     case Ids::CollisionCount: {
-        return ReadIfSupported(&ConnectivityManager::GetEthCollisionCount, aWriter);
+        return ReadIfSupported(&ConnectivityManager::GetEthCollisionCount, aEncoder);
     }
     case Ids::OverrunCount: {
-        return ReadIfSupported(&ConnectivityManager::GetEthOverrunCount, aWriter);
+        return ReadIfSupported(&ConnectivityManager::GetEthOverrunCount, aEncoder);
     }
     default: {
         *aDataRead = false;
@@ -83,7 +83,7 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::T
 }
 
 CHIP_ERROR EthernetDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (ConnectivityManager::*getter)(uint64_t &),
-                                                         TLV::TLVWriter * aWriter)
+                                                         const AttributeValueEncoder & aEncoder)
 {
     uint64_t data;
     CHIP_ERROR err = (DeviceLayer::ConnectivityMgr().*getter)(data);
@@ -96,7 +96,7 @@ CHIP_ERROR EthernetDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (Connectivit
         return err;
     }
 
-    return aWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), data);
+    return aEncoder.Encode(data);
 }
 } // anonymous namespace
 

--- a/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
+++ b/src/app/clusters/general_diagnostics_server/general_diagnostics_server.cpp
@@ -36,15 +36,16 @@ public:
     // Register for the GeneralDiagnostics cluster on all endpoints.
     GeneralDiagosticsAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), GeneralDiagnostics::Id) {}
 
-    CHIP_ERROR Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead) override;
+    CHIP_ERROR Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead) override;
 
 private:
     template <typename T>
-    CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &), TLV::TLVWriter * aWriter);
+    CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &), const AttributeValueEncoder & aEncoder);
 };
 
 template <typename T>
-CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &), TLV::TLVWriter * aWriter)
+CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(T &),
+                                                        const AttributeValueEncoder & aEncoder)
 {
     T data;
     CHIP_ERROR err = (DeviceLayer::PlatformMgr().*getter)(data);
@@ -57,12 +58,12 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformMana
         return err;
     }
 
-    return aWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), data);
+    return aEncoder.Encode(data);
 }
 
 GeneralDiagosticsAttrAccess gAttrAccess;
 
-CHIP_ERROR GeneralDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead)
+CHIP_ERROR GeneralDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead)
 {
     if (aClusterInfo.mClusterId != GeneralDiagnostics::Id)
     {
@@ -74,16 +75,16 @@ CHIP_ERROR GeneralDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TL
     switch (aClusterInfo.mFieldId)
     {
     case Ids::RebootCount: {
-        return ReadIfSupported(&PlatformManager::GetRebootCount, aWriter);
+        return ReadIfSupported(&PlatformManager::GetRebootCount, aEncoder);
     }
     case Ids::UpTime: {
-        return ReadIfSupported(&PlatformManager::GetUpTime, aWriter);
+        return ReadIfSupported(&PlatformManager::GetUpTime, aEncoder);
     }
     case Ids::TotalOperationalHours: {
-        return ReadIfSupported(&PlatformManager::GetTotalOperationalHours, aWriter);
+        return ReadIfSupported(&PlatformManager::GetTotalOperationalHours, aEncoder);
     }
     case Ids::BootReasons: {
-        return ReadIfSupported(&PlatformManager::GetBootReasons, aWriter);
+        return ReadIfSupported(&PlatformManager::GetBootReasons, aEncoder);
     }
     default: {
         *aDataRead = false;

--- a/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
+++ b/src/app/clusters/software_diagnostics_server/software_diagnostics_server.cpp
@@ -40,15 +40,15 @@ public:
     // Register for the SoftwareDiagnostics cluster on all endpoints.
     SoftwareDiagosticsAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), SoftwareDiagnostics::Id) {}
 
-    CHIP_ERROR Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead) override;
+    CHIP_ERROR Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead) override;
 
 private:
-    CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(uint64_t &), TLV::TLVWriter * aWriter);
+    CHIP_ERROR ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(uint64_t &), const AttributeValueEncoder & aEncoder);
 };
 
 SoftwareDiagosticsAttrAccess gAttrAccess;
 
-CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead)
+CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead)
 {
     if (aClusterInfo.mClusterId != SoftwareDiagnostics::Id)
     {
@@ -60,13 +60,13 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::T
     switch (aClusterInfo.mFieldId)
     {
     case Ids::CurrentHeapFree: {
-        return ReadIfSupported(&PlatformManager::GetCurrentHeapFree, aWriter);
+        return ReadIfSupported(&PlatformManager::GetCurrentHeapFree, aEncoder);
     }
     case Ids::CurrentHeapUsed: {
-        return ReadIfSupported(&PlatformManager::GetCurrentHeapUsed, aWriter);
+        return ReadIfSupported(&PlatformManager::GetCurrentHeapUsed, aEncoder);
     }
     case Ids::CurrentHeapHighWatermark: {
-        return ReadIfSupported(&PlatformManager::GetCurrentHeapHighWatermark, aWriter);
+        return ReadIfSupported(&PlatformManager::GetCurrentHeapHighWatermark, aEncoder);
     }
     default: {
         *aDataRead = false;
@@ -77,7 +77,7 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::T
 }
 
 CHIP_ERROR SoftwareDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformManager::*getter)(uint64_t &),
-                                                         TLV::TLVWriter * aWriter)
+                                                         const AttributeValueEncoder & aEncoder)
 {
     uint64_t data;
     CHIP_ERROR err = (DeviceLayer::PlatformMgr().*getter)(data);
@@ -90,7 +90,7 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::ReadIfSupported(CHIP_ERROR (PlatformMan
         return err;
     }
 
-    return aWriter->Put(TLV::ContextTag(AttributeDataElement::kCsTag_Data), data);
+    return aEncoder.Encode(data);
 }
 } // anonymous namespace
 

--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -44,12 +44,12 @@ public:
     // Register for the ThreadNetworkDiagnostics cluster on all endpoints.
     ThreadDiagosticsAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), ThreadNetworkDiagnostics::Id) {}
 
-    CHIP_ERROR Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead) override;
+    CHIP_ERROR Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead) override;
 };
 
 ThreadDiagosticsAttrAccess gAttrAccess;
 
-CHIP_ERROR ThreadDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TLVWriter * aWriter, bool * aDataRead)
+CHIP_ERROR ThreadDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, const AttributeValueEncoder & aEncoder, bool * aDataRead)
 {
     if (aClusterInfo.mClusterId != ThreadNetworkDiagnostics::Id)
     {
@@ -57,7 +57,7 @@ CHIP_ERROR ThreadDiagosticsAttrAccess::Read(ClusterInfo & aClusterInfo, TLV::TLV
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    CHIP_ERROR err = ConnectivityMgr().WriteThreadNetworkDiagnosticAttributeToTlv(aClusterInfo.mFieldId, aWriter);
+    CHIP_ERROR err = ConnectivityMgr().WriteThreadNetworkDiagnosticAttributeToTlv(aClusterInfo.mFieldId, aEncoder);
 
     *aDataRead = true;
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -208,13 +208,20 @@ CHIP_ERROR ReadSingleClusterData(ClusterInfo & aClusterInfo, TLV::TLVWriter * ap
         bool dataRead;
         // TODO: We should probably clone the writer and convert failures here
         // into status responses, unless our caller already does that.
-        ReturnErrorOnFailure(attrOverride->Read(aClusterInfo, apWriter, &dataRead));
+        ReturnErrorOnFailure(attrOverride->Read(aClusterInfo, AttributeValueEncoder(apWriter), &dataRead));
 
         if (dataRead)
         {
-            // TODO: Add DataVersion support
-            ReturnErrorOnFailure(
-                apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_DataVersion), kTemporaryDataVersion));
+            if (apDataExists != nullptr)
+            {
+                *apDataExists = true;
+            }
+            if (apWriter != nullptr)
+            {
+                // TODO: Add DataVersion support
+                ReturnErrorOnFailure(
+                    apWriter->Put(chip::TLV::ContextTag(AttributeDataElement::kCsTag_DataVersion), kTemporaryDataVersion));
+            }
             return CHIP_NO_ERROR;
         }
     }

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -24,7 +24,7 @@
 #pragma once
 #include <memory>
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/CHIPDeviceEvent.h>
@@ -165,7 +165,7 @@ public:
     bool IsThreadProvisioned();
     void ErasePersistentInfo();
 
-    CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     // Ethernet network diagnostics methods
     CHIP_ERROR GetEthPacketRxCount(uint64_t & packetRxCount);
@@ -452,10 +452,10 @@ inline void ConnectivityManager::ErasePersistentInfo()
 
 /*
  * @brief Get runtime value from the thread network based on the given attribute ID.
- *        The info is written in the TLVWriter for the zcl read command reply.
+ *        The info is encoded via the AttributeValueEncoder.
  *
- * @param  attributeId: Id of the attribute for the requested info.
- *         * aWriter: Pointer to a TLVWriter were to write the obtained info.
+ * @param attributeId Id of the attribute for the requested info.
+ * @param aEncoder Encoder to encode the attribute value.
  *
  * @return CHIP_NO_ERROR = Succes.
  *         CHIP_ERROR_NOT_IMPLEMENTED = Runtime value for this attribute to yet available to send as reply
@@ -463,9 +463,10 @@ inline void ConnectivityManager::ErasePersistentInfo()
  *         CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE = Is not a Runtime readable attribute. Use standard read
  *         All other errors should be treated as a read error and reported as such.
  */
-inline CHIP_ERROR ConnectivityManager::WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter)
+inline CHIP_ERROR ConnectivityManager::WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
+                                                                                  const app::AttributeValueEncoder & encoder)
 {
-    return static_cast<ImplClass *>(this)->_WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, aWriter);
+    return static_cast<ImplClass *>(this)->_WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, encoder);
 }
 
 inline Ble::BleLayer * ConnectivityManager::GetBleLayer()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
+#include <app/AttributeAccessInterface.h>
 #include <app/util/basic-types.h>
-#include <lib/core/CHIPTLV.h>
 #include <lib/support/Span.h>
 
 namespace chip {
@@ -108,7 +108,7 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
-    CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
 private:
     // ===== Members for internal use by the following friends.
@@ -375,10 +375,10 @@ inline CHIP_ERROR ThreadStackManager::JoinerStart()
 
 /*
  * @brief Get runtime value from the thread network based on the given attribute ID.
- *        The info is written in the TLVWriter for the zcl read command reply.
+ *        The info is encoded via the AttributeValueEncoder.
  *
- * @param  attributeId: Id of the attribute for the requested info.
- *         * aWriter: Pointer to a TLVWriter were to write the obtained info.
+ * @param attributeId Id of the attribute for the requested info.
+ * @param aEncoder Encoder to encode the attribute value.
  *
  * @return CHIP_NO_ERROR = Succes.
  *         CHIP_ERROR_NOT_IMPLEMENTED = Runtime value for this attribute to yet available to send as reply
@@ -386,9 +386,10 @@ inline CHIP_ERROR ThreadStackManager::JoinerStart()
  *         CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE = Is not a Runtime readable attribute. Use standard read
  *         All other errors should be treated as a read error and reported as such.
  */
-inline CHIP_ERROR ThreadStackManager::WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter)
+inline CHIP_ERROR ThreadStackManager::WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
+                                                                                 const app::AttributeValueEncoder & encoder)
 {
-    return static_cast<ImplClass *>(this)->_WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, aWriter);
+    return static_cast<ImplClass *>(this)->_WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, encoder);
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -55,7 +55,7 @@ protected:
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
     void _ErasePersistentInfo(void);
-    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
@@ -128,9 +128,8 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_SetThread
 }
 
 template <class ImplClass>
-inline CHIP_ERROR
-GenericConnectivityManagerImpl_NoThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
-                                                                                                TLV::TLVWriter * aWriter)
+inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(
+    AttributeId attributeId, const app::AttributeValueEncoder & encoder)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 #include <lib/support/BitFlags.h>
 #include <platform/ThreadStackManager.h>
 
@@ -68,7 +68,7 @@ protected:
     bool _IsThreadAttached();
     bool _IsThreadProvisioned();
     void _ErasePersistentInfo();
-    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     // ===== Members for use by the implementation subclass.
 
@@ -152,11 +152,10 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadPo
 }
 
 template <class ImplClass>
-inline CHIP_ERROR
-GenericConnectivityManagerImpl_Thread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
-                                                                                              TLV::TLVWriter * aWriter)
+inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(
+    AttributeId attributeId, const app::AttributeValueEncoder & encoder)
 {
-    return ThreadStackMgrImpl().WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, aWriter);
+    return ThreadStackMgrImpl().WriteThreadNetworkDiagnosticAttributeToTlv(attributeId, encoder);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -18,7 +18,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/PlatformManager.h>
@@ -463,7 +463,8 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter)
+CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
+                                                                               const app::AttributeValueEncoder & encoder)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/Linux/GlibTypeDeleter.h>
 #include <platform/Linux/dbus/openthread/introspect.h>
@@ -86,7 +86,7 @@ public:
 
     CHIP_ERROR _JoinerStart();
 
-    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     ~ThreadStackManagerImpl() = default;
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -45,8 +45,8 @@
 #include <openthread/srp_client.h>
 #endif
 
+#include <app/AttributeAccessInterface.h>
 #include <lib/core/CHIPEncoding.h>
-#include <lib/core/CHIPTLV.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/FixedBufferAllocator.h>
 #include <lib/support/ThreadOperationalDataset.h>
@@ -811,10 +811,10 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6
 
 /*
  * @brief Get runtime value from the thread network based on the given attribute ID.
- *        The info is written in the TLVWriter for the zcl read command reply.
+ *        The info is encoded via the AttributeValueEncoder.
  *
- * @param  attributeId: Id of the attribute for the requested info.
- *         * aWriter: Pointer to a TLVWriter were to write the obtained info.
+ * @param attributeId Id of the attribute for the requested info.
+ * @param aEncoder Encoder to encode the attribute value.
  *
  * @return CHIP_NO_ERROR = Succes.
  *         CHIP_ERROR_NOT_IMPLEMENTED = Runtime value for this attribute to yet available to send as reply
@@ -823,9 +823,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6
  *         All other errors should be treated as a read error and reported as such.
  */
 template <class ImplClass>
-CHIP_ERROR
-GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
-                                                                                                 TLV::TLVWriter * aWriter)
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(
+    AttributeId attributeId, const app::AttributeValueEncoder & encoder)
 {
     CHIP_ERROR err;
 
@@ -833,31 +832,31 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
     {
     case ThreadNetworkDiagnostics::Attributes::Ids::Channel: {
         uint16_t channel = otLinkGetChannel(mOTInst);
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), channel);
+        err              = encoder.Encode(channel);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RoutingRole: {
         otDeviceRole role = otThreadGetDeviceRole(mOTInst);
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), role);
+        err               = encoder.Encode(role);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::NetworkName: {
         const char * networkName = otThreadGetNetworkName(mOTInst);
-        aWriter->PutString(TLV::ContextTag(AttributeDataElement::kCsTag_Data), networkName, strlen(networkName));
+        encoder.Encode(Span<const char>(networkName, strlen(networkName)));
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::PanId: {
         uint16_t panId = otLinkGetPanId(mOTInst);
-        err            = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), panId);
+        err            = encoder.Encode(panId);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::ExtendedPanId: {
         const otExtendedPanId * pExtendedPanid = otThreadGetExtendedPanId(mOTInst);
-        err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), Encoding::BigEndian::Get64(pExtendedPanid->m8));
+        err                                    = encoder.Encode(Encoding::BigEndian::Get64(pExtendedPanid->m8));
     }
     break;
 
@@ -868,7 +867,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
         meshLocaPrefix[0]                          = OT_IP6_PREFIX_BITSIZE;
 
         memcpy(&meshLocaPrefix[1], pMeshLocalPrefix->m8, OT_MESH_LOCAL_PREFIX_SIZE);
-        err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), ByteSpan(meshLocaPrefix));
+        err = encoder.Encode(ByteSpan(meshLocaPrefix));
     }
     break;
 
@@ -914,283 +913,283 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
 
     case ThreadNetworkDiagnostics::Attributes::Ids::PartitionId: {
         uint32_t partitionId = otThreadGetPartitionId(mOTInst);
-        err                  = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), partitionId);
+        err                  = encoder.Encode(partitionId);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::Weighting: {
         uint8_t weight = otThreadGetLeaderWeight(mOTInst);
-        err            = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), weight);
+        err            = encoder.Encode(weight);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::DataVersion: {
         uint8_t dataVersion = otNetDataGetVersion(mOTInst);
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), dataVersion);
+        err                 = encoder.Encode(dataVersion);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::StableDataVersion: {
         uint8_t stableVersion = otNetDataGetStableVersion(mOTInst);
-        err                   = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), stableVersion);
+        err                   = encoder.Encode(stableVersion);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::LeaderRouterId: {
         uint8_t leaderRouterId = otThreadGetLeaderRouterId(mOTInst);
-        err                    = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), leaderRouterId);
+        err                    = encoder.Encode(leaderRouterId);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::DetachedRoleCount: {
         uint16_t detachedRole = otThreadGetMleCounters(mOTInst)->mDetachedRole;
-        err                   = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), detachedRole);
+        err                   = encoder.Encode(detachedRole);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::ChildRoleCount: {
         uint16_t childRole = otThreadGetMleCounters(mOTInst)->mChildRole;
-        err                = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), childRole);
+        err                = encoder.Encode(childRole);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RouterRoleCount: {
         uint16_t routerRole = otThreadGetMleCounters(mOTInst)->mRouterRole;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), routerRole);
+        err                 = encoder.Encode(routerRole);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::LeaderRoleCount: {
         uint16_t leaderRole = otThreadGetMleCounters(mOTInst)->mLeaderRole;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), leaderRole);
+        err                 = encoder.Encode(leaderRole);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::AttachAttemptCount: {
         uint16_t attachAttempts = otThreadGetMleCounters(mOTInst)->mAttachAttempts;
-        err                     = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), attachAttempts);
+        err                     = encoder.Encode(attachAttempts);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::PartitionIdChangeCount: {
         uint16_t partitionIdChanges = otThreadGetMleCounters(mOTInst)->mPartitionIdChanges;
-        err                         = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), partitionIdChanges);
+        err                         = encoder.Encode(partitionIdChanges);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::BetterPartitionAttachAttemptCount: {
         uint16_t betterPartitionAttachAttempts = otThreadGetMleCounters(mOTInst)->mBetterPartitionAttachAttempts;
-        err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), betterPartitionAttachAttempts);
+        err                                    = encoder.Encode(betterPartitionAttachAttempts);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::ParentChangeCount: {
         uint16_t parentChanges = otThreadGetMleCounters(mOTInst)->mParentChanges;
-        err                    = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), parentChanges);
+        err                    = encoder.Encode(parentChanges);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxTotalCount: {
         uint32_t txTotal = otLinkGetCounters(mOTInst)->mTxTotal;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txTotal);
+        err              = encoder.Encode(txTotal);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxUnicastCount: {
         uint32_t txUnicast = otLinkGetCounters(mOTInst)->mTxUnicast;
-        err                = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txUnicast);
+        err                = encoder.Encode(txUnicast);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxBroadcastCount: {
         uint32_t txBroadcast = otLinkGetCounters(mOTInst)->mTxBroadcast;
-        err                  = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txBroadcast);
+        err                  = encoder.Encode(txBroadcast);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxAckRequestedCount: {
         uint32_t txAckRequested = otLinkGetCounters(mOTInst)->mTxAckRequested;
-        err                     = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txAckRequested);
+        err                     = encoder.Encode(txAckRequested);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxAckedCount: {
         uint32_t txAcked = otLinkGetCounters(mOTInst)->mTxAcked;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txAcked);
+        err              = encoder.Encode(txAcked);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxNoAckRequestedCount: {
         uint32_t txNoAckRequested = otLinkGetCounters(mOTInst)->mTxNoAckRequested;
-        err                       = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txNoAckRequested);
+        err                       = encoder.Encode(txNoAckRequested);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxDataCount: {
         uint32_t txData = otLinkGetCounters(mOTInst)->mTxData;
-        err             = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txData);
+        err             = encoder.Encode(txData);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxDataPollCount: {
         uint32_t txDataPoll = otLinkGetCounters(mOTInst)->mTxDataPoll;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txDataPoll);
+        err                 = encoder.Encode(txDataPoll);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconCount: {
         uint32_t txBeacon = otLinkGetCounters(mOTInst)->mTxBeacon;
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txBeacon);
+        err               = encoder.Encode(txBeacon);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxBeaconRequestCount: {
         uint32_t txBeaconRequest = otLinkGetCounters(mOTInst)->mTxBeaconRequest;
-        err                      = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txBeaconRequest);
+        err                      = encoder.Encode(txBeaconRequest);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxOtherCount: {
         uint32_t txOther = otLinkGetCounters(mOTInst)->mTxOther;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txOther);
+        err              = encoder.Encode(txOther);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxRetryCount: {
         uint32_t txRetry = otLinkGetCounters(mOTInst)->mTxRetry;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txRetry);
+        err              = encoder.Encode(txRetry);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxDirectMaxRetryExpiryCount: {
         uint32_t txDirectMaxRetryExpiry = otLinkGetCounters(mOTInst)->mTxDirectMaxRetryExpiry;
-        err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txDirectMaxRetryExpiry);
+        err                             = encoder.Encode(txDirectMaxRetryExpiry);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxIndirectMaxRetryExpiryCount: {
         uint32_t txIndirectMaxRetryExpiry = otLinkGetCounters(mOTInst)->mTxIndirectMaxRetryExpiry;
-        err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txIndirectMaxRetryExpiry);
+        err                               = encoder.Encode(txIndirectMaxRetryExpiry);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxErrCcaCount: {
         uint32_t txErrCca = otLinkGetCounters(mOTInst)->mTxErrCca;
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), txErrCca);
+        err               = encoder.Encode(txErrCca);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxErrAbortCount: {
         uint32_t TxErrAbort = otLinkGetCounters(mOTInst)->mTxErrAbort;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), TxErrAbort);
+        err                 = encoder.Encode(TxErrAbort);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::TxErrBusyChannelCount: {
         uint32_t TxErrBusyChannel = otLinkGetCounters(mOTInst)->mTxErrBusyChannel;
-        err                       = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), TxErrBusyChannel);
+        err                       = encoder.Encode(TxErrBusyChannel);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxTotalCount: {
         uint32_t rxTotal = otLinkGetCounters(mOTInst)->mRxTotal;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxTotal);
+        err              = encoder.Encode(rxTotal);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxUnicastCount: {
         uint32_t rxUnicast = otLinkGetCounters(mOTInst)->mRxUnicast;
-        err                = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxUnicast);
+        err                = encoder.Encode(rxUnicast);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxBroadcastCount: {
         uint32_t rxBroadcast = otLinkGetCounters(mOTInst)->mRxBroadcast;
-        err                  = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxBroadcast);
+        err                  = encoder.Encode(rxBroadcast);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxDataCount: {
         uint32_t rxData = otLinkGetCounters(mOTInst)->mRxData;
-        err             = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxData);
+        err             = encoder.Encode(rxData);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxDataPollCount: {
         uint32_t rxDataPoll = otLinkGetCounters(mOTInst)->mRxDataPoll;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxDataPoll);
+        err                 = encoder.Encode(rxDataPoll);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconCount: {
         uint32_t rxBeacon = otLinkGetCounters(mOTInst)->mRxBeacon;
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxBeacon);
+        err               = encoder.Encode(rxBeacon);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxBeaconRequestCount: {
         uint32_t rxBeaconRequest = otLinkGetCounters(mOTInst)->mRxBeaconRequest;
-        err                      = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxBeaconRequest);
+        err                      = encoder.Encode(rxBeaconRequest);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxOtherCount: {
         uint32_t rxOther = otLinkGetCounters(mOTInst)->mRxOther;
-        err              = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxOther);
+        err              = encoder.Encode(rxOther);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxAddressFilteredCount: {
         uint32_t rxAddressFiltered = otLinkGetCounters(mOTInst)->mRxAddressFiltered;
-        err                        = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxAddressFiltered);
+        err                        = encoder.Encode(rxAddressFiltered);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxDestAddrFilteredCount: {
         uint32_t rxDestAddrFiltered = otLinkGetCounters(mOTInst)->mRxDestAddrFiltered;
-        err                         = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxDestAddrFiltered);
+        err                         = encoder.Encode(rxDestAddrFiltered);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxDuplicatedCount: {
         uint32_t rxDuplicated = otLinkGetCounters(mOTInst)->mRxDuplicated;
-        err                   = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxDuplicated);
+        err                   = encoder.Encode(rxDuplicated);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrNoFrameCount: {
         uint32_t rxErrNoFrame = otLinkGetCounters(mOTInst)->mRxErrNoFrame;
-        err                   = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrNoFrame);
+        err                   = encoder.Encode(rxErrNoFrame);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrUnknownNeighborCount: {
         uint32_t rxErrUnknownNeighbor = otLinkGetCounters(mOTInst)->mRxErrUnknownNeighbor;
-        err                           = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrUnknownNeighbor);
+        err                           = encoder.Encode(rxErrUnknownNeighbor);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrInvalidSrcAddrCount: {
         uint32_t rxErrInvalidSrcAddr = otLinkGetCounters(mOTInst)->mRxErrInvalidSrcAddr;
-        err                          = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrInvalidSrcAddr);
+        err                          = encoder.Encode(rxErrInvalidSrcAddr);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrSecCount: {
         uint32_t rxErrSec = otLinkGetCounters(mOTInst)->mRxErrSec;
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrSec);
+        err               = encoder.Encode(rxErrSec);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrFcsCount: {
         uint32_t rxErrFcs = otLinkGetCounters(mOTInst)->mRxErrFcs;
-        err               = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrFcs);
+        err               = encoder.Encode(rxErrFcs);
     }
     break;
 
     case ThreadNetworkDiagnostics::Attributes::Ids::RxErrOtherCount: {
         uint32_t rxErrOther = otLinkGetCounters(mOTInst)->mRxErrOther;
-        err                 = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), rxErrOther);
+        err                 = encoder.Encode(rxErrOther);
     }
     break;
 
@@ -1202,7 +1201,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
             otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
             uint64_t activeTimestamp = activeDataset.mPendingTimestamp;
-            err                      = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), activeTimestamp);
+            err                      = encoder.Encode(activeTimestamp);
         }
     }
     break;
@@ -1215,7 +1214,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
             otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
             uint64_t pendingTimestamp = activeDataset.mPendingTimestamp;
-            err                       = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), pendingTimestamp);
+            err                       = encoder.Encode(pendingTimestamp);
         }
     }
     break;
@@ -1228,7 +1227,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
             otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
             uint32_t delay = activeDataset.mDelay;
-            err            = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), delay);
+            err            = encoder.Encode(delay);
         }
     }
     break;
@@ -1264,7 +1263,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetworkDiagnost
 
             uint8_t buffer[sizeof(uint32_t)] = { 0 };
             Encoding::BigEndian::Put32(buffer, bitSwappedChannelMask);
-            err = Encode(*aWriter, TLV::ContextTag(AttributeDataElement::kCsTag_Data), ByteSpan(buffer));
+            err = encoder.Encode(ByteSpan(buffer));
         }
     }
     break;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -36,7 +36,7 @@
 #include <openthread/dns_client.h>
 #endif
 
-#include <lib/core/CHIPTLV.h>
+#include <app/AttributeAccessInterface.h>
 #include <lib/mdns/Advertiser.h>
 #include <lib/mdns/platform/Mdns.h>
 
@@ -93,7 +93,7 @@ protected:
     CHIP_ERROR _GetAndLogThreadTopologyFull(void);
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, TLV::TLVWriter * aWriter);
+    CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
     void _OnWoBLEAdvertisingStart(void);
     void _OnWoBLEAdvertisingStop(void);


### PR DESCRIPTION
Consumers should not have to worry about what the right TLV tag is for
the attribute value, or exactly how to put their data into the TLV
writer.  We can use a partially applied version of the Encode generic
for this.

Fixes: https://github.com/project-chip/connectedhomeip/issues/9938

Also fixes an issue around the handling of null TLVWriter and the
apDataExists outparam in ReadSingleClusterData.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes apart from fixing the (not exercised by anything so far) null TLVWriter and non-null apDataExists bits.  Passes existing tests.