### PR TITLE
Fix EFR32 unit tests

### DIFF
--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -24,7 +24,6 @@ chip_test_suite("tests") {
   sources = [
     "AES_CCM_128_test_vectors.h",
     "AES_CCM_256_test_vectors.h",
-    "CHIPCryptoPALTest.cpp",
     "DerSigConversion_test_vectors.h",
     "ECDH_P256_test_vectors.h",
     "HKDF_SHA256_test_vectors.h",
@@ -43,6 +42,11 @@ chip_test_suite("tests") {
     "SPAKE2P_RFC_test_vectors.h",
     "TestCryptoLayer.h",
   ]
+
+  if (chip_device_platform != "efr32") {
+    # Removed on EFR32, using too much HEAP.
+    sources += [ "CHIPCryptoPALTest.cpp" ]
+  }
 
   cflags = [ "-Wconversion" ]
 


### PR DESCRIPTION


#### Problem
EFR 32 unit tests are failing:
```
<efr32 > Failed do a malloc on HEAP. Is it too small ?
<info  > [-] 
FREERTOS ASSERT ( (volatile void *) NULL )
```

#### Change overview
-Remove CHIPCryptoPALTest which was using too much heap and causing the crash.

#### Testing
Ran EFR32 unit tests on EFR32MG12 board and verified it passed all 228 tests.