### PR TITLE
Disable async DNS when use_dispatch is enabled.

### DIFF
--- a/src/inet/inet.gni
+++ b/src/inet/inet.gni
@@ -33,5 +33,6 @@ declare_args() {
 declare_args() {
   # Enable async DNS.
   chip_inet_config_enable_async_dns_sockets =
-      chip_inet_config_enable_dns_resolver && chip_system_config_use_sockets
+      chip_inet_config_enable_dns_resolver && chip_system_config_use_sockets &&
+      !chip_system_config_use_dispatch
 }


### PR DESCRIPTION
In the use_dispatch setup the Matter stack is expected to not spin up
threads manually, but our async DNS implementation does just that via
pthreads.  This is leading to random failures in TestInetEndpoint on
Darwin due to thread data races.

Fixes https://github.com/project-chip/connectedhomeip/issues/10025

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran the commands the Darwin "builds" job runs with `is_tsan=true` added to the gn gen args.  Verified lots of thread races in unit tests without this change, none with.