### PR TITLE
 Improve K32W Docker image used by Build example - K32W with SE051 workflow

### DIFF
--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -1,19 +1,26 @@
 ARG VERSION=latest
-FROM connectedhomeip/chip-build:${VERSION}
+FROM connectedhomeip/chip-build:${VERSION} as build
 
-# Setup the K32W SDK
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    wget=1.20.3-1ubuntu1 \
+    unzip=6.0-25ubuntu1 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
-    && mkdir -p /opt/sdk \
-    && cd /opt/sdk \
-    && wget https://mcuxpresso.nxp.com/eclipse/sdk/2.6.4/plugins/com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.4.201911251446.jar \
-    && unzip com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.4.201911251446.jar \
-    && rm -rf com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.4.201911251446.jar \
-    && cd sdks \
-    && unzip 1190028246d9243d9a9e27ca783413a8.zip \
-    && rm -rf 1190028246d9243d9a9e27ca783413a8.zip \
     && : # last line
+
+WORKDIR /opt/sdk
+# Setup the K32W SDK
+RUN set -x \
+    && wget -O /tmp/sdk.jar https://mcuxpresso.nxp.com/eclipse/sdk/2.6.4/plugins/com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.4.201911251446.jar \
+    && unzip /tmp/sdk.jar \
+    && unzip sdks/1190028246d9243d9a9e27ca783413a8.zip -d sdks \
+    && rm -rf sdks/1190028246d9243d9a9e27ca783413a8.zip \
+    && : # last line
+
+FROM connectedhomeip/chip-build:${VERSION}
+
+COPY --from=build /opt/sdk/sdks/ /opt/sdk/sdks/
 
 ENV K32W061_SDK_ROOT=/opt/sdk/sdks

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.19 Version bump reason: Update AmebaD to not require python2 anymore
+0.5.20 Version bump reason: Improve K32W Docker image


### PR DESCRIPTION
#### Problem
[Hadolint](https://github.com/hadolint/hadolint) tool helps to build Docker images following best practices. Using those guidelines can help to reduce the size of the image and speed up the pulling process during the CI execution.

#### Change overview
This change uses the [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) feature to get the MCUXpresso SDK Builder in one stage and installing it in the following stage.

#### Testing
This was tested locally using the act tool (`$ act -j k32w`) using the Docker image built with these changes.