### PR TITLE
Save the session info to persistent storage based on section name

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -36,6 +36,7 @@ executable("chip-tool") {
     "commands/common/CHIPCommand.h",
     "commands/common/Command.cpp",
     "commands/common/Commands.cpp",
+    "commands/common/Options.cpp",
     "commands/discover/DiscoverCommand.cpp",
     "commands/discover/DiscoverCommissionablesCommand.cpp",
     "commands/discover/DiscoverCommissionersCommand.cpp",
@@ -56,6 +57,7 @@ executable("chip-tool") {
   deps = [
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
     "${chip_root}/third_party/inipp",
   ]

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "CHIPCommand.h"
+#include "Options.h"
 
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -35,7 +36,7 @@ CHIP_ERROR CHIPCommand::Run()
     ReturnLogErrorOnFailure(chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(0, true));
 #endif
 
-    ReturnLogErrorOnFailure(mStorage.Init());
+    ReturnLogErrorOnFailure(mStorage.Init(ChiptoolCommandOptions::GetInstance().DeviceName.c_str()));
     ReturnLogErrorOnFailure(mOpCredsIssuer.Initialize(mStorage));
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -20,6 +20,8 @@
 
 #include "Command.h"
 
+#include "Options.h"
+
 #include <algorithm>
 #include <string>
 
@@ -40,8 +42,18 @@ int Commands::Run(int argc, char ** argv)
 
     err = chip::Platform::MemoryInit();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Memory failure: %s", chip::ErrorStr(err)));
+    if (CHIP_NO_ERROR == ParseArguments(argc, argv))
+    {
+        if (ChiptoolCommandOptions::GetInstance().DeviceName.length() != 0)
+        {
+            char * processName = argv[0];
+            argv += 2;
+            *argv = processName;
+            argc -= 2;
+        }
+    }
 
-    err = mStorage.Init();
+    err = mStorage.Init(ChiptoolCommandOptions::GetInstance().DeviceName.c_str());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init Storage failure: %s", chip::ErrorStr(err)));
 
     chip::Logging::SetLogFilter(mStorage.GetLoggingLevel());
@@ -166,7 +178,7 @@ bool Commands::IsGlobalCommand(std::string commandName) const
 void Commands::ShowClusters(std::string executable)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "  %s cluster_name command_name [param1 param2 ...]\n", executable.c_str());
+    fprintf(stderr, "  %s [-name section_name] cluster_name command_name [param1 param2 ...]\n", executable.c_str());
     fprintf(stderr, "\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | Clusters:                                                                           |\n");
@@ -184,7 +196,7 @@ void Commands::ShowClusters(std::string executable)
 void Commands::ShowCluster(std::string executable, std::string clusterName, CommandsVector & commands)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "  %s %s command_name [param1 param2 ...]\n", executable.c_str(), clusterName.c_str());
+    fprintf(stderr, "  %s [-name section_name] %s command_name [param1 param2 ...]\n", executable.c_str(), clusterName.c_str());
     fprintf(stderr, "\n");
     fprintf(stderr, "  +-------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | Commands:                                                                           |\n");

--- a/examples/chip-tool/commands/common/Options.cpp
+++ b/examples/chip-tool/commands/common/Options.cpp
@@ -1,0 +1,61 @@
+
+#include "Options.h"
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPArgParser.hpp>
+
+using namespace chip;
+using namespace chip::ArgParser;
+
+namespace {
+
+ChiptoolCommandOptions gChiptoolCommandOptions;
+enum
+{
+    kCommandOption_Name = 0x100,
+};
+
+OptionDef sCommandOptionDefs[]  = { { "name", kArgumentRequired, kCommandOption_Name }, {} };
+const char * sCommandOptionHelp = "  --name <str>\n"
+                                  "       The target device's alias name. Used to align with communication sessions.\n"
+                                  "\n";
+
+bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
+{
+    switch (aIdentifier)
+    {
+    case kCommandOption_Name:
+        if (aValue != NULL)
+        {
+            gChiptoolCommandOptions.GetInstance().DeviceName = std::string(aValue);
+            return true;
+        }
+        break;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+{
+    return true;
+}
+
+OptionSet sCommandOptions             = { HandleOption, sCommandOptionDefs, "CHIP_TOOL_OPTIONS", sCommandOptionHelp };
+OptionSet * sChiptoolCommandOptions[] = { &sCommandOptions, nullptr };
+
+} // namespace
+
+CHIP_ERROR ParseArguments(int argc, char * argv[])
+{
+    if (!chip::ArgParser::ParseArgs(argv[0], argc, argv, sChiptoolCommandOptions, HandleNonOptionArgs, true))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    return CHIP_NO_ERROR;
+}
+
+ChiptoolCommandOptions & ChiptoolCommandOptions::GetInstance()
+{
+    return gChiptoolCommandOptions;
+}

--- a/examples/chip-tool/commands/common/Options.h
+++ b/examples/chip-tool/commands/common/Options.h
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Support functions for parsing command-line arguments.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <lib/core/CHIPError.h>
+#include <setup_payload/SetupPayload.h>
+
+struct ChiptoolCommandOptions
+{
+    chip::SetupPayload payload;
+    std::string DeviceName;
+    static ChiptoolCommandOptions & GetInstance();
+};
+
+CHIP_ERROR ParseArguments(int argc, char * argv[]);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -71,7 +71,7 @@ std::string Base64ToString(const std::string & b64Value)
 
 } // namespace
 
-CHIP_ERROR PersistentStorage::Init()
+CHIP_ERROR PersistentStorage::Init(const char * sectionName)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -83,6 +83,10 @@ CHIP_ERROR PersistentStorage::Init()
         ifs.open(kFilename, std::ifstream::in);
     }
     VerifyOrExit(ifs.is_open(), err = CHIP_ERROR_OPEN_FAILED);
+    if (sectionName && strlen(sectionName))
+        mSectionName.assign(sectionName);
+    else
+        mSectionName.assign(kDefaultSectionName);
 
     mConfig.parse(ifs);
     ifs.close();
@@ -95,7 +99,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 {
     std::string iniValue;
 
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[mSectionName];
     auto it      = section.find(key);
     ReturnErrorCodeIf(it == section.end(), CHIP_ERROR_KEY_NOT_FOUND);
 
@@ -118,19 +122,19 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
 CHIP_ERROR PersistentStorage::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[mSectionName];
     section[key] = StringToBase64(std::string(static_cast<const char *>(value), size));
 
-    mConfig.sections[kDefaultSectionName] = section;
+    mConfig.sections[mSectionName] = section;
     return CommitConfig();
 }
 
 CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
 {
-    auto section = mConfig.sections[kDefaultSectionName];
+    auto section = mConfig.sections[mSectionName];
     section.erase(key);
 
-    mConfig.sections[kDefaultSectionName] = section;
+    mConfig.sections[mSectionName] = section;
     return CommitConfig();
 }
 

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -26,7 +26,7 @@
 class PersistentStorage : public chip::PersistentStorageDelegate
 {
 public:
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(const char * sectionName);
 
     /////////// PersistentStorageDelegate Interface /////////
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
@@ -51,4 +51,5 @@ private:
 
     CHIP_ERROR CommitConfig();
     inipp::Ini<char> mConfig;
+    std::string mSectionName;
 };


### PR DESCRIPTION
Add "-nSectionName" to save the NodeId info for different session.
This feature enable the chip-tool support multiple device management.

TEST:
./chip-tool -naaa pairing ble-wifi SSID PASSWORD 1 20202021 3840
./chip-tool -nbbb pairing ble-wifi SSID PASSWORD 1 20202021 3840
./chip-tool -naaa onoff toggle 1
./chip-tool -nbbb onoff toggle 1

Signed-off-by: Haoran Wang <elven.wang@nxp.com>

#### Problem
What is being fixed?  
chip-tool support only one device commission

#### Change overview
Save the session informtion in different section according to the section name from the command. The "-n" is the name of section of specific ini file.

#### Testing
./chip-tool -naaa pairing ble-wifi SSID PASSWORD 1 20202021 3840
./chip-tool -nbbb pairing ble-wifi SSID PASSWORD 1 20202021 3840
./chip-tool -naaa onoff toggle 1
./chip-tool -nbbb onoff toggle 1
