### PR TITLE
 Improve EFR32 Docker image used by Build example - EFR32 workflow

### DIFF
--- a/integrations/docker/images/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/chip-build-efr32/Dockerfile
@@ -1,13 +1,13 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
-
-
-
 # GNU ARM Embedded toolchain, cross compiler for various platform builds
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    gcc-arm-none-eabi \
-    binutils-arm-none-eabi \
-    ccache
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    gcc-arm-none-eabi=15:9-2019-q4-0ubuntu1 \
+    binutils-arm-none-eabi=2.34-4ubuntu1+13ubuntu1 \
+    ccache=3.7.7-1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/ \
+    && : # last line


### PR DESCRIPTION
#### Problem
[Hadolint](https://github.com/hadolint/hadolint) tool helps to build Docker images following best practices. Using those guidelines can help to reduce the size of the image and speed up the pulling process during the CI execution.

#### Change overview
This change installs only the minimal dependencies needed for EFR32 image. As result the image size has been reduced from 4.6GB to 3.04GB

#### Testing
This was tested locally using the act tool (`$ act -j efr32`) using the Docker image built with these changes.