### PR TITLE
Remove unused cluster id constants.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -175,10 +175,6 @@ static void On{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttri
 {{> clusters_header}}
 
 {{#chip_client_clusters}}
-constexpr chip::ClusterId k{{asUpperCamelCase name}}ClusterId = {{asHex code 4}};
-{{/chip_client_clusters}}
-
-{{#chip_client_clusters}}
 {{> cluster_header}}
 
 {{#chip_cluster_commands}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -14,7 +14,6 @@ namespace clusters {
 
 {{#all_user_clusters}}
 namespace {{asCamelCased name false}} {
-constexpr ClusterId kClusterId = {{asHex code 2}};
 {{#zcl_enums}}
 // Enum for {{label}}
 enum class {{asType label}} : {{asUnderlyingZclType type}} {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -30,11 +30,9 @@ namespace app {
 namespace clusters {
 
 namespace AccountLogin {
-constexpr ClusterId kClusterId = 0x50E;
 
 } // namespace AccountLogin
 namespace AdministratorCommissioning {
-constexpr ClusterId kClusterId = 0x3C;
 // Enum for StatusCode
 enum class StatusCode : uint8_t
 {
@@ -45,7 +43,6 @@ enum class StatusCode : uint8_t
 
 } // namespace AdministratorCommissioning
 namespace ApplicationBasic {
-constexpr ClusterId kClusterId = 0x50D;
 // Enum for ApplicationBasicStatus
 enum class ApplicationBasicStatus : uint8_t
 {
@@ -57,7 +54,6 @@ enum class ApplicationBasicStatus : uint8_t
 
 } // namespace ApplicationBasic
 namespace ApplicationLauncher {
-constexpr ClusterId kClusterId = 0x50C;
 // Enum for ApplicationLauncherStatus
 enum class ApplicationLauncherStatus : uint8_t
 {
@@ -87,7 +83,6 @@ public:
 
 } // namespace ApplicationLauncher
 namespace AudioOutput {
-constexpr ClusterId kClusterId = 0x50B;
 // Enum for AudioOutputType
 enum class AudioOutputType : uint8_t
 {
@@ -122,31 +117,24 @@ public:
 
 } // namespace AudioOutput
 namespace BarrierControl {
-constexpr ClusterId kClusterId = 0x103;
 
 } // namespace BarrierControl
 namespace Basic {
-constexpr ClusterId kClusterId = 0x28;
 
 } // namespace Basic
 namespace BinaryInputBasic {
-constexpr ClusterId kClusterId = 0x0F;
 
 } // namespace BinaryInputBasic
 namespace Binding {
-constexpr ClusterId kClusterId = 0xF000;
 
 } // namespace Binding
 namespace BridgedDeviceBasic {
-constexpr ClusterId kClusterId = 0x39;
 
 } // namespace BridgedDeviceBasic
 namespace ColorControl {
-constexpr ClusterId kClusterId = 0x300;
 
 } // namespace ColorControl
 namespace ContentLauncher {
-constexpr ClusterId kClusterId = 0x50A;
 // Enum for ContentLaunchMetricType
 enum class ContentLaunchMetricType : uint8_t
 {
@@ -299,7 +287,6 @@ public:
 
 } // namespace ContentLauncher
 namespace Descriptor {
-constexpr ClusterId kClusterId = 0x1D;
 
 namespace DeviceType {
 enum FieldId
@@ -322,7 +309,6 @@ public:
 
 } // namespace Descriptor
 namespace DiagnosticLogs {
-constexpr ClusterId kClusterId = 0x32;
 // Enum for LogsIntent
 enum class LogsIntent : uint8_t
 {
@@ -348,15 +334,12 @@ enum class LogsTransferProtocol : uint8_t
 
 } // namespace DiagnosticLogs
 namespace DoorLock {
-constexpr ClusterId kClusterId = 0x101;
 
 } // namespace DoorLock
 namespace ElectricalMeasurement {
-constexpr ClusterId kClusterId = 0xB04;
 
 } // namespace ElectricalMeasurement
 namespace EthernetNetworkDiagnostics {
-constexpr ClusterId kClusterId = 0x37;
 // Enum for PHYRateType
 enum class PHYRateType : uint8_t
 {
@@ -374,7 +357,6 @@ enum class PHYRateType : uint8_t
 
 } // namespace EthernetNetworkDiagnostics
 namespace FixedLabel {
-constexpr ClusterId kClusterId = 0x40;
 
 namespace LabelStruct {
 enum FieldId
@@ -397,11 +379,9 @@ public:
 
 } // namespace FixedLabel
 namespace FlowMeasurement {
-constexpr ClusterId kClusterId = 0x404;
 
 } // namespace FlowMeasurement
 namespace GeneralCommissioning {
-constexpr ClusterId kClusterId = 0x30;
 // Enum for GeneralCommissioningError
 enum class GeneralCommissioningError : uint8_t
 {
@@ -436,7 +416,6 @@ public:
 
 } // namespace GeneralCommissioning
 namespace GeneralDiagnostics {
-constexpr ClusterId kClusterId = 0x33;
 // Enum for BootReasonType
 enum class BootReasonType : uint8_t
 {
@@ -521,7 +500,6 @@ public:
 
 } // namespace GeneralDiagnostics
 namespace GroupKeyManagement {
-constexpr ClusterId kClusterId = 0xF004;
 // Enum for GroupKeySecurityPolicy
 enum class GroupKeySecurityPolicy : uint8_t
 {
@@ -576,15 +554,12 @@ public:
 
 } // namespace GroupKeyManagement
 namespace Groups {
-constexpr ClusterId kClusterId = 0x04;
 
 } // namespace Groups
 namespace Identify {
-constexpr ClusterId kClusterId = 0x03;
 
 } // namespace Identify
 namespace KeypadInput {
-constexpr ClusterId kClusterId = 0x509;
 // Enum for KeypadInputCecKeyCode
 enum class KeypadInputCecKeyCode : uint8_t
 {
@@ -685,15 +660,12 @@ enum class KeypadInputStatus : uint8_t
 
 } // namespace KeypadInput
 namespace LevelControl {
-constexpr ClusterId kClusterId = 0x08;
 
 } // namespace LevelControl
 namespace LowPower {
-constexpr ClusterId kClusterId = 0x508;
 
 } // namespace LowPower
 namespace MediaInput {
-constexpr ClusterId kClusterId = 0x507;
 // Enum for MediaInputType
 enum class MediaInputType : uint8_t
 {
@@ -736,7 +708,6 @@ public:
 
 } // namespace MediaInput
 namespace MediaPlayback {
-constexpr ClusterId kClusterId = 0x506;
 // Enum for MediaPlaybackState
 enum class MediaPlaybackState : uint8_t
 {
@@ -777,7 +748,6 @@ public:
 
 } // namespace MediaPlayback
 namespace NetworkCommissioning {
-constexpr ClusterId kClusterId = 0x31;
 // Enum for NetworkCommissioningError
 enum class NetworkCommissioningError : uint8_t
 {
@@ -846,7 +816,6 @@ public:
 
 } // namespace NetworkCommissioning
 namespace OtaSoftwareUpdateProvider {
-constexpr ClusterId kClusterId = 0x29;
 // Enum for OTAApplyUpdateAction
 enum class OTAApplyUpdateAction : uint8_t
 {
@@ -872,7 +841,6 @@ enum class OTAQueryStatus : uint8_t
 
 } // namespace OtaSoftwareUpdateProvider
 namespace OtaSoftwareUpdateRequestor {
-constexpr ClusterId kClusterId = 0x2A;
 // Enum for OTAAnnouncementReason
 enum class OTAAnnouncementReason : uint8_t
 {
@@ -883,11 +851,9 @@ enum class OTAAnnouncementReason : uint8_t
 
 } // namespace OtaSoftwareUpdateRequestor
 namespace OccupancySensing {
-constexpr ClusterId kClusterId = 0x406;
 
 } // namespace OccupancySensing
 namespace OnOff {
-constexpr ClusterId kClusterId = 0x06;
 // Enum for OnOffDelayedAllOffEffectVariant
 enum class OnOffDelayedAllOffEffectVariant : uint8_t
 {
@@ -909,11 +875,9 @@ enum class OnOffEffectIdentifier : uint8_t
 
 } // namespace OnOff
 namespace OnOffSwitchConfiguration {
-constexpr ClusterId kClusterId = 0x07;
 
 } // namespace OnOffSwitchConfiguration
 namespace OperationalCredentials {
-constexpr ClusterId kClusterId = 0x3E;
 // Enum for NodeOperationalCertStatus
 enum class NodeOperationalCertStatus : uint8_t
 {
@@ -976,15 +940,12 @@ public:
 
 } // namespace OperationalCredentials
 namespace PowerSource {
-constexpr ClusterId kClusterId = 0x2F;
 
 } // namespace PowerSource
 namespace PressureMeasurement {
-constexpr ClusterId kClusterId = 0x403;
 
 } // namespace PressureMeasurement
 namespace PumpConfigurationAndControl {
-constexpr ClusterId kClusterId = 0x200;
 // Enum for PumpControlMode
 enum class PumpControlMode : uint8_t
 {
@@ -1006,15 +967,12 @@ enum class PumpOperationMode : uint8_t
 
 } // namespace PumpConfigurationAndControl
 namespace RelativeHumidityMeasurement {
-constexpr ClusterId kClusterId = 0x405;
 
 } // namespace RelativeHumidityMeasurement
 namespace Scenes {
-constexpr ClusterId kClusterId = 0x05;
 
 } // namespace Scenes
 namespace SoftwareDiagnostics {
-constexpr ClusterId kClusterId = 0x34;
 
 namespace ThreadMetrics {
 enum FieldId
@@ -1043,11 +1001,9 @@ public:
 
 } // namespace SoftwareDiagnostics
 namespace Switch {
-constexpr ClusterId kClusterId = 0x3B;
 
 } // namespace Switch
 namespace TvChannel {
-constexpr ClusterId kClusterId = 0x504;
 // Enum for TvChannelErrorType
 enum class TvChannelErrorType : uint8_t
 {
@@ -1109,7 +1065,6 @@ public:
 
 } // namespace TvChannel
 namespace TargetNavigator {
-constexpr ClusterId kClusterId = 0x505;
 // Enum for NavigateTargetStatus
 enum class NavigateTargetStatus : uint8_t
 {
@@ -1139,11 +1094,9 @@ public:
 
 } // namespace TargetNavigator
 namespace TemperatureMeasurement {
-constexpr ClusterId kClusterId = 0x402;
 
 } // namespace TemperatureMeasurement
 namespace TestCluster {
-constexpr ClusterId kClusterId = 0x50F;
 // Enum for SimpleEnum
 enum class SimpleEnum : uint8_t
 {
@@ -1284,15 +1237,12 @@ public:
 
 } // namespace TestCluster
 namespace Thermostat {
-constexpr ClusterId kClusterId = 0x201;
 
 } // namespace Thermostat
 namespace ThermostatUserInterfaceConfiguration {
-constexpr ClusterId kClusterId = 0x204;
 
 } // namespace ThermostatUserInterfaceConfiguration
 namespace ThreadNetworkDiagnostics {
-constexpr ClusterId kClusterId = 0x35;
 // Enum for NetworkFault
 enum class NetworkFault : uint8_t
 {
@@ -1448,11 +1398,9 @@ public:
 
 } // namespace ThreadNetworkDiagnostics
 namespace WakeOnLan {
-constexpr ClusterId kClusterId = 0x503;
 
 } // namespace WakeOnLan
 namespace WiFiNetworkDiagnostics {
-constexpr ClusterId kClusterId = 0x36;
 // Enum for SecurityType
 enum class SecurityType : uint8_t
 {
@@ -1476,7 +1424,6 @@ enum class WiFiVersionType : uint8_t
 
 } // namespace WiFiNetworkDiagnostics
 namespace WindowCovering {
-constexpr ClusterId kClusterId = 0x102;
 // Enum for WcEndProductType
 enum class WcEndProductType : uint8_t
 {

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1211,60 +1211,6 @@ static void OnThreadNetworkDiagnosticsActiveNetworkFaultsListListAttributeRespon
 | WindowCovering                                                      | 0x0102 |
 \*----------------------------------------------------------------------------*/
 
-constexpr chip::ClusterId kAccountLoginClusterId                         = 0x050E;
-constexpr chip::ClusterId kAdministratorCommissioningClusterId           = 0x003C;
-constexpr chip::ClusterId kApplicationBasicClusterId                     = 0x050D;
-constexpr chip::ClusterId kApplicationLauncherClusterId                  = 0x050C;
-constexpr chip::ClusterId kAudioOutputClusterId                          = 0x050B;
-constexpr chip::ClusterId kBarrierControlClusterId                       = 0x0103;
-constexpr chip::ClusterId kBasicClusterId                                = 0x0028;
-constexpr chip::ClusterId kBinaryInputBasicClusterId                     = 0x000F;
-constexpr chip::ClusterId kBindingClusterId                              = 0xF000;
-constexpr chip::ClusterId kBridgedDeviceBasicClusterId                   = 0x0039;
-constexpr chip::ClusterId kColorControlClusterId                         = 0x0300;
-constexpr chip::ClusterId kContentLauncherClusterId                      = 0x050A;
-constexpr chip::ClusterId kDescriptorClusterId                           = 0x001D;
-constexpr chip::ClusterId kDiagnosticLogsClusterId                       = 0x0032;
-constexpr chip::ClusterId kDoorLockClusterId                             = 0x0101;
-constexpr chip::ClusterId kElectricalMeasurementClusterId                = 0x0B04;
-constexpr chip::ClusterId kEthernetNetworkDiagnosticsClusterId           = 0x0037;
-constexpr chip::ClusterId kFixedLabelClusterId                           = 0x0040;
-constexpr chip::ClusterId kFlowMeasurementClusterId                      = 0x0404;
-constexpr chip::ClusterId kGeneralCommissioningClusterId                 = 0x0030;
-constexpr chip::ClusterId kGeneralDiagnosticsClusterId                   = 0x0033;
-constexpr chip::ClusterId kGroupKeyManagementClusterId                   = 0xF004;
-constexpr chip::ClusterId kGroupsClusterId                               = 0x0004;
-constexpr chip::ClusterId kIdentifyClusterId                             = 0x0003;
-constexpr chip::ClusterId kKeypadInputClusterId                          = 0x0509;
-constexpr chip::ClusterId kLevelControlClusterId                         = 0x0008;
-constexpr chip::ClusterId kLowPowerClusterId                             = 0x0508;
-constexpr chip::ClusterId kMediaInputClusterId                           = 0x0507;
-constexpr chip::ClusterId kMediaPlaybackClusterId                        = 0x0506;
-constexpr chip::ClusterId kNetworkCommissioningClusterId                 = 0x0031;
-constexpr chip::ClusterId kOtaSoftwareUpdateProviderClusterId            = 0x0029;
-constexpr chip::ClusterId kOtaSoftwareUpdateRequestorClusterId           = 0x002A;
-constexpr chip::ClusterId kOccupancySensingClusterId                     = 0x0406;
-constexpr chip::ClusterId kOnOffClusterId                                = 0x0006;
-constexpr chip::ClusterId kOnOffSwitchConfigurationClusterId             = 0x0007;
-constexpr chip::ClusterId kOperationalCredentialsClusterId               = 0x003E;
-constexpr chip::ClusterId kPowerSourceClusterId                          = 0x002F;
-constexpr chip::ClusterId kPressureMeasurementClusterId                  = 0x0403;
-constexpr chip::ClusterId kPumpConfigurationAndControlClusterId          = 0x0200;
-constexpr chip::ClusterId kRelativeHumidityMeasurementClusterId          = 0x0405;
-constexpr chip::ClusterId kScenesClusterId                               = 0x0005;
-constexpr chip::ClusterId kSoftwareDiagnosticsClusterId                  = 0x0034;
-constexpr chip::ClusterId kSwitchClusterId                               = 0x003B;
-constexpr chip::ClusterId kTvChannelClusterId                            = 0x0504;
-constexpr chip::ClusterId kTargetNavigatorClusterId                      = 0x0505;
-constexpr chip::ClusterId kTemperatureMeasurementClusterId               = 0x0402;
-constexpr chip::ClusterId kTestClusterClusterId                          = 0x050F;
-constexpr chip::ClusterId kThermostatClusterId                           = 0x0201;
-constexpr chip::ClusterId kThermostatUserInterfaceConfigurationClusterId = 0x0204;
-constexpr chip::ClusterId kThreadNetworkDiagnosticsClusterId             = 0x0035;
-constexpr chip::ClusterId kWakeOnLanClusterId                            = 0x0503;
-constexpr chip::ClusterId kWiFiNetworkDiagnosticsClusterId               = 0x0036;
-constexpr chip::ClusterId kWindowCoveringClusterId                       = 0x0102;
-
 /*----------------------------------------------------------------------------*\
 | Cluster AccountLogin                                                | 0x050E |
 |------------------------------------------------------------------------------|


### PR DESCRIPTION
We have cluster ids defined in
app-common/zap-generated/ids/Clusters.h; there is no need to define
them other places too.

#### Problem
See above.

#### Change overview
Remove a bunch of unused constants.

#### Testing
No functionality changes.  Tree compiles.