### PR TITLE
ESP32: Read software diagnostics attributes at runtime

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -118,6 +118,24 @@ exit:
     return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
 }
 
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapFree(uint64_t & currentHeapFree)
+{
+    currentHeapFree = esp_get_free_heap_size();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapUsed(uint64_t & currentHeapUsed)
+{
+    currentHeapUsed = heap_caps_get_total_size(MALLOC_CAP_DEFAULT) - esp_get_free_heap_size();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::_GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
+{
+    currentHeapHighWatermark = heap_caps_get_total_size(MALLOC_CAP_DEFAULT) - esp_get_minimum_free_heap_size();
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR PlatformManagerImpl::InitLwIPCoreLock(void)
 {
     return Internal::InitLwIPCoreLock();

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -55,6 +55,9 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _GetCurrentHeapFree(uint64_t & currentHeapFree);
+    CHIP_ERROR _GetCurrentHeapUsed(uint64_t & currentHeapUsed);
+    CHIP_ERROR _GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
#### Problem
* Actual value from the platform is not populated at runtime for software diagnostics attributes.

#### Change overview
* Read Software Diagnostic attributes from a platform at runtime

#### Testing
* All clusters app is compiled and checked using python controller.
```
chip-device-ctrl > zclread ? SoftwareDiagnostics
CurrentHeapHighWatermark
ClusterRevision

chip-device-ctrl > zclread SoftwareDiagnostics CurrentHeapHighWatermark 12344321 0 1
[1632920602.543329][372823:372831] CHIP:IN: Build encrypted message 0x108b358 to 0x0000000000BC5C01 of type 2 and protocolId 1 on exchange 62954r with MessageCounter 2.
[1632920602.543399][372823:372831] CHIP:IN: Sending encrypted msg 0x108b358 to 0x0000000000BC5C01 at utc time: 30789129 msec
[1632920602.543416][372823:372831] CHIP:IN: Sending msg on generic transport
[1632920602.811465][372823:372831] CHIP:EM: Received message of type 0x05 with vendorId 0x0000 and protocolId 0x0001 on exchange 62954i
[1632920602.812255][372823:372831] CHIP:ZCL: ReadAttributesResponse:
[1632920602.812294][372823:372831] CHIP:ZCL:   ClusterId: 0x0000_0034
[1632920602.812312][372823:372831] CHIP:ZCL:   attributeId: 0x0000_0003
[1632920602.812321][372823:372831] CHIP:ZCL:   status: Success                (0x0000)
[1632920602.812330][372823:372831] CHIP:ZCL:   attribute TLV Type: 0x04
[1632920602.812376][372823:372831] CHIP:ZCL:   attributeValue: 147460
[1632920602.812609][372823:372831] CHIP:IN: Build encrypted message 0x108b358 to 0x0000000000BC5C01 of type 1 and protocolId 1 on exchange 62954r with MessageCounter 3.
[1632920602.812653][372823:372831] CHIP:IN: Sending encrypted msg 0x108b358 to 0x0000000000BC5C01 at utc time: 30789398 msec
[1632920602.812677][372823:372831] CHIP:IN: Sending msg on generic transport
AttributeReadResult(path=AttributePath(nodeId=12344321, endpointId=0, clusterId=52, attributeId=3), status=0, value=147460)
chip-device-ctrl > [1632920602.912776][372823:372831] CHIP:EM: Received message of type 0x10 with vendorId 0x0000 and protocolId 0x0000 on exchange 62954i
```