### PR TITLE
Fix Thread task wakeup for the NXP lighting app

### DIFF
--- a/examples/lighting-app/k32w/main/main.cpp
+++ b/examples/lighting-app/k32w/main/main.cpp
@@ -123,3 +123,11 @@ extern "C" void main_task(void const * argument)
 exit:
     return;
 }
+
+extern "C" void otSysEventSignalPending(void)
+{
+    {
+        BaseType_t yieldRequired = ThreadStackMgrImpl().SignalThreadActivityPendingFromISR();
+        portYIELD_FROM_ISR(yieldRequired);
+    }
+}


### PR DESCRIPTION
#### Problem
Code that was waking up Thread task was accidentally removed for the lighting app by this PR https://github.com/project-chip/connectedhomeip/pull/9156

#### Change overview
Re-add missing code

#### Testing
Manual testing using TE6 branch
