### PR TITLE
[EFR32] Software diagnostics read runtime values

### DIFF
--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -30,6 +30,7 @@
 #include <lwip/tcpip.h>
 
 #include "AppConfig.h"
+#include "FreeRTOS.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -54,6 +55,44 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
 exit:
     return err;
+}
+
+/*
+ * The following Heap stats are compiled values done by the FreeRTOS Heap4 implementation.
+ * See /examples/platform/efr32/heap_4_silabs.c
+ * It keeps track of the number of calls to allocate and free memory as well as the
+ * number of free bytes remaining, but says nothing about fragmentation.
+ */
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
+{
+    size_t freeHeapSize = xPortGetFreeHeapSize();
+    currentHeapFree     = static_cast<uint64_t>(freeHeapSize);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapUsed(uint64_t & currentHeapUsed)
+{
+    // Calculate the Heap used based on Total heap - Free heap
+    int64_t heapUsed = (configTOTAL_HEAP_SIZE - xPortGetFreeHeapSize());
+
+    // Something went wrong, this should not happen
+    VerifyOrReturnError(heapUsed >= 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+    currentHeapUsed = static_cast<uint64_t>(heapUsed);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
+{
+    // FreeRTOS records the lowest amount of available heap during runtime
+    // currentHeapHighWatermark wants the highest heap usage point so we calculate it here
+    int64_t HighestHeapUsageRecorded = (configTOTAL_HEAP_SIZE - xPortGetMinimumEverFreeHeapSize());
+
+    // Something went wrong, this should not happen
+    VerifyOrReturnError(HighestHeapUsageRecorded >= 0, CHIP_ERROR_INVALID_INTEGER_VALUE);
+    currentHeapHighWatermark = static_cast<uint64_t>(HighestHeapUsageRecorded);
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/EFR32/PlatformManagerImpl.h
+++ b/src/platform/EFR32/PlatformManagerImpl.h
@@ -53,6 +53,9 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
+    CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
+    CHIP_ERROR _GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
#### Problem
Reading Software Diagnostic attributes return default values on EFR32 platform

#### Change overview
Add platform specific methods to get Heap stats (Current HeapFree, Current HeapUsed, Current HeapHighWater Mark).


#### Testing
Python controller
```
zclread SoftwareDiagnostics CurrentHeapHighWatermark 164 0 0
[1632756048.374790][8978:8986] CHIP:DMG: SendReadRequest: Client[0] [ INIT]
...
[1632756048.436989][8978:8986] CHIP:DMG: ReportData =
[1632756048.437055][8978:8986] CHIP:DMG: {
[1632756048.437099][8978:8986] CHIP:DMG: 	AttributeDataList =
[1632756048.437156][8978:8986] CHIP:DMG: 	[
[1632756048.437213][8978:8986] CHIP:DMG: 		AttributeDataElement =
[1632756048.437289][8978:8986] CHIP:DMG: 		{
[1632756048.437367][8978:8986] CHIP:DMG: 			AttributePath =
[1632756048.437447][8978:8986] CHIP:DMG: 			{
[1632756048.437525][8978:8986] CHIP:DMG: 				NodeId = 0xa4,
[1632756048.437596][8978:8986] CHIP:DMG: 				EndpointId = 0x0,
[1632756048.437681][8978:8986] CHIP:DMG: 				ClusterId = 0x34,
[1632756048.437758][8978:8986] CHIP:DMG: 				FieldTag = 0x3,
[1632756048.437834][8978:8986] CHIP:DMG: 			}
[1632756048.437922][8978:8986] CHIP:DMG:
[1632756048.437997][8978:8986] CHIP:DMG: 			Data = 12008,
[1632756048.438071][8978:8986] CHIP:DMG: 			DataElementVersion = 0x0,
[1632756048.438138][8978:8986] CHIP:DMG: 		},
[1632756048.438209][8978:8986] CHIP:DMG:
[1632756048.438424][8978:8986] CHIP:DMG: 	],
[1632756048.438502][8978:8986] CHIP:DMG:
[1632756048.438556][8978:8986] CHIP:DMG: }
[1632756048.439397][8978:8986] CHIP:ZCL: ReadAttributesResponse:
[1632756048.439468][8978:8986] CHIP:ZCL:   ClusterId: 0x0000_0034
[1632756048.439527][8978:8986] CHIP:ZCL:   attributeId: 0x0000_0003
[1632756048.439577][8978:8986] CHIP:ZCL:   status: Success                (0x0000)
[1632756048.439624][8978:8986] CHIP:ZCL:   attribute TLV Type: 0x04
[1632756048.439679][8978:8986] CHIP:ZCL:   attributeValue: 12008
[1632756048.439908][8978:8986] CHIP:EM: Piggybacking Ack for MessageCounter:2 on exchange: 3711i
AttributeReadResult(path=AttributePath(nodeId=164, endpointId=0, clusterId=52, attributeId=3), status=0, value=12008)
```
