### PR TITLE
Handle failure to clone Sigma1 message

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1377,6 +1377,13 @@ CHIP_ERROR CASESession::IsResumptionRequestPresent(const System::PacketBufferHan
 
     System::PacketBufferHandle msg_clone = msg.CloneData();
 
+    resumptionRequested = false;
+    // We are returning success here even though we failed to clone the data.
+    // This is being done so that the caller can continue processing the request as
+    // a new CASE session setup request.
+    // TODO: Handle the failure of cloning the received message for Sigma1Resume processing
+    VerifyOrExit(!msg_clone.IsNull(), err = CHIP_NO_ERROR);
+
     tlvReader.Init(std::move(msg_clone));
     SuccessOrExit(err = tlvReader.Next(containerType, TLV::AnonymousTag));
     SuccessOrExit(err = tlvReader.EnterContainer(containerType));


### PR DESCRIPTION
#### Problem
The ESP32 is crashing while processing Sigma1 message to check for session resumption flags.
```
0x400fe17e: chip::CASESession::IsResumptionRequestPresent(chip::System::PacketBufferHandle const&, bool&, chip::Span<unsigned char const>&, chip::Span<unsigned char const>&) at connectedhomeip/src/protocols/secure_channel/CASESession.cpp:1380

0x400fecaa: chip::CASESession::HandleSigma1(chip::System::PacketBufferHandle&&) at connectedhomeip/src/protocols/secure_channel/CASESession.cpp:438

0x400feeb1: chip::CASESession::HandleSigma1_and_SendSigma2(chip::System::PacketBufferHandle&&) at connectedhomeip/src/protocols/secure_channel/CASESession.cpp:412

0x400ffa55: chip::CASESession::OnMessageReceived(chip::Messaging::ExchangeContext*, chip::PayloadHeader const&, chip::System::PacketBufferHandle&&) at connectedhomeip/src/protocols/secure_channel/CASESession.cpp:1474
```

#### Change overview
The message is cloned while checking for the resumption TLV elements. The cloning is failing on ESP32 platform.
This PR is adding a check to ensure the message was successfully cloned before it is processed.
The current check is returning success on cloning failure. This is done to continue the current behavior where CASE session can be setup as a new session while using ESP32 devices.

I have also added a TODO to understand why cloning is failing on ESP32 platform, and handle the condition more gracefully.

#### Testing
Tested by commissioning m5stack using chip-tool. Prior to this PR, the m5stack was crashing. Now the commissioning process completes successfully.. 