### PR TITLE
[msg] Authenticate message before counter and duplicate processing.

### DIFF
--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -36,8 +36,8 @@ using System::PacketBufferHandle;
 
 namespace SecureMessageCodec {
 
-CHIP_ERROR Encode(Transport::SecureSession * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
-                  System::PacketBufferHandle & msgBuf, MessageCounter & counter)
+CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+                   System::PacketBufferHandle & msgBuf, MessageCounter & counter)
 {
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -72,8 +72,8 @@ CHIP_ERROR Encode(Transport::SecureSession * state, PayloadHeader & payloadHeade
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Decode(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
-                  System::PacketBufferHandle & msg)
+CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
+                   System::PacketBufferHandle & msg)
 {
     ReturnErrorCodeIf(msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/transport/SecureMessageCodec.h
+++ b/src/transport/SecureMessageCodec.h
@@ -49,8 +49,8 @@ namespace SecureMessageCodec {
  * @param counter       The local counter object to be used
  * @ return CHIP_ERROR  The result of the encode operation
  */
-CHIP_ERROR Encode(Transport::SecureSession * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
-                  System::PacketBufferHandle & msgBuf, MessageCounter & counter);
+CHIP_ERROR Encrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+                   System::PacketBufferHandle & msgBuf, MessageCounter & counter);
 
 /**
  * @brief
@@ -66,8 +66,8 @@ CHIP_ERROR Encode(Transport::SecureSession * state, PayloadHeader & payloadHeade
  *                      unencrypted message.
  * @ return CHIP_ERROR  The result of the decode operation
  */
-CHIP_ERROR Decode(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
-                  System::PacketBufferHandle & msgBuf);
+CHIP_ERROR Decrypt(Transport::SecureSession * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
+                   System::PacketBufferHandle & msgBuf);
 } // namespace SecureMessageCodec
 
 } // namespace chip

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR SessionManager::PrepareMessage(SessionHandle session, PayloadHeader &
         }
 
         MessageCounter & counter = GetSendCounterForPacket(payloadHeader, *state);
-        ReturnErrorOnFailure(SecureMessageCodec::Encode(state, payloadHeader, packetHeader, message, counter));
+        ReturnErrorOnFailure(SecureMessageCodec::Encrypt(state, payloadHeader, packetHeader, message, counter));
 
 #if CHIP_PROGRESS_LOGGING
         destination = state->GetPeerNodeId();
@@ -400,7 +400,7 @@ void SessionManager::SecureMessageDispatch(const PacketHeader & packetHeader, co
     }
 
     // Decrypt and verify the message before message counter verification or any further processing.
-    VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decode(state, payloadHeader, packetHeader, msg),
+    VerifyOrExit(CHIP_NO_ERROR == SecureMessageCodec::Decrypt(state, payloadHeader, packetHeader, msg),
                  ChipLogError(Inet, "Secure transport received message, but failed to decode/authenticate it, discarding"));
 
     // Verify message counter


### PR DESCRIPTION
#### Problem
Per spec, if a message doesn't self-authenticate, it can be discarded ahead of any counter, replay, or duplicate processing.

#### Change overview
Performs message decryption/authentication *before* counter processing as required by specification.

Also renaming `SecureMessageCodec::Encode/Decode` to `SecureMessageCodec::Encrypt/Decrypt` to better differentiate crypto processing of a message from more benign header processing and parsing.  The initial entry point for message decryption can now be found via regex search for `Message.*Decrypt` for example.

#### Testing
Only standard ./gn_build.sh unit test suite.