### PR TITLE
Restrict passcodes to the values 00000001 to 99999998 in decimal as per 5.1.1.6

### DIFF
--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -221,8 +221,8 @@ CHIP_ERROR PASESession::GeneratePASEVerifier(PASEVerifier & verifier, uint32_t p
     {
         ReturnErrorOnFailure(DRBG_get_bytes(reinterpret_cast<uint8_t *>(&setupPIN), sizeof(setupPIN)));
 
-        // Use only kSetupPINCodeFieldLengthInBits bits out of the code
-        setupPIN &= ((1 << kSetupPINCodeFieldLengthInBits) - 1);
+        // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
+        setupPIN = (setupPIN % 99999998) + 1;
     }
 
     return PASESession::ComputePASEVerifier(setupPIN, pbkdf2IterCount, salt, verifier);


### PR DESCRIPTION
#### Problem
* Invalid (out of range) passcodes are generated when opening enhanced commissioning windows

#### Change overview
Restrict passcodes to the values 00000001 to 99999998 in decimal as per 5.1.1.6

#### Testing
* Tested manually using enhanced commissioning window
