### PR TITLE
OTA Requestor and Provider fixes

### DIFF
--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -51,12 +51,18 @@ using chip::Messaging::ExchangeManager;
 constexpr chip::EndpointId kOtaProviderEndpoint = 0;
 
 constexpr uint16_t kOptionFilepath = 'f';
+constexpr uint16_t kOptionQueryImageBehavior = 'q';
+constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
 const char * gOtaFilepath          = nullptr;
 
 // Arbitrary BDX Transfer Params
 constexpr uint32_t kMaxBdxBlockSize = 1024;
 constexpr uint32_t kBdxTimeoutMs    = 5 * 60 * 1000; // OTA Spec mandates >= 5 minutes
 constexpr uint32_t kBdxPollFreqMs   = 500;
+
+// Global variables used for passing the CLI arguments to the OTAProviderExample object
+OTAProviderExample::queryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+uint32_t gDelayedActionTimeSec = 0;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
@@ -75,6 +81,33 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
             gOtaFilepath = aValue;
         }
         break;
+    case kOptionQueryImageBehavior:
+        if (aValue == NULL)
+        {
+            PrintArgError("%s: ERROR: NULL QueryImageBehavior parameter\n", aProgram);
+            retval = false;
+        }
+        else if (strcmp(aValue, "UpdateAvailable") == 0)
+        {
+            gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+        }
+        else if (strcmp(aValue, "Busy") == 0)
+        {
+            gQueryImageBehavior = OTAProviderExample::kRespondWithBusy;
+        }
+        else if (strcmp(aValue, "UpdateNotAvailable") == 0)
+        {
+            gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
+        }
+        else
+        {
+            PrintArgError("%s: ERROR: Invalid QueryImageBehavior parameter:  %s\n", aProgram, aValue);
+            retval = false;
+        }
+        break;
+  case kOptionDelayedActionTimeSec:
+      gDelayedActionTimeSec = static_cast<uint32_t>(strtol(aValue, NULL, 0));
+        break;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;
@@ -86,13 +119,18 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
 
 OptionDef cmdLineOptionsDef[] = {
     { "filepath", chip::ArgParser::kArgumentRequired, kOptionFilepath },
+    { "QueryImageBehavior", chip::ArgParser::kArgumentRequired, kOptionQueryImageBehavior },
+    { "DelayedActionTimeSec", chip::ArgParser::kArgumentRequired, kOptionDelayedActionTimeSec },
     {},
 };
 
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",
-                             "  -f <file>\n"
-                             "  --filepath <file>\n"
-                             "        Path to a file containing an OTA image.\n" };
+                             "  -f/--filepath <file>\n"
+                             "        Path to a file containing an OTA image.\n"
+                             "  -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>\n"
+                             "        Status value in the Query Image Resonse\n"
+                             "  -d/--DelayedActionTimeSec <time>\n"
+                             "        Value in seconds for the DelayedActionTime in the Query Image Resonse\n"};
 
 HelpOptions helpOptions("ota-provider-app", "Usage: ota-provider-app [options]", "1.0");
 
@@ -142,6 +180,9 @@ int main(int argc, char * argv[])
         otaProvider.SetOTAFilePath(gOtaFilepath);
         bdxServer.SetFilepath(gOtaFilepath);
     }
+
+    otaProvider.SetQueryImageBehavior(gQueryImageBehavior);
+    otaProvider.SetDelayedActionTimeSec(gDelayedActionTimeSec);
 
     chip::app::clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, &otaProvider);
 

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -128,9 +128,9 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "  -f/--filepath <file>\n"
                              "        Path to a file containing an OTA image.\n"
                              "  -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>\n"
-                             "        Status value in the Query Image Resonse\n"
+                             "        Status value in the Query Image Response\n"
                              "  -d/--DelayedActionTimeSec <time>\n"
-                             "        Value in seconds for the DelayedActionTime in the Query Image Resonse\n"};
+                             "        Value in seconds for the DelayedActionTime in the Query Image Response\n"};
 
 HelpOptions helpOptions("ota-provider-app", "Usage: ota-provider-app [options]", "1.0");
 

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -53,7 +53,6 @@ constexpr chip::EndpointId kOtaProviderEndpoint = 0;
 constexpr uint16_t kOptionFilepath = 'f';
 constexpr uint16_t kOptionQueryImageBehavior = 'q';
 constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
-const char * gOtaFilepath          = nullptr;
 
 // Arbitrary BDX Transfer Params
 constexpr uint32_t kMaxBdxBlockSize = 1024;
@@ -63,6 +62,7 @@ constexpr uint32_t kBdxPollFreqMs   = 500;
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
 OTAProviderExample::queryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
 uint32_t gDelayedActionTimeSec = 0;
+const char * gOtaFilepath          = nullptr;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {

--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -50,8 +50,8 @@ using chip::Messaging::ExchangeManager;
 // TODO: this should probably be done dynamically
 constexpr chip::EndpointId kOtaProviderEndpoint = 0;
 
-constexpr uint16_t kOptionFilepath = 'f';
-constexpr uint16_t kOptionQueryImageBehavior = 'q';
+constexpr uint16_t kOptionFilepath             = 'f';
+constexpr uint16_t kOptionQueryImageBehavior   = 'q';
 constexpr uint16_t kOptionDelayedActionTimeSec = 'd';
 
 // Arbitrary BDX Transfer Params
@@ -61,8 +61,8 @@ constexpr uint32_t kBdxPollFreqMs   = 500;
 
 // Global variables used for passing the CLI arguments to the OTAProviderExample object
 OTAProviderExample::queryImageBehaviorType gQueryImageBehavior = OTAProviderExample::kRespondWithUpdateAvailable;
-uint32_t gDelayedActionTimeSec = 0;
-const char * gOtaFilepath          = nullptr;
+uint32_t gDelayedActionTimeSec                                 = 0;
+const char * gOtaFilepath                                      = nullptr;
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
 {
@@ -105,8 +105,8 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
             retval = false;
         }
         break;
-  case kOptionDelayedActionTimeSec:
-      gDelayedActionTimeSec = static_cast<uint32_t>(strtol(aValue, NULL, 0));
+    case kOptionDelayedActionTimeSec:
+        gDelayedActionTimeSec = static_cast<uint32_t>(strtol(aValue, NULL, 0));
         break;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
@@ -130,7 +130,7 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "  -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>\n"
                              "        Status value in the Query Image Response\n"
                              "  -d/--DelayedActionTimeSec <time>\n"
-                             "        Value in seconds for the DelayedActionTime in the Query Image Response\n"};
+                             "        Value in seconds for the DelayedActionTime in the Query Image Response\n" };
 
 HelpOptions helpOptions("ota-provider-app", "Usage: ota-provider-app [options]", "1.0");
 

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -81,7 +81,7 @@ bool GenerateBdxUri(const Span<char> & fileDesignator, Span<char> outUri, size_t
 OTAProviderExample::OTAProviderExample()
 {
     memset(mOTAFilePath, 0, kFilepathBufLen);
-    mQueryImageBehavior = kRespondWithNotAvailable;
+    mQueryImageBehavior   = kRespondWithNotAvailable;
     mDelayedActionTimeSec = 0;
 }
 
@@ -105,8 +105,8 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     // TODO: add confiuration for returning BUSY status
 
     EmberAfOTAQueryStatus queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
-    uint32_t softwareVersion      = currentVersion + 1; // This implementation will always indicate that an update is available
-                                                        // (if the user provides a file).
+    uint32_t softwareVersion          = currentVersion + 1; // This implementation will always indicate that an update is available
+                                                            // (if the user provides a file).
     bool userConsentNeeded               = false;
     uint8_t updateToken[kUpdateTokenLen] = { 0 };
     char strBuf[kUpdateTokenStrLen]      = { 0 };
@@ -124,26 +124,30 @@ EmberAfStatus OTAProviderExample::HandleQueryImage(chip::app::CommandHandler * c
     }
 
     // Set Status for the Query Image Response
-    switch(mQueryImageBehavior) {
-        case kRespondWithUpdateAvailable: {
-            if(strlen(mOTAFilePath) != 0) {
-                queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_UPDATE_AVAILABLE;
-            } else {
-                queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
-                ChipLogError(SoftwareUpdate, "No OTA file configured on the Provider");
-            }
-            break;
+    switch (mQueryImageBehavior)
+    {
+    case kRespondWithUpdateAvailable: {
+        if (strlen(mOTAFilePath) != 0)
+        {
+            queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_UPDATE_AVAILABLE;
         }
-        case kRespondWithBusy: {
-            queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_BUSY;
-            break;
-        }
-        case kRespondWithNotAvailable: {
+        else
+        {
             queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
-            break;
+            ChipLogError(SoftwareUpdate, "No OTA file configured on the Provider");
         }
-        default:
-            queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+        break;
+    }
+    case kRespondWithBusy: {
+        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_BUSY;
+        break;
+    }
+    case kRespondWithNotAvailable: {
+        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
+        break;
+    }
+    default:
+        queryStatus = EMBER_ZCL_OTA_QUERY_STATUS_NOT_AVAILABLE;
     }
 
     CommandPathParams cmdParams = { emberAfCurrentEndpoint(), 0 /* mGroupId */, ZCL_OTA_PROVIDER_CLUSTER_ID,

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -42,13 +42,15 @@ public:
                                            uint32_t newVersion) override;
     EmberAfStatus HandleNotifyUpdateApplied(const chip::ByteSpan & updateToken, uint32_t currentVersion) override;
 
-    enum queryImageBehaviorType {
-                                 kRespondWithUpdateAvailable,
-                                 kRespondWithBusy,
-                                 kRespondWithNotAvailable
+    enum queryImageBehaviorType
+    {
+        kRespondWithUpdateAvailable,
+        kRespondWithBusy,
+        kRespondWithNotAvailable
     };
-    void SetQueryImageBehavior(queryImageBehaviorType behavior) {mQueryImageBehavior = behavior;}
-    void SetDelayedActionTimeSec(uint32_t time) {mDelayedActionTimeSec = time;}
+    void SetQueryImageBehavior(queryImageBehaviorType behavior) { mQueryImageBehavior = behavior; }
+    void SetDelayedActionTimeSec(uint32_t time) { mDelayedActionTimeSec = time; }
+
 private:
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -42,7 +42,16 @@ public:
                                            uint32_t newVersion) override;
     EmberAfStatus HandleNotifyUpdateApplied(const chip::ByteSpan & updateToken, uint32_t currentVersion) override;
 
+    enum queryImageBehaviorType {
+                                 kRespondWithUpdateAvailable,
+                                 kRespondWithBusy,
+                                 kRespondWithNotAvailable
+    };
+    void SetQueryImageBehavior(queryImageBehaviorType behavior) {queryImageBehavior = behavior;}
+    void SetDelayedActionTimeSec(uint32_t time) {delayedActionTimeSec = time;}
 private:
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated
+    queryImageBehaviorType queryImageBehavior;
+    uint32_t delayedActionTimeSec;
 };

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -47,11 +47,11 @@ public:
                                  kRespondWithBusy,
                                  kRespondWithNotAvailable
     };
-    void SetQueryImageBehavior(queryImageBehaviorType behavior) {queryImageBehavior = behavior;}
-    void SetDelayedActionTimeSec(uint32_t time) {delayedActionTimeSec = time;}
+    void SetQueryImageBehavior(queryImageBehaviorType behavior) {mQueryImageBehavior = behavior;}
+    void SetDelayedActionTimeSec(uint32_t time) {mDelayedActionTimeSec = time;}
 private:
     static constexpr size_t kFilepathBufLen = 256;
     char mOTAFilePath[kFilepathBufLen]; // null-terminated
-    queryImageBehaviorType queryImageBehavior;
-    uint32_t delayedActionTimeSec;
+    queryImageBehaviorType mQueryImageBehavior;
+    uint32_t mDelayedActionTimeSec;
 };

--- a/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
@@ -109,15 +109,10 @@ void BdxDownloader::HandleTransferSessionOutput(TransferSession::OutputEvent & e
         mTransfer.Reset();
         mExchangeCtx->Close();
         break;
-    case TransferSession::OutputEventType::kAckEOFReceived:
-        ChipLogProgress(BDX, "Transfer complete");
-        mTransfer.Reset();
-        mExchangeCtx->Close();
-        break;
-
     case TransferSession::OutputEventType::kInitReceived:
     case TransferSession::OutputEventType::kAckReceived:
     case TransferSession::OutputEventType::kQueryReceived:
+    case TransferSession::OutputEventType::kAckEOFReceived:
     default:
         ChipLogError(BDX, "%s: unexpected event type", __FUNCTION__);
     }

--- a/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
@@ -99,10 +99,12 @@ void BdxDownloader::HandleTransferSessionOutput(TransferSession::OutputEvent & e
     case TransferSession::OutputEventType::kStatusReceived:
         ChipLogError(BDX, "Got StatusReport %x", static_cast<uint16_t>(event.statusData.statusCode));
         mTransfer.Reset();
+        mExchangeCtx->Close();
         break;
     case TransferSession::OutputEventType::kInternalError:
         ChipLogError(BDX, "InternalError");
         mTransfer.Reset();
+        mExchangeCtx->Close();
         break;
     case TransferSession::OutputEventType::kTransferTimeout:
         ChipLogError(BDX, "Transfer timed out");

--- a/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
+++ b/examples/ota-requestor-app/ota-requestor-common/BDXDownloader.cpp
@@ -107,11 +107,17 @@ void BdxDownloader::HandleTransferSessionOutput(TransferSession::OutputEvent & e
     case TransferSession::OutputEventType::kTransferTimeout:
         ChipLogError(BDX, "Transfer timed out");
         mTransfer.Reset();
+        mExchangeCtx->Close();
         break;
+    case TransferSession::OutputEventType::kAckEOFReceived:
+        ChipLogProgress(BDX, "Transfer complete");
+        mTransfer.Reset();
+        mExchangeCtx->Close();
+        break;
+
     case TransferSession::OutputEventType::kInitReceived:
     case TransferSession::OutputEventType::kAckReceived:
     case TransferSession::OutputEventType::kQueryReceived:
-    case TransferSession::OutputEventType::kAckEOFReceived:
     default:
         ChipLogError(BDX, "%s: unexpected event type", __FUNCTION__);
     }


### PR DESCRIPTION
#### Problem
[ota-provider-app] Add configuration for sending "Busy" status and DelayedActionTime #9478
[ota-requestor-app] Close the BDX ExchangeContext when transfer is over #9525

#### Change overview
Fix for 9478: Add configuration for sending "Busy" status and DelayedActionTime. Add the following command line options to the Provider Linux executable:
    -q/--QueryImageBehavior <UpdateAvailable | Busy | UpdateNotAvailable>
              Status value in the Query Image Response
    -d/--DelayedActionTimeSec <time>
            Value in seconds for the DelayedActionTime in the Query Image Response

Fix for 9525: Close the BDX ExchangeContext when transfer is over. Call mExchangeCtx->Close() in cases of transfer timeout, internal error and status received.

#### Testing
Tested with the Provider/Requestor apps on Linux. Verified the scenarios for successful file transfer, transfer timeout, various command line parameter combinations. 