### PR TITLE
[controller] Make number of active devices configurable

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -36,6 +36,7 @@
 #include <controller/OperationalCredentialsDelegate.h>
 #include <credentials/CHIPOperationalCredentials.h>
 #include <credentials/DeviceAttestationVerifier.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/CHIPTLV.h>
@@ -70,7 +71,7 @@ namespace Controller {
 
 using namespace chip::Protocols::UserDirectedCommissioning;
 
-constexpr uint16_t kNumMaxActiveDevices = 64;
+constexpr uint16_t kNumMaxActiveDevices = CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES;
 constexpr uint16_t kNumMaxPairedDevices = 128;
 
 // Raw functions for cluster callbacks

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2499,5 +2499,14 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES
+ *
+ * @brief Number of devices a controller can be simultaneously connected to
+ */
+#ifndef CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES
+#define CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES 64
+#endif
+
+/**
  * @}
  */


### PR DESCRIPTION
#### Problem
Controller::Device became quite a big data structure and with the default number of active devices it's impossible to use the controller on embedded devices.

#### Change overview
Add `CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES` configuration variable.

#### Testing
CI contains controller tests. Also, verified that with the change I can create a `Controller::DeviceController` object on constrained devices.
