### PR TITLE
Clear exchange context when subscription liveness timeout

### DIFF
--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -93,7 +93,8 @@ public:
     CHIP_ERROR SendSubscribeRequest(ReadPrepareParams & aSubscribePrepareParams);
     CHIP_ERROR OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
     uint64_t GetAppIdentifier() const { return mAppIdentifier; }
-    Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
+
+    NodeId GetPeerNodeId() const { return mPeerNodeId; }
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
     CHIP_ERROR SendStatusResponse(CHIP_ERROR aError);
@@ -177,6 +178,7 @@ private:
     uint16_t mMinIntervalFloorSeconds          = 0;
     uint16_t mMaxIntervalCeilingSeconds        = 0;
     uint64_t mSubscriptionId                   = 0;
+    NodeId mPeerNodeId                         = kUndefinedNodeId;
     InteractionType mInteractionType           = InteractionType::Read;
 };
 

--- a/src/app/util/im-client-callbacks.cpp
+++ b/src/app/util/im-client-callbacks.cpp
@@ -372,7 +372,7 @@ bool IMReadReportAttributesResponseCallback(const app::ReadClient * apReadClient
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
     app::TLVDataFilter tlvFilter             = nullptr;
-    NodeId sourceId                          = apReadClient->GetExchangeContext()->GetSecureSession().GetPeerNodeId();
+    NodeId sourceId                          = apReadClient->GetPeerNodeId();
     // In CHIPClusters.cpp, we are using sequenceNumber as application identifier.
     uint8_t sequenceNumber = static_cast<uint8_t>(apReadClient->GetAppIdentifier());
 
@@ -437,8 +437,8 @@ bool IMSubscribeResponseCallback(const chip::app::ReadClient * apSubscribeClient
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     Callback::Cancelable * onSuccessCallback = nullptr;
     Callback::Cancelable * onFailureCallback = nullptr;
-    err = gCallbacks.GetResponseCallback(apSubscribeClient->GetExchangeContext()->GetSecureSession().GetPeerNodeId(),
-                                         sequenceNumber, &onSuccessCallback, &onFailureCallback);
+    err =
+        gCallbacks.GetResponseCallback(apSubscribeClient->GetPeerNodeId(), sequenceNumber, &onSuccessCallback, &onFailureCallback);
 
     if (CHIP_NO_ERROR != err)
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1852,7 +1852,7 @@ void DeviceControllerInteractionModelDelegate::OnReportData(const app::ReadClien
 CHIP_ERROR DeviceControllerInteractionModelDelegate::ReadError(const app::ReadClient * apReadClient, CHIP_ERROR aError)
 {
     app::ClusterInfo path;
-    path.mNodeId = apReadClient->GetExchangeContext()->GetSecureSession().GetPeerNodeId();
+    path.mNodeId = apReadClient->GetPeerNodeId();
     IMReadReportAttributesResponseCallback(apReadClient, path, nullptr, Protocols::InteractionModel::Status::Failure);
     return CHIP_NO_ERROR;
 }

--- a/src/controller/python/chip/interaction_model/Delegate.cpp
+++ b/src/controller/python/chip/interaction_model/Delegate.cpp
@@ -125,8 +125,7 @@ void PythonInteractionModelDelegate::OnReportData(const app::ReadClient * apRead
         if (CHIP_NO_ERROR == err)
         {
             AttributePath path{ .endpointId = aPath.mEndpointId, .clusterId = aPath.mClusterId, .fieldId = aPath.mFieldId };
-            onReportDataFunct(apReadClient->GetExchangeContext()->GetSecureSession().GetPeerNodeId(),
-                              apReadClient->GetAppIdentifier(),
+            onReportDataFunct(apReadClient->GetPeerNodeId(), apReadClient->GetAppIdentifier(),
                               /* TODO: Use real SubscriptionId */ apReadClient->IsSubscriptionType() ? 1 : 0, &path, sizeof(path),
                               writerBuffer, writer.GetLengthWritten(), to_underlying(status));
         }


### PR DESCRIPTION
#### Problem
* Fixes #10047 

#### Change overview
-- After sending out status report for unsolicited report
during post-subscription, clear out exchange context. Also Clear out
exchange context when liveness timeout happens.
-- Introduce GetPeerNodeId for read client and remove unsafe
GetExchangeContext for read client.

#### Testing
Manually kick out the server, and trigger the subscription client liveness timeout call, and read peer node id.
