### PR TITLE
[clusters] Fix scheduled actions in clusters

### DIFF
--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -106,6 +106,16 @@ void EventControlHandler(chip::System::Layer * systemLayer, void * appState)
         if (control->callback != NULL)
         {
             (control->callback)(control->endpoint);
+            return;
+        }
+
+        for (const EmberEventData & event : emAfEvents)
+        {
+            if (event.control != control)
+                continue;
+            control->status = EMBER_EVENT_INACTIVE;
+            event.handler();
+            break;
         }
     }
 }

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -96,15 +96,21 @@ def main():
                                     endpoint=LIGHTING_ENDPOINT_ID,
                                     group=GROUP_ID), "Failed to test on off cluster")
 
+    logger.info("Testing level control cluster")
+    FailIfNot(test.TestLevelControlCluster(nodeid=1,
+                                           endpoint=LIGHTING_ENDPOINT_ID,
+                                           group=GROUP_ID),
+              "Failed to test level control cluster")
+
     logger.info("Testing sending commands to non exist endpoint")
     FailIfNot(not test.TestOnOffCluster(nodeid=1,
                                         endpoint=233,
                                         group=GROUP_ID), "Failed to test on off cluster on non-exist endpoint")
 
     logger.info("Testing attribute reading")
-    FailIfNot(test.TestReadBasicAttribiutes(nodeid=1,
-                                            endpoint=ENDPOINT_ID,
-                                            group=GROUP_ID),
+    FailIfNot(test.TestReadBasicAttributes(nodeid=1,
+                                           endpoint=ENDPOINT_ID,
+                                           group=GROUP_ID),
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing attribute writing")

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -23,7 +23,7 @@ import sys
 
 from helper.CHIPTestBase import CHIPVirtualHome
 
-logger = logging.getLogger('CHIPInteractionModelTest')
+logger = logging.getLogger('MobileDeviceTest')
 logger.setLevel(logging.INFO)
 
 sh = logging.StreamHandler()

--- a/zzz_generated/thermostat/zap-generated/af-gen-event.h
+++ b/zzz_generated/thermostat/zap-generated/af-gen-event.h
@@ -44,14 +44,10 @@
     EmberEventControl emberAfLevelControlClusterServerTickCallbackControl1;                                                        \
     EmberEventControl emberAfBarrierControlClusterServerTickCallbackControl1;                                                      \
     EmberEventControl emberAfIasZoneClusterServerTickCallbackControl1;                                                             \
-    extern EmberEventControl emberAfPluginColorControlServerHueSatTransitionEventControl;                                          \
-    extern EmberEventControl emberAfPluginColorControlServerTempTransitionEventControl;                                            \
-    extern EmberEventControl emberAfPluginColorControlServerXyTransitionEventControl;                                              \
     extern EmberEventControl emberAfPluginDoorLockServerLockoutEventControl;                                                       \
     extern EmberEventControl emberAfPluginDoorLockServerRelockEventControl;                                                        \
     extern EmberEventControl emberAfPluginIasZoneServerManageQueueEventControl;                                                    \
     extern EmberEventControl emberAfPluginReportingTickEventControl;                                                               \
-    extern void emberAfPluginColorControlServerHueSatTransitionEventHandler(void);                                                 \
     extern void emberAfPluginColorControlServerTempTransitionEventHandler(void);                                                   \
     extern void emberAfPluginColorControlServerXyTransitionEventHandler(void);                                                     \
     extern void emberAfPluginDoorLockServerLockoutEventHandler(void);                                                              \
@@ -86,10 +82,6 @@
         { &emberAfBarrierControlClusterServerTickCallbackControl1,                                                                 \
           emberAfBarrierControlClusterServerTickCallbackWrapperFunction1 },                                                        \
         { &emberAfIasZoneClusterServerTickCallbackControl1, emberAfIasZoneClusterServerTickCallbackWrapperFunction1 },             \
-        { &emberAfPluginColorControlServerHueSatTransitionEventControl,                                                            \
-          emberAfPluginColorControlServerHueSatTransitionEventHandler },                                                           \
-        { &emberAfPluginColorControlServerTempTransitionEventControl, emberAfPluginColorControlServerTempTransitionEventHandler }, \
-        { &emberAfPluginColorControlServerXyTransitionEventControl, emberAfPluginColorControlServerXyTransitionEventHandler },     \
         { &emberAfPluginDoorLockServerLockoutEventControl, emberAfPluginDoorLockServerLockoutEventHandler },                       \
         { &emberAfPluginDoorLockServerRelockEventControl, emberAfPluginDoorLockServerRelockEventHandler },                         \
         { &emberAfPluginIasZoneServerManageQueueEventControl, emberAfPluginIasZoneServerManageQueueEventHandler },                 \

--- a/zzz_generated/tv-casting-app/zap-generated/af-gen-event.h
+++ b/zzz_generated/tv-casting-app/zap-generated/af-gen-event.h
@@ -44,14 +44,10 @@
     EmberEventControl emberAfLevelControlClusterServerTickCallbackControl1;                                                        \
     EmberEventControl emberAfBarrierControlClusterServerTickCallbackControl1;                                                      \
     EmberEventControl emberAfIasZoneClusterServerTickCallbackControl1;                                                             \
-    extern EmberEventControl emberAfPluginColorControlServerHueSatTransitionEventControl;                                          \
-    extern EmberEventControl emberAfPluginColorControlServerTempTransitionEventControl;                                            \
-    extern EmberEventControl emberAfPluginColorControlServerXyTransitionEventControl;                                              \
     extern EmberEventControl emberAfPluginDoorLockServerLockoutEventControl;                                                       \
     extern EmberEventControl emberAfPluginDoorLockServerRelockEventControl;                                                        \
     extern EmberEventControl emberAfPluginIasZoneServerManageQueueEventControl;                                                    \
     extern EmberEventControl emberAfPluginReportingTickEventControl;                                                               \
-    extern void emberAfPluginColorControlServerHueSatTransitionEventHandler(void);                                                 \
     extern void emberAfPluginColorControlServerTempTransitionEventHandler(void);                                                   \
     extern void emberAfPluginColorControlServerXyTransitionEventHandler(void);                                                     \
     extern void emberAfPluginDoorLockServerLockoutEventHandler(void);                                                              \
@@ -86,10 +82,6 @@
         { &emberAfBarrierControlClusterServerTickCallbackControl1,                                                                 \
           emberAfBarrierControlClusterServerTickCallbackWrapperFunction1 },                                                        \
         { &emberAfIasZoneClusterServerTickCallbackControl1, emberAfIasZoneClusterServerTickCallbackWrapperFunction1 },             \
-        { &emberAfPluginColorControlServerHueSatTransitionEventControl,                                                            \
-          emberAfPluginColorControlServerHueSatTransitionEventHandler },                                                           \
-        { &emberAfPluginColorControlServerTempTransitionEventControl, emberAfPluginColorControlServerTempTransitionEventHandler }, \
-        { &emberAfPluginColorControlServerXyTransitionEventControl, emberAfPluginColorControlServerXyTransitionEventHandler },     \
         { &emberAfPluginDoorLockServerLockoutEventControl, emberAfPluginDoorLockServerLockoutEventHandler },                       \
         { &emberAfPluginDoorLockServerRelockEventControl, emberAfPluginDoorLockServerRelockEventHandler },                         \
         { &emberAfPluginIasZoneServerManageQueueEventControl, emberAfPluginIasZoneServerManageQueueEventHandler },                 \


### PR DESCRIPTION
#### Problem
PR #9469 changed the implementation of EventControlHandler function from af-event.cpp, but only updated Color Control Cluster code to use the new approach. As a result, all other clusters using scheduled actions, such as LevelControl.MoveToLevel, got broken.

#### Change overview
Make sure both methods of initializing cluster events are supported until all clusters are aligned one way or another.
Also, add a cirque test for LevelControl.MoveToLevel.

#### Testing
Tested by Cirque and using nRF Connect lighting-app.
