### PR TITLE
Darwin BLE: fix GetMTU() so it returns the actual MTU size instead of zero

### DIFF
--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -114,7 +114,16 @@ namespace DeviceLayer {
             return true;
         }
 
-        uint16_t BlePlatformDelegateImpl::GetMTU(BLE_CONNECTION_OBJECT connObj) const { return 0; }
+        uint16_t BlePlatformDelegateImpl::GetMTU(BLE_CONNECTION_OBJECT connObj) const
+        {
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
+
+            // The negotiated mtu length is a property of the peripheral.
+            uint16_t mtuLength = [[peripheral valueForKey:@"mtuLength"] unsignedShortValue];
+            ChipLogProgress(Ble, "ATT MTU = %u", mtuLength);
+
+            return mtuLength;
+        }
 
         bool BlePlatformDelegateImpl::SendIndication(
             BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId, PacketBufferHandle pBuf)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Darwin BLE platform code hardcodes the MTU size to zero. As such it is slow, overfragmented and none of the BTP packetization optimizations with higher MTU size can be applied or even tested.

#### Change overview
What's in this PR
fix GetMTU() so it returns the actual MTU size instead of zero

#### Testing
How was this tested? (at least one bullet point required)
* tested manually, both with built in BLE controller and with external BLE USB dongle. In order to test  maximum payload cases used nrfconnect lock sample and added following defines locally to prj.conf:
CONFIG_BT_L2CAP_TX_MTU=247
CONFIG_BT_BUF_ACL_TX_SIZE=251
CONFIG_BT_BUF_ACL_RX_SIZE=251
