### PR TITLE
Abort PASE session establishment process if not completed within 60 seconds

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -33,6 +33,12 @@ void HandleCommissioningWindowTimeout(chip::System::Layer * aSystemLayer, void *
     commissionMgr->CloseCommissioningWindow();
 }
 
+void HandleSessionEstablishmentTimeout(chip::System::Layer * aSystemLayer, void * aAppState)
+{
+    chip::CommissioningWindowManager * commissionMgr = static_cast<chip::CommissioningWindowManager *>(aAppState);
+    commissionMgr->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
+}
+
 void OnPlatformEventWrapper(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     chip::CommissioningWindowManager * commissionMgr = reinterpret_cast<chip::CommissioningWindowManager *>(arg);
@@ -85,6 +91,7 @@ void CommissioningWindowManager::Cleanup()
 
 void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
 {
+    DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
     mFailedCommissioningAttempts++;
     ChipLogError(AppServer, "Commissioning failed (attempt %d): %s", mFailedCommissioningAttempts, ErrorStr(err));
 
@@ -107,8 +114,16 @@ void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
     }
 }
 
+void CommissioningWindowManager::OnSessionEstablishmentStarted()
+{
+    // As per specifications, section 5.5: Commissioning Flows
+    constexpr uint16_t kPASESessionEstablishmentTimeoutSeconds = 60;
+    DeviceLayer::SystemLayer().StartTimer(kPASESessionEstablishmentTimeoutSeconds * 1000, HandleSessionEstablishmentTimeout, this);
+}
+
 void CommissioningWindowManager::OnSessionEstablished()
 {
+    DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
     CHIP_ERROR err = mServer->GetSecureSessionManager().NewPairing(
         Optional<Transport::PeerAddress>::Value(mPairingSession.GetPeerAddress()), mPairingSession.GetPeerNodeId(),
         &mPairingSession, CryptoContext::SessionRole::kResponder, 0);

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -62,6 +62,7 @@ public:
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
+    void OnSessionEstablishmentStarted() override;
     void OnSessionEstablished() override;
 
     void Cleanup();

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -402,6 +402,8 @@ CHIP_ERROR CASESession::SendSigma1()
 
     ChipLogDetail(SecureChannel, "Sent Sigma1 msg");
 
+    mDelegate->OnSessionEstablishmentStarted();
+
     return CHIP_NO_ERROR;
 }
 
@@ -461,6 +463,8 @@ CHIP_ERROR CASESession::HandleSigma1(System::PacketBufferHandle && msg)
             // Send Sigma2Resume message to the initiator
             SuccessOrExit(err = SendSigma2Resume(ByteSpan(initiatorRandom)));
 
+            mDelegate->OnSessionEstablishmentStarted();
+
             // Early returning here, since we have sent Sigma2Resume, and no further processing is needed for the Sigma1 message
             return CHIP_NO_ERROR;
         }
@@ -485,6 +489,8 @@ CHIP_ERROR CASESession::HandleSigma1(System::PacketBufferHandle && msg)
     SuccessOrExit(err = tlvReader.GetBytes(mRemotePubKey, static_cast<uint32_t>(mRemotePubKey.Length())));
 
     SuccessOrExit(err = SendSigma2());
+
+    mDelegate->OnSessionEstablishmentStarted();
 
 exit:
 

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -316,6 +316,8 @@ CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t 
     err = SendPBKDFParamRequest();
     SuccessOrExit(err);
 
+    mDelegate->OnSessionEstablishmentStarted();
+
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -425,6 +427,8 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
 
     err = SendPBKDFParamResponse(ByteSpan(initiatorRandom), hasPBKDFParameters);
     SuccessOrExit(err);
+
+    mDelegate->OnSessionEstablishmentStarted();
 
 exit:
 

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -35,20 +35,17 @@ class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
     /**
-     * @brief
      *   Called when session establishment fails with an error
-     *
-     * @param error error code
-     *
-     * TODO: Rename function as per issue: https://github.com/project-chip/connectedhomeip/issues/4468
      */
     virtual void OnSessionEstablishmentError(CHIP_ERROR error) {}
 
     /**
-     * @brief
+     *   Called on start of session establishment process
+     */
+    virtual void OnSessionEstablishmentStarted() {}
+
+    /**
      *   Called when the new secure session has been established
-     *
-     * TODO: Rename function as per issue: https://github.com/project-chip/connectedhomeip/issues/4468
      */
     virtual void OnSessionEstablished() {}
 


### PR DESCRIPTION
#### Problem
As per specifications (section 5.5 Commissioning Flows), the PASE session establishment process must terminate if the process is not completed within 60 seconds. This needs to be enforced in the SDK code.

#### Change overview
Add callback in the delegate to get notified on starting of session establishment process.
Start a timer when the process starts.
If the process doesn't finish within the timeout period, abort the current session establishment process.

#### Testing
Tested it manually by not sending Pake1 message during the session establishment. Ensured that the current session is aborted, and the device starts advertisement for the session establishment availability. A new PAKE session can be established with the device at this point.