### PR TITLE
[ota-provider-app] Set device attestation credentials provider

### DIFF
--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -23,6 +23,8 @@
 #include <app/clusters/ota-provider/ota-provider.h>
 #include <app/server/Server.h>
 #include <app/util/util.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
@@ -121,6 +123,9 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
     chip::Server::GetInstance().Init();
+
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
     err = chip::Server::GetInstance().GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(chip::Protocols::BDX::Id,
                                                                                                         &bdxServer);


### PR DESCRIPTION
#### Problem
The OTA provider app currently does not set the device attestation credentials provider. This results in a failure when the app is being commissioned.

#### Change overview
Set the device attestation credentials provider to `ExampleDACProvider`

#### Testing
Tested manually with the following steps:
* Build ota-provider app: `scripts/examples/gn_build_example.sh examples/ota-provider-app/linux/ out/apps chip_config_network_layer_ble=false`
* Run ota-provider app: `out/apps/chip-ota-provider-app`
* Commission: `out/host/chip-tool pairing onnetwork 0 20202021 3840 ::1 5540`