### PR TITLE
[Android] Make ChipDeviceControllerException a RuntimeException

### DIFF
--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceControllerException.java
@@ -18,7 +18,7 @@
 package chip.devicecontroller;
 
 /** Exception thrown from CHIPDeviceController. */
-public class ChipDeviceControllerException extends Exception {
+public class ChipDeviceControllerException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   public int errorCode;


### PR DESCRIPTION
#### Problem
* See #10034

#### Change overview
* Make ChipDeviceControllerException and ChipClusterException extend RuntimeException.

#### Testing
* Built CHIPTool, triggered error and verified that exception is thrown like normal.
