### PR TITLE
Implement the ThreadDiagnosticsResetCounts method for the zcl command

### DIFF
--- a/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
+++ b/src/app/clusters/thread_network_diagnostics_server/thread_network_diagnostics_server.cpp
@@ -82,6 +82,8 @@ bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(EndpointId endpoi
         ChipLogError(Zcl, "Failed to reset OverrunCount attribute");
     }
 
+    ConnectivityMgr().ResetThreadNetworkDiagnosticsCounts();
+
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -164,7 +164,7 @@ public:
     bool IsThreadAttached();
     bool IsThreadProvisioned();
     void ErasePersistentInfo();
-
+    void ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     // Ethernet network diagnostics methods
@@ -448,6 +448,11 @@ inline bool ConnectivityManager::IsThreadProvisioned()
 inline void ConnectivityManager::ErasePersistentInfo()
 {
     static_cast<ImplClass *>(this)->_ErasePersistentInfo();
+}
+
+inline void ConnectivityManager::ResetThreadNetworkDiagnosticsCounts()
+{
+    static_cast<ImplClass *>(this)->_ResetThreadNetworkDiagnosticsCounts();
 }
 
 /*

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -108,6 +108,7 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
+    void ResetThreadNetworkDiagnosticsCounts(void);
     CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
 private:
@@ -371,6 +372,11 @@ inline CHIP_ERROR ThreadStackManager::GetPollPeriod(uint32_t & buf)
 inline CHIP_ERROR ThreadStackManager::JoinerStart()
 {
     return static_cast<ImplClass *>(this)->_JoinerStart();
+}
+
+inline void ThreadStackManager::ResetThreadNetworkDiagnosticsCounts()
+{
+    static_cast<ImplClass *>(this)->_ResetThreadNetworkDiagnosticsCounts();
 }
 
 /*

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -55,6 +55,7 @@ protected:
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
     void _ErasePersistentInfo(void);
+    void _ResetThreadNetworkDiagnosticsCounts(void);
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -126,6 +127,10 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_SetThread
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_NoThread<ImplClass>::_ResetThreadNetworkDiagnosticsCounts()
+{}
 
 template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_WriteThreadNetworkDiagnosticAttributeToTlv(

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -68,6 +68,7 @@ protected:
     bool _IsThreadAttached();
     bool _IsThreadProvisioned();
     void _ErasePersistentInfo();
+    void _ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     // ===== Members for use by the implementation subclass.
@@ -149,6 +150,12 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadPo
     const ConnectivityManager::ThreadPollingConfig & pollingConfig)
 {
     return ThreadStackMgrImpl().SetThreadPollingConfig(pollingConfig);
+}
+
+template <class ImplClass>
+inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_ResetThreadNetworkDiagnosticsCounts()
+{
+    ThreadStackMgrImpl().ResetThreadNetworkDiagnosticsCounts();
 }
 
 template <class ImplClass>

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -463,6 +463,8 @@ CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+void ThreadStackManagerImpl::_ResetThreadNetworkDiagnosticsCounts() {}
+
 CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId,
                                                                                const app::AttributeValueEncoder & encoder)
 {

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -86,6 +86,8 @@ public:
 
     CHIP_ERROR _JoinerStart();
 
+    void _ResetThreadNetworkDiagnosticsCounts();
+
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
 
     ~ThreadStackManagerImpl() = default;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -809,6 +809,14 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ResetThreadNetworkDiagnosticsCounts(void)
+{
+    // Reset MAC counters
+    otLinkResetCounters(mOTInst);
+    otThreadResetMleCounters(mOTInst);
+    otThreadResetIp6Counters(mOTInst);
+}
 /*
  * @brief Get runtime value from the thread network based on the given attribute ID.
  *        The info is encoded via the AttributeValueEncoder.
@@ -844,7 +852,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
 
     case ThreadNetworkDiagnostics::Attributes::Ids::NetworkName: {
         const char * networkName = otThreadGetNetworkName(mOTInst);
-        encoder.Encode(Span<const char>(networkName, strlen(networkName)));
+        err                      = encoder.Encode(Span<const char>(networkName, strlen(networkName)));
     }
     break;
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -93,6 +93,7 @@ protected:
     CHIP_ERROR _GetAndLogThreadTopologyFull(void);
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
+    void _ResetThreadNetworkDiagnosticsCounts(void);
     CHIP_ERROR _WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, const app::AttributeValueEncoder & encoder);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
     void _OnWoBLEAdvertisingStart(void);


### PR DESCRIPTION
#### Problem
ThreadNetworkDiagnostics ResetCounts do not make any action on the counters.
Reading the ThreadNetworkDiagnostics NetworkName attributes fails/returns error.

#### Change overview
Implement the ResetCount method in GenericThreadStackManagerImpl_OpenThread that calls the reset counters apis for the active thread instance.
Abtraction for platforms that do not implement thread.
Update return code when encode the Networkname tlv.

#### Testing
Manually tested.
Provision thread device with the python controller.
Read a few counter attributes
   ChildRoleCount
   TxDataCount
   RxDataCount
Send the reset command
zcl ThreadNetworkDiagnostics ResetCounts 130 0 0
Re-read the attributes and validate that the attributes value resetted.
 
